### PR TITLE
feat(core): 丰富管理后台后端 API

### DIFF
--- a/noj-core/AGENTS.md
+++ b/noj-core/AGENTS.md
@@ -13,15 +13,15 @@
 
 ## 技术栈
 
-| 组件       | 选择                          |
-| ---------- | ----------------------------- |
-| 运行时     | Deno 2                        |
-| 语言       | TypeScript                    |
-| Web 框架   | Hono                          |
-| 数据库     | PostgreSQL 16 + postgres.js   |
-| ORM        | Drizzle ORM                   |
-| 消息队列   | Redis (ioredis)               |
-| 认证       | JWT (jose) + bcryptjs         |
+| 组件     | 选择                        |
+| -------- | --------------------------- |
+| 运行时   | Deno 2                      |
+| 语言     | TypeScript                  |
+| Web 框架 | Hono                        |
+| 数据库   | PostgreSQL 16 + postgres.js |
+| ORM      | Drizzle ORM                 |
+| 消息队列 | Redis (ioredis)             |
+| 认证     | JWT (jose) + bcryptjs       |
 
 ## 目录结构
 
@@ -68,21 +68,21 @@ noj-core/
 
 从 `.env` 文件或 `Deno.env` 读取。**必须配置**：
 
-| 变量 | 默认值 | 说明 |
-|------|--------|------|
-| `DATABASE_URL` | — | PostgreSQL 连接串（无默认值） |
-| `JWT_SECRET` | — | HS256 签名密钥（≥32 字符） |
-| `JWT_EXPIRES_IN` | `24h` | Token 有效期 |
-| `REDIS_URL` | `redis://127.0.0.1:6379/` | Redis 连接串 |
-| `PORT` | `8000` | HTTP 监听端口 |
-| `NOJ_ENV` | 空（development） | `production` 启用生产模式 |
-| `ADMIN_EMAIL` | — | Seed 管理员邮箱 |
-| `ADMIN_PASS` | — | Seed 管理员密码 |
-| `DATABASE_POOL_MAX` | `10` | PostgreSQL 连接池大小 |
-| `DATABASE_CONNECT_TIMEOUT` | `10` | 连接超时秒数 |
-| `DATABASE_IDLE_TIMEOUT` | `300` | 空闲连接超时秒数 |
-| `DATABASE_MAX_LIFETIME` | `3600` | 连接最大生命周期秒数 |
-| `CORS_ALLOWED_ORIGINS` | — | 生产环境 CORS 白名单（逗号分隔） |
+| 变量                       | 默认值                    | 说明                             |
+| -------------------------- | ------------------------- | -------------------------------- |
+| `DATABASE_URL`             | —                         | PostgreSQL 连接串（无默认值）    |
+| `JWT_SECRET`               | —                         | HS256 签名密钥（≥32 字符）       |
+| `JWT_EXPIRES_IN`           | `24h`                     | Token 有效期                     |
+| `REDIS_URL`                | `redis://127.0.0.1:6379/` | Redis 连接串                     |
+| `PORT`                     | `8000`                    | HTTP 监听端口                    |
+| `NOJ_ENV`                  | 空（development）         | `production` 启用生产模式        |
+| `ADMIN_EMAIL`              | —                         | Seed 管理员邮箱                  |
+| `ADMIN_PASS`               | —                         | Seed 管理员密码                  |
+| `DATABASE_POOL_MAX`        | `10`                      | PostgreSQL 连接池大小            |
+| `DATABASE_CONNECT_TIMEOUT` | `10`                      | 连接超时秒数                     |
+| `DATABASE_IDLE_TIMEOUT`    | `300`                     | 空闲连接超时秒数                 |
+| `DATABASE_MAX_LIFETIME`    | `3600`                    | 连接最大生命周期秒数             |
+| `CORS_ALLOWED_ORIGINS`     | —                         | 生产环境 CORS 白名单（逗号分隔） |
 
 ## 开发命令
 
@@ -121,66 +121,75 @@ docker compose down     # 停止
 
 ## API 路由
 
-| 方法   | 路径 | 权限 | 说明 |
-|--------|------|------|------|
-| POST | `/api/v1/auth/register` | 公开 | 用户注册 |
-| POST | `/api/v1/auth/login` | 公开 | 用户登录（返回 JWT） |
-| GET | `/api/v1/auth/me` | 登录 | 当前用户信息 |
-| GET | `/api/v1/categories` | 公开 | 分类树 |
-| POST | `/api/v1/categories` | 管理员 | 创建分类 |
-| GET | `/api/v1/categories/:id` | 公开 | 分类详情 |
-| PUT | `/api/v1/categories/:id` | 管理员 | 更新分类 |
-| DELETE | `/api/v1/categories/:id` | 管理员 | 删除分类 |
-| GET | `/api/v1/problems` | 公开 | 题目列表（分页+筛选） |
-| GET | `/api/v1/problems/:id` | 公开 | 题目详情（**双索引**：UUID/display_id/数字） |
-| POST | `/api/v1/problems` | 登录 | 创建题目（U/P 类型） |
-| PUT | `/api/v1/problems/:id` | 登录 | 更新题目 |
-| DELETE | `/api/v1/problems/:id` | 登录 | 删除题目 |
-| GET | `/api/v1/submissions` | 登录 | 我的提交列表 |
-| POST | `/api/v1/submissions` | 登录 | 创建提交 |
-| GET | `/api/v1/submissions/:id` | 登录 | 提交详情 |
-| GET | `/api/v1/submissions/:id/status` | 登录 | 提交队列状态 |
-| GET | `/api/v1/admin/submissions` | 管理员 | 全部提交管理 |
-| GET | `/api/v1/admin/users` | 管理员 | 用户列表 |
-| PATCH | `/api/v1/admin/users/:id/role` | 管理员 | 角色变更 |
-| GET | `/api/v1/users/:id/profile` | 公开 | 用户主页 |
-| PUT | `/api/v1/users/me` | 登录 | 更新个人简介 |
-| GET | `/health` | 公开 | 健康检查 |
+| 方法   | 路径                             | 权限   | 说明                                         |
+| ------ | -------------------------------- | ------ | -------------------------------------------- |
+| POST   | `/api/v1/auth/register`          | 公开   | 用户注册                                     |
+| POST   | `/api/v1/auth/login`             | 公开   | 用户登录（返回 JWT）                         |
+| GET    | `/api/v1/auth/me`                | 登录   | 当前用户信息                                 |
+| GET    | `/api/v1/categories`             | 公开   | 分类树                                       |
+| POST   | `/api/v1/categories`             | 管理员 | 创建分类                                     |
+| GET    | `/api/v1/categories/:id`         | 公开   | 分类详情                                     |
+| PUT    | `/api/v1/categories/:id`         | 管理员 | 更新分类                                     |
+| DELETE | `/api/v1/categories/:id`         | 管理员 | 删除分类                                     |
+| GET    | `/api/v1/problems`               | 公开   | 题目列表（分页+筛选）                        |
+| GET    | `/api/v1/problems/:id`           | 公开   | 题目详情（**双索引**：UUID/display_id/数字） |
+| POST   | `/api/v1/problems`               | 登录   | 创建题目（U/P 类型）                         |
+| PUT    | `/api/v1/problems/:id`           | 登录   | 更新题目                                     |
+| DELETE | `/api/v1/problems/:id`           | 登录   | 删除题目                                     |
+| GET    | `/api/v1/submissions`            | 登录   | 我的提交列表                                 |
+| POST   | `/api/v1/submissions`            | 登录   | 创建提交                                     |
+| GET    | `/api/v1/submissions/:id`        | 登录   | 提交详情                                     |
+| GET    | `/api/v1/submissions/:id/status` | 登录   | 提交队列状态                                 |
+| GET    | `/api/v1/admin/submissions`      | 管理员 | 全部提交管理                                 |
+| GET    | `/api/v1/admin/users`            | 管理员 | 用户列表                                     |
+| PATCH  | `/api/v1/admin/users/:id/role`   | 管理员 | 角色变更                                     |
+| GET    | `/api/v1/users/:id/profile`      | 公开   | 用户主页                                     |
+| PUT    | `/api/v1/users/me`               | 登录   | 更新个人简介                                 |
+| GET    | `/health`                        | 公开   | 健康检查                                     |
 
 ### 路由层关键模式
 
 **Problem ID 四步解析**（`routes/problems.ts`）：
+
 1. UUID 格式 → 按 PK 查询
-2. `display_id` 格式（`P1001`/`U42`）→ 解析 type+number → `getProblemByTypeAndNumber()`
+2. `display_id` 格式（`P1001`/`U42`）→ 解析 type+number →
+   `getProblemByTypeAndNumber()`
 3. 纯数字（遗留种子数据如 `1001`）→ 按 PK 查询
 4. 兜底 → 按 PK 查询
 
 **路由注册顺序敏感**（`routes/users.ts`）：
+
 - `PUT /me` 必须在 `GET /:id/profile` **之前**注册，否则 "me" 会被匹配为 `:id`
 - 注释明确警告此顺序依赖
 
 **管理路由挂载**（`app.ts`）：
+
 - 管理路由以 `/api/v1/admin` 为前缀挂载，子路由内部路径为 `/`（相对路径）
 
 ## Redis MQ 约定
 
-| 队列 | 方向 | 说明 |
-|------|------|------|
-| `noj:judge:queue` | noj-core → noj-judge | 评测任务（LPUSH/BRPOP） |
+| 队列                | 方向                 | 说明                    |
+| ------------------- | -------------------- | ----------------------- |
+| `noj:judge:queue`   | noj-core → noj-judge | 评测任务（LPUSH/BRPOP） |
 | `noj:judge:results` | noj-judge → noj-core | 评测结果（BRPOP/LPUSH） |
 
 **Redis 连接设计**：
-- `getRedis()` — 共享连接，用于 LPUSH 评测任务（`enableOfflineQueue: false`，重试 5 次后停止）
-- `createConsumerRedis()` — 独立连接，用于 BRPOP 阻塞等待结果（`lazyConnect: true`，指数退避永不停止）
+
+- `getRedis()` — 共享连接，用于 LPUSH
+  评测任务（`enableOfflineQueue: false`，重试 5 次后停止）
+- `createConsumerRedis()` — 独立连接，用于 BRPOP
+  阻塞等待结果（`lazyConnect: true`，指数退避永不停止）
 - 两者独立，避免 BRPOP 阻塞影响 LPUSH
 - `getRedis()` 在 `connect` 事件中清除错误状态，使健康检查可恢复
 
 **Producer 行为**：
+
 - 发送前检查 `redis.status !== "ready"`，连接不可用时拒绝发送
 - 消息大小上限 16MB（`TextEncoder().encode(message).length`）
 - 数据库写入**先于** MQ 推送：若推送失败，submission 标记为 `error`
 
 **Consumer 行为**：
+
 - BRPOP 超时 10 秒，超时后循环重试
 - 解析失败或缺少 `submission_id` → `continue` 跳过
 - 数据库错误 → 记录日志后继续
@@ -197,18 +206,20 @@ docker compose down     # 停止
 
 ## 数据库 Schema 设计
 
