### PR TITLE
feat(core,ui): 用户榜单（Phase 1 收口）

### DIFF
--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -9,6 +9,7 @@ import checkin from "./routes/checkin.ts";
 import queue from "./routes/queue.ts";
 import submissions from "./routes/submissions.ts";
 import users from "./routes/users.ts";
+import rankings from "./routes/rankings.ts";
 import sse from "./routes/sse.ts";
 import { AppError } from "./lib/errors.ts";
 import { listJudgeImages } from "./services/judge-images.ts";
@@ -85,6 +86,7 @@ export function createApp(): Hono {
   app.route("/api/v1/queue", queue);
   app.route("/api/v1/submissions", submissions);
   app.route("/api/v1/users", users);
+  app.route("/api/v1/rankings", rankings);
   // 评测镜像公开列表（必须在 sse 路由之前注册，避免被 SSE 的 authMiddleware 拦截）
   app.get("/api/v1/judge-images", async (c) => {
     const items = await listJudgeImages();

--- a/noj-core/src/routes/rankings.ts
+++ b/noj-core/src/routes/rankings.ts
@@ -1,0 +1,60 @@
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth.ts";
+import { getGlobalRankings, getMyRanking } from "../services/rankings.ts";
+import { BadRequestError } from "../lib/errors.ts";
+
+type Env = {
+  Variables: {
+    userId: string;
+    userRole: string;
+  };
+};
+
+const router = new Hono<Env>();
+
+/**
+ * 全站用户榜单。
+ * GET /api/v1/rankings?page=1&limit=50
+ * 公开访问，无需认证。
+ */
+router.get("/", async (c) => {
+  const pageRaw = c.req.query("page") ?? "1";
+  const limitRaw = c.req.query("limit") ?? "50";
+
+  const page = Number.parseInt(pageRaw, 10);
+  if (!Number.isFinite(page)) {
+    throw new BadRequestError("page 必须为整数");
+  }
+
+  const limit = Number.parseInt(limitRaw, 10);
+  if (!Number.isFinite(limit)) {
+    throw new BadRequestError("limit 必须为整数");
+  }
+
+  const { data, total } = await getGlobalRankings({ page, limit });
+  const perPage = Math.min(Math.max(limit, 1), 100);
+  const totalPages = total === 0 ? 0 : Math.ceil(total / perPage);
+
+  return c.json({
+    data,
+    pagination: {
+      page,
+      per_page: perPage,
+      total,
+      total_pages: totalPages,
+    },
+  });
+});
+
+/**
+ * 当前登录用户的排名。
+ * GET /api/v1/rankings/me
+ * 需登录。未上榜（无通过记录）返回 null。
+ */
+router.get("/me", authMiddleware, async (c) => {
+  const userId = c.var.userId!;
+  const row = await getMyRanking(userId);
+  return c.json({ data: row });
+});
+
+export default router;

--- a/noj-core/src/routes/users.ts
+++ b/noj-core/src/routes/users.ts
@@ -3,6 +3,7 @@ import { authMiddleware } from "../middleware/auth.ts";
 import { parseJsonBody } from "../lib/request.ts";
 import { ValidationError } from "../lib/errors.ts";
 import { getUserProfile, updateUserProfile } from "../services/users.ts";
+import { getMyRanking } from "../services/rankings.ts";
 
 const users = new Hono<{ Variables: { userId: string; userRole: string } }>();
 
@@ -28,11 +29,14 @@ users.put("/me", authMiddleware, async (c) => {
  * 获取用户主页。
  * GET /api/v1/users/:id/profile
  * 公开访问，无需认证。
+ * 响应对象额外包含 `rank` 字段（number | null），表示该用户全站榜单排名。
  */
 users.get("/:id/profile", async (c) => {
   const userId = c.req.param("id") as string;
   const profile = await getUserProfile(userId);
-  return c.json({ data: profile }, 200);
+  // 追加 rank 字段：复用 rankings service 的 getMyRanking，确保排序逻辑一致
+  const ranking = await getMyRanking(userId);
+  return c.json({ data: { ...profile, rank: ranking?.rank ?? null } }, 200);
 });
 
 export default users;

--- a/noj-core/src/services/rankings.ts
+++ b/noj-core/src/services/rankings.ts
@@ -1,0 +1,201 @@
+import { sql } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+// deno-lint-ignore no-unused-vars -- referenced inside raw SQL templates
+import { evaluationResults } from "../db/schema.ts";
+// deno-lint-ignore no-unused-vars -- referenced inside raw SQL templates
+import { submissions } from "../db/schema.ts";
+// deno-lint-ignore no-unused-vars -- referenced inside raw SQL templates
+import { users } from "../db/schema.ts";
+import { BadRequestError } from "../lib/errors.ts";
+
+/**
+ * 用户榜单条目。
+ *
+ * rank 为 1-based 全局名次，由 SQL 的 ROW_NUMBER() 在排序键上计算，
+ * 保证跨分页的一致性（避免第 2 页首行 rank=1 等异常）。
+ */
+export interface RankingRow {
+  rank: number;
+  user_id: string;
+  username: string;
+  solved_count: number;
+  total_submissions: number;
+  /** 0–1 浮点数，保留 3 位小数（与 users.ts:getUserProfile 一致） */
+  acceptance_rate: number;
+}
+
+export interface RankingsPage {
+  data: RankingRow[];
+  total: number;
+}
+
+const RANKING_DEFAULT_LIMIT = 50;
+const RANKING_MAX_LIMIT = 100;
+
+/**
+ * 全站用户榜单。
+ *
+ * 排序键（确保稳定）：
+ * 1. solved_count DESC（独立通过的题目数）
+ * 2. acceptance_rate DESC（同题数下高效者靠前）
+ * 3. total_submissions ASC（同分下提交少者靠前，避免"刷提交"）
+ * 4. users.created_at ASC（最终 tiebreaker）
+ *
+ * 排除 root 系统用户（id='0'），仅展示至少有 1 道题通过的用户。
+ * rank 由 SQL ROW_NUMBER() 在排序键上计算，确保跨分页一致。
+ *
+ * @throws {BadRequestError} page < 1 或 limit < 1 时
+ */
+export async function getGlobalRankings(params: {
+  page: number;
+  limit?: number;
+}): Promise<RankingsPage> {
+  if (!Number.isInteger(params.page) || params.page < 1) {
+    throw new BadRequestError("page 必须为正整数");
+  }
+  const limit = params.limit ?? RANKING_DEFAULT_LIMIT;
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new BadRequestError("limit 必须为正整数");
+  }
+  const cappedLimit = Math.min(limit, RANKING_MAX_LIMIT);
+  const offset = (params.page - 1) * cappedLimit;
+
+  const db = getDb();
+
+  // 1. 聚合 + ROW_NUMBER() 计算 rank，单次 SQL 完成
+  const rows = await db.execute<{
+    user_id: string;
+    username: string;
+    total_submissions: number;
+    solved_count: number;
+    accepted: number;
+    acceptance_rate: number;
+    rank: number;
+  }>(sql`
+    SELECT
+      u.id AS user_id,
+      u.username,
+      COUNT(*)::int AS total_submissions,
+      COUNT(DISTINCT s.problem_id) FILTER (WHERE er.status = 'Accepted')::int AS solved_count,
+      COUNT(*) FILTER (WHERE er.status = 'Accepted')::int AS accepted,
+      CASE WHEN COUNT(*) = 0 THEN 0
+           ELSE ROUND(
+             (COUNT(*) FILTER (WHERE er.status = 'Accepted')::float / COUNT(*))::numeric,
+             3
+           )::float
+      END AS acceptance_rate,
+      ROW_NUMBER() OVER (
+        ORDER BY
+          COUNT(DISTINCT s.problem_id) FILTER (WHERE er.status = 'Accepted') DESC,
+          CASE WHEN COUNT(*) = 0 THEN 0
+               ELSE COUNT(*) FILTER (WHERE er.status = 'Accepted')::float / COUNT(*)
+          END DESC,
+          COUNT(*) ASC,
+          u.created_at ASC
+      )::int AS rank
+    FROM users u
+    INNER JOIN submissions s ON s.user_id = u.id
+    LEFT JOIN evaluation_results er ON er.submission_id = s.id
+    WHERE u.id <> '0' AND s.status = 'finished'
+    GROUP BY u.id, u.username, u.created_at
+    HAVING COUNT(*) FILTER (WHERE er.status = 'Accepted') > 0
+    ORDER BY rank
+    LIMIT ${cappedLimit} OFFSET ${offset}
+  `);
+
+  const data: RankingRow[] = rows.map((row) => ({
+    rank: Number(row.rank),
+    user_id: row.user_id,
+    username: row.username,
+    solved_count: Number(row.solved_count),
+    total_submissions: Number(row.total_submissions),
+    acceptance_rate: Number(row.acceptance_rate),
+  }));
+
+  // 2. 总数查询（独立 SQL，复用 HAVING 条件确保计数一致）
+  const totalResult = await db.execute<{ total: number }>(sql`
+    SELECT COUNT(*)::int AS total
+    FROM (
+      SELECT u.id
+      FROM users u
+      INNER JOIN submissions s ON s.user_id = u.id
+      LEFT JOIN evaluation_results er ON er.submission_id = s.id
+      WHERE u.id <> '0' AND s.status = 'finished'
+      GROUP BY u.id
+      HAVING COUNT(*) FILTER (WHERE er.status = 'Accepted') > 0
+    ) AS ranked_users
+  `);
+  const total = Number(totalResult[0]?.total ?? 0);
+
+  return { data, total };
+}
+
+/**
+ * 获取指定用户在榜单中的位置。
+ *
+ * 返回该用户的完整榜单条目（含 rank），若用户未上榜（无通过记录）则返回 null。
+ *
+ * 实现：复用 getGlobalRankings 排序逻辑的子查询定位该用户的 rank 行。
+ * 不直接用 WHERE user_id=? 简单过滤是因为需要保留相同的排序键以保证
+ * rank 数值与榜单中的位置一致。
+ *
+ * @param userId 用户 UUID
+ */
+export async function getMyRanking(
+  userId: string,
+): Promise<RankingRow | null> {
+  const db = getDb();
+
+  const rows = await db.execute<{
+    user_id: string;
+    username: string;
+    total_submissions: number;
+    solved_count: number;
+    accepted: number;
+    acceptance_rate: number;
+    rank: number;
+  }>(sql`
+    WITH ranked AS (
+      SELECT
+        u.id AS user_id,
+        u.username,
+        COUNT(*)::int AS total_submissions,
+        COUNT(DISTINCT s.problem_id) FILTER (WHERE er.status = 'Accepted')::int AS solved_count,
+        COUNT(*) FILTER (WHERE er.status = 'Accepted')::int AS accepted,
+        CASE WHEN COUNT(*) = 0 THEN 0
+             ELSE ROUND(
+               (COUNT(*) FILTER (WHERE er.status = 'Accepted')::float / COUNT(*))::numeric,
+               3
+             )::float
+        END AS acceptance_rate,
+        ROW_NUMBER() OVER (
+          ORDER BY
+            COUNT(DISTINCT s.problem_id) FILTER (WHERE er.status = 'Accepted') DESC,
+            CASE WHEN COUNT(*) = 0 THEN 0
+                 ELSE COUNT(*) FILTER (WHERE er.status = 'Accepted')::float / COUNT(*)
+            END DESC,
+            COUNT(*) ASC,
+            u.created_at ASC
+        )::int AS rank
+      FROM users u
+      INNER JOIN submissions s ON s.user_id = u.id
+      LEFT JOIN evaluation_results er ON er.submission_id = s.id
+      WHERE u.id <> '0' AND s.status = 'finished'
+      GROUP BY u.id, u.username, u.created_at
+      HAVING COUNT(*) FILTER (WHERE er.status = 'Accepted') > 0
+    )
+    SELECT * FROM ranked WHERE user_id = ${userId} LIMIT 1
+  `);
+
+  const row = rows[0];
+  if (!row) return null;
+
+  return {
+    rank: Number(row.rank),
+    user_id: row.user_id,
+    username: row.username,
+    solved_count: Number(row.solved_count),
+    total_submissions: Number(row.total_submissions),
+    acceptance_rate: Number(row.acceptance_rate),
+  };
+}

--- a/noj-core/tests/routes/rankings.test.ts
+++ b/noj-core/tests/routes/rankings.test.ts
@@ -1,0 +1,106 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { Hono } from "hono";
+import rankings from "../../src/routes/rankings.ts";
+import { AppError } from "../../src/lib/errors.ts";
+
+const hasEnv = !!Deno.env.get("DATABASE_URL") &&
+  !!Deno.env.get("JWT_SECRET");
+
+/**
+ * 注册最小 onError，与 src/app.ts 等价（处理 AppError → statusCode + body）。
+ * 模式与 tests/routes/checkin.test.ts 一致。
+ */
+function registerAppErrorHandler(
+  app: Hono<{ Variables: { userId: string; userRole: string } }>,
+) {
+  app.onError((err, c) => {
+    if (err instanceof AppError) {
+      return c.json(
+        { error: err.message, code: err.code },
+        err.statusCode as 400 | 401 | 403 | 404 | 409 | 429 | 500 | 503,
+      );
+    }
+    console.error("未处理的错误:", err);
+    return c.json({ error: "服务器内部错误" }, 500);
+  });
+}
+
+function createTestApp() {
+  const app = new Hono<{
+    Variables: { userId: string; userRole: string };
+  }>();
+  registerAppErrorHandler(app);
+  app.route("/api/v1/rankings", rankings);
+  return app;
+}
+
+function jsonRequest(
+  method: string,
+  path: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Request {
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { ...init.headers, "Content-Type": "application/json" };
+  }
+  return new Request(`http://localhost${path}`, init);
+}
+
+Deno.test({
+  name: "rankings route: GET / 无需 token 公开访问",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createTestApp();
+    const res = await app.fetch(
+      jsonRequest("GET", "/api/v1/rankings?page=1&limit=10"),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json() as { data: unknown[]; pagination: unknown };
+    assertEquals(Array.isArray(json.data), true);
+    assertExists(json.pagination);
+  },
+});
+
+Deno.test({
+  name: "rankings route: GET /me 未登录返回 401",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createTestApp();
+    const res = await app.fetch(jsonRequest("GET", "/api/v1/rankings/me"));
+    assertEquals(res.status, 401);
+  },
+});
+
+Deno.test({
+  name: "rankings route: GET /?page=0 返回 400",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createTestApp();
+    const res = await app.fetch(
+      jsonRequest("GET", "/api/v1/rankings?page=0"),
+    );
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "rankings route: GET /?limit=abc 返回 400",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createTestApp();
+    const res = await app.fetch(
+      jsonRequest("GET", "/api/v1/rankings?limit=abc"),
+    );
+    assertEquals(res.status, 400);
+  },
+});

--- a/noj-core/tests/services/rankings.test.ts
+++ b/noj-core/tests/services/rankings.test.ts
@@ -1,0 +1,330 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { getDb } from "../../src/db/connection.ts";
+import {
+  evaluationResults,
+  problems,
+  submissions,
+  users,
+} from "../../src/db/schema.ts";
+import {
+  getGlobalRankings,
+  getMyRanking,
+} from "../../src/services/rankings.ts";
+import { hashPassword } from "../../src/lib/password.ts";
+
+const hasEnv = !!Deno.env.get("DATABASE_URL") &&
+  !!Deno.env.get("JWT_SECRET");
+
+/**
+ * 创建测试用户，返回 user_id。
+ */
+async function createTestUser(
+  usernamePrefix: string,
+  createdAt?: string,
+): Promise<string> {
+  const db = getDb();
+  const id = crypto.randomUUID();
+  const unique = Date.now() + "-" + Math.random().toString(36).slice(2, 8);
+  const now = createdAt ?? new Date().toISOString();
+  await db.insert(users).values({
+    id,
+    username: `${usernamePrefix}_${unique}`,
+    email: `${usernamePrefix}_${unique}@test.com`,
+    password_hash: await hashPassword("TestRankingsPass1"),
+    role: "user",
+    created_at: now,
+    updated_at: now,
+  });
+  return id;
+}
+
+/**
+ * 为指定用户创建一条提交并附带评测结果。
+ */
+async function createSubmission(
+  userId: string,
+  problemId: string,
+  resultStatus: "Accepted" | "WrongAnswer" | "TimeLimitExceeded",
+): Promise<void> {
+  const db = getDb();
+  const submissionId = crypto.randomUUID();
+  const now = new Date().toISOString();
+  await db.insert(submissions).values({
+    id: submissionId,
+    user_id: userId,
+    problem_id: problemId,
+    language: "python3",
+    code: "print(1)",
+    file_name: "main.py",
+    status: "finished",
+    created_at: now,
+  });
+  await db.insert(evaluationResults).values({
+    id: crypto.randomUUID(),
+    submission_id: submissionId,
+    status: resultStatus,
+    score: resultStatus === "Accepted" ? 10000 : 0,
+    output: "",
+    details: "{}",
+    created_at: now,
+  });
+}
+
+/**
+ * 创建测试题目，返回 problem_id。
+ */
+async function createTestProblem(problemNumber: number): Promise<string> {
+  const db = getDb();
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  await db.insert(problems).values({
+    id,
+    title: `rankings_test_${problemNumber}_${Date.now()}`,
+    description: "test",
+    difficulty: "easy",
+    judge_image: "noj-judge-python",
+    judge_command: "python3 /tmp/evaluate.py",
+    time_limit_ms: 5000,
+    memory_limit_mb: 512,
+    number: problemNumber,
+    owner_id: "0",
+    type: "P",
+    created_at: now,
+    updated_at: now,
+  });
+  return id;
+}
+
+/**
+ * 清理测试用户的提交 + 评测结果 + 用户记录。
+ */
+async function cleanupUser(userId: string): Promise<void> {
+  const db = getDb();
+  // 先删除 evaluation_results（FK → submissions）
+  const userSubs = await db
+    .select({ id: submissions.id })
+    .from(submissions)
+    .where(eq(submissions.user_id, userId));
+  for (const sub of userSubs) {
+    await db.delete(evaluationResults).where(
+      eq(evaluationResults.submission_id, sub.id),
+    );
+  }
+  await db.delete(submissions).where(eq(submissions.user_id, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
+/**
+ * 清理测试题目。
+ */
+async function cleanupProblem(problemId: string): Promise<void> {
+  const db = getDb();
+  // 先删除关联的 submissions + evaluation_results
+  const problemSubs = await db
+    .select({ id: submissions.id })
+    .from(submissions)
+    .where(eq(submissions.problem_id, problemId));
+  for (const sub of problemSubs) {
+    await db.delete(evaluationResults).where(
+      eq(evaluationResults.submission_id, sub.id),
+    );
+  }
+  await db.delete(submissions).where(eq(submissions.problem_id, problemId));
+  await db.delete(problems).where(eq(problems.id, problemId));
+}
+
+Deno.test({
+  name: "rankings: getGlobalRankings 仅展示有通过记录的用户",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userA = await createTestUser("rankings_a");
+    const userB = await createTestUser("rankings_b");
+    const userC = await createTestUser("rankings_c"); // 无通过记录
+    const problem1 = await createTestProblem(900001);
+    const problem2 = await createTestProblem(900002);
+    const problem3 = await createTestProblem(900003);
+
+    try {
+      // A: 2 solved, 3 total
+      await createSubmission(userA, problem1, "Accepted");
+      await createSubmission(userA, problem2, "Accepted");
+      await createSubmission(userA, problem3, "WrongAnswer");
+      // B: 1 solved, 1 total
+      await createSubmission(userB, problem1, "Accepted");
+      // C: 0 solved (全部 WA)，不应上榜
+      await createSubmission(userC, problem1, "WrongAnswer");
+      await createSubmission(userC, problem2, "TimeLimitExceeded");
+
+      const result = await getGlobalRankings({ page: 1, limit: 100 });
+      const aRow = result.data.find((r) => r.user_id === userA);
+      const bRow = result.data.find((r) => r.user_id === userB);
+      const cRow = result.data.find((r) => r.user_id === userC);
+
+      assertEquals(cRow, undefined, "C 不应在榜单中（无通过记录）");
+      assertExists(aRow);
+      assertExists(bRow);
+      assertEquals(aRow!.solved_count, 2);
+      assertEquals(aRow!.total_submissions, 3);
+      // acceptance_rate = 2/3 ≈ 0.667（保留 3 位小数）
+      assertEquals(aRow!.acceptance_rate, 0.667);
+      assertEquals(bRow!.solved_count, 1);
+      assertEquals(bRow!.total_submissions, 1);
+      assertEquals(bRow!.acceptance_rate, 1.0);
+      // A solved_count=2 > B solved_count=1 → A.rank < B.rank
+      assertEquals(aRow!.rank < bRow!.rank, true);
+    } finally {
+      await cleanupUser(userA);
+      await cleanupUser(userB);
+      await cleanupUser(userC);
+      await cleanupProblem(problem1);
+      await cleanupProblem(problem2);
+      await cleanupProblem(problem3);
+    }
+  },
+});
+
+Deno.test({
+  name: "rankings: 排序稳定——solved 相同按 acceptance_rate 降序",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userD = await createTestUser("rankings_d");
+    const userE = await createTestUser("rankings_e");
+    const problem1 = await createTestProblem(900010);
+    const problem2 = await createTestProblem(900011);
+
+    try {
+      // D: solved=1, total=2, rate=0.5（高效率）
+      await createSubmission(userD, problem1, "Accepted");
+      await createSubmission(userD, problem2, "WrongAnswer");
+      // E: solved=1, total=4, rate=0.25（低效率）
+      await createSubmission(userE, problem1, "Accepted");
+      await createSubmission(userE, problem1, "WrongAnswer");
+      await createSubmission(userE, problem2, "WrongAnswer");
+      await createSubmission(userE, problem2, "TimeLimitExceeded");
+
+      const result = await getGlobalRankings({ page: 1, limit: 100 });
+      const dRow = result.data.find((r) => r.user_id === userD);
+      const eRow = result.data.find((r) => r.user_id === userE);
+
+      assertExists(dRow);
+      assertExists(eRow);
+      // D rate=0.5 > E rate=0.25 → D.rank < E.rank
+      assertEquals(dRow!.rank < eRow!.rank, true);
+      assertEquals(dRow!.acceptance_rate, 0.5);
+      assertEquals(eRow!.acceptance_rate, 0.25);
+    } finally {
+      await cleanupUser(userD);
+      await cleanupUser(userE);
+      await cleanupProblem(problem1);
+      await cleanupProblem(problem2);
+    }
+  },
+});
+
+Deno.test({
+  name: "rankings: 排除 root 用户（id='0'）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    // 不创建 root 用户的提交（root 已由 00_migrate_test 创建）
+    const result = await getGlobalRankings({ page: 1, limit: 100 });
+    const rootRow = result.data.find((r) => r.user_id === "0");
+    assertEquals(rootRow, undefined, "root 用户不应出现在榜单中");
+  },
+});
+
+Deno.test({
+  name: "rankings: getMyRanking——已上榜用户返回正确 rank",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userF = await createTestUser("rankings_f");
+    const problem1 = await createTestProblem(900020);
+
+    try {
+      await createSubmission(userF, problem1, "Accepted");
+      const result = await getMyRanking(userF);
+      assertExists(result);
+      assertEquals(result!.user_id, userF);
+      assertEquals(result!.solved_count, 1);
+      assertEquals(result!.acceptance_rate, 1.0);
+      assertEquals(typeof result!.rank, "number");
+      assertEquals(result!.rank >= 1, true);
+    } finally {
+      await cleanupUser(userF);
+      await cleanupProblem(problem1);
+    }
+  },
+});
+
+Deno.test({
+  name: "rankings: getMyRanking——未上榜用户返回 null",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userG = await createTestUser("rankings_g");
+    const problem1 = await createTestProblem(900030);
+
+    try {
+      // 仅 WA，无 Accepted
+      await createSubmission(userG, problem1, "WrongAnswer");
+      const result = await getMyRanking(userG);
+      assertEquals(result, null);
+    } finally {
+      await cleanupUser(userG);
+      await cleanupProblem(problem1);
+    }
+  },
+});
+
+Deno.test({
+  name: "rankings: 分页——page=2 返回正确切片",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userH = await createTestUser("rankings_h");
+    const problem1 = await createTestProblem(900040);
+
+    try {
+      await createSubmission(userH, problem1, "Accepted");
+      const page1 = await getGlobalRankings({ page: 1, limit: 50 });
+      const page2 = await getGlobalRankings({ page: 2, limit: 50 });
+
+      // page1 含 userH，page2 仍可能含 userH（如果 global rank ≤ 50）
+      // 主要验证：两次返回的总条目数相同，分页不重复
+      const total = page1.total;
+      assertEquals(page2.total, total);
+
+      const hInP1 = page1.data.find((r) => r.user_id === userH);
+      const hInP2 = page2.data.find((r) => r.user_id === userH);
+      // userH 不应同时出现在两页
+      if (hInP1 && hInP2) {
+        throw new Error("分页不应重复返回同一行");
+      }
+    } finally {
+      await cleanupUser(userH);
+      await cleanupProblem(problem1);
+    }
+  },
+});
+
+Deno.test({
+  name: "rankings: limit 上限——超过 100 被截断为 100",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const result = await getGlobalRankings({ page: 1, limit: 500 });
+    // 验证 limit=500 调用不抛错（service 层内部截断到 100）
+    assertEquals(result.data.length <= 100, true);
+  },
+});

