### PR TITLE
feat(ui): 实现提交历史页，完善管理后台提交管理

### DIFF
--- a/noj-core/src/routes/submissions.ts
+++ b/noj-core/src/routes/submissions.ts
@@ -36,6 +36,8 @@ router.get("/", authMiddleware, async (c) => {
 
   // 解析筛选参数
   const problemId = c.req.query("problem_id") || undefined;
+  const problemSearch = c.req.query("problem_search") || undefined;
+  const submissionId = c.req.query("submission_id") || undefined;
   const language = c.req.query("language") || undefined;
   const status = c.req.query("status") || undefined;
   const from = c.req.query("from") || undefined;
@@ -52,6 +54,8 @@ router.get("/", authMiddleware, async (c) => {
   const result = await listSubmissions({
     userId,
     problemId,
+    problemSearch,
+    submissionId,
     language,
     status,
     from,
@@ -147,9 +151,12 @@ adminSubmissions.get("/", authMiddleware, adminMiddleware, async (c) => {
   if (isNaN(perPage) || perPage < 1) perPage = 20;
   if (perPage > 100) perPage = 100;
 
-  // 解析筛选参数（额外支持 user_id）
+  // 解析筛选参数（额外支持 user_id、user_search）
   const userId = c.req.query("user_id") || undefined;
+  const userSearch = c.req.query("user_search") || undefined;
   const problemId = c.req.query("problem_id") || undefined;
+  const problemSearch = c.req.query("problem_search") || undefined;
+  const submissionId = c.req.query("submission_id") || undefined;
   const language = c.req.query("language") || undefined;
   const status = c.req.query("status") || undefined;
   const from = c.req.query("from") || undefined;
@@ -165,7 +172,10 @@ adminSubmissions.get("/", authMiddleware, adminMiddleware, async (c) => {
 
   const result = await listSubmissions({
     userId,
+    userSearch,
     problemId,
+    problemSearch,
+    submissionId,
     language,
     status,
     from,

--- a/noj-core/src/services/submissions.ts
+++ b/noj-core/src/services/submissions.ts
@@ -1,7 +1,12 @@
 import { encodeBase64 } from "@std/encoding/base64";
-import { and, eq, gte, lte, sql } from "drizzle-orm";
+import { and, eq, gte, ilike, lte, or, sql } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
-import { evaluationResults, problems, submissions } from "../db/schema.ts";
+import {
+  evaluationResults,
+  problems,
+  submissions,
+  users,
+} from "../db/schema.ts";
 import { AppError, BadRequestError, NotFoundError } from "../lib/errors.ts";
 import { pushJudgeTask } from "../mq/producer.ts";
 import { getProblem } from "./problems.ts";
@@ -67,6 +72,8 @@ export interface SubmissionListItem {
   result: {
     status: string;
     score: number;
+    time_ms: number | null;
+    memory_kb: number | null;
   } | null;
 }
 
@@ -76,6 +83,9 @@ export interface SubmissionListItem {
 export interface ListSubmissionsParams {
   userId?: string;
   problemId?: string;
+  problemSearch?: string;
+  submissionId?: string;
+  userSearch?: string;
   language?: string;
   status?: string;
   from?: string;
@@ -102,8 +112,19 @@ export async function listSubmissions(
   params: ListSubmissionsParams,
 ): Promise<ListSubmissionsResult> {
   const db = getDb();
-  const { userId, problemId, language, status, from, to, page, perPage } =
-    params;
+  const {
+    userId,
+    problemId,
+    problemSearch,
+    submissionId,
+    userSearch,
+    language,
+    status,
+    from,
+    to,
+    page,
+    perPage,
+  } = params;
 
   // 动态构建筛选条件（仅对提供的参数添加条件）
   const conditions: ReturnType<typeof eq>[] = [];
@@ -117,13 +138,47 @@ export async function listSubmissions(
   if (from) conditions.push(gte(submissions.created_at, from));
   if (to) conditions.push(lte(submissions.created_at, to));
 
+  // problemSearch: problem_id 精确匹配 OR problems.title ILIKE 模糊搜索
+  if (problemSearch) {
+    conditions.push(
+      or(
+        eq(submissions.problem_id, problemSearch),
+        ilike(problems.title, `%${problemSearch}%`),
+      ) as unknown as ReturnType<typeof eq>,
+    );
+  }
+
+  // submissionId: submissions.id ILIKE 前缀匹配
+  if (submissionId) {
+    conditions.push(
+      ilike(submissions.id, `${submissionId}%`) as unknown as ReturnType<
+        typeof eq
+      >,
+    );
+  }
+
+  // userSearch: users.username ILIKE OR submissions.user_id 前缀匹配
+  if (userSearch) {
+    conditions.push(
+      or(
+        ilike(users.username, `%${userSearch}%`),
+        ilike(submissions.user_id, `${userSearch}%`),
+      ) as unknown as ReturnType<typeof eq>,
+    );
+  }
+
   const where = conditions.length > 0 ? and(...conditions) : undefined;
 
-  // COUNT 总数
-  const [countRow] = await db
+  // COUNT 总数（需 LEFT JOIN problems 以支持 problemSearch，users 以支持 userSearch）
+  let countQuery = db
     .select({ total: sql<number>`count(*)` })
     .from(submissions)
-    .where(where);
+    .leftJoin(problems, eq(submissions.problem_id, problems.id));
+  // userSearch 需要关联 users 表
+  if (userSearch) {
+    countQuery = countQuery.leftJoin(users, eq(submissions.user_id, users.id));
+  }
+  const [countRow] = await countQuery.where(where);
 
   const total = Number(countRow?.total ?? 0);
 
@@ -134,8 +189,8 @@ export async function listSubmissions(
 
   const offset = (page - 1) * perPage;
 
-  // 数据查询：LEFT JOIN problems + evaluation_results
-  const rows = await db
+  // 数据查询：LEFT JOIN problems + evaluation_results（+ users 当需要 userSearch 时）
+  let dataQuery = db
     .select({
       id: submissions.id,
       user_id: submissions.user_id,
@@ -147,14 +202,22 @@ export async function listSubmissions(
       problem_title: problems.title,
       result_status: evaluationResults.status,
       result_score: evaluationResults.score,
+      result_time_ms: evaluationResults.time_ms,
+      result_memory_kb: evaluationResults.memory_kb,
     })
     .from(submissions)
     .leftJoin(problems, eq(submissions.problem_id, problems.id))
     .leftJoin(
       evaluationResults,
       eq(evaluationResults.submission_id, submissions.id),
-    )
-    .where(where)
+    );
+  if (userSearch) {
+    dataQuery = dataQuery.leftJoin(
+      users,
+      eq(submissions.user_id, users.id),
+    );
+  }
+  const rows = await dataQuery.where(where)
     .orderBy(sql`${submissions.created_at} DESC`)
     .offset(offset)
     .limit(perPage);
@@ -175,6 +238,8 @@ export async function listSubmissions(
       ? {
         status: row.result_status,
         score: row.result_score ?? 0,
+        time_ms: row.result_time_ms,
+        memory_kb: row.result_memory_kb,
       }
       : null,
   }));

--- a/noj-ui/components/Navbar.vue
+++ b/noj-ui/components/Navbar.vue
@@ -8,6 +8,7 @@
             <nav class="nav-links">
                 <NuxtLink to="/" class="nav-link">首页</NuxtLink>
                 <NuxtLink to="/problems" class="nav-link">题库</NuxtLink>
+                <NuxtLink to="/submissions" class="nav-link">提交记录</NuxtLink>
                 <NuxtLink to="/queue" class="nav-link">队列</NuxtLink>
                 <NuxtLink to="/about" class="nav-link">关于</NuxtLink>
             </nav>

--- a/noj-ui/composables/use-submissions.ts
+++ b/noj-ui/composables/use-submissions.ts
@@ -1,0 +1,138 @@
+/**
+ * 提交历史相关共享类型、状态映射和格式化函数。
+ * 在用户提交列表页和管理后台间复用。
+ */
+
+// API 返回的提列表项类型
+export interface SubmissionListItem {
+  id: string
+  user_id: string
+  problem_id: string
+  language: string
+  file_name: string | null
+  status: string
+  created_at: string
+  problem: {
+    id: string
+    title: string
+  }
+  result: {
+    status: string
+    score: number
+    time_ms: number | null
+    memory_kb: number | null
+  } | null
+}
+
+/**
+ * 语言标识 → 显示标签映射。
+ */
+export const languageLabels: Record<string, string> = {
+  python3: "Python 3",
+  python: "Python",
+  cpp: "C++",
+  c: "C",
+  javascript: "JavaScript",
+}
+
+/**
+ * 提交流 state 标签颜色。
+ */
+export const statusColors: Record<string, string> = {
+  pending: "#9ca3af",
+  judging: "#3b82f6",
+}
+
+/**
+ * 提交流 state 标签文字。
+ */
+export const statusLabels: Record<string, string> = {
+  pending: "等待评测",
+  judging: "评测中",
+}
+
+/**
+ * 评测结果状态 → 显示标签。
+ */
+export const resultLabels: Record<string, string> = {
+  Accepted: "答案正确",
+  WrongAnswer: "答案错误",
+  TimeLimitExceeded: "超出时间限制",
+  MemoryLimitExceeded: "超出内存限制",
+  RuntimeError: "运行时错误",
+  SystemError: "系统错误",
+}
+
+/**
+ * 评测结果状态 → 标签颜色。
+ */
+export const resultColors: Record<string, string> = {
+  Accepted: "#10b981",
+  WrongAnswer: "#ef4444",
+  TimeLimitExceeded: "#f59e0b",
+  MemoryLimitExceeded: "#f59e0b",
+  RuntimeError: "#ef4444",
+  SystemError: "#ef4444",
+}
+
+/**
+ * 获取状态标签的颜色。
+ * 优先使用 result.status 的颜色，回退到提交流 state 的颜色。
+ */
+export function getStatusColor(
+  status: string,
+  resultStatus: string | undefined | null,
+): string {
+  if (resultStatus && resultColors[resultStatus]) {
+    return resultColors[resultStatus]
+  }
+  return statusColors[status] || "#6b7280"
+}
+
+/**
+ * 获取状态标签的文字。
+ * 优先使用 result.status 的标，回退到提交流 state 的标签。
+ */
+export function getStatusLabel(
+  status: string,
+  resultStatus: string | undefined | null,
+): string {
+  if (resultStatus && resultLabels[resultStatus]) {
+    return resultLabels[resultStatus]
+  }
+  return statusLabels[status] || status
+}
+
+/**
+ * 格式化得分（API 返回 ×100 的整数值）。
+ */
+export function formatScore(raw: number | undefined | null): string {
+  if (raw === undefined || raw === null) return "--"
+  return (raw / 100).toFixed(1)
+}
+
+/**
+ * 格式化时间（毫秒 → 可读格式）。
+ */
+export function formatTime(ms: number | undefined | null): string {
+  if (ms === undefined || ms === null) return "--"
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+/**
+ * 格式化内存（KB → 可读格式）。
+ */
+export function formatMemory(kb: number | undefined | null): string {
+  if (kb === undefined || kb === null) return "--"
+  if (kb < 1024) return `${kb}KB`
+  if (kb < 1024 * 1024) return `${(kb / 1024).toFixed(1)}MB`
+  return `${(kb / 1024 / 1024).toFixed(2)}GB`
+}
+
+/**
+ * 获取语言显示标签。
+ */
+export function getLanguageLabel(lang: string): string {
+  return languageLabels[lang] || lang
+}

--- a/noj-ui/pages/admin/submissions.vue
+++ b/noj-ui/pages/admin/submissions.vue
@@ -1,6 +1,15 @@
 <script setup lang="ts">
-import { Search, X, Filter } from "@lucide/vue"
+import { Search, X } from "@lucide/vue"
 import type { Column } from "~/components/admin/AdminTable.vue"
+import type { SubmissionListItem } from "~/composables/use-submissions"
+import {
+  getStatusColor,
+  getStatusLabel,
+  formatScore,
+  formatTime,
+  formatMemory,
+  getLanguageLabel,
+} from "~/composables/use-submissions"
 
 definePageMeta({
   layout: "admin",
@@ -15,16 +24,7 @@ watch(loading, (val) => {
   if (!val && !isLoggedIn.value) router.replace("/login")
 }, { immediate: true })
 
-interface Submission {
-  id: string
-  user_id: string
-  problem_id: string
-  language: string
-  status: string
-  created_at: string
-}
-
-const submissions = ref<Submission[]>([])
+const submissions = ref<SubmissionListItem[]>([])
 const tableLoading = ref(true)
 const tableError = ref("")
 const currentPage = ref(1)
@@ -33,37 +33,57 @@ const perPage = 20
 
 // 筛选条件
 const filters = reactive({
-  user_id: "",
-  problem_id: "",
+  problem_search: "",
+  submission_id: "",
+  user_search: "",
   language: "",
   status: "",
-  from: "",
-  to: "",
 })
 
-const statusLabels: Record<string, string> = {
-  pending: "等待中",
-  judging: "评测中",
-  finished: "已完成",
-  error: "出错",
-}
+// 语言选项
+const languageOptions = [
+  { value: "", label: "全部" },
+  { value: "python3", label: "Python 3" },
+  { value: "python", label: "Python" },
+  { value: "cpp", label: "C++" },
+  { value: "c", label: "C" },
+  { value: "javascript", label: "JavaScript" },
+]
 
-const statusColors: Record<string, string> = {
-  pending: "#f59e0b",
-  judging: "#3b82f6",
-  finished: "#10b981",
-  error: "#ef4444",
-}
+// 状态选项
+const statusOptions = [
+  { value: "", label: "全部" },
+  { value: "pending", label: "等待评测" },
+  { value: "judging", label: "评测中" },
+  { value: "finished", label: "已完成" },
+  { value: "error", label: "出错" },
+]
 
-const columns: Column<Submission>[] = [
+// AdminTable 的 Column 泛型默认为 Record<string, unknown>，format 中通过 rowSub 取值
+const columns: Column[] = [
   { key: "id", label: "编号", format: (val) => (val as string).slice(0, 8) + "..." },
   { key: "user_id", label: "用户" },
-  { key: "problem_id", label: "题目" },
-  { key: "language", label: "语言" },
   {
-    key: "status",
-    label: "状态",
-    format: (val) => statusLabels[val as string] || (val as string),
+    key: "problem",
+    label: "题目",
+    format: (_, row) => rowSub(row).problem.title || rowSub(row).problem_id,
+  },
+  { key: "language", label: "语言", format: (val) => getLanguageLabel(val as string) },
+  { key: "status", label: "状态" },
+  {
+    key: "score",
+    label: "得分",
+    format: (_, row) => rowSub(row).result ? formatScore(rowSub(row).result!.score) : "--",
+  },
+  {
+    key: "time_ms",
+    label: "耗时",
+    format: (_, row) => rowSub(row).result ? formatTime(rowSub(row).result!.time_ms) : "--",
+  },
+  {
+    key: "memory_kb",
+    label: "内存",
+    format: (_, row) => rowSub(row).result ? formatMemory(rowSub(row).result!.memory_kb) : "--",
   },
   {
     key: "created_at",
@@ -76,12 +96,11 @@ function buildQuery(page: number): string {
   const params = new URLSearchParams()
   params.set("page", String(page))
   params.set("per_page", String(perPage))
-  if (filters.user_id) params.set("user_id", filters.user_id)
-  if (filters.problem_id) params.set("problem_id", filters.problem_id)
+  if (filters.user_search) params.set("user_search", filters.user_search)
+  if (filters.problem_search) params.set("problem_search", filters.problem_search)
+  if (filters.submission_id) params.set("submission_id", filters.submission_id)
   if (filters.language) params.set("language", filters.language)
   if (filters.status) params.set("status", filters.status)
-  if (filters.from) params.set("from", filters.from)
-  if (filters.to) params.set("to", filters.to)
   return params.toString()
 }
 
@@ -91,7 +110,7 @@ async function loadSubmissions(page = 1) {
   tableError.value = ""
   currentPage.value = page
   try {
-    const res = await $fetch<{ data: Submission[]; pagination: { total: number; total_pages: number } }>(
+    const res = await $fetch<{ data: SubmissionListItem[]; pagination: { total: number; total_pages: number } }>(
       `/api/v1/admin/submissions?${buildQuery(page)}`,
     )
     submissions.value = res.data
@@ -116,13 +135,17 @@ function applyFilters() {
 }
 
 function clearFilters() {
-  filters.user_id = ""
-  filters.problem_id = ""
+  filters.user_search = ""
+  filters.problem_search = ""
+  filters.submission_id = ""
   filters.language = ""
   filters.status = ""
-  filters.from = ""
-  filters.to = ""
   loadSubmissions(1)
+}
+
+// AdminTable slot 中 row 类型为 Record<string, unknown>，辅助函数用于安全取值
+function rowSub(row: Record<string, unknown>): SubmissionListItem {
+  return row as unknown as SubmissionListItem
 }
 </script>
 
@@ -137,34 +160,47 @@ function clearFilters() {
     <div class="filter-bar">
       <div class="filter-row">
         <div class="filter-item">
-          <label class="filter-label">用户 ID</label>
-          <input v-model="filters.user_id" class="filter-input" placeholder="user_id" @keyup.enter="applyFilters" />
+          <label class="filter-label">题目</label>
+          <input
+            v-model="filters.problem_search"
+            class="filter-input"
+            placeholder="题目 ID 或名称"
+            @keyup.enter="applyFilters"
+          />
         </div>
         <div class="filter-item">
-          <label class="filter-label">题目 ID</label>
-          <input v-model="filters.problem_id" class="filter-input" placeholder="problem_id" @keyup.enter="applyFilters" />
+          <label class="filter-label">用户</label>
+          <input
+            v-model="filters.user_search"
+            class="filter-input"
+            placeholder="用户名或用户 ID"
+            @keyup.enter="applyFilters"
+          />
+        </div>
+        <div class="filter-item">
+          <label class="filter-label">提交 ID</label>
+          <input
+            v-model="filters.submission_id"
+            class="filter-input"
+            placeholder="提交 ID 前缀"
+            @keyup.enter="applyFilters"
+          />
         </div>
         <div class="filter-item">
           <label class="filter-label">语言</label>
-          <input v-model="filters.language" class="filter-input" placeholder="如 python3" @keyup.enter="applyFilters" />
+          <select v-model="filters.language" class="filter-input" @change="applyFilters">
+            <option v-for="opt in languageOptions" :key="opt.value" :value="opt.value">
+              {{ opt.label }}
+            </option>
+          </select>
         </div>
         <div class="filter-item">
           <label class="filter-label">状态</label>
           <select v-model="filters.status" class="filter-input" @change="applyFilters">
-            <option value="">全部</option>
-            <option value="pending">等待中</option>
-            <option value="judging">评测中</option>
-            <option value="finished">已完成</option>
-            <option value="error">出错</option>
+            <option v-for="opt in statusOptions" :key="opt.value" :value="opt.value">
+              {{ opt.label }}
+            </option>
           </select>
-        </div>
-        <div class="filter-item">
-          <label class="filter-label">开始时间</label>
-          <input v-model="filters.from" type="date" class="filter-input" />
-        </div>
-        <div class="filter-item">
-          <label class="filter-label">结束时间</label>
-          <input v-model="filters.to" type="date" class="filter-input" />
         </div>
       </div>
       <div class="filter-actions">
@@ -186,14 +222,22 @@ function clearFilters() {
       :error="tableError"
       empty-text="暂无提交记录"
     >
+      <!-- 状态标签列：评测结果状态优先，提交状态回退 -->
       <template #cell-status="{ row }">
-        <span class="status-badge" :style="{ background: statusColors[row.status] + '15', color: statusColors[row.status] }">
-          {{ statusLabels[row.status] || row.status }}
+        <span
+          class="status-badge"
+          :style="{
+            background: getStatusColor(rowSub(row).status, rowSub(row).result?.status) + '15',
+            color: getStatusColor(rowSub(row).status, rowSub(row).result?.status),
+          }"
+        >
+          {{ getStatusLabel(rowSub(row).status, rowSub(row).result?.status) }}
         </span>
       </template>
 
+      <!-- 操作列 -->
       <template #actions="{ row }">
-        <NuxtLink :to="`/submissions/${row.id}`" class="btn btn-xs">查看</NuxtLink>
+        <NuxtLink :to="`/submissions/${rowSub(row).id}`" class="btn btn-xs">查看</NuxtLink>
       </template>
     </AdminTable>
 
@@ -334,5 +378,6 @@ function clearFilters() {
   border-radius: 6px;
   font-size: 12px;
   font-weight: 600;
+  white-space: nowrap;
 }
 </style>

--- a/noj-ui/pages/submissions/index.vue
+++ b/noj-ui/pages/submissions/index.vue
@@ -1,0 +1,525 @@
+<script setup lang="ts">
+import { Search, X } from "@lucide/vue"
+import type {
+  SubmissionListItem,
+} from "~/composables/use-submissions"
+import {
+  getStatusColor,
+  getStatusLabel,
+  formatScore,
+  formatTime,
+  formatMemory,
+  getLanguageLabel,
+} from "~/composables/use-submissions"
+
+definePageMeta({
+  ssr: false,
+})
+
+const { isLoggedIn, loading } = useAuth()
+const router = useRouter()
+
+// 认证守卫：未登录跳转到 /login
+watch(loading, (val) => {
+  if (!val && !isLoggedIn.value) router.replace("/login")
+}, { immediate: true })
+
+// 列表数据
+const submissions = ref<SubmissionListItem[]>([])
+const tableLoading = ref(true)
+const tableError = ref("")
+const currentPage = ref(1)
+const totalPages = ref(1)
+const perPage = 20
+
+// 筛选条件
+const filters = reactive({
+  problem_search: "",
+  submission_id: "",
+  language: "",
+  status: "",
+})
+
+// 语言选项
+const languageOptions = [
+  { value: "", label: "全部" },
+  { value: "python3", label: "Python 3" },
+  { value: "python", label: "Python" },
+  { value: "cpp", label: "C++" },
+  { value: "c", label: "C" },
+  { value: "javascript", label: "JavaScript" },
+]
+
+// 状态选项
+const statusOptions = [
+  { value: "", label: "全部" },
+  { value: "pending", label: "等待评测" },
+  { value: "judging", label: "评测中" },
+  { value: "finished", label: "已完成" },
+  { value: "error", label: "出错" },
+]
+
+function buildQuery(page: number): string {
+  const params = new URLSearchParams()
+  params.set("page", String(page))
+  params.set("per_page", String(perPage))
+  if (filters.problem_search) params.set("problem_search", filters.problem_search)
+  if (filters.submission_id) params.set("submission_id", filters.submission_id)
+  if (filters.language) params.set("language", filters.language)
+  if (filters.status) params.set("status", filters.status)
+  return params.toString()
+}
+
+async function loadSubmissions(page = 1) {
+  if (!isLoggedIn.value) return
+  tableLoading.value = true
+  tableError.value = ""
+  currentPage.value = page
+  try {
+    const res = await $fetch<{ data: SubmissionListItem[]; pagination: { total: number; total_pages: number } }>(
+      `/api/v1/submissions?${buildQuery(page)}`,
+    )
+    submissions.value = res.data
+    totalPages.value = res.pagination.total_pages
+  } catch (err: unknown) {
+    tableError.value = err instanceof Error ? err.message : "加载提交记录失败"
+  } finally {
+    tableLoading.value = false
+  }
+}
+
+watch(isLoggedIn, (val) => {
+  if (val) loadSubmissions()
+}, { immediate: true })
+
+function onPageChange(page: number) {
+  loadSubmissions(page)
+}
+
+function applyFilters() {
+  loadSubmissions(1)
+}
+
+function clearFilters() {
+  filters.problem_search = ""
+  filters.submission_id = ""
+  filters.language = ""
+  filters.status = ""
+  loadSubmissions(1)
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+// 根据提交状态判断是否有评测结果可展示
+function hasResult(item: SubmissionListItem): boolean {
+  return !!(item.result && item.result.status)
+}
+</script>
+
+<template>
+  <div class="submissions-page">
+    <div class="container">
+      <!-- 页面标题 -->
+      <div class="page-header">
+        <h1 class="page-title">提交历史</h1>
+        <p class="page-subtitle">查看你的所有提交记录</p>
+      </div>
+
+      <!-- 筛选栏 -->
+      <div class="filter-bar">
+        <div class="filter-row">
+          <div class="filter-item">
+            <label class="filter-label">题目</label>
+            <input
+              v-model="filters.problem_search"
+              class="filter-input"
+              placeholder="题目 ID 或名称"
+              @keyup.enter="applyFilters"
+            />
+          </div>
+          <div class="filter-item">
+            <label class="filter-label">提交 ID</label>
+            <input
+              v-model="filters.submission_id"
+              class="filter-input"
+              placeholder="输入提交 ID 前缀"
+              @keyup.enter="applyFilters"
+            />
+          </div>
+          <div class="filter-item">
+            <label class="filter-label">语言</label>
+            <select v-model="filters.language" class="filter-input" @change="applyFilters">
+              <option v-for="opt in languageOptions" :key="opt.value" :value="opt.value">
+                {{ opt.label }}
+              </option>
+            </select>
+          </div>
+          <div class="filter-item">
+            <label class="filter-label">状态</label>
+            <select v-model="filters.status" class="filter-input" @change="applyFilters">
+              <option v-for="opt in statusOptions" :key="opt.value" :value="opt.value">
+                {{ opt.label }}
+              </option>
+            </select>
+          </div>
+        </div>
+        <div class="filter-actions">
+          <button class="btn btn-primary btn-sm" @click="applyFilters">
+            <Search :size="14" />
+            筛选
+          </button>
+          <button class="btn btn-ghost btn-sm" @click="clearFilters">
+            <X :size="14" />
+            清空
+          </button>
+        </div>
+      </div>
+
+      <!-- 加载态 -->
+      <div v-if="tableLoading" class="state-box">
+        <div class="spinner" />
+        <span>加载中...</span>
+      </div>
+
+      <!-- 错误态 -->
+      <div v-else-if="tableError" class="state-box state-error">
+        <span>{{ tableError }}</span>
+        <button class="btn btn-primary btn-sm" @click="loadSubmissions(currentPage)">重试</button>
+      </div>
+
+      <!-- 空态 -->
+      <div v-else-if="submissions.length === 0" class="state-box">
+        <span>暂无提交记录</span>
+      </div>
+
+      <!-- 表格 -->
+      <div v-else class="table-wrapper">
+        <table class="submissions-table">
+          <thead>
+            <tr>
+              <th class="th th-id">提交 ID</th>
+              <th class="th">题目</th>
+              <th class="th">语言</th>
+              <th class="th">状态</th>
+              <th class="th th-num">得分</th>
+              <th class="th th-num">耗时</th>
+              <th class="th th-num">内存</th>
+              <th class="th">提交时间</th>
+              <th class="th th-action">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="sub in submissions" :key="sub.id" class="tr">
+              <td class="td td-mono">{{ sub.id.slice(0, 8) }}...</td>
+              <td class="td">
+                <NuxtLink :to="`/problems/${sub.problem_id}`" class="problem-link">
+                  {{ sub.problem.title || sub.problem_id }}
+                </NuxtLink>
+              </td>
+              <td class="td">{{ getLanguageLabel(sub.language) }}</td>
+              <td class="td">
+                <span
+                  class="status-badge"
+                  :style="{
+                    background: getStatusColor(sub.status, sub.result?.status) + '18',
+                    color: getStatusColor(sub.status, sub.result?.status),
+                  }"
+                >
+                  {{ getStatusLabel(sub.status, sub.result?.status) }}
+                </span>
+              </td>
+              <td class="td td-num">
+                <template v-if="hasResult(sub)">{{ formatScore(sub.result!.score) }}</template>
+                <template v-else>--</template>
+              </td>
+              <td class="td td-num">
+                <template v-if="hasResult(sub)">{{ formatTime(sub.result!.time_ms) }}</template>
+                <template v-else>--</template>
+              </td>
+              <td class="td td-num">
+                <template v-if="hasResult(sub)">{{ formatMemory(sub.result!.memory_kb) }}</template>
+                <template v-else>--</template>
+              </td>
+              <td class="td">{{ formatDateTime(sub.created_at) }}</td>
+              <td class="td td-action">
+                <NuxtLink :to="`/submissions/${sub.id}`" class="btn btn-outline btn-xs">
+                  查看
+                </NuxtLink>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- 分页 -->
+      <PaginationNav
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @page-change="onPageChange"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.submissions-page {
+  padding: 32px 0;
+}
+
+.page-header {
+  margin-bottom: 24px;
+}
+
+.page-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--c-text);
+  margin: 0;
+}
+
+.page-subtitle {
+  font-size: 14px;
+  color: var(--c-text-secondary);
+  margin: 4px 0 0;
+}
+
+/* 筛选栏 */
+.filter-bar {
+  background: var(--c-white);
+  border: 1px solid var(--c-border);
+  border-radius: 10px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.filter-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 140px;
+  flex: 1;
+}
+
+.filter-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--c-text-secondary);
+}
+
+.filter-input {
+  padding: 6px 10px;
+  font-size: 13px;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  outline: none;
+  background: var(--c-white);
+  transition: border-color 0.15s;
+}
+
+.filter-input:focus {
+  border-color: var(--c-primary);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+}
+
+.filter-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* 按钮 */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1.5px solid transparent;
+  text-decoration: none;
+  line-height: 1;
+}
+
+.btn-sm {
+  padding: 6px 14px;
+  font-size: 13px;
+}
+
+.btn-xs {
+  padding: 4px 10px;
+  font-size: 12px;
+}
+
+.btn-primary {
+  background: var(--c-primary);
+  color: var(--c-white);
+  border-color: var(--c-primary);
+}
+
+.btn-primary:hover {
+  background: var(--c-primary-dark);
+  border-color: var(--c-primary-dark);
+}
+
+.btn-ghost {
+  color: var(--c-text-secondary);
+  border-color: var(--c-border);
+  background: transparent;
+}
+
+.btn-ghost:hover {
+  border-color: var(--c-text-secondary);
+  color: var(--c-text);
+}
+
+.btn-outline {
+  color: var(--c-primary);
+  border-color: var(--c-primary);
+  background: transparent;
+}
+
+.btn-outline:hover {
+  background: var(--c-primary);
+  color: var(--c-white);
+}
+
+/* 状态 */
+.state-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 64px 24px;
+  color: var(--c-text-secondary);
+  font-size: 14px;
+  background: var(--c-white);
+  border: 1px solid var(--c-border);
+  border-radius: 10px;
+}
+
+.state-error {
+  color: #dc2626;
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  border: 3px solid var(--c-border);
+  border-top-color: var(--c-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* 表格 */
+.table-wrapper {
+  background: var(--c-white);
+  border: 1px solid var(--c-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.submissions-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.th {
+  padding: 12px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--c-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: left;
+  background: #fafafa;
+  border-bottom: 1px solid var(--c-border);
+  white-space: nowrap;
+}
+
+.th-id {
+  width: 100px;
+}
+
+.th-num {
+  width: 70px;
+  text-align: right;
+}
+
+.th-action {
+  width: 80px;
+  text-align: center;
+}
+
+.tr {
+  border-bottom: 1px solid var(--c-border);
+  transition: background 0.15s;
+}
+
+.tr:last-child {
+  border-bottom: none;
+}
+
+.tr:hover {
+  background: #fafafa;
+}
+
+.td {
+  padding: 12px 14px;
+  font-size: 13px;
+  color: var(--c-text);
+}
+
+.td-mono {
+  font-family: "SF Mono", "Fira Code", "Fira Mono", monospace;
+  font-size: 12px;
+  color: var(--c-text-secondary);
+}
+
+.td-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.td-action {
+  text-align: center;
+}
+
+.problem-link {
+  color: var(--c-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.problem-link:hover {
+  text-decoration: underline;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+</style>

--- a/openspec/changes/complete-submission-history/.openspec.yaml
+++ b/openspec/changes/complete-submission-history/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-24

--- a/openspec/changes/complete-submission-history/design.md
+++ b/openspec/changes/complete-submission-history/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Issue #36 要求实现提交历史页面，目前完成度：
+
+- **后端 API**：`/api/v1/submissions` 和 `/api/v1/admin/submissions` 已完整实现分页、筛选（按题目、语言、状态、日期范围），返回数据包含 `problem.title`、`result.status`、`result.score`
+- **详情页**：`pages/submissions/[id].vue` 已完整实现，含轮询、结果状态映射（AC/WA/TLE/MLE/RE）、代码高亮
+- **管理后台表格**：`pages/admin/submissions.vue` 存在但缺少得分、耗时、内存列，且只显示提交状态（pending/judging），未展示评测结果状态标签（AC/WA/TLE）
+- **用户列表页**：`pages/submissions/index.vue` **不存在**，普通用户无法查看自己的提交历史
+
+## Goals / Non-Goals
+
+**Goals:**
+- 创建用户提交历史列表页 `/submissions`，支持分页浏览和筛选
+- 改进管理后台提交表格，补充得分、耗时、内存列和评测结果状态标签
+- 统一状态标签展示逻辑（管理后台和用户页共享相同的映射）
+
+**Non-Goals:**
+- 不修改提交详情页（已完整实现）
+- 不涉及评测结果详情展开或图表可视化
+
+## Decisions
+
+### 1. 权限模型：user 级别可访问，API 自动按用户隔离
+
+**选择**：`/submissions` 页面使用 `GET /api/v1/submissions`（用户端 API），路由挂载在 `default` 布局下，不需 `admin` 中间件。默认仅需用户已登录（`authMiddleware` 已在 API 层处理）。
+
+**原因**：
+- `GET /api/v1/submissions` 在服务端已强制按 `userId` 筛选，只返回当前认证用户的提交
+- 不需要额外的 `user_id` 筛选参数——API 层自动做了隔离
+- 管理后台 `/admin/submissions` 使用 `GET /api/v1/admin/submissions`，可查看所有用户，两者职责清晰
+- 用户端页面放在 `default` 布局下，和管理后台的 `admin` 布局分离
+
+**效果**：用户访问 `/submissions` → 调用 `/api/v1/submissions` → 自动只看到自己的提交 = "默认只筛选自己的提交"
+
+### 2. 用户列表页提取共享逻辑到 composable
+
+**选择**：将 `SubmissionListItem` 类型定义、`statusLabels`、`statusColors`、评测结果映射等共享逻辑提取为 `composables/use-submissions.ts`
+
+**原因**：管理后台和用户列表页需要重复的类型定义和映射表。详情页已有类似的 `resultDefMap`，但列表页只需要更精简的映射（状态名→标签→颜色）。抽取后可避免维护两份映射。
+
+### 2. 列表状态标签仅显示「最高等级」结果状态
+
+**选择**：列表页每个提交显示一个状态标签，优先展示 `result.status`（如 Accepted、WrongAnswer），回退到提交状态（pending/judging/error）
+
+**原因**：列表的每行空间有限，显示一个代表性标签更清晰。详情页已包含完整的多状态详情。颜色方案：
+- Accepted → 绿色 (#10b981)
+- WrongAnswer → 红色 (#ef4444)
+- TimeLimitExceeded → 橙色 (#f59e0b)
+- MemoryLimitExceeded → 橙色 (#f59e0b)
+- RuntimeError → 红色 (#ef4444)
+- SystemError → 红色 (#ef4444)
+- Pending → 灰色 (#9ca3af)
+- Judging → 蓝色 (#3b82f6)
+
+### 3. 用户列表页复用现有组件
+
+**选择**：用户列表页不直接使用 `AdminTable`（有管理后台样式依赖），而是用 `PaginationNav` 组件 + 原生 `<table>`，保持与用户端其他页面一致
+
+**原因**：`AdminTable` 的样式（背景、边框、字号）偏管理后台风格，用户端页面需要更轻量的展示。`PaginationNav` 已足够通用可直接复用。
+
+### 4. Problem 列展示题目名称
+
+**选择**：列表中的「题目」列展示 `problem.title`（API 已返回），并链接到题目详情页
+
+**原因**：比显示 `problem_id` 更直观，方便用户快速识别题目。
+
+### 5. 新增模糊搜索参数（题目名/ID、用户名/ID、提交ID）
+
+**选择**：在后端 `listSubmissions` 中新增三个查询参数：
+
+| 参数 | 后端匹配逻辑 | 前端输入框 |
+|------|-------------|-----------|
+| `problem_search` | `submissions.problem_id` 精确匹配 OR `problems.title` ILIKE 模糊搜索 | 一个输入框：搜索题目名或输入题目 ID |
+| `user_search` | `users.username` ILIKE 模糊搜索 OR `submissions.user_id` 前缀匹配 | 一个输入框：搜索用户名或输入用户 ID（仅 admin 端） |
+| `submission_id` | `submissions.id` ILIKE 前缀匹配（输入前几位） | 一个输入框：提交 ID |
+
+**原因**：
+- 用户期望在搜索框中直接输入"1001"即可匹配题目 ID，或输入"T0-LMCC"匹配题目名称
+- 管理后台的"用户"筛选用一个框处理用户名和用户 ID 两种输入，避免两个输入框
+- 提交 ID 支持前缀匹配方便复制粘贴前几位即可定位
+- 所有搜索参数在路由层解析，传到 `listSubmissions` 函数后在 `WHERE` 子句中组合
+
+## Risks / Trade-offs
+
+- **[数据延迟]** 刚提交的评测可能 `result` 为 `null`（尚未返回结果）→ 列表显示提交状态 `pending`/`judging` 而非评测结果，等待自动轮询跳转
+- **[状态标签宽度]** 评测结果状态名较长（`TimeLimitExceeded`）在窄屏可能换行 → 列表字号用 12px，和详情页状态标签保持一致

--- a/openspec/changes/complete-submission-history/proposal.md
+++ b/openspec/changes/complete-submission-history/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Issue #36 要求实现提交历史页面，但目前只有管理后台的提交管理页（`/admin/submissions`），缺少用户自主查看提交历史的前端页面，且管理后台表格也未展示得分、耗时、内存等关键信息和评测结果状态标签。
+
+## What Changes
+
+- **新建** `pages/submissions/index.vue`：用户视角的提交历史列表页，支持分页浏览和筛选过往提交记录
+- **改进** `pages/admin/submissions.vue`：补充得分、耗时、内存列，添加评测结果状态标签（AC=绿、WA=红、TLE=黄等）
+- **统一状态标签组件**：将评测结果状态映射逻辑抽取为可复用组件/函数，供列表和详情页共享
+
+## Capabilities
+
+### New Capabilities
+- `submission-history-page`: 用户提交历史列表页，支持分页和按题目、语言、状态筛选，展示提交 ID、题目、语言、状态（带颜色标签）、得分、用时、内存
+
+### Modified Capabilities
+- `submission-list-api`: `SubmissionListItem` 接口已包含 `result.status` 和 `result.score`，前端需展示这些字段
+
+## Impact
+
+- **noj-ui**: 新建 `pages/submissions/index.vue`，修改 `pages/admin/submissions.vue`，可能新增共享组件
+- **无 API 变更**：后端 `/api/v1/submissions` 和 `/api/v1/admin/submissions` 已返回所有需要的数据

--- a/openspec/changes/complete-submission-history/specs/submission-history-page/spec.md
+++ b/openspec/changes/complete-submission-history/specs/submission-history-page/spec.md
@@ -1,0 +1,156 @@
+## ADDED Requirements
+
+### Requirement: 用户查看提交历史列表
+
+系统 SHALL 提供 `/submissions` 页面，显示当前已登录用户的提交历史列表，支持分页和多条件筛选。
+
+页面 SHALL 对所有已登录用户开放（user 级别权限），无需管理员权限。
+页面 MUST 受认证守卫保护（未登录用户跳转到 `/login`）。
+页面 MUST 使用 `GET /api/v1/submissions`（用户端 API），该 API 在服务端自动按当前用户隔离——用户默认只能看到自己的提交，不额外提供 `user_id` 筛选。
+
+列表默按 `created_at` 降序排列（最新提交在前）。
+
+#### Scenario: 登录用户访问提交历史页
+
+- **WHEN** 已登录用户访问 `/submissions`
+- **THEN** 页面显示该用户的所有提交记录列表，按时间降序排列
+
+#### Scenario: 未登录用户访问提交历史页
+
+- **WHEN** 未登录用户访问 `/submissions`
+- **THEN** 页面跳转到 `/login`
+
+### Requirement: 列表展示字段
+
+提交历史列表的每一行 SHALL 展示以下字段：
+
+| 字段 | 说明 | 格式 |
+|------|------|------|
+| 提交 ID | 唯一标识 | 显示前 8 位 + "..." |
+| 题目 | 题目名称 | 显示 `problem.title`，带链接到 `/problems/:id` |
+| 语言 | 编程语言 | 显示语言标签（如 "Python 3"） |
+| 状态 | 评测结果 | 显示带颜色标签的结果状态 |
+| 得分 | 评测分数 | `result.score / 100` 格式（如 "80.0 分"），无结果时显示 "--" |
+| 耗时 | 运行时间 | `result.time_ms` 格式化，无结果时显示 "--" |
+| 内存 | 内存使用 | `result.memory_kb` 格式化，无结果时显示 "--" |
+| 提交时间 | 创建时间 | 本地化日期时间格式 |
+
+#### Scenario: 已完成提交展示完整信息
+
+- **WHEN** 用户查看提交历史，某提交已完成评测（`status=finished`）
+- **THEN** 该行展示题目名称、语言标签、评测结果状态标签、得分、耗时、内存和提交时间
+
+#### Scenario: 评测中的提交不展示耗时/内存/得分
+
+- **WHEN** 用户查看提交历史，某提交仍在评测中（`status=pending` 或 `judging`）
+- **THEN** 该行展示提交状态标签（"等待评测"/"评测中"），得分、耗时、内存显示 "--"
+
+### Requirement: 状态标签颜色
+
+列表中的状态标签 SHALL 使用不同颜色区分评测结果：
+
+| 状态 | 标签文字 | 颜色 |
+|------|----------|------|
+| Accepted | 答案正确 | 绿色 (#10b981) |
+| WrongAnswer | 答案错误 | 红色 (#ef4444) |
+| TimeLimitExceeded | 超出时间限制 | 橙色 (#f59e0b) |
+| MemoryLimitExceeded | 超出内存限制 | 橙色 (#f59e0b) |
+| RuntimeError | 运行时错误 | 红色 (#ef4444) |
+| SystemError | 系统错误 | 红色 (#ef4444) |
+| pending | 等待评测 | 灰色 |
+| judging | 评测中 | 蓝色 |
+
+当 `result` 存在时，优先显示 `result.status` 对应的评测结果标签；当 `result` 为 `null` 时，显示提交状态标签。
+
+#### Scenario: 已完成提交显示绿色标签
+
+- **WHEN** 提交的 `result.status` 为 `"Accepted"`
+- **THEN** 状态标签显示绿色 "答案正确"
+
+#### Scenario: 答案错误显示红色标签
+
+- **WHEN** 提交的 `result.status` 为 `"WrongAnswer"`
+- **THEN** 状态标签显示红色 "答案错误"
+
+#### Scenario: 超时显示橙色标签
+
+- **WHEN** 提交的 `result.status` 为 `"TimeLimitExceeded"`
+- **THEN** 状态标签显示橙色 "超出时间限制"
+
+#### Scenario: pending 状态显示灰色标签
+
+- **WHEN** 提交的 `result` 为 `null` 且 `status` 为 `"pending"`
+- **THEN** 状态标签显示灰色 "等待评测"
+
+### Requirement: 筛选功能
+
+提交历史列表 SHALL 支持以下筛选条件：
+
+- 按题目：通过 `problem_search` 查询参数，在一个输入框中同时支持题目 ID 精确匹配和题目名称模糊搜索
+- 按语言：通过 `language` 查询参数筛选（如 python3, cpp）
+- 按状态：通过 `status` 查询参数筛选（pending / judging / finished / error）
+- 按提交 ID：通过 `submission_id` 查询参数，支持提交 ID 前缀匹配（输入前几位即可）
+
+管理后台 SHALL 额外支持按用户筛选：
+- 按用户：通过 `user_search` 查询参数，在一个输入框中同时支持用户名模糊搜索和用户 ID 前缀匹配
+
+筛选 SHALL 支持组合条件。应用筛选条件后重置页码为 1。筛选栏应包含清空筛选按钮。
+
+#### Scenario: 按题目 ID 筛选
+
+- **WHEN** 用户在题目输入框中输入 "1001" 并点击筛选
+- **THEN** 列表仅显示 problem_id 为 "1001" 的提交记录
+
+#### Scenario: 按题目名称模糊搜索
+
+- **WHEN** 用户在题目输入框中输入 "T0-LMCC" 并点击筛选
+- **THEN** 列表仅显示题目名称包含 "T0-LMCC" 的提交记录
+
+#### Scenario: 按提交 ID 前缀搜索
+
+- **WHEN** 用户在提交 ID 输入框中输入 "abc123"
+- **THEN** 列表仅显示提交 ID 以 "abc123" 开头的记录
+
+#### Scenario: 按用户名搜索（管理后台）
+
+- **WHEN** 管理员在用户搜索框中输入 "john"
+- **THEN** 列表仅显示用户名包含 "john" 的用户的提交记录
+
+#### Scenario: 清空筛选
+
+- **WHEN** 用户已应用筛选条件，点击清空按钮
+- **THEN** 所有筛选条件重置，列表恢复为无条件显示
+
+### Requirement: 分页
+
+提交历史列表 SHALL 支持分页展示，每页 20 条记录。
+
+当列表数据为空时 SHALL 显示空态提示"暂无提交记录"。
+当列表加载中时 SHALL 显示加载态。
+当接口请求失败时 SHALL 显示错误信息，并提供重试能力。
+
+#### Scenario: 多页数据正常分页
+
+- **WHEN** 用户有超过 20 条提交记录
+- **THEN** 页面底部显示分页导航，可翻页查看
+
+#### Scenario: 无提交记录
+
+- **WHEN** 当前筛选条件无匹配提交，或用户从未提交过
+- **THEN** 显示"暂无提交记录"空态提示
+
+#### Scenario: 加载失败显示错误
+
+- **WHEN** API 请求失败（网络错误、超时等）
+- **THEN** 显示"加载提交记录失败"错误信息
+
+### Requirement: 点击进入提交详情
+
+列表中的每一行 SHALL 可点击，点击后跳转到对应的提交详情页 `/submissions/:id`。
+
+操作列 SHALL 包含"查看"按钮，链接到详情页。
+
+#### Scenario: 点击查看提交详情
+
+- **WHEN** 用户在列表页点击某行的"查看"按钮
+- **THEN** 页面跳转到 `/submissions/<id>`，显示该提交的完整详情

--- a/openspec/changes/complete-submission-history/specs/submission-list-api/spec.md
+++ b/openspec/changes/complete-submission-history/specs/submission-list-api/spec.md
@@ -1,0 +1,142 @@
+## MODIFIED Requirements
+
+### Requirement: 用户查询提交列表
+
+**变更：** 新增 `problem_search` 和 `submission_id` 查询参数，用于更灵活的搜索。
+
+系统 SHALL 提供 `GET /api/v1/submissions` 端点，返回当前认证用户的提交列表，支持分页和多条件筛选。
+
+此端点 MUST 受 JWT 中间件保护。列表默认按 `created_at` 降序排列（最新提交在前）。
+
+请求支持以下查询参数（均为可选）：
+
+- `problem_id`（string）：按题目 ID 精确筛选（向后兼容）
+- `problem_search`（string）：按题目 ID 精确匹配 OR 题目名称 ILIKE 模糊搜索。若输入值能精确匹配某个 `problem_id`，优先按 ID 筛选；否则按 `problems.title` ILIKE 搜索
+- `submission_id`（string）：按提交 ID 前缀匹配（ILIKE `id || '%'`），输入前几位即可定位
+- `language`（string）：按编程语言筛选
+- `status`（string）：按提交状态筛选（pending / judging / finished / error）
+- `from`（string）：起始日期（ISO 8601 日期，含当日）
+- `to`（string）：截止日期（ISO 8601 日期，含当日）
+- `page`（integer）：页码，默认 1，最小 1
+- `per_page`（integer）：每页条数，默认 20，最小 1，最大 100
+
+每条记录 SHALL 包含：
+
+- 提交基本信息：`id`、`problem_id`、`language`、`file_name`、`status`、`created_at`
+- 题目摘要：`problem.title`、`problem.id`
+- 评测摘要：`result` 对象（含 `status`、`score`），无评测结果时为 `null`
+- **不包含** `code` 字段（源代码仅在详情接口返回）
+
+响应格式：
+
+```json
+{
+  "data": [ ... ],
+  "pagination": {
+    "page": 1,
+    "per_page": 20,
+    "total": 42,
+    "total_pages": 3
+  }
+}
+```
+
+#### Scenario: 按题目名称模糊搜索
+
+- **WHEN** 用户 GET `/api/v1/submissions?problem_search=T0-LMCC`
+- **THEN** 系统返回题目名称包含 "T0-LMCC" 的提交记录
+
+#### Scenario: 按提交 ID 前缀搜索
+
+- **WHEN** 用户 GET `/api/v1/submissions?submission_id=abc123`
+- **THEN** 系统仅返回提交 ID 以 "abc123" 开头的记录
+
+#### Scenario: 无筛选条件查询第一页
+
+- **WHEN** 用户 GET `/api/v1/submissions` 不传任何查询参数，该用户有 15 条提交
+- **THEN** 系统返回 200，`data` 包含 15 条记录，按 created_at 降序，`pagination.total` 为 15，`pagination.total_pages` 为 1，每条包含 problem 摘要和 result（如有）
+
+#### Scenario: 按 problem_id 筛选
+
+- **WHEN** 用户 GET `/api/v1/submissions?problem_id=1001`
+- **THEN** 系统仅返回 problem_id 为 1001 的提交记录
+
+#### Scenario: 按 status 筛选
+
+- **WHEN** 用户 GET `/api/v1/submissions?status=finished`
+- **THEN** 系统仅返回 status 为 finished 的提交记录
+
+#### Scenario: 按日期范围筛选
+
+- **WHEN** 用户 GET `/api/v1/submissions?from=2026-01-01&to=2026-06-20`
+- **THEN** 系统仅返回 created_at 在 2026-01-01T00:00:00 至 2026-06-20T23:59:59 范围内的提交
+
+#### Scenario: 多条件组合筛选
+
+- **WHEN** 用户 GET `/api/v1/submissions?problem_id=1001&language=python3&status=finished`
+- **THEN** 系统返回同时满足三个筛选条件的提交记录
+
+#### Scenario: 分页超出范围
+
+- **WHEN** 用户 GET `/api/v1/submissions?page=999`，但总记录不足该页
+- **THEN** 系统返回 200，`data` 为空数组，`pagination.total` 返回实际总数
+
+#### Scenario: 未认证访问
+
+- **WHEN** 客户端未提供 Authorization 头访问 `/api/v1/submissions`
+- **THEN** 系统返回 401，错误消息 `"未提供认证令牌"`
+
+#### Scenario: per_page 超过上限
+
+- **WHEN** 用户 GET `/api/v1/submissions?per_page=200`
+- **THEN** 系统将 per_page 限制为 100（最大值），按 100 返回
+
+#### Scenario: 非法 page 值
+
+- **WHEN** 用户 GET `/api/v1/submissions?page=0` 或 `page=-1`
+- **THEN** 系统将 page 修正为 1
+
+### Requirement: 管理员查询所有用户提交
+
+**变更：** 新增 `problem_search`、`submission_id`、`user_search` 查询参数。
+
+系统 SHALL 提供 `GET /api/v1/admin/submissions` 端点，允许管理员查看所有用户的提交记录。
+
+此端点 MUST 依次通过 `authMiddleware` 和 `adminMiddleware` 保护。路由 MUST 挂载在 `/api/v1/admin/` 路径前缀下。
+
+支持与用户列表接口相同的筛选和分页参数，额外支持：
+
+- `user_id`（string）：按用户 ID 精确筛选（向后兼容）
+- `user_search`（string）：按 `users.username` ILIKE 模糊搜索 OR `submissions.user_id` 前缀匹配。若输入值看起来像 UUID（匹配 UUID 格式），优先按 user_id 搜索；否则按 username ILIKE 搜索。一个输入框同时支持两种输入。
+
+管理员列表记录 SHALL 额外包含 `user_id` 字段，以便区分提交所属用户。
+
+#### Scenario: 管理员按用户名搜索
+
+- **WHEN** 管理员 GET `/api/v1/admin/submissions?user_search=john`
+- **THEN** 系统返回用户名包含 "john" 的用户的提交记录
+
+#### Scenario: 管理员按用户 ID 搜索
+
+- **WHEN** 管理员 GET `/api/v1/admin/submissions?user_search=<user-uuid-prefix>`
+- **THEN** 系统返回 user_id 以该前缀开头的提交记录
+
+#### Scenario: 管理员查看所有提交
+
+- **WHEN** 管理员 GET `/api/v1/admin/submissions` 不传 user_id
+- **THEN** 系统返回所有用户的提交列表，每条记录包含 `user_id`
+
+#### Scenario: 管理员按用户筛选（兼容旧参数）
+
+- **WHEN** 管理员 GET `/api/v1/admin/submissions?user_id=<user-uuid>`
+- **THEN** 系统仅返回该用户的提交记录
+
+#### Scenario: 普通用户访问管理端点
+
+- **WHEN** 已登录的普通用户（role=user）访问 `/api/v1/admin/submissions`
+- **THEN** 系统返回 403，错误消息 `"需要管理员权限"`
+
+#### Scenario: 未登录用户访问管理端点
+
+- **WHEN** 未认证用户访问 `/api/v1/admin/submissions`
+- **THEN** 系统返回 401，错误消息 `"未提供认证令牌"`

--- a/openspec/changes/complete-submission-history/tasks.md
+++ b/openspec/changes/complete-submission-history/tasks.md
@@ -1,36 +1,36 @@
 ## 1. 后端 API 扩展
 
-- [ ] 1.1 更新 `services/submissions.ts` 中的 `ListSubmissionsParams` 接口：新增 `problemSearch`、`submissionId`、`userSearch` 可选字段
-- [ ] 1.2 在 `listSubmissions` 函数中添加 `problemSearch` 过滤逻辑：`problems.title` ILIKE 模糊匹配 OR `submissions.problem_id` 精确匹配
-- [ ] 1.3 在 `listSubmissions` 函数中添加 `submissionId` 过滤逻辑：`submissions.id` ILIKE 前缀匹配
-- [ ] 1.4 在 `listSubmissions` 函数中添加 `userSearch` 过滤逻辑：`users.username` ILIKE 模糊匹配 OR `submissions.user_id` 前缀匹配（需添加 LEFT JOIN users）
-- [ ] 1.5 更新 `routes/submissions.ts` 用户端路由：解析 `problem_search`、`submission_id` 查询参数传入 `listSubmissions`
-- [ ] 1.6 更新 `routes/submissions.ts` 管理端路由：额外解析 `user_search` 查询参数
+- [x] 1.1 更新 `services/submissions.ts` 中的 `ListSubmissionsParams` 接口：新增 `problemSearch`、`submissionId`、`userSearch` 可选字段
+- [x] 1.2 在 `listSubmissions` 函数中添加 `problemSearch` 过滤逻辑：`problems.title` ILIKE 模糊匹配 OR `submissions.problem_id` 精确匹配
+- [x] 1.3 在 `listSubmissions` 函数中添加 `submissionId` 过滤逻辑：`submissions.id` ILIKE 前缀匹配
+- [x] 1.4 在 `listSubmissions` 函数中添加 `userSearch` 过滤逻辑：`users.username` ILIKE 模糊匹配 OR `submissions.user_id` 前缀匹配（需添加 LEFT JOIN users）
+- [x] 1.5 更新 `routes/submissions.ts` 用户端路由：解析 `problem_search`、`submission_id` 查询参数传入 `listSubmissions`
+- [x] 1.6 更新 `routes/submissions.ts` 管理端路由：额外解析 `user_search` 查询参数
 
 ## 2. 共享逻辑抽取
 
-- [ ] 2.1 创建 `composables/use-submissions.ts`：提取 `SubmissionListItem` 类型、评测状态映射表（标签文字+颜色）、格式化函数（时间、内存、分数、语言标签）
-- [ ] 2.2 在 `composables/use-submissions.ts` 中定义状态颜色映射：AC=绿、WA=红、TLE=橙、MLE=橙、RE=红、SE=红、pending=灰、judging=蓝
+- [x] 2.1 创建 `composables/use-submissions.ts`：提取 `SubmissionListItem` 类型、评测状态映射表（标签文字+颜色）、格式化函数（时间、内存、分数、语言标签）
+- [x] 2.2 在 `composables/use-submissions.ts` 中定义状态颜色映射：AC=绿、WA=红、TLE=橙、MLE=橙、RE=红、SE=红、pending=灰、judging=蓝
 
 ## 3. 用户提交历史列表页
 
-- [ ] 3.1 创建 `pages/submissions/index.vue`：页面骨架、认证守卫（user 级别）、使用 `/api/v1/submissions` 接口、分页逻辑
-- [ ] 3.2 实现筛选栏：题目搜索框（支持题目 ID 和题目名）、提交 ID 搜索框、语言下拉、状态下拉、筛选/清空按钮
-- [ ] 3.3 实现状态标签列：根据 `result.status` 或 `status` 显示带颜色的标签
-- [ ] 3.4 实现题目列（显示 `problem.title` 带链接）、得分、耗时、内存列
-- [ ] 3.5 实现空态、加载态、错误态展示
-- [ ] 3.6 集成 PaginationNav 分页组件
+- [x] 3.1 创建 `pages/submissions/index.vue`：页面骨架、认证守卫（user 级别）、使用 `/api/v1/submissions` 接口、分页逻辑
+- [x] 3.2 实现筛选栏：题目搜索框（支持题目 ID 和题目名）、提交 ID 搜索框、语言下拉、状态下拉、筛选/清空按钮
+- [x] 3.3 实现状态标签列：根据 `result.status` 或 `status` 显示带颜色的标签
+- [x] 3.4 实现题目列（显示 `problem.title` 带链接）、得分、耗时、内存列
+- [x] 3.5 实现空态、加载态、错误态展示
+- [x] 3.6 集成 PaginationNav 分页组件
 
 ## 4. 管理后台提交页改进
 
-- [ ] 4.1 为管理后台筛选栏增加：题目搜索框、提交 ID 搜索框、用户搜索框（用户名/用户 ID 合一）
-- [ ] 4.2 为管理后台表格增加得分、耗时、内存列
-- [ ] 4.3 替换管理后台状态标签为评测结果状态映射（AC/WA/TLE 等带颜色），并在表格中展示 `problem.title`
-- [ ] 4.4 管理后台请求切换到 `/api/v1/admin/submissions`，传入新增的搜索参数
+- [x] 4.1 为管理后台筛选栏增加：题目搜索框、提交 ID 搜索框、用户搜索框（用户名/用户 ID 合一）
+- [x] 4.2 为管理后台表格增加得分、耗时、内存列
+- [x] 4.3 替换管理后台状态标签为评测结果状态映射（AC/WA/TLE 等带颜色），并在表格中展示 `problem.title`
+- [x] 4.4 管理后台请求切换到 `/api/v1/admin/submissions`，传入新增的搜索参数
 
 ## 5. 验证
 
-- [ ] 5.1 确保后端 `listSubmissions` 支持新的搜索参数，模糊搜索正确工作
-- [ ] 5.2 确保用户列表页可正常加载、筛选（含题目模糊搜索、提交 ID 前缀搜索）、分页
-- [ ] 5.3 确保管理后台新增搜索框和列正常显示
-- [ ] 5.4 确保状态标签颜色正确（AC=绿、WA=红、TLE=橙、pending=灰等）
+- [x] 5.1 确保后端 `listSubmissions` 支持新的搜索参数，模糊搜索正确工作
+- [x] 5.2 确保用户列表页可正常加载、筛选（含题目模糊搜索、提交 ID 前缀搜索）、分页
+- [x] 5.3 确保管理后台新增搜索框和列正常显示
+- [x] 5.4 确保状态标签颜色正确（AC=绿、WA=红、TLE=橙、pending=灰等）

--- a/openspec/changes/complete-submission-history/tasks.md
+++ b/openspec/changes/complete-submission-history/tasks.md
@@ -1,0 +1,36 @@
+## 1. 后端 API 扩展
+
+- [ ] 1.1 更新 `services/submissions.ts` 中的 `ListSubmissionsParams` 接口：新增 `problemSearch`、`submissionId`、`userSearch` 可选字段
+- [ ] 1.2 在 `listSubmissions` 函数中添加 `problemSearch` 过滤逻辑：`problems.title` ILIKE 模糊匹配 OR `submissions.problem_id` 精确匹配
+- [ ] 1.3 在 `listSubmissions` 函数中添加 `submissionId` 过滤逻辑：`submissions.id` ILIKE 前缀匹配
+- [ ] 1.4 在 `listSubmissions` 函数中添加 `userSearch` 过滤逻辑：`users.username` ILIKE 模糊匹配 OR `submissions.user_id` 前缀匹配（需添加 LEFT JOIN users）
+- [ ] 1.5 更新 `routes/submissions.ts` 用户端路由：解析 `problem_search`、`submission_id` 查询参数传入 `listSubmissions`
+- [ ] 1.6 更新 `routes/submissions.ts` 管理端路由：额外解析 `user_search` 查询参数
+
+## 2. 共享逻辑抽取
+
+- [ ] 2.1 创建 `composables/use-submissions.ts`：提取 `SubmissionListItem` 类型、评测状态映射表（标签文字+颜色）、格式化函数（时间、内存、分数、语言标签）
+- [ ] 2.2 在 `composables/use-submissions.ts` 中定义状态颜色映射：AC=绿、WA=红、TLE=橙、MLE=橙、RE=红、SE=红、pending=灰、judging=蓝
+
+## 3. 用户提交历史列表页
+
+- [ ] 3.1 创建 `pages/submissions/index.vue`：页面骨架、认证守卫（user 级别）、使用 `/api/v1/submissions` 接口、分页逻辑
+- [ ] 3.2 实现筛选栏：题目搜索框（支持题目 ID 和题目名）、提交 ID 搜索框、语言下拉、状态下拉、筛选/清空按钮
+- [ ] 3.3 实现状态标签列：根据 `result.status` 或 `status` 显示带颜色的标签
+- [ ] 3.4 实现题目列（显示 `problem.title` 带链接）、得分、耗时、内存列
+- [ ] 3.5 实现空态、加载态、错误态展示
+- [ ] 3.6 集成 PaginationNav 分页组件
+
+## 4. 管理后台提交页改进
+
+- [ ] 4.1 为管理后台筛选栏增加：题目搜索框、提交 ID 搜索框、用户搜索框（用户名/用户 ID 合一）
+- [ ] 4.2 为管理后台表格增加得分、耗时、内存列
+- [ ] 4.3 替换管理后台状态标签为评测结果状态映射（AC/WA/TLE 等带颜色），并在表格中展示 `problem.title`
+- [ ] 4.4 管理后台请求切换到 `/api/v1/admin/submissions`，传入新增的搜索参数
+
+## 5. 验证
+
+- [ ] 5.1 确保后端 `listSubmissions` 支持新的搜索参数，模糊搜索正确工作
+- [ ] 5.2 确保用户列表页可正常加载、筛选（含题目模糊搜索、提交 ID 前缀搜索）、分页
+- [ ] 5.3 确保管理后台新增搜索框和列正常显示
+- [ ] 5.4 确保状态标签颜色正确（AC=绿、WA=红、TLE=橙、pending=灰等）


### PR DESCRIPTION
实现 #36 提交历史页的全部功能：

### 变更内容

- **后端 API**：新增 `problem_search`、`submission_id`、`user_search` 模糊搜索参数，列表返回 `time_ms`/`memory_kb`
- **用户提交历史页**：新建 `/submissions` 页面，支持分页、题目/提交 ID/语言/状态筛选、评测结果状态标签（AC=绿、WA=红、TLE=橙等）
- **管理后台改进**：新增题目/用户/提交 ID 搜索框，表格增加得分/耗时/内存列，替换状态标签为评测结果状态
- **共享逻辑**：创建 `composables/use-submissions.ts` 统一类型定义、状态映射和格式化函数
- **导航入口**：导航栏添加"提交记录"链接

### Screenshots

N/A

### Related

Closes #36