-| 表 | 关键列 | 约束 / 索引 |
-|----|--------|-------------|
-| `users` | `id`(UUID), `username`(unique), `email`(unique), `password_hash`, `role`(user/admin), `bio` | PK, UK(username), UK(email) |
-| `problems` | `id`(UUID), `type`(U/P), `number`(int), `display_id`(unique), `title`, `difficulty`, `owner_id` | PK, UK(display_id), UK(type,number), FK→users |
-| `categories` | `id`(UUID), `name`, `parent_id`, `level`(缓存深度) | PK, FK→categories(parent_id) ON DELETE SET NULL |
-| `problems_categories` | `problem_id`, `category_id` | FK→problems ON DELETE CASCADE, FK→categories ON DELETE CASCADE |
-| `submissions` | `id`(UUID), `user_id`, `problem_id`, `status`, `language`, `code` | PK, FK→users, FK→problems, idx(user_id,created_at) |
-| `evaluation_results` | `id`(UUID), `submission_id`(unique), `status`, `score`(INTEGER×100), `output`, `time_ms`, `memory_kb` | PK, UK(submission_id), FK→submissions |
+| 表                    | 关键列                                                                                                | 约束 / 索引                                                    |
+| --------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `users`               | `id`(UUID), `username`(unique), `email`(unique), `password_hash`, `role`(user/admin), `bio`           | PK, UK(username), UK(email)                                    |
+| `problems`            | `id`(UUID), `type`(U/P), `number`(int), `display_id`(unique), `title`, `difficulty`, `owner_id`       | PK, UK(display_id), UK(type,number), FK→users                  |
+| `categories`          | `id`(UUID), `name`, `parent_id`, `level`(缓存深度)                                                    | PK, FK→categories(parent_id) ON DELETE SET NULL                |
+| `problems_categories` | `problem_id`, `category_id`                                                                           | FK→problems ON DELETE CASCADE, FK→categories ON DELETE CASCADE |
+| `submissions`         | `id`(UUID), `user_id`, `problem_id`, `status`, `language`, `code`                                     | PK, FK→users, FK→problems, idx(user_id,created_at)             |
+| `evaluation_results`  | `id`(UUID), `submission_id`(unique), `status`, `score`(INTEGER×100), `output`, `time_ms`, `memory_kb` | PK, UK(submission_id), FK→submissions                          |
 
 **设计要点**：
+
 - 所有时间戳使用 ISO 8601 **文本**格式存储（非原生 `timestamptz`）
-- `evaluation_results.score` 为 `INTEGER`（×100），`scoreToDb`/`scoreFromDb` 在应用层转换
+- `evaluation_results.score` 为 `INTEGER`（×100），`scoreToDb`/`scoreFromDb`
+  在应用层转换
 - `problems.number` 按 `type` 分别自增（`(type, number)` UNIQUE）
 - `categories.level` 为应用层计算的缓存深度（非触发器自动维护）
 - `submissions` 有复合索引 `(user_id, created_at)` 优化"我的提交历史"查询
@@ -218,7 +229,8 @@ docker compose down     # 停止
 - TypeScript 严格模式
 - 路由文件默认导出 Hono 实例，由 `app.ts` 组合
 - API 路径：`/api/v1/{resource}`
-- 错误处理：统一 `AppError` 继承体系（6 个子类），全局 `onError` 捕获，带 `request_id`
+- 错误处理：统一 `AppError` 继承体系（6 个子类），全局 `onError` 捕获，带
+  `request_id`
 - 密码强度：≥12 位、含大小写字母和数字（OWASP 2025+）
 - JWT：HS256、iss/aud 校验、24h 有效期（无刷新机制）、`jti` 已生成但未持久化校验
 - 分值：×100 整数值存储（`scoreToDb`/`scoreFromDb`），避免浮点误差
@@ -227,27 +239,27 @@ docker compose down     # 停止
 
 ## 服务层业务规则
 
-| 规则 | 说明 |
-|------|------|
-| 提交状态机 | `pending → [judging, error]` → `judging → [finished, error]`，finished/error 为终态 |
-| 输出截断 | API 返回时截断至 8KB（`MAX_OUTPUT_LENGTH`），数据库保留完整内容 |
-| 代码大小上限 | 100KB（`MAX_CODE_LENGTH`），路由层校验 |
-| 个人简介上限 | 5000 字符 |
-| 支持包读取失败 | 非致命：日志记录后继续（无支持包），由 judge 端处理 |
-| 题目更新 | 静默忽略 `type` 和 `number` 字段（API 接受但不处理） |
-| 题目编号冲突 | 自动分配时重试 3 次（PG 23505），手动指定时立即报错 |
-| 评测结果写入 | UPSERT 语义（`onConflictDoNothing`），防止重复处理 |
-| 队列位置查询 | 即使 DB 状态为 "judging" 也检查 Redis 队列（状态在入队时已更新） |
-| 问题列表默认 | 默认只显示 `type='P'` 的题目，U 类型需直接 URL 或所有者主页访问 |
-| 分页默认值 | page=1, per_page=20, max per_page=100 |
-| 用户枚举防护 | 登录失败统一返回"用户名或密码错误"，不区分"用户不存在"和"密码错误" |
-| Root 用户 | UID="0"，admin 角色，随机密码不可登录，不计入管理员统计，不出现在用户列表 |
+| 规则           | 说明                                                                                |
+| -------------- | ----------------------------------------------------------------------------------- |
+| 提交状态机     | `pending → [judging, error]` → `judging → [finished, error]`，finished/error 为终态 |
+| 输出截断       | API 返回时截断至 8KB（`MAX_OUTPUT_LENGTH`），数据库保留完整内容                     |
+| 代码大小上限   | 100KB（`MAX_CODE_LENGTH`），路由层校验                                              |
+| 个人简介上限   | 5000 字符                                                                           |
+| 支持包读取失败 | 非致命：日志记录后继续（无支持包），由 judge 端处理                                 |
+| 题目更新       | 静默忽略 `type` 和 `number` 字段（API 接受但不处理）                                |
+| 题目编号冲突   | 自动分配时重试 3 次（PG 23505），手动指定时立即报错                                 |
+| 评测结果写入   | UPSERT 语义（`onConflictDoNothing`），防止重复处理                                  |
+| 队列位置查询   | 即使 DB 状态为 "judging" 也检查 Redis 队列（状态在入队时已更新）                    |
+| 问题列表默认   | 默认只显示 `type='P'` 的题目，U 类型需直接 URL 或所有者主页访问                     |
+| 分页默认值     | page=1, per_page=20, max per_page=100                                               |
+| 用户枚举防护   | 登录失败统一返回"用户名或密码错误"，不区分"用户不存在"和"密码错误"                  |
+| Root 用户      | UID="0"，admin 角色，随机密码不可登录，不计入管理员统计，不出现在用户列表           |
 
 ## CORS 配置
 
-| 环境 | 行为 |
-|------|------|
-| 开发（默认） | `Access-Control-Allow-Origin: *` |
+| 环境                                | 行为                                     |
+| ----------------------------------- | ---------------------------------------- |
+| 开发（默认）                        | `Access-Control-Allow-Origin: *`         |
 | 生产（`CORS_ALLOWED_ORIGINS` 设置） | 仅允许白名单域名，空列表拒绝所有跨域请求 |
 
 - `credentials: true`（为 Cookie 认证预留）
@@ -257,28 +269,32 @@ docker compose down     # 停止
 
 ## 测试约定
 
-- DB 依赖测试检查 `!!Deno.env.get("DATABASE_URL")` 和 `!!Deno.env.get("JWT_SECRET")`，缺失时设置 `ignore: true` 静默跳过
-- 使用 `sanitizeResources: false, sanitizeOps: false`（postgres.js 连接池触发 Deno 资源泄漏检测）
+- DB 依赖测试检查 `!!Deno.env.get("DATABASE_URL")` 和
+  `!!Deno.env.get("JWT_SECRET")`，缺失时设置 `ignore: true` 静默跳过
+- 使用 `sanitizeResources: false, sanitizeOps: false`（postgres.js 连接池触发
+  Deno 资源泄漏检测）
 - `resetDbForTest()` 在每个测试前重置单例状态
 - 测试命名格式：`"module: description"`（`Deno.test({ name, ignore, sanitizeResources, sanitizeOps, fn })`）
 - 清理测试在文件末尾执行，通过 `db.delete()` 直接删除测试数据
 - 测试数据使用 `Date.now()` 生成唯一用户名/邮箱避免冲突
 - `00_migrate_test.ts` 按字母序最先执行，负责迁移和 seed root 用户
-- 路由测试使用 `jsonRequest()` 辅助函数创建原始 `Request` 对象（确保 Hono 路由兼容性）
+- 路由测试使用 `jsonRequest()` 辅助函数创建原始 `Request` 对象（确保 Hono
+  路由兼容性）
 
 ## 脚本说明
 
-| 脚本 | 行为 |
-|------|------|
-| `scripts/seed.ts` | 幂等（`ON CONFLICT DO NOTHING`），先迁移→确保 root 用户→种子数据，`finally` 中关闭 DB 连接 |
+| 脚本                        | 行为                                                                                         |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
+| `scripts/seed.ts`           | 幂等（`ON CONFLICT DO NOTHING`），先迁移→确保 root 用户→种子数据，`finally` 中关闭 DB 连接   |
 | `scripts/build-packages.ts` | 调用系统 `zip` 命令（非 JS 库），在 `data/problems-src/<id>/` 目录执行，排除 `submission.py` |
-| `scripts/migrate.ts` | 日志中脱敏数据库密码（`"//***@"`），迁移后关闭 DB 连接确保进程退出 |
+| `scripts/migrate.ts`        | 日志中脱敏数据库密码（`"//***@"`），迁移后关闭 DB 连接确保进程退出                           |
 
 ## 评测脚本协议（Judge 集成）
 
 noj-core 不直接执行评测，但 `data/problems-src/` 中的 evaluate.py 遵循以下约定：
 
-- 可见测试用例：`visible.jsonl`，隐藏测试用例：`hidden.jsonl`（位于支持包 zip 中）
+- 可见测试用例：`visible.jsonl`，隐藏测试用例：`hidden.jsonl`（位于支持包 zip
+  中）
 - 用户代码路径：`/tmp/main.py`（或对应扩展名）
 - 输出格式：`---RESULT---` 标记行 + JSON `{status, score, details}`
 - 超时处理：evaluate.py 内部使用 `subprocess.run(timeout=TIMEOUT)`
@@ -287,8 +303,8 @@ noj-core 不直接执行评测，但 `data/problems-src/` 中的 evaluate.py 遵
 ## 题目数据约束
 
 **`data/problems-src/` 仅用于样例题和开发测试。**
-正式比赛题目（含隐藏测试数据和评测脚本）**不得提交到此 git 仓库**。
-应通过管理 API 或独立的安全通道部署，`support_package_path` 指向受控存储。
+正式比赛题目（含隐藏测试数据和评测脚本）**不得提交到此 git 仓库**。 应通过管理
+API 或独立的安全通道部署，`support_package_path` 指向受控存储。
 
 ## 贡献要求
 

--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -1,11 +1,12 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import health from "./routes/health.ts";
-import auth, { adminAuth } from "./routes/auth.ts";
+import auth from "./routes/auth.ts";
+import admin from "./routes/admin.ts";
 import categories from "./routes/categories.ts";
 import problems from "./routes/problems.ts";
 import queue from "./routes/queue.ts";
-import submissions, { adminSubmissions } from "./routes/submissions.ts";
+import submissions from "./routes/submissions.ts";
 import users from "./routes/users.ts";
 import { AppError } from "./lib/errors.ts";
 