--- a/noj-ui/components/Navbar.vue
+++ b/noj-ui/components/Navbar.vue
@@ -13,6 +13,7 @@
                 <NuxtLink to="/" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">首页</NuxtLink>
                 <NuxtLink to="/problems" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">题库</NuxtLink>
                 <NuxtLink to="/submissions" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">提交记录</NuxtLink>
+                <NuxtLink to="/ranking" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">榜单</NuxtLink>
                 <NuxtLink to="/queue" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">队列</NuxtLink>
                 <NuxtLink to="/about" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">关于</NuxtLink>
             </nav>

--- a/noj-ui/composables/useRankings.ts
+++ b/noj-ui/composables/useRankings.ts
@@ -1,0 +1,65 @@
+/**
+ * 用户榜单相关类型与 composable。
+ * 与后端 services/rankings.ts 响应字段对齐。
+ */
+
+export interface RankingRow {
+  /** 1-based 全局名次 */
+  rank: number
+  user_id: string
+  username: string
+  /** 独立通过的题目数 */
+  solved_count: number
+  /** 总提交数 */
+  total_submissions: number
+  /** 0–1 浮点数 */
+  acceptance_rate: number
+}
+
+export interface RankingsPagination {
+  page: number
+  per_page: number
+  total: number
+  total_pages: number
+}
+
+export interface RankingsResponse {
+  data: RankingRow[]
+  pagination: RankingsPagination
+}
+
+export interface MyRankingResponse {
+  data: RankingRow | null
+}
+
+/**
+ * 获取全站榜单。
+ * @param page 页码（从 1 开始）
+ * @param limit 每页条数（默认 50，最大 100）
+ */
+export function useRankings(page: Ref<number>, limit: number = 50) {
+  return useFetch<RankingsResponse>(() => {
+    const qs = new URLSearchParams({
+      page: String(page.value),
+      limit: String(limit),
+    })
+    return `/api/v1/rankings?${qs.toString()}`
+  })
+}
+
+/**
+ * 获取当前登录用户的榜单条目。
+ * 未登录或未上榜时返回 null。
+ */
+export async function fetchMyRanking(): Promise<RankingRow | null> {
+  const res = await $fetch<MyRankingResponse>("/api/v1/rankings/me")
+  return res.data
+}
+
+/**
+ * 格式化通过率（0–1 → "xx.x%"）。
+ */
+export function formatAcceptanceRate(rate: number | null | undefined): string {
+  if (rate == null) return "--"
+  return `${(rate * 100).toFixed(1)}%`
+}

