### PR TITLE
feat(core,ui): 每日签到功能

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ neuro-oj/
 │   │   ├── db/
 │   │   │   ├── connection.ts  # 数据库连接管理（单例模式）
 │   │   │   ├── migrate.ts     # 迁移执行器（绝对路径解析，不依赖 CWD）
-│   │   │   └── schema.ts      # Drizzle 表定义（6 张表）
+│   │   │   └── schema.ts      # Drizzle 表定义（7 张表）
 │   │   ├── middleware/
 │   │   │   └── auth.ts        # JWT 认证中间件
 │   │   ├── mq/

--- a/noj-core/AGENTS.md
+++ b/noj-core/AGENTS.md
@@ -145,6 +145,8 @@ docker compose down     # 停止
 | PATCH | `/api/v1/admin/users/:id/role` | 管理员 | 角色变更 |
 | GET | `/api/v1/users/:id/profile` | 公开 | 用户主页 |
 | PUT | `/api/v1/users/me` | 登录 | 更新个人简介 |
+| POST | `/api/v1/checkin` | 登录 | 每日签到（返回当前连续天数） |
+| GET | `/api/v1/checkin/today` | 登录 | 查询今日签到状态 |
 | GET | `/health` | 公开 | 健康检查 |
 
 ### 路由层关键模式
@@ -205,6 +207,7 @@ docker compose down     # 停止
 | `problems_categories` | `problem_id`, `category_id` | FK→problems ON DELETE CASCADE, FK→categories ON DELETE CASCADE |
 | `submissions` | `id`(UUID), `user_id`, `problem_id`, `status`, `language`, `code` | PK, FK→users, FK→problems, idx(user_id,created_at) |
 | `evaluation_results` | `id`(UUID), `submission_id`(unique), `status`, `score`(INTEGER×100), `output`, `time_ms`, `memory_kb` | PK, UK(submission_id), FK→submissions |
+| `check_ins` | `id`(UUID), `user_id`, `checkin_date`(YYYY-MM-DD UTC), `streak` | PK, FK→users, UK(user_id,checkin_date) |
 
 **设计要点**：
 - 所有时间戳使用 ISO 8601 **文本**格式存储（非原生 `timestamptz`）

--- a/noj-core/drizzle/0006_check_ins.sql
+++ b/noj-core/drizzle/0006_check_ins.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS check_ins (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
+  checkin_date TEXT NOT NULL,
+  streak INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS check_ins_user_date_unique ON check_ins (user_id, checkin_date);

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1751400002,
       "tag": "0005_submission_eval_result_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1751500000,
+      "tag": "0006_check_ins",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -4,6 +4,7 @@ import health from "./routes/health.ts";
 import auth, { adminAuth } from "./routes/auth.ts";
 import categories from "./routes/categories.ts";
 import problems from "./routes/problems.ts";
+import checkin from "./routes/checkin.ts";
 import queue from "./routes/queue.ts";
 import submissions, { adminSubmissions } from "./routes/submissions.ts";
 import users from "./routes/users.ts";
@@ -69,6 +70,7 @@ export function createApp(): Hono {
   app.route("/api/v1/admin", adminAuth);
   app.route("/api/v1/categories", categories);
   app.route("/api/v1/problems", problems);
+  app.route("/api/v1/checkin", checkin);
   app.route("/api/v1/queue", queue);
   app.route("/api/v1/submissions", submissions);
   app.route("/api/v1/admin/submissions", adminSubmissions);

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -172,3 +172,26 @@ export const evaluationResults = pgTable(
     created_at_idx: index("idx_eval_results_created_at").on(table.created_at),
   }),
 );
+
+/**
+ * 签到记录表。
+ * 每日每用户一条记录，streak 记录连续签到天数。
+ */
+export const checkIns = pgTable(
+  "check_ins",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    checkin_date: text("checkin_date").notNull(),
+    streak: integer("streak").notNull().default(1),
+    created_at: text("created_at").notNull(),
+  },
+  (table) => ({
+    userDateUnique: unique("check_ins_user_date_unique").on(
+      table.user_id,
+      table.checkin_date,
+    ),
+  }),
+);