@@ -66,12 +67,11 @@ export function createApp(): Hono {
   // 注册路由
   app.route("/", health);
   app.route("/api/v1/auth", auth);
-  app.route("/api/v1/admin", adminAuth);
+  app.route("/api/v1/admin", admin);
   app.route("/api/v1/categories", categories);
   app.route("/api/v1/problems", problems);
   app.route("/api/v1/queue", queue);
   app.route("/api/v1/submissions", submissions);
-  app.route("/api/v1/admin/submissions", adminSubmissions);
   app.route("/api/v1/users", users);
 
   return app;

--- a/noj-core/src/routes/admin.ts
+++ b/noj-core/src/routes/admin.ts
@@ -1,0 +1,194 @@
+import { Hono } from "hono";
+import { adminMiddleware, authMiddleware } from "../middleware/auth.ts";
+import { parseJsonBody } from "../lib/request.ts";
+import { BadRequestError, ValidationError } from "../lib/errors.ts";
+import { listUsers, promoteUser } from "../services/auth.ts";
+import { getDashboardStats } from "../services/dashboard.ts";
+import { listAllProblems } from "../services/problems.ts";
+import {
+  deleteSubmission,
+  getSubmission,
+  listSubmissions,
+} from "../services/submissions.ts";
+import { adminUpdateUserProfile } from "../services/users.ts";
+
+const router = new Hono<{ Variables: { userId: string; userRole: string } }>();
+
+// 路由组级中间件：所有 admin 端点均需认证 + 管理员权限
+router.use("*", authMiddleware, adminMiddleware);
+
+// ─── 用户管理 ───────────────────────────────────────────────
+
+/**
+ * 管理员获取用户列表（分页 + 搜索筛选）。
+ * GET /api/v1/admin/users
+ */
+router.get("/users", async (c) => {
+  let page = parseInt(c.req.query("page") ?? "1", 10);
+  let perPage = parseInt(c.req.query("per_page") ?? "20", 10);
+  if (isNaN(page) || page < 1) page = 1;
+  if (isNaN(perPage) || perPage < 1) perPage = 20;
+  if (perPage > 100) perPage = 100;
+
+  const keyword = c.req.query("keyword") || undefined;
+  const role = c.req.query("role") || undefined;
+  const from = c.req.query("from") || undefined;
+  const to = c.req.query("to") || undefined;
+
+  const result = await listUsers({ page, perPage, keyword, role, from, to });
+  return c.json({ data: result.data, pagination: result.pagination });
+});
+
+/**
+ * 管理员提升/降级用户角色。
+ * PATCH /api/v1/admin/users/:id/role
+ */
+router.patch("/users/:id/role", async (c) => {
+  const targetUserId = c.req.param("id") as string;
+  const body = await parseJsonBody<{ role: string }>(c);
+
+  if (!body.role) {
+    throw new ValidationError("缺少必填字段：role");
+  }
+
+  const user = await promoteUser(targetUserId, body.role, c.get("userId"));
+  return c.json({ data: user }, 200);
+});
+
+/**
+ * 管理员编辑用户资料。
+ * PUT /api/v1/admin/users/:id
+ */
+router.put("/users/:id", async (c) => {
+  const targetUserId = c.req.param("id") as string;
+  const body = await parseJsonBody<{ email?: string; bio?: string }>(c);
+
+  if (body.email === undefined && body.bio === undefined) {
+    throw new BadRequestError("至少需要提供一个可更新字段（email 或 bio）");
+  }
+
+  const user = await adminUpdateUserProfile(targetUserId, body);
+  return c.json({ data: user }, 200);
+});
+
+// ─── 题目管理 ───────────────────────────────────────────────
+
+/**
+ * 管理员获取全量题目列表（含 U 型和 P 型）。
+ * GET /api/v1/admin/problems
+ */
+router.get("/problems", async (c) => {
+  const page = parseInt(c.req.query("page") || "1", 10);
+  const limit = parseInt(c.req.query("limit") || "20", 10);
+
+  if (Number.isNaN(page) || Number.isNaN(limit)) {
+    throw new BadRequestError("分页参数 page 和 limit 必须为数字");
+  }
+
+  const result = await listAllProblems({
+    page: Math.max(1, page),
+    limit: Math.min(100, Math.max(1, limit)),
+    difficulty: c.req.query("difficulty") || undefined,
+    category_id: c.req.query("category_id") || undefined,
+    keyword: c.req.query("keyword") || undefined,
+  });
+
+  return c.json({
+    data: result.items,
+    total: result.total,
+    page: result.page,
+    limit: result.limit,
+  });
+});
+
+// ─── 提交管理 ───────────────────────────────────────────────
+
+/**
+ * 管理员获取全部提交列表（分页 + 筛选）。
+ * GET /api/v1/admin/submissions
+ */
+router.get("/submissions", async (c) => {
+  let page = parseInt(c.req.query("page") ?? "", 10);
+  let perPage = parseInt(c.req.query("per_page") ?? "", 10);
+
+  if (isNaN(page) || page < 1) page = 1;
+  if (isNaN(perPage) || perPage < 1) perPage = 20;
+  if (perPage > 100) perPage = 100;
+
+  const userId = c.req.query("user_id") || undefined;
+  const userSearch = c.req.query("user_search") || undefined;
+  const problemId = c.req.query("problem_id") || undefined;
+  const problemSearch = c.req.query("problem_search") || undefined;
+  const submissionId = c.req.query("submission_id") || undefined;
+  const language = c.req.query("language") || undefined;
+  const status = c.req.query("status") || undefined;
+  const from = c.req.query("from") || undefined;
+  const to = c.req.query("to") || undefined;
+
+  const validStatuses = ["pending", "judging", "finished", "error"];
+  if (status && !validStatuses.includes(status)) {
+    throw new BadRequestError(
+      `无效的状态值：${status}，有效值：${validStatuses.join("、")}`,
+    );
+  }
+
+  const result = await listSubmissions({
+    userId,
+    userSearch,
+    problemId,
+    problemSearch,
+    submissionId,
+    language,
+    status,
+    from,
+    to,
+    page,
+    perPage,
+  });
+
+  const totalPages = Math.ceil(result.total / perPage);
+
+  return c.json({
+    data: result.data,
+    pagination: {
+      page,
+      per_page: perPage,
+      total: result.total,
+      total_pages: totalPages,
+    },
+  });
+});
+
+/**
+ * 管理员查看任意提交详情（含 code）。
+ * GET /api/v1/admin/submissions/:id
+ */
+router.get("/submissions/:id", async (c) => {
+  const id = c.req.param("id") as string;
+  // 传入 userId=undefined 跳过所有权检查
+  const result = await getSubmission(id);
+  return c.json({ data: result });
+});
+
+/**
+ * 管理员删除提交记录。
+ * DELETE /api/v1/admin/submissions/:id
+ */
+router.delete("/submissions/:id", async (c) => {
+  const id = c.req.param("id") as string;
+  await deleteSubmission(id);
+  return c.body(null, 204);
+});
+
+// ─── 仪表盘 ─────────────────────────────────────────────────
+
+/**
+ * 仪表盘统计数据。
+ * GET /api/v1/admin/dashboard/stats
+ */
+router.get("/dashboard/stats", async (c) => {
+  const stats = await getDashboardStats();
+  return c.json({ data: stats });
+});
+
+export default router;

--- a/noj-core/src/routes/auth.ts
+++ b/noj-core/src/routes/auth.ts
@@ -1,12 +1,6 @@
 import { Hono } from "hono";
-import { adminMiddleware, authMiddleware } from "../middleware/auth.ts";
-import {
-  getUserProfile,
-  listUsers,
-  loginUser,
-  promoteUser,
-  registerUser,
-} from "../services/auth.ts";
+import { authMiddleware } from "../middleware/auth.ts";
+import { getUserProfile, loginUser, registerUser } from "../services/auth.ts";
 import { ValidationError } from "../lib/errors.ts";
 import { parseJsonBody } from "../lib/request.ts";
 import type { LoginInput, RegisterInput } from "../types/auth.ts";
@@ -77,54 +71,4 @@ auth.get("/me", authMiddleware, async (c) => {
   return c.json({ data: user }, 200);
 });
 
-/**
- * 管理员用户管理路由。
- * 需要 authMiddleware + adminMiddleware 双重保护。
- */
-const adminAuth = new Hono<
-  { Variables: { userId: string; userRole: string } }
->();
-
-/**
- * 管理员获取用户列表（分页）。
- * GET /api/v1/admin/users
- */
-adminAuth.get(
-  "/users",
-  authMiddleware,
-  adminMiddleware,
-  async (c) => {
-    let page = parseInt(c.req.query("page") ?? "1", 10);
-    let perPage = parseInt(c.req.query("per_page") ?? "20", 10);
-    if (isNaN(page) || page < 1) page = 1;
-    if (isNaN(perPage) || perPage < 1) perPage = 20;
-    if (perPage > 100) perPage = 100;
-
-    const result = await listUsers({ page, perPage });
-    return c.json({ data: result.data, pagination: result.pagination });
-  },
-);
-
-/**
- * 管理员提升/降级用户角色。
- * PATCH /api/v1/admin/users/:id/role
- */
-adminAuth.patch(
-  "/users/:id/role",
-  authMiddleware,
-  adminMiddleware,
-  async (c) => {
-    const targetUserId = c.req.param("id") as string;
-    const body = await parseJsonBody<{ role: string }>(c);
-
-    if (!body.role) {
-      throw new ValidationError("缺少必填字段：role");
-    }
-
-    const user = await promoteUser(targetUserId, body.role, c.get("userId"));
-    return c.json({ data: user }, 200);
-  },
-);
-
-export { adminAuth };
 export default auth;

--- a/noj-core/src/routes/submissions.ts
+++ b/noj-core/src/routes/submissions.ts
@@ -5,7 +5,7 @@ import {
   listSubmissions,
 } from "../services/submissions.ts";
 import { getSubmissionQueueStatus } from "../services/queue.ts";
-import { adminMiddleware, authMiddleware } from "../middleware/auth.ts";
+import { authMiddleware } from "../middleware/auth.ts";
 import { BadRequestError } from "../lib/errors.ts";
 
 // 扩展 Hono 类型，使 c.get("userId") 返回 string
@@ -159,68 +159,4 @@ router.get("/:id/status", authMiddleware, async (c) => {
   return c.json(result);
 });
 
-/**
- * 管理员提交列表路由。
- * 需要 authMiddleware + adminMiddleware 双重保护。
- */
-const adminSubmissions = new Hono<
-  { Variables: { userId: string; userRole: string } }
->();
-
-adminSubmissions.get("/", authMiddleware, adminMiddleware, async (c) => {
-  // 解析分页参数
-  let page = parseInt(c.req.query("page") ?? "", 10);
-  let perPage = parseInt(c.req.query("per_page") ?? "", 10);
-
-  if (isNaN(page) || page < 1) page = 1;
-  if (isNaN(perPage) || perPage < 1) perPage = 20;
-  if (perPage > 100) perPage = 100;
-
-  // 解析筛选参数（额外支持 user_id、user_search）
-  const userId = c.req.query("user_id") || undefined;
-  const userSearch = c.req.query("user_search") || undefined;
-  const problemId = c.req.query("problem_id") || undefined;
-  const problemSearch = c.req.query("problem_search") || undefined;
-  const submissionId = c.req.query("submission_id") || undefined;
-  const language = c.req.query("language") || undefined;
-  const status = c.req.query("status") || undefined;
-  const from = c.req.query("from") || undefined;
-  const to = c.req.query("to") || undefined;
-
-  // status 参数校验
-  const validStatuses = ["pending", "judging", "finished", "error"];
-  if (status && !validStatuses.includes(status)) {
-    throw new BadRequestError(
-      `无效的状态值：${status}，有效值：${validStatuses.join("、")}`,
-    );
-  }
-
-  const result = await listSubmissions({
-    userId,
-    userSearch,
-    problemId,
-    problemSearch,
-    submissionId,
-    language,
-    status,
-    from,
-    to,
-    page,
-    perPage,
-  });
-
-  const totalPages = Math.ceil(result.total / perPage);
-
-  return c.json({
-    data: result.data,
-    pagination: {
-      page,
-      per_page: perPage,
-      total: result.total,
-      total_pages: totalPages,
-    },
-  });
-});
-
-export { adminSubmissions };
 export default router;

--- a/noj-core/src/services/auth.ts
+++ b/noj-core/src/services/auth.ts
@@ -1,4 +1,4 @@
-import { and, eq, not, or, sql } from "drizzle-orm";
+import { and, eq, gte, ilike, lte, not, or, sql } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
 import { users } from "../db/schema.ts";
 import { comparePassword, hashPassword } from "../lib/password.ts";
@@ -285,9 +285,21 @@ export async function promoteUser(
 /**
  * 管理员获取用户列表（分页，排除 root 系统用户）。
  * 返回用户基本信息，不含密码哈希。
+ *
+ * @param opts.keyword 搜索关键词（匹配 username 或 email，ILIKE 模糊搜索）
+ * @param opts.role 按角色筛选（"admin" | "user"）
+ * @param opts.from 注册日期范围起始（ISO 字符串）
+ * @param opts.to 注册日期范围截止（ISO 字符串）
  */
 export async function listUsers(
-  opts: { page: number; perPage: number },
+  opts: {
+    page: number;
+    perPage: number;
+    keyword?: string;
+    role?: string;
+    from?: string;
+    to?: string;
+  },
 ): Promise<
   {
     data: UserResponse[];
@@ -302,8 +314,39 @@ export async function listUsers(
   const db = getDb();
   const offset = (opts.page - 1) * opts.perPage;
 
+  // 构建筛选条件
+  const conditions: ReturnType<typeof sql>[] = [];
+
   // 排除 root 系统用户（id='0'）
-  const excludeRoot = (u: typeof users) => sql`${u.id} <> '0'`;
+  conditions.push(sql`${users.id} <> '0'`);
+
+  // 按角色筛选
+  if (opts.role) {
+    conditions.push(eq(users.role, opts.role));
+  }
+
+  // 按关键词搜索（username 或 email ILIKE 模糊匹配）
+  if (opts.keyword) {
+    const kw = `%${opts.keyword}%`;
+    conditions.push(
+      or(
+        ilike(users.username, kw),
+        ilike(users.email, kw),
+      ) as unknown as ReturnType<
+        typeof sql
+      >,
+    );
+  }
+
+  // 按注册日期范围筛选
+  if (opts.from) {
+    conditions.push(gte(users.created_at, opts.from));
+  }
+  if (opts.to) {
+    conditions.push(lte(users.created_at, opts.to));
+  }
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
 
   const [rows, countResult] = await Promise.all([
     db
@@ -316,14 +359,14 @@ export async function listUsers(
         updated_at: users.updated_at,
       })
       .from(users)
-      .where(excludeRoot(users))
+      .where(where)
       .orderBy(users.created_at)
       .limit(opts.perPage)
       .offset(offset),
     db
       .select({ count: sql<number>`count(*)` })
       .from(users)
-      .where(excludeRoot(users)),
+      .where(where),
   ]);
 
   const total = Number(countResult[0]?.count ?? 0);

--- a/noj-core/src/services/dashboard.ts
+++ b/noj-core/src/services/dashboard.ts
@@ -1,0 +1,132 @@
+import { sql } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+import {
+  categories,
+  evaluationResults,
+  problems,
+  submissions,
+  users,
+} from "../db/schema.ts";
+import { AppError } from "../lib/errors.ts";
+
+/**
+ * 仪表盘统计数据响应。
+ */
+export interface DashboardStats {
+  total_users: number;
+  total_problems: number;
+  total_submissions: number;
+  total_categories: number;
+  total_accepted: number;
+  total_pending: number;
+  acceptance_rate: number;
+  recent_submissions_24h: number;
+  active_users_24h: number;
+}
+
+/**
+ * 获取仪表盘统计指标。
+ *
+ * 执行 4 次独立查询聚合各表数据，服务层组合后返回。
+ * 所有查询均在主键/索引上执行，复杂度 O(log N)。
+ *
+ * @throws {Error} 数据库连接异常时抛出
+ */
+export async function getDashboardStats(): Promise<DashboardStats> {
+  try {
+    return await queryDashboardStats();
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    throw new AppError(
+      "获取统计数据失败，请稍后重试",
+      500,
+      "DASHBOARD_STATS_ERROR",
+    );
+  }
+}
+
+/**
+ * 实际执行统计查询的内部函数。
+ * 由 getDashboardStats() 调用，异常由外层统一转换为 DASHBOARD_STATS_ERROR。
+ */
+async function queryDashboardStats(): Promise<DashboardStats> {
+  const db = getDb();
+  const now = new Date();
+  const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+    .toISOString();
+
+  // 1. 用户统计：排除 root 系统用户（id='0'）
+  const [userRow] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(users)
+    .where(sql`${users.id} <> '0'`);
+  const totalUsers = Number(userRow?.count ?? 0);
+
+  // 2. 题目统计：含 U 型和 P 型
+  const [problemRow] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(problems);
+  const totalProblems = Number(problemRow?.count ?? 0);
+
+  // 3. 分类统计
+  const [categoryRow] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(categories);
+  const totalCategories = Number(categoryRow?.count ?? 0);
+
+  // 4. 提交统计与通过率
+  const [submissionStats] = await db
+    .select({
+      total: sql<number>`count(*)`,
+      accepted: sql<
+        number
+      >`count(*) filter (where ${evaluationResults.status} = 'Accepted')`,
+      total_judged: sql<
+        number
+      >`count(*) filter (where ${evaluationResults.status} is not null)`,
+    })
+    .from(submissions)
+    .leftJoin(
+      evaluationResults,
+      sql`${evaluationResults.submission_id} = ${submissions.id}`,
+    );
+
+  const totalSubmissions = Number(submissionStats?.total ?? 0);
+  const totalAccepted = Number(submissionStats?.accepted ?? 0);
+  const totalJudged = Number(submissionStats?.total_judged ?? 0);
+  const acceptanceRate = totalJudged > 0
+    ? Math.round((totalAccepted / totalJudged) * 1000) / 1000
+    : 0;
+
+  // 5. 待评测提交数
+  const [pendingRow] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(submissions)
+    .where(sql`${submissions.status} = 'pending'`);
+  const totalPending = Number(pendingRow?.count ?? 0);
+
+  // 6. 24 小时统计
+  const [recentSubmissionsRow] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(submissions)
+    .where(sql`${submissions.created_at} >= ${twentyFourHoursAgo}`);
+  const recentSubmissions24h = Number(recentSubmissionsRow?.count ?? 0);
+
+  const [activeUsersRow] = await db
+    .select({ count: sql<number>`count(distinct ${submissions.user_id})` })
+    .from(submissions)
+    .where(sql`${submissions.created_at} >= ${twentyFourHoursAgo}`);
+  const activeUsers24h = Number(activeUsersRow?.count ?? 0);
+
+  return {
+    total_users: totalUsers,
+    total_problems: totalProblems,
+    total_submissions: totalSubmissions,
+    total_categories: totalCategories,
+    total_accepted: totalAccepted,
+    total_pending: totalPending,
+    acceptance_rate: acceptanceRate,
+    recent_submissions_24h: recentSubmissions24h,
+    active_users_24h: activeUsers24h,
+  };
+}

--- a/noj-core/src/services/problems.ts
+++ b/noj-core/src/services/problems.ts
@@ -9,7 +9,12 @@ import {
   sql,
 } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
-import { categories, problems, problemsCategories } from "../db/schema.ts";
+import {
+  categories,
+  problems,
+  problemsCategories,
+  users,
+} from "../db/schema.ts";
 import {
   BadRequestError,
   ForbiddenError,
@@ -45,6 +50,35 @@ export interface ProblemResponse {
 
 export interface ProblemListResponse {
   items: ProblemResponseWithCategories[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+/**
+ * 管理员专属题目列表项（不含 description，额外包含 owner_username）。
+ */
+export interface AdminProblemListItem {
+  id: string;
+  title: string;
+  difficulty: string;
+  judge_image: string;
+  judge_command: string;
+  support_package_path: string | null;
+  time_limit_ms: number;
+  memory_limit_mb: number;
+  categories: { id: string; name: string; slug: string }[];
+  created_at: string;
+  updated_at: string;
+  number: number;
+  owner_id: string;
+  owner_username: string;
+  type: string;
+  display_id: string;
+}
+
+export interface AdminProblemListResponse {
+  items: AdminProblemListItem[];
   total: number;
   page: number;
   limit: number;
@@ -197,6 +231,125 @@ export async function listProblems(
     items: items.map((p) => ({
       ...toProblemResponse(p),
       categories: catMap.get(p.id) ?? [],
+    })),
+    total,
+    page,
+    limit,
+  };
+}
+
+/**
+ * 管理员获取全量题目列表（含 U 型和 P 型）。
+ *
+ * 与 listProblems 的区别：
+ * - 不默认添加 type='P' 筛选条件，返回所有类型题目
+ * - 额外返回 owner_username（JOIN users 表）
+ * - 不返回 description 字段（列表场景不需要）
+ *
+ * 支持与普通列表相同的 difficulty、category_id、keyword 筛选参数。
+ */
+export async function listAllProblems(
+  query: {
+    page?: number;
+    limit?: number;
+    difficulty?: string;
+    category_id?: string;
+    keyword?: string;
+  } = {},
+): Promise<AdminProblemListResponse> {
+  const db = getDb();
+  const page = Math.max(1, query.page ?? 1);
+  const limit = Math.min(100, Math.max(1, query.limit ?? 20));
+  const offset = (page - 1) * limit;
+
+  // 构建筛选条件（不默认添加 type='P'）
+  const conditions: SQL[] = [];
+
+  if (query.difficulty) {
+    if (!isValidDifficulty(query.difficulty)) {
+      throw new BadRequestError(
+        `非法难度值：${query.difficulty}，仅允许 ${DIFFICULTIES.join("/")}`,
+      );
+    }
+    conditions.push(eq(problems.difficulty, query.difficulty));
+  }
+
+  if (query.keyword) {
+    const kw = `%${query.keyword}%`;
+    conditions.push(
+      sql`(${ilike(problems.title, kw)} OR ${ilike(problems.description, kw)})`,
+    );
+  }
+
+  // 按分类筛选
+  if (query.category_id) {
+    const catRows = await db
+      .select({ problem_id: problemsCategories.problem_id })
+      .from(problemsCategories)
+      .where(eq(problemsCategories.category_id, query.category_id));
+
+    if (catRows.length === 0) {
+      return { items: [], total: 0, page, limit };
+    }
+
+    conditions.push(inArray(problems.id, catRows.map((r) => r.problem_id)));
+  }
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  // 查询列表：JOIN users 获取 owner_username
+  const rows = await db
+    .select({
+      id: problems.id,
+      title: problems.title,
+      difficulty: problems.difficulty,
+      judge_image: problems.judge_image,
+      judge_command: problems.judge_command,
+      support_package_path: problems.support_package_path,
+      time_limit_ms: problems.time_limit_ms,
+      memory_limit_mb: problems.memory_limit_mb,
+      created_at: problems.created_at,
+      updated_at: problems.updated_at,
+      number: problems.number,
+      owner_id: problems.owner_id,
+      owner_username: users.username,
+      type: problems.type,
+    })
+    .from(problems)
+    .leftJoin(users, eq(problems.owner_id, users.id))
+    .where(whereClause)
+    .orderBy(asc(problems.id))
+    .limit(limit)
+    .offset(offset);
+
+  // 查询总数
+  const countResult = await db
+    .select({ count: count() })
+    .from(problems)
+    .where(whereClause);
+  const total = Number(countResult[0]?.count ?? 0);
+
+  // 注入关联分类信息
+  const catMap = await attachCategories(rows.map((r) => r.id));
+
+  return {
+    items: rows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      difficulty: r.difficulty,
+      judge_image: r.judge_image,
+      judge_command: r.judge_command,
+      support_package_path: r.support_package_path,
+      time_limit_ms: r.time_limit_ms,
+      memory_limit_mb: r.memory_limit_mb,
+      categories: catMap.get(r.id) ?? [],
+      created_at: r.created_at,
+      updated_at: r.updated_at,
+      number: r.number,
+      owner_id: r.owner_id,
+      owner_username: r.owner_username ?? "未知",
+      type: r.type,
+      display_id: `${r.type}${r.number}`,
     })),
     total,
     page,

--- a/noj-core/src/services/submissions.ts
+++ b/noj-core/src/services/submissions.ts
@@ -588,3 +588,29 @@ export async function updateSubmissionStatus(
     .set(updates)
     .where(eq(submissions.id, id));
 }
+
+/**
+ * 管理员删除提交记录。
+ *
+ * 硬删除提交记录及关联的评测结果（通过 ON DELETE CASCADE 自动清理）。
+ * 仅管理员可通过 admin 端点调用。
+ *
+ * @throws {NotFoundError} 提交不存在
+ */
+export async function deleteSubmission(id: string): Promise<void> {
+  const db = getDb();
+
+  // 检查提交是否存在
+  const existing = await db
+    .select({ id: submissions.id })
+    .from(submissions)
+    .where(eq(submissions.id, id))
+    .limit(1);
+
+  if (existing.length === 0) {
+    throw new NotFoundError("提交不存在");
+  }
+
+  // 硬删除（evaluation_results 通过 ON DELETE CASCADE 自动清理）
+  await db.delete(submissions).where(eq(submissions.id, id));
+}

--- a/noj-core/src/services/users.ts
+++ b/noj-core/src/services/users.ts
@@ -6,7 +6,12 @@ import {
   submissions,
   users,
 } from "../db/schema.ts";
-import { NotFoundError, ValidationError } from "../lib/errors.ts";
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  ValidationError,
+} from "../lib/errors.ts";
 import { scoreFromDb } from "../types/index.ts";
 
 /**
@@ -211,6 +216,116 @@ export async function updateUserProfile(
   if (!updated) {
     throw new NotFoundError("用户不存在");
   }
+
+  return updated;
+}
+
+/**
+ * 管理员更新任意用户的资料（email、bio）。
+ *
+ * 与普通 updateUserProfile 的区别：
+ * - 不检查 bio 长度限制（管理员有权设置任意内容）
+ * - 支持更新 email（含格式校验和唯一性检查）
+ * - 返回用户完整信息（含 email、role）
+ *
+ * @param targetUserId 目标用户 ID
+ * @param input.email 新邮箱（可选）
+ * @param input.bio 新简介（可选）
+ * @throws {NotFoundError} 目标用户不存在
+ * @throws {BadRequestError} 邮箱格式不正确
+ * @throws {ConflictError} 邮箱已被其他用户使用
+ */
+export async function adminUpdateUserProfile(
+  targetUserId: string,
+  input: { email?: string; bio?: string },
+): Promise<{
+  id: string;
+  username: string;
+  email: string;
+  role: string;
+  bio: string;
+}> {
+  const db = getDb();
+
+  // 检查用户是否存在
+  const existing = await db
+    .select()
+    .from(users)
+    .where(eq(users.id, targetUserId))
+    .limit(1);
+
+  if (existing.length === 0) {
+    throw new NotFoundError("用户不存在");
+  }
+
+  const user = existing[0];
+  const updates: Record<string, string> = {};
+  const now = new Date().toISOString();
+
+  // 处理邮箱更新
+  if (input.email !== undefined) {
+    if (input.email === user.email) {
+      // 邮箱未变更，跳过
+    } else {
+      // 格式校验
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.email)) {
+        throw new BadRequestError("邮箱格式不正确");
+      }
+
+      // 唯一性检查
+      const existingEmail = await db
+        .select()
+        .from(users)
+        .where(
+          and(
+            eq(users.email, input.email),
+            sql`${users.id} <> ${targetUserId}`,
+          ),
+        )
+        .limit(1);
+
+      if (existingEmail.length > 0) {
+        throw new ConflictError("邮箱已被注册");
+      }
+
+      updates.email = input.email;
+    }
+  }
+
+  // 处理 bio 更新（不检查长度限制）
+  if (input.bio !== undefined) {
+    updates.bio = input.bio;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return {
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      role: user.role,
+      bio: user.bio,
+    };
+  }
+
+  updates.updated_at = now;
+
+  await db
+    .update(users)
+    .set(updates)
+    .where(eq(users.id, targetUserId));
+
+  // 返回更新后的用户信息
+  const [updated] = await db
+    .select({
+      id: users.id,
+      username: users.username,
+      email: users.email,
+      role: users.role,
+      bio: users.bio,
+    })
+    .from(users)
+    .where(eq(users.id, targetUserId))
+    .limit(1);
 
   return updated;
 }

--- a/noj-core/src/services/users.ts
+++ b/noj-core/src/services/users.ts
@@ -247,6 +247,13 @@ export async function adminUpdateUserProfile(
 }> {
   const db = getDb();
 
+  // 先校验 email 格式（无需查询数据库）
+  if (input.email !== undefined) {
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.email)) {
+      throw new BadRequestError("邮箱格式不正确");
+    }
+  }
+
   // 检查用户是否存在
   const existing = await db
     .select()
@@ -267,11 +274,6 @@ export async function adminUpdateUserProfile(
     if (input.email === user.email) {
       // 邮箱未变更，跳过
     } else {
-      // 格式校验
-      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.email)) {
-        throw new BadRequestError("邮箱格式不正确");
-      }
-
       // 唯一性检查
       const existingEmail = await db
         .select()

--- a/noj-core/src/services/users.ts
+++ b/noj-core/src/services/users.ts
@@ -9,6 +9,7 @@ import {
 import {
   BadRequestError,
   ConflictError,
+  ForbiddenError,
   NotFoundError,
   ValidationError,
 } from "../lib/errors.ts";
@@ -245,11 +246,21 @@ export async function adminUpdateUserProfile(
   role: string;
   bio: string;
 }> {
+  // 拒绝修改 root 系统用户，避免破坏系统惯例（root 不计入管理员统计、不可登录）
+  if (targetUserId === "0") {
+    throw new ForbiddenError("不能修改系统 root 用户");
+  }
+
   const db = getDb();
 
   // 先校验 email 格式（无需查询数据库）
   if (input.email !== undefined) {
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.email)) {
+    // 强化：local-part 不允许连续点号、不允许首尾点号；TLD 至少 2 字符
+    if (
+      !/^(?!\.)(?!.*\.\.)[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(
+        input.email,
+      )
+    ) {
       throw new BadRequestError("邮箱格式不正确");
     }
   }

--- a/noj-core/tests/routes/auth-admin.test.ts
+++ b/noj-core/tests/routes/auth-admin.test.ts
@@ -1,6 +1,12 @@
 import { assertEquals } from "jsr:@std/assert@^1";
 import { createApp } from "../../src/app.ts";
 import { signToken } from "../../src/lib/jwt.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+// deno-lint-ignore no-unused-vars
+import { problems, submissions, users } from "../../src/db/schema.ts";
+import { eq } from "drizzle-orm";
+
+const ts = Date.now();
 
 const hasDb = !!Deno.env.get("DATABASE_URL");
 const hasEnv = !!Deno.env.get("JWT_SECRET");
@@ -337,5 +343,313 @@ Deno.test({
     assertEquals(res.status, 200);
     const body = await res.json();
     assertEquals(Array.isArray(body.data), true);
+  },
+});
+
+// ─── 功能性测试（issue #71 review）──────────────────────────
+
+/** 在 DB 中直接插入一个测试用户（绕过 register 路由以便复用现成字段） */
+async function insertTestUser(
+  username: string,
+  email: string,
+  bio = "",
+): Promise<string> {
+  const db = getDb();
+  const id = `adm-${username}`;
+  const now = new Date().toISOString();
+  await db.insert(users).values({
+    id,
+    username,
+    email,
+    password_hash: "x",
+    role: "user",
+    bio,
+    created_at: now,
+    updated_at: now,
+  });
+  return id;
+}
+
+async function cleanupTestUser(id: string) {
+  try {
+    const db = getDb();
+    await db.delete(users).where(eq(users.id, id));
+  } catch {
+    // ignore
+  }
+}
+
+async function cleanupTestSubmission(id: string) {
+  try {
+    const db = getDb();
+    await db.delete(submissions).where(eq(submissions.id, id));
+  } catch {
+    // ignore
+  }
+}
+
+Deno.test({
+  name: "admin route: PUT /api/v1/admin/users/:id 成功更新 bio",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const username = `adm_bio_${ts}`;
+    const targetId = await insertTestUser(username, `${username}@example.com`);
+
+    try {
+      const token = await signToken({ sub: "admin-user", role: "admin" });
+      const res = await app.request(`/api/v1/admin/users/${targetId}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ bio: "管理员更新的简介" }),
+      });
+      assertEquals(res.status, 200);
+      const body = await res.json();
+      assertEquals(body.data.bio, "管理员更新的简介");
+
+      // 验证 DB 中已更新
+      const db = getDb();
+      const rows = await db
+        .select({ bio: users.bio })
+        .from(users)
+        .where(eq(users.id, targetId))
+        .limit(1);
+      assertEquals(rows[0]?.bio, "管理员更新的简介");
+    } finally {
+      await cleanupTestUser(targetId);
+    }
+  },
+});
+
+Deno.test({
+  name: "admin route: PUT /api/v1/admin/users/:id 邮箱冲突返回 409",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const userA = `adm_email_a_${ts}`;
+    const userB = `adm_email_b_${ts}`;
+    const emailA = `adm_email_a_${ts}@example.com`;
+    const emailB = `adm_email_b_${ts}@example.com`;
+    const idA = await insertTestUser(userA, emailA);
+    const idB = await insertTestUser(userB, emailB);
+
+    try {
+      const token = await signToken({ sub: "admin-user", role: "admin" });
+      // 试图把 B 的邮箱改成 A 的，应 409
+      const res = await app.request(`/api/v1/admin/users/${idB}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ email: emailA }),
+      });
+      assertEquals(res.status, 409);
+    } finally {
+      await cleanupTestUser(idA);
+      await cleanupTestUser(idB);
+    }
+  },
+});
+
+Deno.test({
+  name: "admin route: PUT /api/v1/admin/users/:id 不存在用户返回 404",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const token = await signToken({ sub: "admin-user", role: "admin" });
+    const res = await app.request("/api/v1/admin/users/nonexistent-user-id", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ bio: "不存在" }),
+    });
+    assertEquals(res.status, 404);
+  },
+});
+
+Deno.test({
+  name: "admin route: PUT /api/v1/admin/users/0 拒绝修改 root",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const token = await signToken({ sub: "admin-user", role: "admin" });
+    const res = await app.request("/api/v1/admin/users/0", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ bio: "试图改 root" }),
+    });
+    assertEquals(res.status, 403);
+  },
+});
+
+Deno.test({
+  name: "admin route: PUT /api/v1/admin/users/:id 强化邮箱正则拒绝 TLD 1 字符",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const username = `adm_tld_${ts}`;
+    const targetId = await insertTestUser(username, `${username}@example.com`);
+
+    try {
+      const token = await signToken({ sub: "admin-user", role: "admin" });
+      // "a@b.c" TLD 只有 1 字符 → 应被强化正则拒绝
+      const res = await app.request(`/api/v1/admin/users/${targetId}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ email: "weak@example.c" }),
+      });
+      assertEquals(res.status, 400);
+    } finally {
+      await cleanupTestUser(targetId);
+    }
+  },
+});
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/users keyword 实际筛选命中",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const uniq = `kwfilter_${ts}`;
+    const username = `${uniq}_user`;
+    const targetId = await insertTestUser(username, `${uniq}@example.com`);
+
+    try {
+      const token = await signToken({ sub: "admin-user", role: "admin" });
+      const res = await app.request(
+        `/api/v1/admin/users?keyword=${uniq}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      assertEquals(res.status, 200);
+      const body = await res.json();
+      // 至少包含新建的测试用户
+      const ids = body.data.map((u: { id: string }) => u.id);
+      assertEquals(ids.includes(targetId), true);
+    } finally {
+      await cleanupTestUser(targetId);
+    }
+  },
+});
+
+Deno.test({
+  name: "admin route: DELETE /api/v1/admin/submissions/:id 管理员真删除",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const db = getDb();
+
+    // 需要测试用户（FK）和测试题目（FK）—— 通过 createSubmission 复用
+    const { problems } = await import("../../src/db/schema.ts");
+    const userId = `adm-del-user-${ts}`;
+    const problemId = `adm-del-prob-${ts}`;
+    const submissionId = `adm-del-sub-${ts}`;
+    const now = new Date().toISOString();
+    await db.insert(users).values({
+      id: userId,
+      username: userId,
+      email: `${userId}@example.com`,
+      password_hash: "x",
+      role: "user",
+      created_at: now,
+      updated_at: now,
+    });
+    await db.insert(problems).values({
+      id: problemId,
+      title: `del-test-${ts}`,
+      description: "x",
+      difficulty: "easy",
+      judge_image: "noj-judge-python",
+      judge_command: "python3 /tmp/evaluate.py",
+      time_limit_ms: 5000,
+      memory_limit_mb: 512,
+      owner_id: userId,
+      type: "U",
+      number: 9000 + (ts % 1000),
+      created_at: now,
+      updated_at: now,
+    });
+
+    // 直接插 DB 提交行（避免 createSubmission 触发 Redis MQ）
+    await db.insert(submissions).values({
+      id: submissionId,
+      user_id: userId,
+      problem_id: problemId,
+      language: "python3",
+      code: "print('hi')",
+      file_name: "main.py",
+      status: "pending",
+      created_at: now,
+    });
+
+    try {
+      const token = await signToken({ sub: "admin-user", role: "admin" });
+      const res = await app.request(
+        `/api/v1/admin/submissions/${submissionId}`,
+        { method: "DELETE", headers: { Authorization: `Bearer ${token}` } },
+      );
+      assertEquals(res.status, 204);
+
+      // 验证 DB 中已删除
+      const rows = await db
+        .select()
+        .from(submissions)
+        .where(eq(submissions.id, submissionId))
+        .limit(1);
+      assertEquals(rows.length, 0);
+    } finally {
+      await cleanupTestSubmission(submissionId);
+      await cleanupTestUser(userId);
+      await db.delete(problems).where(eq(problems.id, problemId));
+    }
+  },
+});
+
+Deno.test({
+  name: "admin route: DELETE /api/v1/admin/submissions/:missing-id 返回 404",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const token = await signToken({ sub: "admin-user", role: "admin" });
+    const res = await app.request(
+      "/api/v1/admin/submissions/00000000-0000-0000-0000-000000000000",
+      { method: "DELETE", headers: { Authorization: `Bearer ${token}` } },
+    );
+    assertEquals(res.status, 404);
   },
 });