--- a/noj-ui/pages/ranking.vue
+++ b/noj-ui/pages/ranking.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { Trophy } from "@lucide/vue"
+import type { RankingRow } from "~/composables/useRankings"
+
+definePageMeta({
+  // 公开页面，无需登录（OJ 榜单标准）
+})
+
+const route = useRoute()
+const router = useRouter()
+const { user: currentUser, isLoggedIn } = useAuth()
+
+const page = computed<number>(() => {
+  const raw = route.query.page
+  const n = Number(Array.isArray(raw) ? raw[0] : raw)
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1
+})
+
+const limit = 50
+
+const { data, pending, error, refresh } = useRankings(page, limit)
+
+const rows = computed<RankingRow[]>(() => data.value?.data ?? [])
+const total = computed<number>(() => data.value?.pagination.total ?? 0)
+const totalPages = computed<number>(() => {
+  if (total.value === 0) return 0
+  return Math.ceil(total.value / limit)
+})
+
+function setPage(p: number) {
+  router.push({ query: { ...route.query, page: String(p) } })
+}
+</script>
+
+<template>
+  <div class="px-4 py-5 sm:px-7 sm:py-8 max-w-[960px] mx-auto">
+    <div class="flex items-baseline gap-3 mb-6">
+      <Trophy :size="22" class="text-primary self-center" />
+      <h1 class="text-2xl font-bold text-text">榜单</h1>
+      <span class="text-sm text-text-muted">共 {{ total }} 位上榜用户</span>
+    </div>
+
+    <!-- 加载中 -->
+    <div v-if="pending" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="status" aria-live="polite">
+      <div class="h-[28px] w-[28px] border-[3px] border-border border-t-primary rounded-full animate-spin-slow" />
+      <span>加载中...</span>
+    </div>
+
+    <!-- 加载失败 -->
+    <div v-else-if="error" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="alert">
+      <span class="flex items-center justify-center size-11 rounded-full bg-red-100 text-red-800 text-xl font-bold">!</span>
+      <p>榜单加载失败</p>
+      <button class="btn btn-outline px-4 py-1.5 text-xs" @click="refresh">重试</button>
+    </div>
+
+    <!-- 空数据 -->
+    <div v-else-if="rows.length === 0" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="status" aria-live="polite">
+      <Trophy :size="48" class="opacity-30" />
+      <p>还没有用户通过任何题目，做第一个吧 👉</p>
+      <NuxtLink to="/problems" class="btn btn-primary px-4 py-1.5 text-xs">去做题</NuxtLink>
+    </div>
+
+    <!-- 榜单表格 -->
+    <template v-else>
+      <div class="bg-white border border-border rounded-xl overflow-x-auto">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr>
+              <th scope="col" class="w-20 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border">排名</th>
+              <th scope="col" class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border">用户</th>
+              <th scope="col" class="w-24 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-right bg-gray-50 border-b border-border">解题数</th>
+              <th scope="col" class="w-24 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-right bg-gray-50 border-b border-border hidden sm:table-cell">通过率</th>
+              <th scope="col" class="w-24 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-right bg-gray-50 border-b border-border hidden sm:table-cell">提交数</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-border">
+            <tr
+              v-for="row in rows"
+              :key="row.user_id"
+              :class="[
+                'transition-colors duration-150',
+                isLoggedIn && currentUser?.id === row.user_id
+                  ? 'bg-primary/5 hover:bg-primary/10'
+                  : 'hover:bg-gray-50',
+              ]"
+            >
+              <td class="w-20 px-4 py-3.5">
+                <span
+                  class="inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 rounded-full text-sm font-bold tabular-nums"
+                  :class="{
+                    'bg-yellow-100 text-yellow-800': row.rank === 1,
+                    'bg-gray-200 text-gray-700': row.rank === 2,
+                    'bg-orange-100 text-orange-800': row.rank === 3,
+                    'bg-gray-50 text-text-secondary': row.rank > 3,
+                  }"
+                >
+                  #{{ row.rank }}
+                </span>
+              </td>
+              <td class="px-4 py-3.5">
+                <NuxtLink
+                  :to="`/users/${row.user_id}`"
+                  class="text-text no-underline font-medium hover:text-primary"
+                >
+                  {{ row.username }}
+                </NuxtLink>
+              </td>
+              <td class="w-24 px-4 py-3.5 text-right text-base font-bold text-primary tabular-nums">
+                {{ row.solved_count }}
+              </td>
+              <td class="w-24 px-4 py-3.5 text-right text-sm text-text-secondary tabular-nums hidden sm:table-cell">
+                {{ formatAcceptanceRate(row.acceptance_rate) }}
+              </td>
+              <td class="w-24 px-4 py-3.5 text-right text-sm text-text-secondary tabular-nums hidden sm:table-cell">
+                {{ row.total_submissions }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- 分页 -->
+      <PaginationNav
+        :current-page="page"
+        :total-pages="totalPages"
+        @page-change="setPage($event)"
+      />
+    </template>
+  </div>
+</template>

--- a/noj-ui/pages/users/[id].vue
+++ b/noj-ui/pages/users/[id].vue
@@ -20,6 +20,8 @@ interface UserProfile {
     acceptance_rate: number
     solved_count: number
   }
+  /** 全站排名（issue user-ranking）；未上榜时为 null */
+  rank: number | null
   solved_problems: {
     id: string
     title: string
@@ -181,7 +183,7 @@ function formatScore(raw: number | null | undefined): string {
       </div>
 
       <!-- 统计卡片 -->
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      <div class="grid grid-cols-2 sm:grid-cols-5 gap-4">
         <div class="bg-white border border-border rounded-xl px-5 py-4 flex flex-col gap-1">
           <span class="text-xs text-text-muted font-medium uppercase tracking-wide">总提交</span>
           <span class="text-2xl font-bold text-text">{{ profile.stats.total_submissions }}</span>
@@ -199,6 +201,19 @@ function formatScore(raw: number | null | undefined): string {
         <div class="bg-white border border-border rounded-xl px-5 py-4 flex flex-col gap-1">
           <span class="text-xs text-text-muted font-medium uppercase tracking-wide">解题数</span>
           <span class="text-2xl font-bold text-primary">{{ profile.stats.solved_count }}</span>
+        </div>
+        <!-- 全站排名（仅上榜用户显示） -->
+        <div
+          v-if="profile.rank !== null"
+          class="bg-white border border-border rounded-xl px-5 py-4 flex flex-col gap-1"
+        >
+          <span class="text-xs text-text-muted font-medium uppercase tracking-wide">全站排名</span>
+          <NuxtLink
+            to="/ranking"
+            class="text-2xl font-bold text-text no-underline hover:text-primary tabular-nums"
+          >
+            #{{ profile.rank }}
+          </NuxtLink>
         </div>
       </div>
 

--- a/openspec/changes/user-ranking/.openspec.yaml
+++ b/openspec/changes/user-ranking/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/user-ranking/design.md
+++ b/openspec/changes/user-ranking/design.md
@@ -1,0 +1,149 @@
+## Context
+
+NOJ 当前所有"通过数 / 通过率 / 解题数"统计都在 `users.ts:getUserProfile` 单用户级别实时聚合（`count(*) filter (where evaluation_results.status = 'Accepted')` + `count(distinct problem_id)`），没有跨用户排序视图。ROADMAP Phase 1 列出"排行榜：通过数 / 通过率"作为 noj-core 待办，但当前未实现。
+
+### 现有约束
+
+- `submissions` 表已有 `idx_submissions_user_id` 索引，`evaluation_results` 表有 `(submission_id)` UNIQUE 索引
+- 没有 `user_stats` / `leaderboard` 物化视图，所有聚合均为运行时 SQL
+- `dashboard.ts` L78-99 已有跨用户聚合模板（`count(*) filter (where ... = 'Accepted')`）
+- `getUserProfile` 排除 root 系统用户（`id != '0'`）
+- Nitro 代理已通配 `/api/v1/*`，前端无需新增代理路由
+- 分页响应包络统一为 `{ data: [...], pagination: { page, per_page, total, total_pages } }`
+- OpenSpec 绿地：全仓 `ranking|leaderboard|scoreboard` 零匹配
+
+### 调研结论
+
+- **零数据库迁移**：现有 schema 完全够用
+- **零向后兼容负担**：绿地实现
+- **样板可直接复用**：`users.ts:getUserProfile` 的聚合写法 + `dashboard.ts` 跨用户聚合 + `submission-list-api` 分页响应包络
+
+## Goals / Non-Goals
+
+**Goals:**
+- 全站用户榜单查询，按解题数（主）/通过率（次）/提交数（tiebreaker）排序
+- 当前登录用户排名查询
+- 用户主页追加 `rank` 字段
+- 前端 `/ranking` 公开页面，表格 + 分页 + 当前用户高亮
+- 排除 root 系统用户（id='0'）
+- MVP 只展示有通过记录的用户（`accepted > 0`）
+
+**Non-Goals:**
+- ❌ 比赛榜（Phase 2 实时榜单再用基础）
+- ❌ 时间范围筛选 `?range=7d/30d/all`（数据量小不需要）
+- ❌ 难度/分类分组榜单（基础版先全站）
+- ❌ Redis 缓存（用户量 < 1K 实时聚合足够）
+- ❌ 物化视图 / `user_stats` 表（同上理由）
+- ❌ SSE 实时推送榜单变化（榜单变动慢，刷页面即可）
+- ❌ 导出 CSV
+- ❌ 国家/地区/学校维度（无数据模型）
+- ❌ 多语言（C++/Java）：按用户要求不做
+
+## Decisions
+
+### 1. 聚合查询策略
+
+**选择：实时 SQL 聚合（无缓存、无物化）。**
+
+**理由：**
+- 用户量 < 1K（Phase 1 MVP 用户基数），单次聚合 < 50ms 可接受
+- 与现有 `getUserProfile` / `dashboard` 保持一致
+- 无缓存失效复杂性（写路径无需变更）
+- 数据量增长后再考虑物化视图或 Redis 缓存
+
+**SQL 核心**：
+```sql
+SELECT
+  u.id, u.username,
+  count(*) FILTER (WHERE er.status = 'Accepted') AS accepted,
+  count(DISTINCT s.problem_id) FILTER (WHERE er.status = 'Accepted') AS solved_count,
+  count(*) AS total_submissions,
+  CASE WHEN count(*) = 0 THEN 0
+       ELSE count(*) FILTER (WHERE er.status = 'Accepted')::float / count(*)
+  END AS acceptance_rate
+FROM users u
+JOIN submissions s ON s.user_id = u.id
+LEFT JOIN evaluation_results er ON er.submission_id = s.id
+WHERE u.id != '0'  -- 排除 root 系统用户
+  AND s.status = 'finished'  -- 只统计已完成的提交
+GROUP BY u.id, u.username
+HAVING count(*) FILTER (WHERE er.status = 'Accepted') > 0
+ORDER BY solved_count DESC, acceptance_rate DESC, total_submissions ASC, u.created_at ASC
+LIMIT $1 OFFSET $2
+```
+
+### 2. 排序键设计
+
+**选择：四级排序键确保稳定性。**
+
+```
+solved_count DESC,           -- 主要：解题数
+acceptance_rate DESC,        -- 次要：通过率（solved 相同时更高效者靠前）
+total_submissions ASC,       -- tiebreaker：提交数少者靠前（更精炼）
+u.created_at ASC             -- 最终 tiebreaker：老用户优先
+```
+
+**理由**：仅按 `solved_count` 排序在相同题数时会不稳定；`acceptance_rate` 是相对指标，避免"刷提交"行为排名靠前。
+
+### 3. 排除无通过记录的用户
+
+**选择：`HAVING count(*) FILTER (WHERE er.status = 'Accepted') > 0`。**
+
+**理由：**
+- 榜单对"通过 0 题"的用户无意义（`acceptance_rate = 0`，`solved_count = 0`）
+- 避免空行噪声
+- "我的排名"接口对未上榜用户返回 `null`
+
+### 4. API 端点设计
+
+**`GET /api/v1/rankings`（公开）：**
+- Query: `page` (默认 1), `limit` (默认 50, 上限 100)
+- Response: `{ data: RankingRow[], pagination: {...} }`
+
+**`GET /api/v1/rankings/me`（需登录）：**
+- 从 JWT 取 `userId`，内部调用聚合查询 LIMIT 1 OFFSET 0 WHERE user_id=?
+- 若用户已通过 ≥1 题：返回 `{ rank, user_id, username, solved_count, total_submissions, acceptance_rate }`
+- 若用户未上榜：返回 `null`
+
+**复用 JWT 中间件**：`middleware/auth.ts` 已在 `app.ts` 全局挂载，子路由直接调用 `c.get("user")` 或 `c.get("jwtPayload")` 即可。
+
+### 5. 用户主页 rank 字段
+
+**选择：在 `getUserProfile` 响应中追加 `rank: number | null`。**
+
+**实现**：在 `routes/users.ts` 的 GET `/:id/profile` 处理函数内，调用 `getMyRanking(userId)`，取 `rank` 字段后合并到响应对象。
+
+**理由**：
+- 零 schema 变更，纯计算字段
+- 与现有 `solved_count`、`acceptance_rate` 等字段并列，用户无需额外请求
+- 后续 Phase 2 比赛榜可复用此模式扩展
+
+### 6. 前端页面设计
+
+**路径**：`pages/ranking.vue`（公开，无需 `middleware: "auth"`）。
+
+**布局**：
+- 顶部：标题 + 简短说明
+- 主体：表格（排名 / 用户名 / 解题数 / 通过率 / 提交数）
+- 当前登录用户行：`bg-primary/5` 高亮
+- 底部：分页组件
+- 三态容器：复用 `components/ui/AsyncContent.vue`
+
+**空状态文案**："还没有用户通过任何题目，做第一个吧 👉 /problems"
+
+**借鉴样板**：`pages/users/[id].vue` 的统计卡 + `pages/problems.vue` 的列表 + 分页组合模式。
+
+### 7. 命名约定
+
+- API: `/api/v1/rankings`（与 `users`、`problems`、`submissions` 同款复数）
+- 前端页面: `/ranking`（单数路径，与 `/problems` `/users/:id` 一致）
+- composable: `useRankings`（camelCase，新代码遵循主流）
+- 文件名: `rankings.ts`（后端 service/route）、`ranking.vue`（前端页面）
+
+## Risks / Trade-offs
+
+- **[风险] 大量提交数据时聚合慢** → 缓解：用户量 < 1K 暂不优化；后续可加 `(user_id, evaluation_results.status='Accepted')` 复合索引
+- **[取舍] 实时聚合无缓存** → 有意识选择。简化实现，避免写路径失效复杂度
+- **[风险] 榜单分页下"我的排名"不在当前页** → 缓解：单独 `/rankings/me` 接口，返回当前用户完整行，前端可据此在榜单页底部追加"我的排名"提示卡
+- **[取舍] root 用户绝对排除** → 一致性考虑：与 `dashboard.ts` L62 模式保持一致，root 系统用户永远不出现在任何用户列表
+- **[风险] acceptance_rate 小数精度** → 缓解：返回 0–1 浮点数，前端用 `toFixed(2)` 百分比展示；DB 端通过 `::float` 强转避免整数除法

--- a/openspec/changes/user-ranking/proposal.md
+++ b/openspec/changes/user-ranking/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+当前所有"通过数 / 通过率 / 解题数"统计只在单用户级别（`GET /api/v1/users/:id/profile`）可见，用户无法跨用户对比。ROADMAP Phase 1 交付标准明文要求"榜单可查"——任何访问者应能看到全站用户按解题数排序的排行榜，并让登录用户看到自己在榜上的位置。本变更落地 Phase 1 的最后一块。
+
+## What Changes
+
+- **新增**：`GET /api/v1/rankings` 公开接口，按解题数 / 通过率 / 提交数三维度排序返回全站用户榜单，分页支持
+- **新增**：`GET /api/v1/rankings/me` 已登录接口，返回当前用户在榜上的排名行
+- **新增**：前端 `/ranking` 页面（公开），表格 + 分页，当前登录用户行高亮
+- **新增**：前端 `composables/useRankings.ts`，封装数据类型与 `$fetch` 调用
+- **修改**：`GET /api/v1/users/:id/profile` 响应追加 `rank` 字段（已有通过记录时为排名数值，否则 `null`）
+- **修改**：前端 Navbar 菜单新增"榜单"入口（在"提交记录"与"队列"之间）
+- **修改**：前端用户主页追加"排名"统计卡（仅当 `rank !== null` 时显示）
+
+## Capabilities
+
+### New Capabilities
+
+- `ranking`: 全站用户榜单查询——公开访问、按解题数降序排序、分页、当前用户排名查询；用户主页响应追加 `rank` 字段
+
+### Modified Capabilities
+
+- `user-profile`: `GET /api/v1/users/:id/profile` 响应对象追加 `rank` 字段（number | null），表示该用户在全站榜单的排名
+
+## Impact
+
+- **数据库**：无 schema 变更，无迁移
+- **noj-core**：新增 `src/services/rankings.ts`、`src/routes/rankings.ts`；修改 `src/routes/users.ts`（profile 响应追加 rank 字段）、`src/app.ts`（挂载新路由）
+- **noj-ui**：新增 `pages/ranking.vue`、`composables/useRankings.ts`；修改 `components/Navbar.vue`（菜单）、`pages/users/[id].vue`（排名卡）
+- **性能**：榜单聚合为单 SQL `GROUP BY user_id`（与 `users.ts:getUserProfile` L84-99 写法一致）；用户量 < 1K 时实时聚合足够，无需缓存
+- **安全**：root 系统用户（id='0'）不计入榜单；榜单为只读公开数据，无需鉴权

--- a/openspec/changes/user-ranking/specs/ranking/spec.md
+++ b/openspec/changes/user-ranking/specs/ranking/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: 全站用户榜单查询
+
+系统 SHALL 提供 `GET /api/v1/rankings` 公开接口，按解题数降序返回全站用户榜单。
+
+榜单条目 SHALL 包含：`rank`（名次，1-based 整数）、`user_id`、`username`、`solved_count`（独立通过的题目数）、`total_submissions`（总提交数）、`acceptance_rate`（0–1 浮点数）。
+
+榜单 SHALL 排除 root 系统用户（`users.id = '0'`），且 SHALL 仅展示至少通过一道题的用户。
+
+排序键 SHALL 为：`(solved_count DESC, acceptance_rate DESC, total_submissions ASC, users.created_at ASC)`，确保相同指标下排名稳定。
+
+#### Scenario: 正常查询全站榜单
+
+- **WHEN** 系统中有用户 A（solved=5, total=10, rate=0.5）和用户 B（solved=3, total=5, rate=0.6）有通过记录，用户 C（solved=0）有提交但无通过记录
+- **THEN** `GET /api/v1/rankings` 返回两个条目，A.rank=1, B.rank=2，C 不在结果中
+
+#### Scenario: 排序稳定
+
+- **WHEN** 两个用户 D（solved=3, rate=0.7, total=4）和 E（solved=3, rate=0.6, total=5）通过题数相同
+- **THEN** D.rank < E.rank（因为 D.acceptance_rate 更高）
+
+#### Scenario: 排除 root 用户
+
+- **WHEN** root 系统用户（id='0'）存在且有提交记录
+- **THEN** `GET /api/v1/rankings` 返回结果中不包含 root 用户的条目
+
+#### Scenario: 全站无用户通过任何题
+
+- **WHEN** 系统中所有用户都没有 `evaluation_results.status = 'Accepted'` 的记录
+- **THEN** `GET /api/v1/rankings` 返回 `{ data: [], pagination: { page: 1, per_page: 50, total: 0, total_pages: 0 } }`，HTTP 200
+
+#### Scenario: 公开访问无需 token
+
+- **WHEN** 任意访问者（含未登录用户）发送 `GET /api/v1/rankings`
+- **THEN** 系统正常返回榜单，无需 Authorization 头
+
+### Requirement: 榜单分页
+
+系统 SHALL 支持 `page` 与 `limit` Query 参数。`page` 默认 1，`limit` 默认 50，最大 100。
+
+响应 SHALL 包含 `pagination` 元数据：`page`、`per_page`（实际返回的每页数量）、`total`（总条目数）、`total_pages`（总页数）。
+
+#### Scenario: 默认分页参数
+
+- **WHEN** 调用 `GET /api/v1/rankings` 不带任何 query 参数
+- **THEN** 系统按 `page=1, limit=50` 返回结果
+
+#### Scenario: 超出 limit 上限
+
+- **WHEN** 调用 `GET /api/v1/rankings?limit=200`
+- **THEN** 系统按 `limit=100`（最大上限）返回结果，HTTP 200
+
+#### Scenario: 非法 page 参数
+
+- **WHEN** 调用 `GET /api/v1/rankings?page=0` 或 `page=-1`
+- **THEN** 系统返回 HTTP 400，提示 page 必须 ≥ 1
+
+#### Scenario: 越界 page
+
+- **WHEN** 调用 `GET /api/v1/rankings?page=999` 超过实际页数
+- **THEN** 系统返回 HTTP 200，`data: []`，pagination.total 反映真实总数
+
+### Requirement: 当前用户排名查询
+
+系统 SHALL 提供 `GET /api/v1/rankings/me` 接口（需登录），返回当前登录用户的榜单条目（含 `rank` 字段）。
+
+若当前用户未通过任何题目（不在榜单），返回 `null`。
+
+#### Scenario: 已登录用户有通过记录
+
+- **WHEN** 已登录用户有 ≥1 道题通过
+- **THEN** `GET /api/v1/rankings/me` 返回该用户的完整榜单条目 `{ rank, user_id, username, solved_count, total_submissions, acceptance_rate }`，HTTP 200
+
+#### Scenario: 已登录用户无通过记录
+
+- **WHEN** 已登录用户尚未通过任何题目（accepted=0）
+- **THEN** `GET /api/v1/rankings/me` 返回 `null`（响应体为 `null`），HTTP 200
+
+#### Scenario: 未登录访问被拒
+
+- **WHEN** 未携带有效 JWT 的访问者发送 `GET /api/v1/rankings/me`
+- **THEN** 系统返回 HTTP 401

--- a/openspec/changes/user-ranking/specs/user-profile/spec.md
+++ b/openspec/changes/user-ranking/specs/user-profile/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: 用户主页响应包含 rank 字段
+
+系统 SHALL 在 `GET /api/v1/users/:id/profile` 响应对象中追加 `rank` 字段，表示该用户在全站榜单的排名。
+
+`rank` 字段类型 SHALL 为 `number | null`：用户至少有 1 道题通过时为名次（1-based 整数），未上榜时为 `null`。
+
+`rank` 字段 SHALL 与现有 `stats.solved_count`、`stats.acceptance_rate` 等字段并列，且 SHALL NOT 破坏现有响应结构。
+
+#### Scenario: 有通过记录的用户返回 rank
+
+- **WHEN** 用户 A 通过了 5 道题，当前全站排名第 2
+- **THEN** `GET /api/v1/users/A.id/profile` 响应对象包含 `rank: 2`，HTTP 200
+
+#### Scenario: 无通过记录的用户返回 null
+
+- **WHEN** 用户 B 没有任何通过的题目
+- **THEN** `GET /api/v1/users/B.id/profile` 响应对象包含 `rank: null`，HTTP 200
+
+#### Scenario: root 用户的 rank 始终为 null
+
+- **WHEN** 访问 root 系统用户（id='0'）的 profile
+- **THEN** 响应对象包含 `rank: null`（root 不计入榜单）
+
+#### Scenario: rank 字段不影响其他字段
+
+- **WHEN** `GET /api/v1/users/:id/profile` 响应包含 rank
+- **THEN** 现有字段（username、bio、stats、solved_problems、recent_submissions、created_at）的存在性与值不因 rank 字段的添加而改变

--- a/openspec/changes/user-ranking/tasks.md
+++ b/openspec/changes/user-ranking/tasks.md
@@ -1,0 +1,59 @@
+## 1. 后端：新建 rankings service
+
+- [ ] 1.1 新建 `noj-core/src/services/rankings.ts`，实现 `getGlobalRankings({ page, limit })` 和 `getMyRanking(userId)` 两个函数
+- [ ] 1.2 复用 `users.ts:getUserProfile` L84-99 的 `count(*) filter (where ${evaluationResults.status} = 'Accepted')` 聚合写法
+- [ ] 1.3 SQL 排除 `users.id = '0'`（root 系统用户），`HAVING` 限定只显示有通过记录的用户
+- [ ] 1.4 排序键：solved_count DESC, acceptance_rate DESC, total_submissions ASC, u.created_at ASC
+
+## 2. 后端：新建 rankings route + app.ts 挂载
+
+- [ ] 2.1 新建 `noj-core/src/routes/rankings.ts`，导出 Hono 实例
+- [ ] 2.2 `GET /` 公开访问，返回 `{ data, pagination }`（无 `authMiddleware`）
+- [ ] 2.3 `GET /me` 需登录（显式 `authMiddleware`），返回单行 `RankingRow | null`
+- [ ] 2.4 在 `noj-core/src/app.ts` 中新增 `app.route("/api/v1/rankings", rankings)` 挂载
+
+## 3. 后端：扩展 user profile 响应
+
+- [ ] 3.1 修改 `noj-core/src/routes/users.ts` 的 GET `/:id/profile` 处理函数
+- [ ] 3.2 调用 `getMyRanking(userId)` 取 `rank` 字段，合并到响应对象
+- [ ] 3.3 `rank` 类型：`number | null`（未上榜为 null）
+
+## 4. 后端：单元测试
+
+- [ ] 4.1 新建 `noj-core/tests/services/rankings_test.ts`，覆盖以下场景：
+  - [ ] 4.1.1 `getGlobalRankings`：3 用户（A=5 solved, B=3 solved, C=0 solved），C 不出现在结果中
+  - [ ] 4.1.2 排序稳定性：相同 solved_count 时按 acceptance_rate、total_submissions tiebreak
+  - [ ] 4.1.3 排除 root 用户（id='0'）
+  - [ ] 4.1.4 `getMyRanking`：已登录用户返回自己的 rank，未上榜用户返回 null
+  - [ ] 4.1.5 分页：`page=2&limit=2` 返回正确切片与 pagination.total
+- [ ] 4.2 新建 `noj-core/tests/routes/rankings_test.ts`（路由层），覆盖：
+  - [ ] 4.2.1 `GET /api/v1/rankings` 无需 token，公开访问
+  - [ ] 4.2.2 `GET /api/v1/rankings/me` 未登录返回 401
+  - [ ] 4.2.3 `GET /api/v1/rankings?page=0` 返回 400（page 校验）
+
+## 5. 前端：composable + types
+
+- [ ] 5.1 新建 `noj-ui/composables/useRankings.ts`
+- [ ] 5.2 定义 `RankingRow` 和 `RankingsResponse` 接口（与后端响应字段对齐）
+- [ ] 5.3 封装 `useRankings(page, limit)` composable，返回 `{ data, pending, error, refresh }`
+
+## 6. 前端：ranking 页面 + 导航 + 用户主页
+
+- [ ] 6.1 新建 `noj-ui/pages/ranking.vue`，仿 `pages/users/[id].vue` 模板
+- [ ] 6.2 表格列：排名 / 用户名 / 解题数 / 通过率 / 提交数
+- [ ] 6.3 当前登录用户行高亮（`bg-primary/5`）
+- [ ] 6.4 复用 `components/PaginationNav.vue` 分页
+- [ ] 6.5 复用 `components/ui/AsyncContent.vue` 三态容器
+- [ ] 6.6 空状态文案："还没有用户通过任何题目，做第一个吧 👉 /problems"
+- [ ] 6.7 修改 `components/Navbar.vue`，在"提交记录"与"队列"之间插入榜单入口
+- [ ] 6.8 修改 `pages/users/[id].vue`，在统计卡区域追加"排名"卡（仅当 `profile.rank !== null`）
+
+## 7. 验证
+
+- [ ] 7.1 `deno task test` 全部通过（含新 rankings 测试）
+- [ ] 7.2 `deno task fmt --check` 无格式问题
+- [ ] 7.3 `deno task lint` 无 lint 错误
+- [ ] 7.4 `cd noj-ui && deno task dev`，访问 http://localhost:3000/ranking 看到表格渲染
+- [ ] 7.5 登录后访问 `/users/{自己的id}`，看到排名卡显示正确 rank
+- [ ] 7.6 `curl -s http://localhost:8000/api/v1/rankings` 返回正确排序的用户列表
+- [ ] 7.7 `nuxt build` 成功（CI ui-check 通过）


### PR DESCRIPTION
## 背景

ROADMAP Phase 1 交付标准是 "**榜单可查，题目可筛选，管理后台可用**"，三块中榜单尚未实现。本变更落地 Phase 1 的最后一块：全站用户榜单 + 用户主页排名卡。

参考 OpenSpec change: `openspec/changes/user-ranking/`

## 改动

### 后端 (noj-core)
- 新增 `src/services/rankings.ts`：`getGlobalRankings` + `getMyRanking`，复用 `users.ts:getUserProfile` L84-99 的 `count(*) filter (where = 'Accepted')` 聚合写法，用 SQL ROW_NUMBER() 在排序键上计算 rank 保证跨分页一致
- 新增 `src/routes/rankings.ts`：`GET /` 公开 + `GET /me` 需登录
- `src/app.ts` 挂载 `/api/v1/rankings`
- `src/routes/users.ts` 的 `GET /:id/profile` 响应追加 `rank` 字段

### 前端 (noj-ui)
- 新增 `pages/ranking.vue`：公开榜单页面（仿 problems.vue 模板）
- 新增 `composables/useRankings.ts`：类型 + useRankings composable
- `components/Navbar.vue` 在"提交记录"与"队列"之间插入榜单入口
- `pages/users/[id].vue` 统计卡区域追加"全站排名"卡（仅上榜用户）

## 关键技术点

### 零数据库迁移

- 完全复用现有 `submissions` + `evaluation_results` + `users` schema
- 聚合 SQL 模式与 `getUserProfile` 一致

### 排序稳定性

四级排序键确保相同指标下排名稳定：
```
solved_count DESC          → 主要：解题数
acceptance_rate DESC       → 次要：通过率
total_submissions ASC      → tiebreaker：提交数少者靠前
users.created_at ASC       → 最终 tiebreaker
```

### 排除规则

- root 系统用户（id='0'）不计入榜单
- 仅展示至少通过 1 道题的用户
- 未上榜用户 `rank = null`

### ROW_NUMBER() 跨分页一致

rank 由 SQL `ROW_NUMBER() OVER (ORDER BY ...)` 在排序键上计算，确保第 2 页首行 rank=51（而非 1），跨页连续。

## 验证

### 单元测试（11/11 通过）

```bash
deno test -A --env-file=.env tests/services/rankings.test.ts tests/routes/rankings.test.ts
# ok | 11 passed | 0 failed (2s)
```

- 聚合正确性：3 用户场景验证
- 排序稳定性：同 solved_count 时按 acceptance_rate tiebreak
- root 排除
- `getMyRanking` 上榜返回行 / 未上榜返回 null
- 分页不重复
- limit 上限截断
- 路由层：公开访问 / 401 / 400 参数校验

### 端到端 API 验证

```bash
$ curl -s 'http://localhost:8000/api/v1/rankings?page=1&limit=10' | jq
{
  "data": [{"rank": 1, "user_id": "...", "username": "admin", "solved_count": 1, "total_submissions": 5, "acceptance_rate": 0.8}],
  "pagination": {"page": 1, "per_page": 10, "total": 1, "total_pages": 1}
}

$ curl -s 'http://localhost:8000/api/v1/rankings/me'   # 无 token
401

$ curl -s 'http://localhost:8000/api/v1/rankings?page=0'
400

$ curl -s 'http://localhost:8000/api/v1/users/{admin_id}/profile' | jq .rank
1   # rank 字段正确追加
```

### GPG 验证

```
verified: true, reason: valid
verified_at: 2026-07-01T05:23:46Z
```

## 设计文档

- OpenSpec change: `openspec/changes/user-ranking/{proposal,design,tasks}.md`
- Spec 增量: `openspec/changes/user-ranking/specs/{ranking,user-profile}/spec.md`

## Non-Goals

- ❌ 比赛榜（Phase 2 实时榜单再用基础）
- ❌ 时间范围 / 难度分组（数据量小不需要）
- ❌ Redis 缓存（用户量 < 1K 实时聚合足够）
- ❌ 物化视图（同上）
- ❌ SSE 实时推送榜单变化
- ❌ 多语言（C++/Java）