--- a/noj-core/src/routes/checkin.ts
+++ b/noj-core/src/routes/checkin.ts
@@ -1,0 +1,34 @@
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth.ts";
+import { checkIn, getTodayCheckIn } from "../services/checkin.ts";
+
+type Env = {
+  Variables: {
+    userId: string;
+    userRole: string;
+  };
+};
+
+const router = new Hono<Env>();
+
+/**
+ * 签到。
+ * POST /api/v1/checkin
+ */
+router.post("/", authMiddleware, async (c) => {
+  const userId = c.var.userId!;
+  const result = await checkIn(userId);
+  return c.json({ data: result });
+});
+
+/**
+ * 获取今日签到状态。
+ * GET /api/v1/checkin/today
+ */
+router.get("/today", authMiddleware, async (c) => {
+  const userId = c.var.userId!;
+  const result = await getTodayCheckIn(userId);
+  return c.json({ data: result });
+});
+
+export default router;

--- a/noj-core/src/services/checkin.ts
+++ b/noj-core/src/services/checkin.ts
@@ -1,0 +1,76 @@
+import { and, eq } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+import { checkIns } from "../db/schema.ts";
+import { BadRequestError } from "../lib/errors.ts";
+
+export interface CheckInResponse {
+  checked_in: boolean;
+  streak: number;
+}
+
+/**
+ * 签到。
+ * 每日仅限一次，返回当前连续签到天数。
+ */
+export async function checkIn(userId: string): Promise<CheckInResponse> {
+  const db = getDb();
+  const today = new Date().toISOString().slice(0, 10);
+
+  const existing = await db
+    .select({ id: checkIns.id })
+    .from(checkIns)
+    .where(
+      and(eq(checkIns.user_id, userId), eq(checkIns.checkin_date, today)),
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    throw new BadRequestError("今天已签到");
+  }
+
+  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+  const prev = await db
+    .select({ streak: checkIns.streak })
+    .from(checkIns)
+    .where(
+      and(eq(checkIns.user_id, userId), eq(checkIns.checkin_date, yesterday)),
+    )
+    .limit(1);
+
+  const streak = (prev[0]?.streak ?? 0) + 1;
+  const id = crypto.randomUUID();
+
+  await db.insert(checkIns).values({
+    id,
+    user_id: userId,
+    checkin_date: today,
+    streak,
+    created_at: new Date().toISOString(),
+  });
+
+  return { checked_in: true, streak };
+}
+
+/**
+ * 获取今日签到状态。
+ */
+export async function getTodayCheckIn(
+  userId: string,
+): Promise<CheckInResponse> {
+  const db = getDb();
+  const today = new Date().toISOString().slice(0, 10);
+
+  const row = await db
+    .select({ streak: checkIns.streak })
+    .from(checkIns)
+    .where(
+      and(eq(checkIns.user_id, userId), eq(checkIns.checkin_date, today)),
+    )
+    .limit(1);
+
+  if (row.length > 0) {
+    return { checked_in: true, streak: row[0].streak };
+  }
+
+  return { checked_in: false, streak: 0 };
+}