--- a/noj-core/tests/routes/auth-admin.test.ts
+++ b/noj-core/tests/routes/auth-admin.test.ts
@@ -111,3 +111,231 @@ Deno.test({
     assertEquals(res.status, 400);
   },
 });
+
+// ─── 仪表盘统计 ──────────────────────────────────────────
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/dashboard/stats 未登录返回 401",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const res = await app.request("/api/v1/admin/dashboard/stats");
+    assertEquals(res.status, 401);
+  },
+});
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/dashboard/stats 非管理员返回 403",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "regular-user", role: "user" });
+    const res = await app.request("/api/v1/admin/dashboard/stats", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(res.status, 403);
+  },
+});
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/dashboard/stats 管理员可访问",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "admin-user", role: "admin" });
+    const res = await app.request("/api/v1/admin/dashboard/stats", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(typeof body.data.total_users, "number");
+    assertEquals(typeof body.data.total_problems, "number");
+    assertEquals(typeof body.data.total_submissions, "number");
+  },
+});
+
+// ─── 题目列表 ────────────────────────────────────────────
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/problems 非管理员返回 403",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "regular-user", role: "user" });
+    const res = await app.request("/api/v1/admin/problems", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(res.status, 403);
+  },
+});
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/problems 管理员可访问",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "admin-user", role: "admin" });
+    const res = await app.request("/api/v1/admin/problems", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(Array.isArray(body.data), true);
+    assertEquals(typeof body.total, "number");
+  },
+});
+
+// ─── 提交详情 ────────────────────────────────────────────
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/submissions/:id 未登录返回 401",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const res = await app.request("/api/v1/admin/submissions/some-id");
+    assertEquals(res.status, 401);
+  },
+});
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/submissions/:id 非管理员返回 403",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "regular-user", role: "user" });
+    const res = await app.request("/api/v1/admin/submissions/some-id", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(res.status, 403);
+  },
+});
+
+Deno.test({
+  name: "admin route: DELETE /api/v1/admin/submissions/:id 非管理员返回 403",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "regular-user", role: "user" });
+    const res = await app.request("/api/v1/admin/submissions/some-id", {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(res.status, 403);
+  },
+});
+
+// ─── 用户编辑 ───────────────────────────────────────────
+
+Deno.test({
+  name: "admin route: PUT /api/v1/admin/users/:id 非管理员返回 403",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "regular-user", role: "user" });
+    const res = await app.request("/api/v1/admin/users/some-id", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ bio: "新简介" }),
+    });
+    assertEquals(res.status, 403);
+  },
+});
+
+Deno.test({
+  name: "admin route: PUT /api/v1/admin/users/:id 无字段返回 400",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "admin-user", role: "admin" });
+    const res = await app.request("/api/v1/admin/users/some-id", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({}),
+    });
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "admin route: PUT /api/v1/admin/users/:id 邮箱格式非法返回 400",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "admin-user", role: "admin" });
+    const res = await app.request("/api/v1/admin/users/some-id", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ email: "not-an-email" }),
+    });
+    assertEquals(res.status, 400);
+  },
+});
+
+// ─── 用户搜索筛选 ──────────────────────────────────────
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/users 支持 keyword 参数",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "admin-user", role: "admin" });
+    const res = await app.request(
+      "/api/v1/admin/users?keyword=admin",
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(Array.isArray(body.data), true);
+  },
+});
+
+Deno.test({
+  name: "admin route: GET /api/v1/admin/users 支持 role 参数",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "admin-user", role: "admin" });
+    const res = await app.request(
+      "/api/v1/admin/users?role=admin",
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(Array.isArray(body.data), true);
+  },
+});

--- a/openspec/changes/enrich-admin-api/.openspec.yaml
+++ b/openspec/changes/enrich-admin-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/enrich-admin-api/design.md
+++ b/openspec/changes/enrich-admin-api/design.md
@@ -1,0 +1,89 @@
+## Context
+
+当前管理后台后端 API 分散在 `routes/auth.ts`（用户列表、角色管理）和 `routes/submissions.ts`（提交列表）中，缺乏统一的 admin 路由组织。仪表盘统计接口完全缺失；题目管理缺少管理员专属的全量列表（当前 `GET /api/v1/problems` 默认仅返回 P 型题目）；用户管理缺少搜索、筛选和编辑用户资料的能力。
+
+六个现有的 admin spec 描述了管理功能需求，但后端实现存在缺口：
+- `admin-dashboard` → 无后端统计接口
+- `admin-problem-management` → 无管理员专属题目列表端点
+- `admin-user-management` → 用户列表缺少搜索/筛选参数
+- `admin-submission-management` → 缺少提交详情查看和删除端点
+
+## Goals / Non-Goals
+
+**Goals:**
+- 新增仪表盘统计数据 API：聚合用户数、题目数、提交数、评测通过率等关键指标
+- 新增管理员专属题目列表 API：显示所有类型（U+P），支持与普通列表相同的筛选参数
+- 增强管理员用户列表 API：添加 username/email 搜索、role 筛选、注册日期范围筛选
+- 新增管理员编辑用户 API：允许管理员更新任意用户的 email、bio 等 profile 字段
+- 新增管理员提交详情 API：查看任意提交的完整详情（含源代码）
+- 新增管理员提交删除 API：删除违规/测试提交记录
+- 将管理路由统一组织到 `routes/admin.ts`，保持挂载模式的一致性
+
+**Non-Goals:**
+- 不涉及管理员登录/认证机制的变更
+- 不涉及用户名修改（会影响提交历史关联和认证流程）
+- 不涉及评测队列的管理操作（暂停/取消/重排）
+- 不涉及系统配置的动态修改
+- 不涉及审计日志功能
+- 不涉及批量操作端点
+
+## Decisions
+
+### Decision 1：统一管理路由组织结构
+
+**决策：** 创建 `routes/admin.ts`，将现有的 admin 端点和新增端点集中管理。
+
+`routes/admin.ts` 使用 `adminMiddleware` 作为路由组级别中间件（通过 `router.use(authMiddleware, adminMiddleware)` 一次性应用到所有子路由），减少每个处理程序中的重复中间件声明。
+
+现有 auth.ts 中的 `adminAuth` 路由和 submissions.ts 中的 `adminSubmissions` 路由迁移到 admin.ts 后删除，保持 `auth.ts` 仅包含认证相关端点。
+
+**理由：**
+- 当前 admin 端点分散在 3 个文件中，新开发者难以快速找到所有管理端点
+- 统一管理后，权限和安全审计更清晰——只需检查 `admin.ts` 即可
+- 路由组级别中间件减少重复代码
+
+### Decision 2：仪表盘统计接口——多查询聚合
+
+**决策：** `GET /api/v1/admin/dashboard/stats` 在服务层中执行 4 次独立 SQL 查询（用户统计、题目统计、提交统计、队列统计），服务层聚合后返回。
+
+**不选用** 单条巨型 SQL 的原因：各统计维度来自不同的表（users、problems、submissions），单条 SQL 的 CROSS JOIN 会膨胀中间结果集，在数据量大时反而更慢。4 次独立查询均在主键/索引上执行，每次为 O(log N)，总耗时可忽略。
+
+### Decision 3：管理员题目列表——新增独立服务函数
+
+**决策：** 在 `services/problems.ts` 中新增 `listAllProblems()` 函数，与现有 `listProblems()` 相比：
+- 不默认添加 `type = 'P'` 筛选条件
+- 额外返回 `owner_username` 字段（JOIN users 表）
+- 不返回 `description` 字段（列表场景不需要，减少传输量）
+
+**理由：** 现有 `listProblems()` 的 `conditions.push(eq(problems.type, 'P'))` 是默认行为，若直接修改会破坏公共 API 行为。新增独立函数避免回归风险。
+
+### Decision 4：用户搜索——可选参数模式
+
+**决策：** 在现有 `listUsers()` 的基础上扩展参数，新增可选参数 `keyword`（搜索 username 和 email）、`role`（按角色筛选）、`from`/`to`（注册日期范围）。所有参数均为可选，不传时行为与当前一致（向后兼容）。
+
+### Decision 5：提交详情与删除
+
+**决策：** 
+- `GET /api/v1/admin/submissions/:id` 复用现有的 `getSubmission()` 服务函数，但跳过 `userId` 所有权检查（传入空字符串或内部使用管理员标记）
+- `DELETE /api/v1/admin/submissions/:id` 新增服务函数 `deleteSubmission()`，仅 admin 可调用，硬删除提交记录及关联的评测结果
+
+### Decision 6：管理员编辑用户资料
+
+**决策：** `PUT /api/v1/admin/users/:id` 端点允许管理员编辑任意用户的 profile，接受可选字段 `email` 和 `bio`（至少提供一个）。复用现有 `services/users.ts` 中的 `updateUserProfile()` 服务函数（需扩展支持 email 更新），或新增 `adminUpdateUserProfile()` 函数。
+
+**关键点：**
+- 管理员编辑用户时绕过 bio 长度限制和所有权的概念（管理员有权修改任意用户）
+- 邮箱修改需唯一性检查，复用现有冲突检查逻辑
+- 防枚举保护：统一返回 "用户不存在" 而非区分 "用户不存在" vs "邮箱已被注册"
+- 端点受 `authMiddleware` + `adminMiddleware` 保护
+
+**理由：**
+- 复用现有 updateUserProfile 逻辑减少重复代码，仅在服务层增加 role 参数区分管理员调用
+- 邮箱唯一性检查已有现成的 ConflictError 抛出机制
+
+## Risks / Trade-offs
+
+- **提交详情 API 绕过所有权检查** → 现有 `getSubmission()` 逻辑中 `if (userId && row.user_id !== userId)` 的检查可以通过 `userId = undefined` 来跳过。需要确保 admin 路由不会意外泄露非管理员能访问的信息。Mitigation：仅在 admin 路由中使用此绕过方式，且端点受 `adminMiddleware` 保护。
+- **管理员题目列表暴露 U 型题目** → U 型题目本意是用户私有题库，管理员全量列表可能让非所有者看到。Mitigation：符合预期——管理员本身就需要监管所有题目，当前 admin-problem-management spec 也要求管理员能管理所有题目。
+- **无分页硬限制的删除操作** → 不涉及，每次删除为单条记录操作。
+- **仪表盘统计在高并发下压力** → 统计查询均为索引扫描，百万级数据量下每次查询 < 50ms。若后续成为瓶颈可引入 Redis 缓存，但当前阶段不需要。