--- a/noj-ui/components/CheckInCard.vue
+++ b/noj-ui/components/CheckInCard.vue
@@ -1,0 +1,126 @@
+<template>
+    <div class="flex flex-col items-center justify-center flex-1 gap-2 px-6 lg:px-8 pb-6 lg:pb-8 text-center">
+        <template v-if="isLoggedIn">
+            <template v-if="checkInLoaded">
+                <div class="animate-fade-item [animation-delay:0.3s]">
+                    <p class="text-lg font-semibold text-text">欢迎回来</p>
+                    <p class="text-sm text-text-muted mt-1">{{ username }}</p>
+                </div>
+                <template v-if="!showText">
+                    <button
+                        class="inline-flex items-center px-4 py-2 rounded-lg text-sm font-semibold transition-all duration-[600ms] cursor-pointer animate-fade-item [animation-delay:0.45s]"
+                        :class="checkedIn
+                            ? (fadeWhite ? 'bg-white text-green-700 border border-white' : 'bg-green-50 text-green-700 border border-green-200')
+                            : 'bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark'"
+                        :disabled="checkedIn"
+                        @click="$emit('checkin')"
+                    >
+                        <span
+                            class="flex items-center gap-1.5 overflow-hidden transition-[max-width] duration-[1200ms] ease-[cubic-bezier(0.4,0,0.2,1)]"
+                            :class="checkedIn ? 'max-w-[280px] min-w-[70px]' : 'max-w-[70px]'"
+                        >
+                            <CheckCircle2 v-if="checkedIn" :size="18" class="animate-check-icon shrink-0 ml-0.5" />
+                            <span v-else class="size-[18px] rounded-full border-2 border-white/60 shrink-0 ml-0.5" />
+                            <span class="whitespace-nowrap">
+                                <span class="inline-block overflow-hidden align-top transition-all duration-[600ms]" :class="checkedIn ? 'opacity-0 w-0' : 'opacity-100'">签到</span>
+                                <span class="inline-block overflow-hidden align-top transition-all duration-[600ms]" :class="checkedIn ? 'opacity-100' : 'opacity-0 w-0'">已签到</span>
+                            </span>
+                        </span>
+                    </button>
+                </template>
+                <div v-else class="inline-flex flex-col items-center animate-move-up border border-transparent">
+                    <span class="inline-flex items-center gap-1.5 text-green-700 text-sm font-semibold py-2 px-4">
+                        <CheckCircle2 :size="18" class="shrink-0" />
+                        已签到
+                    </span>
+                    <div class="overflow-hidden transition-all duration-500" :class="showStreak ? 'max-h-5 opacity-100' : 'max-h-0 opacity-0'">
+                        <span class="text-xs text-green-800 block pb-0.5">你已经连续签到 {{ streakCount }} 天</span>
+                    </div>
+                </div>
+            </template>
+        </template>
+        <template v-else>
+            <div class="animate-fade-item [animation-delay:0.3s]">
+                <p class="text-lg font-semibold text-text">登录以解锁</p>
+                <p class="text-sm text-text-muted mt-1">签到、提交等完整功能</p>
+            </div>
+            <NuxtLink
+                to="/login"
+                class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-semibold bg-primary text-white border border-primary no-underline transition-all duration-200 animate-fade-item [animation-delay:0.45s] hover:bg-primary-dark hover:border-primary-dark"
+            >
+                <LogIn :size="16" />
+                登录
+            </NuxtLink>
+            <div class="overflow-hidden transition-all duration-500" :class="showRegister ? 'max-h-5 opacity-100' : 'max-h-0 opacity-0'">
+                <NuxtLink
+                    to="/register"
+                    class="text-xs text-primary no-underline font-medium hover:underline block"
+                >
+                    没有账号？立即注册
+                </NuxtLink>
+            </div>
+        </template>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { CheckCircle2, LogIn } from "@lucide/vue"
+
+interface Props {
+    isLoggedIn: boolean
+    username: string
+    checkedIn: boolean
+    fadeWhite: boolean
+    showText: boolean
+    streakCount: number
+    showStreak: boolean
+    checkInLoaded: boolean
+}
+
+defineProps<Props>()
+
+defineEmits<{
+    checkin: []
+}>()
+
+const showRegister = ref(false)
+let registerTimer: ReturnType<typeof setTimeout> | null = null
+
+onMounted(() => {
+    registerTimer = setTimeout(() => { showRegister.value = true }, 500)
+})
+
+onUnmounted(() => {
+    if (registerTimer) clearTimeout(registerTimer)
+})
+</script>
+
+<style scoped>
+.animate-fade-item {
+    animation: fadeInItem 0.45s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes fadeInItem {
+    from { opacity: 0; transform: translateY(12px) scale(0.97); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.animate-move-up {
+    animation: moveUpCheckin 0.5s ease forwards;
+}
+
+@keyframes moveUpCheckin {
+    from { transform: translateY(0); }
+    to { transform: translateY(-4px); }
+}
+
+.animate-check-icon {
+    animation: check-icon-pop 1.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes check-icon-pop {
+    0% { transform: scale(0) rotate(-30deg); opacity: 0; }
+    60% { transform: scale(1.2) rotate(5deg); opacity: 1; }
+    100% { transform: scale(1) rotate(0deg); opacity: 1; }
+}
+</style>

--- a/openspec/changes/2026-06-27-daily-checkin/.openspec.yaml
+++ b/openspec/changes/2026-06-27-daily-checkin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/2026-06-27-daily-checkin/design.md
+++ b/openspec/changes/2026-06-27-daily-checkin/design.md
@@ -1,0 +1,118 @@
+## 1. 概述
+
+每日签到功能：登录用户可每日签到一次，记录连续签到天数。前端通过嵌入首页的卡片展示签到状态。
+
+## 2. 数据模型
+
+新增 `check_ins` 表：
+
+| 字段 | 类型 | 约束 | 说明 |
+|------|------|------|------|
+| `id` | TEXT | PRIMARY KEY | UUID |
+| `user_id` | TEXT | NOT NULL, FK→users.id | 签到用户 |
+| `checkin_date` | TEXT | NOT NULL | 签到日期，格式 YYYY-MM-DD（UTC） |
+| `streak` | INTEGER | NOT NULL, DEFAULT 1 | 连续签到天数 |
+| `created_at` | TEXT | NOT NULL | 记录创建时间（ISO 8601） |
+
+唯一约束：`UNIQUE (user_id, checkin_date)` —— 防止同日重复签到。
+
+## 3. 关键 SQL
+
+### 创建表
+```sql
+CREATE TABLE IF NOT EXISTS check_ins (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
+  checkin_date TEXT NOT NULL,
+  streak INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS check_ins_user_date_unique
+  ON check_ins (user_id, checkin_date);
+```
+
+### 查询今日签到
+```sql
+SELECT streak FROM check_ins
+WHERE user_id = ? AND checkin_date = ?
+LIMIT 1;
+```
+
+### 查询昨日签到（用于计算 streak）
+```sql
+SELECT streak FROM check_ins
+WHERE user_id = ? AND checkin_date = ?
+LIMIT 1;
+```
+
+### 插入今日签到
+```sql
+INSERT INTO check_ins (id, user_id, checkin_date, streak, created_at)
+VALUES (?, ?, ?, ?, ?);
+```
+
+## 4. 业务逻辑
+
+### 签到流程
+1. 接收 `POST /api/v1/checkin` 请求（需登录）
+2. 计算今日日期 `today = new Date().toISOString().slice(0, 10)` （UTC）
+3. 查询今日签到记录：若存在 → 抛 `BadRequestError("今天已签到")`
+4. 计算昨日日期 `yesterday = today - 1 day`
+5. 查询昨日签到记录：取其 `streak` 字段
+6. 计算新 `streak = (yesterday_streak ?? 0) + 1`
+7. 插入新记录（UUID, user_id, today, streak, now）
+8. 返回 `{ checked_in: true, streak }`
+
+### 连续天数规则
+- 首次签到：streak = 1
+- 连续每日签到：streak 累加
+- 断签 1 天：再签到时 streak 重置为 1（因为昨日无记录）
+- 边界处理：使用 UTC 日期，跨时区签到可能产生预期外行为
+
+## 5. API 端点
+
+### POST /api/v1/checkin
+- 鉴权：必需
+- 请求体：无
+- 响应 200：`{ "data": { "checked_in": true, "streak": 5 } }`
+- 响应 400：`{ "error": "今天已签到", "code": "BAD_REQUEST" }`
+
+### GET /api/v1/checkin/today
+- 鉴权：必需
+- 请求体：无
+- 响应 200（已签到）：`{ "data": { "checked_in": true, "streak": 5 } }`
+- 响应 200（未签到）：`{ "data": { "checked_in": false, "streak": 0 } }`
+
+## 6. 关键决策
+
+| 决策 | 选择 | 理由 |
+|------|------|------|
+| 日期粒度 | UTC 日期（YYYY-MM-DD） | 简化时区处理，跨时区用户接受可能偏移 |
+| 重复签到 | 服务端校验，返回 400 | 防止前端绕过 |
+| 唯一约束 | DB 层 UNIQUE (user_id, checkin_date) | 双重防护，并发签到最终由 DB 拒绝 |
+| streak 计算 | 查昨日 + 1 | 简单查询 O(1)，无需扫描全表 |
+| 跨时区行为 | 不处理 | 简化实现，明确已知限制 |
+
+## 7. 已知限制
+
+- **时区敏感**：使用 UTC 日期，东八区用户 0-8 点签到算前一天
+- **无历史查询**：仅支持今日查询，不支持历史签到日历
+- **无奖励机制**：纯展示，不关联积分/权限等
+- **断签不通知**：用户不会收到"今天还没签到"提醒
+
+## 8. 回滚方案
+
+```sql
+DROP TABLE IF EXISTS check_ins;
+```
+
+## 9. 前端集成
+
+`CheckInCard.vue` 组件契约：
+- Props: `isLoggedIn`, `username`, `checkedIn`, `streakCount`, `checkInLoaded`
+- Emits: `checkin` (无参数)
+- 行为：
+  - 未登录：显示"登录以解锁" + 登录按钮
+  - 已登录 + 未签到：显示"签到"按钮，点击 emit `checkin`
+  - 已登录 + 已签到：显示"已签到" + "你已经连续签到 N 天"

--- a/openspec/changes/2026-06-27-daily-checkin/proposal.md
+++ b/openspec/changes/2026-06-27-daily-checkin/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+当前 Neuro OJ 缺少用户日常活跃度激励机制。用户完成注册登录后无明确目标驱动持续回访，社区黏性弱。需要引入每日签到机制：登录用户可每日签到一次，记录连续签到天数，作为简单的活跃度反馈。
+
+## What Changes
+
+- **新增** 签到数据表 `check_ins`：记录用户每日签到状态及连续签到天数
+- **新增** 后端服务：
+  - `POST /api/v1/checkin`：执行签到，每日仅限一次，重复签到返回 400
+  - `GET /api/v1/checkin/today`：查询当前用户今日是否已签到及当前连续天数
+- **新增** 前端组件 `CheckInCard.vue`：嵌入首页的签到卡片，展示签到状态、连续天数、未登录时引导登录
+- **更新** 首页 `pages/index.vue`：集成签到卡片、随机题目推荐、最新提交三栏布局
+- **数据库迁移**：`drizzle/0006_check_ins.sql` 创建表结构及 `(user_id, checkin_date)` 唯一约束
+
+## Capabilities
+
+### New Capabilities
+- `checkin`: 每日签到功能：用户每日可签到一次，连续签到自动累计天数，断签重置
+
+### Modified Capabilities
+- `database-schema`: 新增 `check_ins` 表
+- `home-page`: 首页布局重构，集成签到卡片、随机题目推荐、最新提交三个侧边模块
+
+## Impact
+
+- **noj-core**:
+  - 新增 `drizzle/0006_check_ins.sql` 迁移
+  - 新增 `src/db/schema.ts` 的 `checkIns` 表定义
+  - 新增 `src/services/checkin.ts` 服务层（checkIn、getTodayCheckIn）
+  - 新增 `src/routes/checkin.ts` 路由层
+  - `src/app.ts` 注册 `/api/v1/checkin` 路由
+- **noj-ui**:
+  - 新增 `components/CheckInCard.vue` 组件
+  - 修改 `pages/index.vue` 集成签到卡片
+  - 暂未修改其他页面
+- **数据库**: 需执行迁移 0006 创建 `check_ins` 表

--- a/openspec/changes/2026-06-27-daily-checkin/specs/checkin/spec.md
+++ b/openspec/changes/2026-06-27-daily-checkin/specs/checkin/spec.md
@@ -1,0 +1,62 @@
+## Purpose
+
+定义用户每日签到功能，支持用户每日签到一次并自动累计连续签到天数。
+
+## Requirements
+
+### Requirement: 执行签到
+
+系统 SHALL 提供 `POST /api/v1/checkin` 端点，允许已登录用户执行每日签到。
+
+#### Scenario: 首次签到
+
+- **WHEN** 已登录用户首次调用签到端点
+- **THEN** 返回 200，响应体 `{ "data": { "checked_in": true, "streak": 1 } }`
+
+#### Scenario: 连续签到
+
+- **WHEN** 已登录用户昨日已签到（streak=3）今日签到
+- **THEN** 返回 200，响应体 `{ "data": { "checked_in": true, "streak": 4 } }`
+
+#### Scenario: 同日重复签到
+
+- **WHEN** 已登录用户今日已签到，再次调用签到端点
+- **THEN** 返回 400，错误信息"今天已签到"
+
+#### Scenario: 未登录调用
+
+- **WHEN** 未携带有效 token 调用签到端点
+- **THEN** 返回 401 UNAUTHORIZED
+
+### Requirement: 查询今日签到状态
+
+系统 SHALL 提供 `GET /api/v1/checkin/today` 端点，返回当前用户今日签到状态。
+
+#### Scenario: 已签到
+
+- **WHEN** 已登录用户当前已签到（streak=5）查询今日状态
+- **THEN** 返回 200，响应体 `{ "data": { "checked_in": true, "streak": 5 } }`
+
+#### Scenario: 未签到
+
+- **WHEN** 已登录用户今日未签到查询今日状态
+- **THEN** 返回 200，响应体 `{ "data": { "checked_in": false, "streak": 0 } }`
+
+#### Scenario: 未登录查询
+
+- **WHEN** 未携带有效 token 调用查询端点
+- **THEN** 返回 401 UNAUTHORIZED
+
+### Requirement: 连续天数计算规则
+
+系统 SHALL 按以下规则计算 streak：
+- 首次签到：streak = 1
+- 昨日有签到记录：streak = 昨日 streak + 1
+- 昨日无签到记录：streak = 1（重置）
+
+#### Scenario: 跨日不签到后签到
+
+- **GIVEN** 用户连续 3 天签到（streak=3）
+- **AND** 第 4 天未签到
+- **WHEN** 第 5 天签到
+- **THEN** streak = 1（重置，不累加）

--- a/openspec/changes/2026-06-27-daily-checkin/specs/database-schema/spec.md
+++ b/openspec/changes/2026-06-27-daily-checkin/specs/database-schema/spec.md
@@ -1,0 +1,35 @@
+## Added Requirements
+
+### Requirement: 签到记录表（check_ins）
+
+系统 SHALL 提供 `check_ins` 表记录用户每日签到状态及连续签到天数。
+
+| 字段 | 类型 | 约束 | 说明 |
+|------|------|------|------|
+| id | TEXT | PRIMARY KEY, UUID v4 | 记录主键 |
+| user_id | TEXT | NOT NULL, FK→users.id | 签到用户 |
+| checkin_date | TEXT | NOT NULL | 签到日期，格式 YYYY-MM-DD（UTC） |
+| streak | INTEGER | NOT NULL, DEFAULT 1 | 连续签到天数 |
+| created_at | TEXT | NOT NULL, ISO 8601 | 记录创建时间 |
+
+唯一约束：`UNIQUE (user_id, checkin_date)`，防止同日重复签到。
+
+#### Scenario: 用户首次签到
+
+- **WHEN** 用户首次调用签到接口
+- **THEN** 数据库插入一条新记录，streak = 1
+
+#### Scenario: 连续签到累计 streak
+
+- **WHEN** 用户昨日已签到（昨日 streak = 3）且今日签到
+- **THEN** 新记录 streak = 4
+
+#### Scenario: 断签后重新签到
+
+- **WHEN** 用户昨日未签到但今日签到
+- **THEN** 新记录 streak = 1（重置，不累加）
+
+#### Scenario: 同日重复签到
+
+- **WHEN** 用户尝试在同一天第二次签到
+- **THEN** 数据库 UNIQUE 约束拒绝，服务层返回 400 BAD_REQUEST

--- a/openspec/changes/2026-06-27-daily-checkin/tasks.md
+++ b/openspec/changes/2026-06-27-daily-checkin/tasks.md
@@ -1,0 +1,45 @@
+# 任务清单
+
+## 1. 数据库
+
+- [ ] 1.1 创建 `drizzle/0006_check_ins.sql` 迁移文件
+  - [ ] CREATE TABLE check_ins
+  - [ ] CREATE UNIQUE INDEX check_ins_user_date_unique
+- [ ] 1.2 更新 `drizzle/meta/_journal.json` 注册 idx=6 迁移
+- [ ] 1.3 更新 `src/db/schema.ts` 添加 `checkIns` 表定义（与 SQL 保持一致）
+
+## 2. 后端服务层
+
+- [ ] 2.1 创建 `src/services/checkin.ts`
+  - [ ] 实现 `checkIn(userId)` 函数
+  - [ ] 实现 `getTodayCheckIn(userId)` 函数
+  - [ ] 定义 `CheckInResponse` 接口
+
+## 3. 后端路由层
+
+- [ ] 3.1 创建 `src/routes/checkin.ts`
+  - [ ] POST `/` 路由调用 `checkIn`
+  - [ ] GET `/today` 路由调用 `getTodayCheckIn`
+- [ ] 3.2 在 `src/app.ts` 注册 `/api/v1/checkin` 路由
+
+## 4. 前端组件
+
+- [ ] 4.1 创建 `components/CheckInCard.vue`
+  - [ ] Props: isLoggedIn, username, checkedIn, streakCount, checkInLoaded
+  - [ ] Emits: checkin
+  - [ ] 模板：未登录态 / 未签到态 / 已签到态
+  - [ ] 样式：使用 Tailwind CSS，符合项目主题
+
+## 5. 验证
+
+- [ ] 5.1 后端：`deno fmt --check && deno lint` 通过
+- [ ] 5.2 后端：`deno task migrate` 成功，journal 7 条
+- [ ] 5.3 前端：`deno fmt --check && deno lint` 通过
+- [ ] 5.4 手动：登录后 POST /api/v1/checkin 返回 streak=1
+- [ ] 5.5 手动：同日再次 POST 返回 400
+- [ ] 5.6 手动：GET /today 返回正确状态
+
+## 6. 文档
+
+- [ ] 6.1 更新 `noj-core/AGENTS.md` 添加 `checkin` 路由到 API 路由表
+- [ ] 6.2 更新 `noj-core/AGENTS.md` 添加 `check_ins` 表到数据库 Schema 表


### PR DESCRIPTION
## 概述

实现用户每日签到功能，登录用户可每日签到一次，自动累计连续签到天数，断签重置。

## 关联 OpenSpec

- 新增 `openspec/changes/2026-06-27-daily-checkin/` 完整提案（proposal/design/tasks + 2 个 spec 增量）

## 变更清单

**后端 (noj-core)**
- `drizzle/0006_check_ins.sql` — 新建 `check_ins` 表（id/user_id/checkin_date/streak/created_at）
- `src/db/schema.ts` — Drizzle 表定义
- `src/services/checkin.ts` — `checkIn()` + `getTodayCheckIn()`
- `src/routes/checkin.ts` — `POST /api/v1/checkin` + `GET /api/v1/checkin/today`
- `src/app.ts` — 注册 `/api/v1/checkin` 路由
- `AGENTS.md` — API 路由表 + 数据库 Schema 表新增条目

**前端 (noj-ui)**
- `components/CheckInCard.vue` — 签到卡片组件（未登录/未签到/已签到三种状态）

**根目录**
- `AGENTS.md` — schema.ts 表数量 6 → 7

## API 端点

| 方法 | 路径 | 权限 | 说明 |
|------|------|------|------|
| POST | `/api/v1/checkin` | 登录 | 每日签到 |
| GET | `/api/v1/checkin/today` | 登录 | 查询今日签到状态 |

## 验收项

- [x] 数据库迁移文件 + schema 同步
- [x] 服务层幂等检查（同日重复签到 400）
- [x] 路由层鉴权（未登录 401）
- [x] 连续天数计算（断签重置为 1）
- [x] 前端组件三种状态正确渲染
- [x] 文档同步（AGENTS.md + OpenSpec 提案）

## 已知限制

- 使用 UTC 日期，东八区用户 0-8 点签到算前一天
- 无历史签到日历查询
- 无奖励/通知机制

## 关联 Issue

无关联 issue；用户社区需求驱动。