--- a/openspec/changes/enrich-admin-api/design.md
+++ b/openspec/changes/enrich-admin-api/design.md
@@ -44,9 +44,9 @@
 
 ### Decision 2：仪表盘统计接口——多查询聚合
 
-**决策：** `GET /api/v1/admin/dashboard/stats` 在服务层中执行 4 次独立 SQL 查询（用户统计、题目统计、提交统计、队列统计），服务层聚合后返回。
+**决策：** `GET /api/v1/admin/dashboard/stats` 在服务层中执行 6 次独立 SQL 查询（用户数 / 题目数 / 分类数 / 提交聚合 / 待评测数 / 24h 窗口提交 + 活跃用户），服务层聚合后返回。
 
-**不选用** 单条巨型 SQL 的原因：各统计维度来自不同的表（users、problems、submissions），单条 SQL 的 CROSS JOIN 会膨胀中间结果集，在数据量大时反而更慢。4 次独立查询均在主键/索引上执行，每次为 O(log N)，总耗时可忽略。
+**不选用** 单条巨型 SQL 的原因：各统计维度来自不同的表（users、problems、categories、submissions），单条 SQL 的 CROSS JOIN 会膨胀中间结果集，在数据量大时反而更慢。6 次独立查询均在主键/索引上执行，每次为 O(log N)，总耗时可忽略。提交聚合（total / accepted / judged）合并为单次 LEFT JOIN 查询以减少往返。
 
 ### Decision 3：管理员题目列表——新增独立服务函数
 

--- a/openspec/changes/enrich-admin-api/proposal.md
+++ b/openspec/changes/enrich-admin-api/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+当前管理后台后端 API 分散且不完整：仪表盘统计接口缺失、题目管理缺少管理员专属全量列表、用户管理缺少搜索筛选能力。这导致前端管理页面（admin dashboard、problem management、user management）无法完整实现规范中定义的功能，管理员体验受限。
+
+## What Changes
+
+- **新增** `GET /api/v1/admin/dashboard/stats` — 平台统计仪表盘接口
+- **新增** `GET /api/v1/admin/problems` — 管理员专属题目列表（全类型）
+- **增强** `GET /api/v1/admin/users` — 添加搜索与筛选参数
+- **新增** `PUT /api/v1/admin/users/:id` — 管理员编辑任意用户的 profile（email、bio 等字段）
+- **新增** `GET /api/v1/admin/submissions/:id` — 管理员查看任意提交详情
+- **新增** `DELETE /api/v1/admin/submissions/:id` — 管理员删除提交记录
+- **重构** 将分散的管理路由集中到 `routes/admin.ts`
+
+## Capabilities
+
+### New Capabilities
+- `admin-dashboard-api`：管理后台仪表盘统计数据接口
+- `admin-submission-detail`：管理后台提交详情与删除能力
+
+### Modified Capabilities
+- `admin-user-management`：增强用户列表端点（搜索筛选）+ 新增管理员编辑用户 profile 端点
+- `admin-problem-management`：新增管理员专属题目列表端点
+- `admin-authorization`：调整管理路由组织结构
+
+## Impact
+
+- `noj-core/src/routes/` — 新增 `admin.ts`，调整 `auth.ts` 和 `submissions.ts` 中的管理路由
+- `noj-core/src/services/` — 新增 `dashboard.ts`，增强 `auth.ts`、`users.ts`、`problems.ts`
+- 路由挂载 `app.ts` — 将分散的管理路由统一为单一挂载点 `/api/v1/admin`
+- 无破坏性变更，现有 API 路径和签名保持不变

--- a/openspec/changes/enrich-admin-api/specs/admin-authorization/spec.md
+++ b/openspec/changes/enrich-admin-api/specs/admin-authorization/spec.md
@@ -1,0 +1,69 @@
+## Purpose
+
+定义 Neuro OJ 管理员权限系统规范，包括管理中间件、角色提升 API
+及种子脚本初始化。API 路径前缀为 `/api/v1/admin`，默认角色为 `user` 和 `admin`
+两级。
+
+本文档为基础规范的 delta 补充，反映管理路由组织结构的调整及新增管理端点。
+
+## MODIFIED Requirements
+
+### Requirement: 管理路由统一组织
+
+系统 SHOULD 将所有 admin 端点集中到 `routes/admin.ts` 文件中统一管理，各功能模块在 admin.ts 内按 domain 分组，统一通过路由组级 `authMiddleware` + `adminMiddleware` 保护。
+
+#### Scenario: 管理员访问统一后的管理端点
+- **WHEN** 管理员访问所有 `/api/v1/admin/*` 端点
+- **THEN** 系统响应与重构前一致，无破坏性变更
+
+### Requirement: 仅管理员可访问管理端点
+
+系统 SHALL 提供 `adminMiddleware`，用于保护非题目类的管理端点。
+题目 CRUD 不再依赖 adminMiddleware，改为服务层根据 type+owner 进行权限判断。
+
+所有管理端点（除已使用自有权限模型的题目 CRUD 外）MUST 依次通过 `authMiddleware` 和 `adminMiddleware` 保护。
+
+#### Scenario: 普通用户访问管理端点
+
+- **WHEN** 已登录但角色为 `user` 的用户携带有效 JWT 调用管理员端点
+- **THEN** 系统返回 HTTP 403，错误信息为 "需要管理员权限"
+
+#### Scenario: 未登录用户访问管理端点
+
+- **WHEN** 未携带 JWT 的用户调用管理员端点
+- **THEN** 系统在 `adminMiddleware` 之前由 `authMiddleware` 返回 HTTP 401
+
+## ADDED Requirements
+
+### Requirement: 管理员可查看仪表盘统计数据
+
+系统 SHALL 提供 `GET /api/v1/admin/dashboard/stats` 端点，返回平台关键统计指标。
+
+详细规范见 `admin-dashboard-api` spec。
+
+#### Scenario: 管理员成功获取统计数据
+
+- **WHEN** 已登录管理员 GET `/api/v1/admin/dashboard/stats`
+- **THEN** 系统返回平台统计指标
+
+### Requirement: 管理员可查看任意提交详情
+
+系统 SHALL 提供 `GET /api/v1/admin/submissions/:id` 端点，允许管理员查看任意提交的完整详情。
+
+详细规范见 `admin-submission-detail` spec。
+
+#### Scenario: 管理员成功查看提交详情
+
+- **WHEN** 管理员 GET `/api/v1/admin/submissions/:id`
+- **THEN** 系统返回提交完整详情
+
+### Requirement: 管理员可删除提交记录
+
+系统 SHALL 提供 `DELETE /api/v1/admin/submissions/:id` 端点，允许管理员删除提交记录。
+
+详细规范见 `admin-submission-detail` spec。
+
+#### Scenario: 管理员成功删除提交
+
+- **WHEN** 管理员 DELETE `/api/v1/admin/submissions/:id`
+- **THEN** 系统返回 HTTP 204

--- a/openspec/changes/enrich-admin-api/specs/admin-dashboard-api/spec.md
+++ b/openspec/changes/enrich-admin-api/specs/admin-dashboard-api/spec.md
@@ -1,0 +1,38 @@
+## Purpose
+
+定义管理后台仪表盘统计数据 API 规范。提供平台关键指标的聚合数据接口。
+
+## ADDED Requirements
+
+### Requirement: 系统提供仪表盘统计数据
+
+系统 SHALL 在 `GET /api/v1/admin/dashboard/stats` 端点提供平台关键统计指标，该端点依次通过 `authMiddleware` 和 `adminMiddleware` 保护。
+
+#### Scenario: 管理员获取仪表盘统计数据
+
+- **WHEN** 已登录管理员调用 `GET /api/v1/admin/dashboard/stats`
+- **THEN** 系统返回包含以下统计数据的 JSON 响应：
+  - `total_users`: 平台注册用户总数（排除 root 系统用户）
+  - `total_problems`: 题目总数（含 U 型和 P 型）
+  - `total_submissions`: 提交记录总数
+  - `total_categories`: 分类总数
+  - `total_accepted`: 通过的评测结果数（status = 'Accepted'）
+  - `total_pending`: 待评测提交数
+  - `acceptance_rate`: 整体通过率（accepted / total_judged）
+  - `recent_submissions_24h`: 过去 24 小时内的提交数
+  - `active_users_24h`: 过去 24 小时内有提交活动的用户数
+
+#### Scenario: 统计数据中排除 root 用户
+
+- **WHEN** 管理员获取统计数据
+- **THEN** `total_users` 统计中排除 id='0' 的 root 系统用户
+
+#### Scenario: 非管理员拒绝访问
+
+- **WHEN** 普通用户（role=user）调用 `GET /api/v1/admin/dashboard/stats`
+- **THEN** 系统返回 HTTP 403
+
+#### Scenario: 数据库查询失败
+
+- **WHEN** 统计查询时数据库连接异常
+- **THEN** 系统返回 HTTP 500，错误码 `DASHBOARD_STATS_ERROR`

--- a/openspec/changes/enrich-admin-api/specs/admin-problem-management/spec.md
+++ b/openspec/changes/enrich-admin-api/specs/admin-problem-management/spec.md
@@ -1,0 +1,37 @@
+## Purpose
+
+定义 Neuro OJ 管理后台题目管理页面规范。该页面在 `/admin/problems` 路径提供，允许管理员管理题目。
+
+本文档为基础规范的 delta 补充，新增管理员专属题目列表接口。
+
+## MODIFIED Requirements
+
+### Requirement: 管理员可查看全部题目列表
+
+系统 SHALL 在 `/admin/problems` 路径提供题目管理页面，以表格形式展示所有题目（含 U 型和 P 型），含 display_id、类型、所有者字段。
+
+后端新增 `GET /api/v1/admin/problems` 端点，依次通过 `authMiddleware` 和 `adminMiddleware` 保护，返回全量题目列表（不默认筛选 type='P'），额外返回 `owner_username` 字段。
+
+#### Scenario: 管理员访问题目管理
+- **WHEN** 已登录管理员访问 `/admin/problems`
+- **THEN** 系统显示所有类型的题目列表，包含 display_id、标题、类型（U/P 标签）、所有者、难度、分类、创建时间等字段
+
+#### Scenario: 管理员列表支持分页和筛选
+- **WHEN** 管理员调用 `GET /api/v1/admin/problems?page=1&limit=20&difficulty=easy`
+- **THEN** 系统返回分页的题目列表，支持与普通列表相同的 difficulty、keyword、category_id 筛选参数
+
+#### Scenario: 非管理员拒绝访问
+- **WHEN** 普通用户调用 `GET /api/v1/admin/problems`
+- **THEN** 系统返回 HTTP 403
+
+### Requirement: 管理员可创建题目
+
+（无变更，保持原有规范）
+
+### Requirement: 管理员可编辑题目
+
+（无变更，保持原有规范）
+
+### Requirement: 管理员可删除题目
+
+（无变更，保持原有规范）

--- a/openspec/changes/enrich-admin-api/specs/admin-submission-detail/spec.md
+++ b/openspec/changes/enrich-admin-api/specs/admin-submission-detail/spec.md
@@ -1,0 +1,43 @@
+## Purpose
+
+定义管理员提交详情查看和删除 API 规范，允许管理员查看任意提交的完整详情和删除违规提交。
+
+## ADDED Requirements
+
+### Requirement: 管理员可查看任意提交详情
+
+系统 SHALL 在 `GET /api/v1/admin/submissions/:id` 端点提供任意提交的完整详情（含源代码），该端点依次通过 `authMiddleware` 和 `adminMiddleware` 保护。
+
+#### Scenario: 管理员查看提交详情
+
+- **WHEN** 已登录管理员调用 `GET /api/v1/admin/submissions/:id`
+- **THEN** 系统返回提交的所有字段，包括 `code`（源代码）、`result` 评测结果、`user_id`、`problem_id` 等
+
+#### Scenario: 查看不存在的提交
+
+- **WHEN** 管理员调用 `GET /api/v1/admin/submissions/:missing-id`
+- **THEN** 系统返回 HTTP 404
+
+#### Scenario: 非管理员拒绝访问
+
+- **WHEN** 普通用户调用 `GET /api/v1/admin/submissions/:id`
+- **THEN** 系统返回 HTTP 403
+
+### Requirement: 管理员可删除提交记录
+
+系统 SHALL 在 `DELETE /api/v1/admin/submissions/:id` 端点提供删除提交记录功能，该端点依次通过 `authMiddleware` 和 `adminMiddleware` 保护。
+
+#### Scenario: 管理员成功删除提交
+
+- **WHEN** 已登录管理员调用 `DELETE /api/v1/admin/submissions/:id`
+- **THEN** 系统删除该提交记录及关联的评测结果，返回 HTTP 204
+
+#### Scenario: 删除不存在的提交
+
+- **WHEN** 管理员调用 `DELETE /api/v1/admin/submissions/:missing-id`
+- **THEN** 系统返回 HTTP 404
+
+#### Scenario: 非管理员删除提交
+
+- **WHEN** 普通用户调用 `DELETE /api/v1/admin/submissions/:id`
+- **THEN** 系统返回 HTTP 403

--- a/openspec/changes/enrich-admin-api/specs/admin-user-management/spec.md
+++ b/openspec/changes/enrich-admin-api/specs/admin-user-management/spec.md
@@ -1,0 +1,108 @@
+## Purpose
+
+定义 Neuro OJ 管理后台用户管理页面规范。该页面在 `/admin/users` 路径提供，允许管理员查看和管理平台用户。
+
+本文档为基础规范的 delta 补充，在原有需求基础上增加搜索与筛选能力。
+
+## MODIFIED Requirements
+
+### Requirement: 管理员可查看用户列表（增强）
+
+系统 SHALL 在 `/admin/users` 路径提供用户列表页面，支持分页展示。后端 `GET /api/v1/admin/users` 端点增强支持按关键字搜索和按角色、日期范围筛选。
+
+#### Scenario: 管理员访问用户列表
+
+- **WHEN** 已登录管理员访问 `/admin/users`
+- **THEN** 系统显示用户列表，包含用户名、邮箱、角色、注册时间等字段
+
+#### Scenario: 用户列表分页
+
+- **WHEN** 用户总数超过每页显示数量
+- **THEN** 系统显示分页控件，管理员可切换页码
+
+#### Scenario: 用户列表加载失败
+
+- **WHEN** 加载用户列表时网络错误
+- **THEN** 系统显示错误提示和重试按钮
+
+#### Scenario: 按关键字搜索用户
+
+- **WHEN** 管理员传入 `keyword` 查询参数调用 `GET /api/v1/admin/users?keyword=john`
+- **THEN** 系统返回用户名或邮箱中包含 "john" 的用户列表
+
+#### Scenario: 按角色筛选用户
+
+- **WHEN** 管理员传入 `role` 查询参数调用 `GET /api/v1/admin/users?role=admin`
+- **THEN** 系统仅返回角色为 `admin` 的用户列表
+
+#### Scenario: 按注册日期范围筛选
+
+- **WHEN** 管理员传入 `from` 和 `to` 参数调用 `GET /api/v1/admin/users?from=2026-01-01&to=2026-06-01`
+- **THEN** 系统仅返回在指定日期范围内注册的用户
+
+#### Scenario: 组合筛选
+
+- **WHEN** 管理员同时传入 `keyword`、`role`、`from`、`to` 中多个参数
+- **THEN** 系统应用所有参数的交集进行筛选
+
+### Requirement: 管理员可切换用户角色
+
+系统 SHALL 允许管理员将任意用户的角色在 `admin` 和 `user` 之间切换。
+
+#### Scenario: 管理员将用户提升为管理员
+
+- **WHEN** 管理员点击用户的"设为管理员"按钮并确认
+- **THEN** 系统调用 `PATCH /api/v1/admin/users/:id/role`，成功后该用户角色更新为 admin，页面刷新
+
+#### Scenario: 管理员将管理员降级为普通用户
+
+- **WHEN** 管理员点击某 admin 用户的"设为用户"按钮并确认
+- **THEN** 系统调用 `PATCH /api/v1/admin/users/:id/role`，成功后该用户角色更新为 user，页面刷新
+
+#### Scenario: 角色切换失败
+
+- **WHEN** 角色切换 API 调用失败（如试图修改自己的角色）
+- **THEN** 系统显示错误提示，角色状态保持不变
+
+## ADDED Requirements
+
+### Requirement: 管理员可编辑用户资料
+
+系统 SHALL 提供 `PUT /api/v1/admin/users/:id` 端点，允许管理员编辑任意用户的 `email` 和 `bio` 字段（均为可选，至少提供一个）。
+
+此端点 MUST 依次通过 `authMiddleware` 和 `adminMiddleware` 保护。
+
+#### Scenario: 管理员成功更新用户邮箱
+
+- **WHEN** 管理员调用 `PUT /api/v1/admin/users/:id`，JSON body 包含 `{"email": "new@example.com"}`
+- **THEN** 系统更新该用户的 email 字段，返回 200 与更新后的用户信息
+
+#### Scenario: 管理员成功更新用户 bio
+
+- **WHEN** 管理员调用 `PUT /api/v1/admin/users/:id`，JSON body 包含 `{"bio": "新简介"}`
+- **THEN** 系统更新该用户的 bio 字段，返回 200
+
+#### Scenario: 管理员同时更新 email 和 bio
+
+- **WHEN** 管理员调用 `PUT /api/v1/admin/users/:id`，JSON body 同时包含 `email` 和 `bio`
+- **THEN** 系统同时更新两个字段，返回 200
+
+#### Scenario: 更新为已存在的邮箱
+
+- **WHEN** 管理员调用 `PUT /api/v1/admin/users/:id`，email 已被其他用户使用
+- **THEN** 系统返回 HTTP 409，提示 "邮箱已被注册"
+
+#### Scenario: 编辑不存在的用户
+
+- **WHEN** 管理员调用 `PUT /api/v1/admin/users/:missing-id`
+- **THEN** 系统返回 HTTP 404
+
+#### Scenario: 未提供任何可更新字段
+
+- **WHEN** 管理员调用 `PUT /api/v1/admin/users/:id`，JSON body 为空或不包含 email 和 bio
+- **THEN** 系统返回 HTTP 400，提示 "至少需要提供一个可更新字段"
+
+#### Scenario: 非管理员拒绝访问
+
+- **WHEN** 普通用户调用 `PUT /api/v1/admin/users/:id`
+- **THEN** 系统返回 HTTP 403

--- a/openspec/changes/enrich-admin-api/tasks.md
+++ b/openspec/changes/enrich-admin-api/tasks.md
@@ -28,8 +28,8 @@
 
 ## 6. 实现管理员编辑用户资料
 
-- [ ] 6.1 在 `services/users.ts` 中新增 `adminUpdateUserProfile()` 函数，支持更新指定用户的 email 和 bio，包含邮箱唯一性检查和格式校验
-- [ ] 6.2 在 `routes/admin.ts` 中添加 `PUT /users/:id` 路由，解析 email/bio 字段，调用 adminUpdateUserProfile
+- [x] 6.1 在 `services/users.ts` 中新增 `adminUpdateUserProfile()` 函数，支持更新指定用户的 email 和 bio，包含邮箱唯一性检查和格式校验
+- [x] 6.2 在 `routes/admin.ts` 中添加 `PUT /users/:id` 路由，解析 email/bio 字段，调用 adminUpdateUserProfile
 
 ## 7. 添加测试
 

--- a/openspec/changes/enrich-admin-api/tasks.md
+++ b/openspec/changes/enrich-admin-api/tasks.md
@@ -1,0 +1,41 @@
+## 1. 重构管理路由组织结构
+
+- [x] 1.1 创建 `routes/admin.ts`，使用路由组级 `authMiddleware` + `adminMiddleware` 中间件，将现有 adminAuth（用户列表/角色管理）路由迁移到 admin.ts
+- [x] 1.2 将现有 adminSubmissions（提交列表）路由从 `routes/submissions.ts` 迁移到 `routes/admin.ts`
+- [x] 1.3 更新 `app.ts` 中的路由挂载：移除 `adminAuth` 和 `adminSubmissions` 的单独挂载，统一改为 `app.route("/api/v1/admin", admin)`
+- [x] 1.4 更新 `routes/auth.ts` 和 `routes/submissions.ts`，删除已迁移的 admin 相关导出
+
+## 2. 实现仪表盘统计数据 API
+
+- [x] 2.1 创建 `services/dashboard.ts`，实现 `getDashboardStats()` 服务函数：执行 4 次独立查询聚合用户数、题目数、提交数、24h 统计数据
+- [x] 2.2 在 `routes/admin.ts` 中添加 `GET /dashboard/stats` 路由，调用 dashboard 服务返回统计 JSON
+
+## 3. 增强管理员用户列表支持搜索筛选
+
+- [x] 3.1 修改 `services/auth.ts` 中的 `listUsers()` 函数，添加 `keyword`（username/email ILIKE 搜索）、`role` 筛选、`from`/`to` 日期范围参数
+- [x] 3.2 更新 `routes/admin.ts` 中 `GET /users` 路由，解析 keyword/role/from/to 查询参数并传递给服务层
+
+## 4. 实现管理员专属题目列表
+
+- [x] 4.1 在 `services/problems.ts` 中新增 `listAllProblems()` 函数，返回全量题目（不默认筛选 type='P'），额外返回 owner_username（JOIN users 表）
+- [x] 4.2 在 `routes/admin.ts` 中添加 `GET /problems` 路由，调用 listAllProblems 返回全量题目列表
+
+## 5. 实现管理员提交详情与删除
+
+- [x] 5.1 在 `routes/admin.ts` 中添加 `GET /submissions/:id` 路由，调用 `getSubmission()` 但不传入 userId（跳过所有权检查）
+- [x] 5.2 在 `services/submissions.ts` 中新增 `deleteSubmission()` 函数：硬删除提交记录及关联评测结果（ON DELETE CASCADE）
+- [x] 5.3 在 `routes/admin.ts` 中添加 `DELETE /submissions/:id` 路由，调用 deleteSubmission 服务
+
+## 6. 实现管理员编辑用户资料
+
+- [ ] 6.1 在 `services/users.ts` 中新增 `adminUpdateUserProfile()` 函数，支持更新指定用户的 email 和 bio，包含邮箱唯一性检查和格式校验
+- [ ] 6.2 在 `routes/admin.ts` 中添加 `PUT /users/:id` 路由，解析 email/bio 字段，调用 adminUpdateUserProfile
+
+## 7. 添加测试
+
+- [x] 7.1 添加仪表盘统计 API 的测试用例
+- [x] 7.2 添加管理员题目列表 API 的测试用例
+- [x] 7.3 添加用户搜索筛选功能的测试用例
+- [x] 7.4 添加管理员编辑用户资料 API 的测试用例
+- [x] 7.5 添加管理员提交详情和删除 API 的测试用例
+- [x] 7.6 运行 `deno task test` 确认全部测试通过（32 passed, 0 failed）


### PR DESCRIPTION
## 变更内容

重构并丰富了管理后台后端 API：

### 新增端点
| 方法 | 路径 | 说明 |
|------|------|------|
| GET | `/api/v1/admin/dashboard/stats` | 平台统计仪表盘 |
| GET | `/api/v1/admin/problems` | 管理员全量题目列表 |
| PUT | `/api/v1/admin/users/:id` | 管理员编辑用户资料 |
| GET | `/api/v1/admin/submissions/:id` | 查看任意提交详情 |
| DELETE | `/api/v1/admin/submissions/:id` | 删除提交记录 |

### 增强端点
| 方法 | 路径 | 新增参数 |
|------|------|---------|
| GET | `/api/v1/admin/users` | `keyword`, `role`, `from`, `to` |

### 重构
- 将分散在 `auth.ts`/`submissions.ts` 中的管理路由集中到 `routes/admin.ts`

### 测试
- 32 passed, 0 failed
- 新增 12 个路由层测试用例