### PR TITLE
fix(core,judge,ui): code audit batch 1+2 — 9 项 P0/P1 修复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ neuro-oj/
 │   │   │   ├── request.ts     # parseJsonBody<T>() 安全 JSON 解析
 │   │   │   └── logging.ts     # 生产安全日志（UUID 截断、分值隐藏）
 │   │   └── types/
-│   │       ├── index.ts       # JudgeTask, JudgeResult, SubmissionStatus
+│   │       ├── index.ts       # JudgeTask, JudgeResult, SubmissionStatus, LANGUAGE_EXT_MAP
 │   │       ├── auth.ts        # RegisterInput, LoginInput, UserResponse
 │   │       └── problems.ts    # CreateProblemInput, DIFFICULTIES, PROBLEM_TYPES
 │   ├── scripts/
@@ -402,7 +402,7 @@ cd noj-core && deno task seed
 
 - 格式：`<type>(<scope>): <description>`
 - type：`feat` `fix` `docs` `style` `refactor` `perf` `test` `chore` `ci` `build`
-- scope 可选：`core` `ui` `judge` `root`
+- scope 可选：`core` `ui` `judge` `root`；多 scope 使用逗号分隔：`fix(core,ui): 描述`
 - description 使用**中文**
 - 示例：`feat(core): 添加评测任务分发 API` / `fix(judge): 修复容器超时未清理`
 

--- a/noj-core/AGENTS.md
+++ b/noj-core/AGENTS.md
@@ -58,8 +58,9 @@ noj-core/
 │   │   ├── request.ts          # parseJsonBody<T>() 安全 JSON 解析
 │   │   └── logging.ts          # 生产安全日志（UUID 截断、分值隐藏）
 │   └── types/             # 类型定义
-│       ├── auth.ts        # RegisterInput, LoginInput, UserResponse
-│       └── problems.ts    # DIFFICULTIES, PROBLEM_TYPES, 校验函数
+│       ├── index.ts        # JudgeTask, JudgeResult, SubmissionStatus, LANGUAGE_EXT_MAP
+│       ├── auth.ts         # RegisterInput, LoginInput, UserResponse
+│       └── problems.ts     # DIFFICULTIES, PROBLEM_TYPES, 校验函数
 ├── scripts/               # CLI 脚本（seed、build-packages、migrate）
 ├── data/
 │   ├── problems-src/<id>/ # 题目源文件（版本控制，仅样例题）
@@ -277,7 +278,7 @@ docker compose down     # 停止
 | 支持包读取失败       | 非致命：日志记录后继续（无支持包），由 judge 端处理                                                                         |
 | 题目更新             | 静默忽略 `type` 和 `number` 字段（API 接受但不处理）                                                                        |
 | 题目编号冲突         | 自动分配时重试 3 次（PG 23505），手动指定时立即报错                                                                         |
-| 评测结果写入         | UPSERT 语义（`onConflictDoNothing`），防止重复处理                                                                          |
+| 评测结果写入         | UPSERT 语义（`onConflictDoUpdate`），用最新结果覆盖旧数据；配合 `rejudge_seq` 防护乱序覆盖                                  |
 | 队列位置查询         | 即使 DB 状态为 "judging" 也检查 Redis 队列（状态在入队时已更新）                                                            |
 | 问题列表默认         | 默认只显示 `type='P'` 的题目，U 类型需直接 URL 或所有者主页访问                                                             |
 | 分页默认值           | page=1, per_page=20, max per_page=100                                                                                       |

--- a/noj-core/src/db/connection.ts
+++ b/noj-core/src/db/connection.ts
@@ -5,22 +5,21 @@ import * as schema from "./schema.ts";
 
 let _db: ReturnType<typeof drizzle> | null = null;
 let _client: ReturnType<typeof postgres> | null = null;
-let _error: Error | null = null;
 
 /**
  * 获取 Drizzle ORM 数据库实例（单例模式）。
  * 首次调用时初始化 postgres.js 连接。
  * 必须通过环境变量 `DATABASE_URL` 配置连接字符串，无默认值。
+ *
+ * 注意：不在模块级别缓存连接错误，启动期 DB 暂不可用时让调用方
+ * 收到原始错误，DB 恢复后下一次调用即可成功重连。
  */
 export function getDb() {
   if (_db) return _db;
-  if (_error) throw _error;
 
   const databaseUrl = Deno.env.get("DATABASE_URL");
   if (!databaseUrl) {
-    const err = new Error("环境变量 DATABASE_URL 未设置");
-    _error = err;
-    throw err;
+    throw new Error("环境变量 DATABASE_URL 未设置");
   }
 
   try {
@@ -49,9 +48,9 @@ export function getDb() {
     _db = drizzle(_client, { schema });
     return _db;
   } catch (err) {
-    _error = err instanceof Error ? err : new Error(String(err));
-    console.error("数据库初始化失败:", _error.message);
-    throw _error;
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("数据库初始化失败:", message);
+    throw err;
   }
 }
 
@@ -63,9 +62,6 @@ export function getDb() {
 export async function checkDbHealth(): Promise<
   { ok: boolean; error?: string }
 > {
-  if (_error) {
-    return { ok: false, error: _error.message };
-  }
   if (!_client) {
     return { ok: false, error: "未初始化" };
   }
@@ -96,5 +92,4 @@ export async function resetDbForTest() {
   }
   _db = null;
   _client = null;
-  _error = null;
 }

--- a/noj-core/src/middleware/auth.ts
+++ b/noj-core/src/middleware/auth.ts
@@ -68,11 +68,11 @@ export async function authMiddleware(c: Context, next: Next) {
  * 管理员中间件——检查当前用户是否为管理员。
  *
  * 需要在 authMiddleware 之后使用，依赖其注入的 userRole 字段。
- * 若用户角色不为 "admin"，返回 403 禁止访问。
+ * 若用户角色不为 "admin"，抛 ForbiddenError 由 app.ts onError 统一处理。
  */
 export async function adminMiddleware(c: Context, next: Next) {
   if (c.get("userRole") !== "admin") {
-    return c.json({ error: "需要管理员权限" }, 403);
+    throw new ForbiddenError("需要管理员权限");
   }
   await next();
 }

--- a/noj-core/src/routes/submissions.ts
+++ b/noj-core/src/routes/submissions.ts
@@ -6,7 +6,7 @@ import {
 } from "../services/submissions.ts";
 import { getSubmissionQueueStatus } from "../services/queue.ts";
 import { authMiddleware } from "../middleware/auth.ts";
-import { BadRequestError } from "../lib/errors.ts";
+import { BadRequestError, NotFoundError } from "../lib/errors.ts";
 
 // 扩展 Hono 类型，使 c.get("userId") 返回 string
 type Env = {
@@ -154,7 +154,7 @@ router.get("/:id/status", authMiddleware, async (c) => {
 
   const result = await getSubmissionQueueStatus(id, userId, userRole);
   if (!result) {
-    return c.json({ error: "提交不存在" }, 404);
+    throw new NotFoundError("提交不存在");
   }
   return c.json(result);
 });

--- a/noj-core/src/services/submissions.ts
+++ b/noj-core/src/services/submissions.ts
@@ -11,10 +11,11 @@ import { AppError, BadRequestError, NotFoundError } from "../lib/errors.ts";
 import { pushJudgeTask } from "../mq/producer.ts";
 import { Channels, publishEvent } from "../lib/event-bus.ts";
 import { getProblem } from "./problems.ts";
-import type {
-  JudgeResult,
-  JudgeTask,
-  SubmissionStatus,
+import {
+  type JudgeResult,
+  type JudgeTask,
+  LANGUAGE_EXT_MAP,
+  type SubmissionStatus,
 } from "../types/index.ts";
 import { getSubmissionQueueStatus } from "./queue.ts";
 
@@ -289,14 +290,8 @@ export async function createSubmission(
   }
 
   // 生成文件默认名
-  const extMap: Record<string, string> = {
-    python3: "main.py",
-    python: "main.py",
-    cpp: "main.cpp",
-    c: "main.c",
-    javascript: "main.js",
-  };
-  const fileName = input.file_name || extMap[input.language] || "main.txt";
+  const fileName = input.file_name || LANGUAGE_EXT_MAP[input.language] ||
+    "main.txt";
 
   // 创建提交记录并推送到评测队列（在同一个 try 块中保证一致性）
   const id = crypto.randomUUID();
@@ -489,20 +484,20 @@ export async function saveEvaluationResult(
   //
   // 方案：JudgeResult 携带 rejudge_seq（由 noj-judge 从 JudgeTask 透传），
   // 此处比对 submissions 当前值。结果 seq < 当前 seq → 丢弃。
-  if (result.rejudge_seq !== undefined) {
-    const [sub] = await db
-      .select({ rejudge_seq: submissions.rejudge_seq })
-      .from(submissions)
-      .where(eq(submissions.id, result.submission_id))
-      .limit(1);
+  // 缺失 rejudge_seq 时按 0 处理（首次提交走默认值），此时仍需检查。
+  const incomingSeq = result.rejudge_seq ?? 0;
+  const [sub] = await db
+    .select({ rejudge_seq: submissions.rejudge_seq })
+    .from(submissions)
+    .where(eq(submissions.id, result.submission_id))
+    .limit(1);
 
-    if (sub && result.rejudge_seq < sub.rejudge_seq) {
-      console.warn(
-        `忽略过时的评测结果: submission=${result.submission_id}, ` +
-          `result_seq=${result.rejudge_seq}, current_seq=${sub.rejudge_seq}`,
-      );
-      return;
-    }
+  if (sub && incomingSeq < sub.rejudge_seq) {
+    console.warn(
+      `忽略过时的评测结果: submission=${result.submission_id}, ` +
+        `result_seq=${incomingSeq}, current_seq=${sub.rejudge_seq}`,
+    );
+    return;
   }
 
   const now = new Date().toISOString();
@@ -533,7 +528,15 @@ export async function saveEvaluationResult(
       })
       .where(eq(submissions.id, result.submission_id));
 
-    // 插入评测结果（使用 UPSERT 语义防止重复消费）
+    // 插入评测结果（使用 UPSERT 语义防止重复消费，并在重测后用最新结果覆盖）
+    //
+    // 修复 issue #86：重测流程中 rejudgeSubmission 会先 DELETE 旧 evaluation_results，
+    // 再发送新 JudgeTask。但若旧结果到达顺序在新结果到达之前出现（例如消费者网络抖动
+    // 触发的延迟重投），旧结果 INSERT 成功后会占据 submission_id 的 UNIQUE 槽位，
+    // 之后到达的新结果因 onConflictDoNothing 被 silently 跳过，导致评测结果停留在旧值。
+    //
+    // 改为 onConflictDoUpdate：若 submission_id 已存在，直接覆盖为本次结果。
+    // 配合 rejudge_seq 防护（旧结果 seq 已被丢弃），不会污染正确的新结果。
     await tx
       .insert(evaluationResults)
       .values({
@@ -547,7 +550,18 @@ export async function saveEvaluationResult(
         memory_kb: result.memory_kb ?? null,
         created_at: now,
       })
-      .onConflictDoNothing({ target: evaluationResults.submission_id });
+      .onConflictDoUpdate({
+        target: evaluationResults.submission_id,
+        set: {
+          status: result.status,
+          score: result.score,
+          output: result.output,
+          details: JSON.stringify(result.details),
+          time_ms: result.time_ms ?? null,
+          memory_kb: result.memory_kb ?? null,
+          created_at: now,
+        },
+      });
   });
 }
 
@@ -622,15 +636,6 @@ export async function updateSubmissionStatus(
 
 /** 批量重测单次最大提交数。 */
 const MAX_BATCH_REJUDGE = 500;
-
-/** 语言 → 默认文件名映射（与 createSubmission 保持一致）。 */
-const extMap: Record<string, string> = {
-  python3: "main.py",
-  python: "main.py",
-  cpp: "main.cpp",
-  c: "main.c",
-  javascript: "main.js",
-};
 
 /**
  * 管理员重测提交。
@@ -708,7 +713,7 @@ export async function rejudgeSubmission(id: string): Promise<void> {
     language: submission.language,
     code: submission.code,
     file_name: submission.file_name ??
-      (extMap[submission.language] || "main.txt"),
+      (LANGUAGE_EXT_MAP[submission.language] || "main.txt"),
     time_limit_ms: problem.time_limit_ms,
     memory_limit_mb: problem.memory_limit_mb,
     rejudge_seq: updated?.rejudge_seq ?? 0,
@@ -891,7 +896,8 @@ export async function rejudgeProblemSubmissions(
         support_package_base64,
         language: sub.language,
         code: sub.code,
-        file_name: sub.file_name ?? (extMap[sub.language] || "main.txt"),
+        file_name: sub.file_name ??
+          (LANGUAGE_EXT_MAP[sub.language] || "main.txt"),
         time_limit_ms: problem.time_limit_ms,
         memory_limit_mb: problem.memory_limit_mb,
         rejudge_seq: currentSeq,

--- a/noj-core/src/types/index.ts
+++ b/noj-core/src/types/index.ts
@@ -74,3 +74,18 @@ export function scoreToDb(value: number): number {
 export function scoreFromDb(value: number): number {
   return value / SCORE_SCALE;
 }
+
+/**
+ * 编程语言 → 默认文件名映射（评测 worker 期望的文件名）。
+ *
+ * 当提交未显式提供 file_name 时，按此表推断默认文件名。
+ * 单一来源：所有需要推断默认文件名的服务（createSubmission、
+ * rejudgeSubmission、rejudgeProblemSubmissions）均引用此常量。
+ */
+export const LANGUAGE_EXT_MAP: Record<string, string> = {
+  python3: "main.py",
+  python: "main.py",
+  cpp: "main.cpp",
+  c: "main.c",
+  javascript: "main.js",
+};

--- a/noj-core/tests/routes/submissions.test.ts
+++ b/noj-core/tests/routes/submissions.test.ts
@@ -241,3 +241,27 @@ Deno.test({
     assertEquals(body.pagination.total, 0);
   },
 });
+
+Deno.test({
+  name:
+    "submissions route: GET /api/v1/submissions/:id/status 提交不存在时返回 404 + code + request_id",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await signToken({ sub: "test-user", role: "user" });
+    const res = await app.request(
+      "/api/v1/submissions/nonexistent-id/status",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    assertEquals(res.status, 404);
+    const body = await res.json();
+    assertEquals(body.error, "提交不存在");
+    assertEquals(body.code, "NOT_FOUND");
+    assertEquals(typeof body.request_id, "string");
+    assertExists(body.request_id);
+  },
+});

--- a/noj-core/tests/routes/submissions.test.ts
+++ b/noj-core/tests/routes/submissions.test.ts
@@ -6,19 +6,33 @@ const hasEnv = !!Deno.env.get("JWT_SECRET");
 const hasDb = !!Deno.env.get("DATABASE_URL");
 const skip = !(hasEnv && hasDb);
 
+async function jsonRequest(
+  app: ReturnType<typeof createApp>,
+  path: string,
+  method: string,
+  body?: Record<string, unknown>,
+  token?: string,
+): Promise<Response> {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+
+  const req = new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return await app.fetch(req);
+}
+
 Deno.test({
   name: "submissions route: POST /api/v1/submissions 无 token 返回 401",
   ignore: !hasEnv,
   fn: async () => {
     const app = createApp();
-    const res = await app.request("/api/v1/submissions", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        problem_id: "1001",
-        language: "python3",
-        code: "print('hi')",
-      }),
+    const res = await jsonRequest(app, "/api/v1/submissions", "POST", {
+      problem_id: "1001",
+      language: "python3",
+      code: "print('hi')",
     });
     assertEquals(res.status, 401);
     const body = await res.json();
@@ -31,18 +45,17 @@ Deno.test({
   ignore: !hasEnv,
   fn: async () => {
     const app = createApp();
-    const res = await app.request("/api/v1/submissions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer invalid-token-here",
-      },
-      body: JSON.stringify({
+    const res = await jsonRequest(
+      app,
+      "/api/v1/submissions",
+      "POST",
+      {
         problem_id: "1001",
         language: "python3",
         code: "print('hi')",
-      }),
-    });
+      },
+      "invalid-token-here",
+    );
     assertEquals(res.status, 401);
     const body = await res.json();
     assertEquals(body.error, "认证令牌无效或已过期");
@@ -55,14 +68,9 @@ Deno.test({
   fn: async () => {
     const app = createApp();
     const token = await signToken({ sub: "test-user", role: "user" });
-    const res = await app.request("/api/v1/submissions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ problem_id: "1001" }), // 缺少 language 和 code
-    });
+    const res = await jsonRequest(app, "/api/v1/submissions", "POST", {
+      problem_id: "1001",
+    }, token);
     assertEquals(res.status, 400);
     const body = await res.json();
     assertEquals(body.error.includes("缺少必填字段"), true);
@@ -74,7 +82,7 @@ Deno.test({
   ignore: !hasEnv,
   fn: async () => {
     const app = createApp();
-    const res = await app.request("/api/v1/submissions/123");
+    const res = await jsonRequest(app, "/api/v1/submissions/123", "GET");
     assertEquals(res.status, 401);
   },
 });
@@ -88,9 +96,13 @@ Deno.test({
   fn: async () => {
     const app = createApp();
     const token = await signToken({ sub: "test-user", role: "user" });
-    const res = await app.request("/api/v1/submissions/nonexistent-id", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const res = await jsonRequest(
+      app,
+      "/api/v1/submissions/nonexistent-id",
+      "GET",
+      undefined,
+      token,
+    );
     assertEquals(res.status, 404);
     const body = await res.json();
     assertEquals(body.error, "提交不存在");
@@ -104,7 +116,7 @@ Deno.test({
   ignore: !hasEnv,
   fn: async () => {
     const app = createApp();
-    const res = await app.request("/api/v1/submissions");
+    const res = await jsonRequest(app, "/api/v1/submissions", "GET");
     assertEquals(res.status, 401);
   },
 });
@@ -114,9 +126,13 @@ Deno.test({
   ignore: !hasEnv,
   fn: async () => {
     const app = createApp();
-    const res = await app.request("/api/v1/submissions", {
-      headers: { Authorization: "Bearer invalid-token" },
-    });
+    const res = await jsonRequest(
+      app,
+      "/api/v1/submissions",
+      "GET",
+      undefined,
+      "invalid-token",
+    );
     assertEquals(res.status, 401);
   },
 });
@@ -130,9 +146,13 @@ Deno.test({
   fn: async () => {
     const app = createApp();
     const token = await signToken({ sub: "test-list-empty", role: "user" });
-    const res = await app.request("/api/v1/submissions", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const res = await jsonRequest(
+      app,
+      "/api/v1/submissions",
+      "GET",
+      undefined,
+      token,
+    );
     assertEquals(res.status, 200);
     const body = await res.json();
     assertEquals(Array.isArray(body.data), true);
@@ -152,9 +172,13 @@ Deno.test({
   fn: async () => {
     const app = createApp();
     const token = await signToken({ sub: "test-user", role: "user" });
-    const res = await app.request("/api/v1/submissions?status=invalid", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const res = await jsonRequest(
+      app,
+      "/api/v1/submissions?status=invalid",
+      "GET",
+      undefined,
+      token,
+    );
     assertEquals(res.status, 400);
   },
 });
@@ -167,9 +191,13 @@ Deno.test({
   fn: async () => {
     const app = createApp();
     const token = await signToken({ sub: "test-user", role: "user" });
-    const res = await app.request("/api/v1/submissions?per_page=999", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const res = await jsonRequest(
+      app,
+      "/api/v1/submissions?per_page=999",
+      "GET",
+      undefined,
+      token,
+    );
     assertEquals(res.status, 200);
     const body = await res.json();
     assertEquals(body.pagination.per_page, 100);
@@ -183,7 +211,7 @@ Deno.test({
   ignore: !hasEnv,
   fn: async () => {
     const app = createApp();
-    const res = await app.request("/api/v1/admin/submissions");
+    const res = await jsonRequest(app, "/api/v1/admin/submissions", "GET");
     assertEquals(res.status, 401);
   },
 });
@@ -194,9 +222,13 @@ Deno.test({
   fn: async () => {
     const app = createApp();
     const token = await signToken({ sub: "test-regular", role: "user" });
-    const res = await app.request("/api/v1/admin/submissions", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const res = await jsonRequest(
+      app,
+      "/api/v1/admin/submissions",
+      "GET",
+      undefined,
+      token,
+    );
     assertEquals(res.status, 403);
     const body = await res.json();
     assertEquals(body.error, "需要管理员权限");
@@ -211,9 +243,13 @@ Deno.test({
   fn: async () => {
     const app = createApp();
     const token = await signToken({ sub: "test-admin", role: "admin" });
-    const res = await app.request("/api/v1/admin/submissions", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const res = await jsonRequest(
+      app,
+      "/api/v1/admin/submissions",
+      "GET",
+      undefined,
+      token,
+    );
     assertEquals(res.status, 200);
     const body = await res.json();
     assertEquals(Array.isArray(body.data), true);
@@ -229,11 +265,12 @@ Deno.test({
   fn: async () => {
     const app = createApp();
     const token = await signToken({ sub: "test-admin", role: "admin" });
-    const res = await app.request(
+    const res = await jsonRequest(
+      app,
       "/api/v1/admin/submissions?user_id=nonexistent-user",
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
+      "GET",
+      undefined,
+      token,
     );
     assertEquals(res.status, 200);
     const body = await res.json();
@@ -251,11 +288,12 @@ Deno.test({
   fn: async () => {
     const app = createApp();
     const token = await signToken({ sub: "test-user", role: "user" });
-    const res = await app.request(
+    const res = await jsonRequest(
+      app,
       "/api/v1/submissions/nonexistent-id/status",
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
+      "GET",
+      undefined,
+      token,
     );
     assertEquals(res.status, 404);
     const body = await res.json();

--- a/noj-core/tests/services/submissions.test.ts
+++ b/noj-core/tests/services/submissions.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import { assertEquals, assertExists, assertRejects } from "jsr:@std/assert@^1";
 import {
   createSubmission,
   getSubmission,
@@ -254,5 +254,162 @@ Deno.test({
     );
     assertEquals(parsed.status, "Accepted");
     assertEquals(parsed.score, 1000);
+  },
+});
+
+Deno.test({
+  name:
+    "submissions service: saveEvaluationResult 重复写同一 submission 应 UPDATE 而非 silently 跳过（issue #86）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    const subId = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    // 创建测试用户
+    const userId = crypto.randomUUID();
+    await db.insert(users).values({
+      id: userId,
+      username: `upsert_test_${Date.now()}`,
+      email: `upsert_test_${Date.now()}@test.com`,
+      password_hash: "x",
+      role: "user",
+      created_at: now,
+      updated_at: now,
+    });
+
+    // 准备 submission（status=judging 让 UPDATE 通行）
+    await db.insert(submissions).values({
+      id: subId,
+      user_id: userId,
+      problem_id: TEST_PROBLEM_ID,
+      language: "python3",
+      code: "print(1)",
+      status: "judging",
+      created_at: now,
+    });
+
+    try {
+      // 第一次写入：WrongAnswer
+      await saveEvaluationResult({
+        submission_id: subId,
+        status: "WrongAnswer",
+        score: 500,
+        output: '---RESULT---\n{"first":true}',
+        details: {},
+      });
+
+      // 第二次写入：Accepted（rejudge 后）
+      await saveEvaluationResult({
+        submission_id: subId,
+        status: "Accepted",
+        score: 1000,
+        output: '---RESULT---\n{"new":true}',
+        details: { rejudge: true },
+        time_ms: 200,
+        memory_kb: 2048,
+      });
+
+      // 断言：只有 1 行（UNIQUE 保持），但内容是第二次的
+      const rows = await db.select().from(evaluationResults)
+        .where(eq(evaluationResults.submission_id, subId));
+      assertEquals(rows.length, 1);
+      assertEquals(rows[0].status, "Accepted");
+      assertEquals(rows[0].score, 1000);
+      assertEquals(rows[0].output, '---RESULT---\n{"new":true}');
+      assertEquals(JSON.parse(rows[0].details), { rejudge: true });
+      assertEquals(rows[0].time_ms, 200);
+      assertEquals(rows[0].memory_kb, 2048);
+    } finally {
+      // 清理
+      await db.delete(evaluationResults).where(
+        eq(evaluationResults.submission_id, subId),
+      );
+      await db.delete(submissions).where(eq(submissions.id, subId));
+      await db.delete(users).where(eq(users.id, userId));
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "submissions service: saveEvaluationResult rejudge_seq 防护：旧结果不应覆盖新结果",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    const subId = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    const userId = crypto.randomUUID();
+    await db.insert(users).values({
+      id: userId,
+      username: `seq_guard_${Date.now()}`,
+      email: `seq_guard_${Date.now()}@test.com`,
+      password_hash: "x",
+      role: "user",
+      created_at: now,
+      updated_at: now,
+    });
+
+    await db.insert(submissions).values({
+      id: subId,
+      user_id: userId,
+      problem_id: TEST_PROBLEM_ID,
+      language: "python3",
+      code: "print(1)",
+      status: "judging",
+      rejudge_seq: 2, // 当前序列号=2
+      created_at: now,
+    });
+
+    try {
+      // 写入 seq=2 的新结果（应成功）
+      await saveEvaluationResult({
+        submission_id: subId,
+        status: "Accepted",
+        score: 1000,
+        output: "---NEW---",
+        details: { seq: 2 },
+        rejudge_seq: 2,
+      });
+
+      // 写入 seq=1 的旧结果（应被丢弃，仅 console.warn）
+      const originalWarn = console.warn;
+      const warnings: string[] = [];
+      console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+      try {
+        await saveEvaluationResult({
+          submission_id: subId,
+          status: "WrongAnswer",
+          score: 500,
+          output: "---OLD---",
+          details: { seq: 1 },
+          rejudge_seq: 1,
+        });
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      // 断言：evaluation_results 仍只有 1 行，且是 seq=2 的内容
+      const rows = await db.select().from(evaluationResults)
+        .where(eq(evaluationResults.submission_id, subId));
+      assertEquals(rows.length, 1);
+      assertEquals(rows[0].status, "Accepted");
+      assertEquals(rows[0].output, "---NEW---");
+
+      // 断言：丢弃日志被记录
+      const ignoredLog = warnings.find((w) => w.includes("忽略过时的评测结果"));
+      assertExists(ignoredLog, "应记录旧结果被丢弃的日志");
+    } finally {
+      await db.delete(evaluationResults).where(
+        eq(evaluationResults.submission_id, subId),
+      );
+      await db.delete(submissions).where(eq(submissions.id, subId));
+      await db.delete(users).where(eq(users.id, userId));
+    }
   },
 });

--- a/noj-judge/Cargo.lock
+++ b/noj-judge/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,7 +735,6 @@ dependencies = [
  "bollard",
  "futures-util",
  "redis",
- "scopeguard",
  "serde",
  "serde_json",
  "serial_test",
@@ -874,6 +891,23 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
@@ -1287,10 +1321,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/noj-judge/Cargo.toml
+++ b/noj-judge/Cargo.toml
@@ -12,14 +12,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 futures-util = "0.3"
 tar = "0.4"
 tokio-util = "0.7"
-scopeguard = "1.2"
 axum = "0.8"
 
 [dev-dependencies]

--- a/noj-judge/src/main.rs
+++ b/noj-judge/src/main.rs
@@ -22,26 +22,59 @@ use crate::config::Config;
 use crate::pool::PoolManager;
 
 /// 等待所有 in-flight 任务完成（带 30s 超时兜底）。
+///
+/// 超时后必须**显式** `abort()` 剩余 `JoinHandle`，否则：
+/// 1. `FuturesUnordered` 在本函数返回后被 drop，drop 时**不会**等待 task 完成；
+/// 2. task 内部的 future（如 `bollard` exec、cgroup read）会被取消；
+/// 3. Docker exec 在 daemon 侧无法被取消，会残留到自然结束——这就是 exec 泄漏。
+///
+/// 因此超时分支里我们主动遍历 `tasks.iter_mut()` 调用 `abort()`，
+/// 然后用 5s 兜底 `join_all` 收集结果（best-effort，不阻塞进程退出）。
 async fn drain_tasks(tasks: &mut FuturesUnordered<tokio::task::JoinHandle<()>>) {
     info!(
         "关闭信号已接收，等待 {} 个正在执行的任务完成...",
         tasks.len()
     );
-    let timeout_dur = std::time::Duration::from_secs(30);
-    let timeout = tokio::time::sleep(timeout_dur);
-    tokio::pin!(timeout);
+    let drain_timeout = std::time::Duration::from_secs(30);
+    let deadline = tokio::time::sleep(drain_timeout);
+    tokio::pin!(deadline);
     loop {
         tokio::select! {
-            _ = &mut timeout => {
+            _ = &mut deadline => {
                 warn!("等待超时，{} 个任务未完成，强制退出", tasks.len());
                 break;
             }
             _ = tasks.next() => {
                 if tasks.is_empty() {
                     info!("所有 in-flight 任务已完成");
-                    break;
+                    return;
                 }
             }
+        }
+    }
+
+    // 显式 abort 所有剩余任务，阻止 FuturesUnordered drop 后 task 被悄悄取消
+    let remaining = tasks.len();
+    warn!("drain 超时，强制 abort {} 个剩余 task", remaining);
+    for handle in tasks.iter_mut() {
+        handle.abort();
+    }
+    // best-effort 等待 abort 完成，最多 5s（不阻塞进程退出）
+    let drain = futures_util::future::join_all(tasks);
+    match tokio::time::timeout(std::time::Duration::from_secs(5), drain).await {
+        Ok(results) => {
+            let aborted = results
+                .iter()
+                .filter(|r| r.as_ref().err().is_some_and(|e| e.is_cancelled()))
+                .count();
+            let finished = results.len() - aborted;
+            info!(
+                "剩余任务 abort 完成: finished={}, aborted={}",
+                finished, aborted
+            );
+        }
+        Err(_) => {
+            warn!("abort 后 join_all 仍超时，进程将直接退出");
         }
     }
 }
@@ -49,7 +82,12 @@ async fn drain_tasks(tasks: &mut FuturesUnordered<tokio::task::JoinHandle<()>>) 
 fn main() -> Result<()> {
     let rt = tokio::runtime::Runtime::new().context("创建 Tokio 运行时失败")?;
     rt.block_on(async {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,noj_judge=debug")),
+        )
+        .init();
 
     let config = Config::from_env();
     info!("noj-judge 启动 (pool_enabled={})", config.pool.enabled);

--- a/noj-judge/src/pool/mod.rs
+++ b/noj-judge/src/pool/mod.rs
@@ -846,13 +846,33 @@ impl PoolManager {
                 .map_err(anyhow::Error::from)
         })
         .await?;
-        with_timeout(5, "start_container", async {
+        let start_result = with_timeout(5, "start_container", async {
             docker
                 .start_container(&result.id, None)
                 .await
                 .map_err(anyhow::Error::from)
         })
-        .await?;
+        .await;
+        if let Err(start_err) = start_result {
+            // 启动失败：清理已创建但未启动的容器，避免 zombie 容器泄漏
+            if let Err(rm_err) = docker
+                .remove_container(
+                    &result.id,
+                    Some(bollard::query_parameters::RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await
+            {
+                warn!(
+                    container_id = %result.id,
+                    error = %rm_err,
+                    "create_container 启动失败后清理容器也失败，可能存在 zombie 容器"
+                );
+            }
+            return Err(start_err);
+        }
         Ok(result.id)
     }
 

--- a/noj-ui/AGENTS.md
+++ b/noj-ui/AGENTS.md
@@ -163,8 +163,8 @@ cd dist
 - **仅拦截** `POST /api/v1/auth/login`：解析登录响应，提取 JWT 设置 Cookie，从响应体删除 `token` 字段
 - **不拦截**注册等其他认证端点
 - 非登录请求：从 Cookie 读取 `noj:token`，注入 `Authorization: Bearer` 头后直接 `proxyRequest()`
-- 错误处理：`$fetch.raw` 抛出的 `err.response` 被捕获并原样转发状态码和 body
-- **无 URL 校验**：所有路径直接拼接 `apiBase + event.path`，无白名单过滤
+- **路径白名单**：仅允许 `/api/v1/` 前缀的请求透传，非匹配路径返回 404
+- 错误处理：`$fetch.raw` 抛出的 `err.response` 被捕获并原样转发状态码和 body，白名单响应头（`retry-after`、`x-ratelimit-*`、`x-request-id`、`www-authenticate`）透传给客户端
 
 ### 安全模型
 

--- a/noj-ui/server/api/[...slug].ts
+++ b/noj-ui/server/api/[...slug].ts
@@ -1,5 +1,23 @@
+const FORWARDABLE_HEADERS = new Set([
+  "retry-after",
+  "x-ratelimit-limit",
+  "x-ratelimit-remaining",
+  "x-ratelimit-reset",
+  "x-request-id",
+  "www-authenticate",
+]);
+
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
+
+  // 路径白名单：仅允许转发到 noj-core v1 API
+  if (!event.path.startsWith("/api/v1/")) {
+    return sendError(
+      event,
+      createError({ statusCode: 404, statusMessage: "Not Found" }),
+    );
+  }
+
   const target = `${config.apiBase}${event.path}`;
 
   const cookies = parseCookies(event);
@@ -72,11 +90,25 @@ export default defineEventHandler(async (event) => {
       }
 
       setResponseStatus(event, response.status);
+      setHeader(event, "cache-control", "no-store, private");
       return data;
     } catch (err) {
-      const e = err as { response?: { status: number; _data: unknown } };
+      const e = err as {
+        response?: {
+          status: number;
+          _data: unknown;
+          headers?: Record<string, string>;
+        };
+      };
       if (e.response) {
         setResponseStatus(event, e.response.status);
+        if (e.response.headers) {
+          for (const [name, value] of Object.entries(e.response.headers)) {
+            if (FORWARDABLE_HEADERS.has(name.toLowerCase())) {
+              setHeader(event, name, value);
+            }
+          }
+        }
         return e.response._data;
       }
       throw err;


### PR DESCRIPTION
## 背景

基于 2026-07-01 code audit（详见 issue #85 tracking）整理的 P0 必修项。本 PR 合并 Batch 1（5 项）+ Batch 2（4 项），共 **9 项修复**。

> **注意**：force push 已覆盖原 Batch 1 commit 79b700b1 → 新 commit 9a1cdcc1。新增 Batch 2 改动，title 也已更新。

## 改动总览（9 项）

### Batch 1（原 5 项）

| Issue | 模块 | 类型 | 工作量 |
|-------|------|------|--------|
| #86 | core | bug（数据正确性） | 3h |
| #88 | ui | security | 1h |
| — | core | consistency | 10min |
| — | core | consistency | 5min |
| — | judge | chore + observability | 10min |

- **#86** saveEvaluationResult UPSERT 修复：`onConflictDoNothing` → `onConflictDoUpdate`，重测时真正更新字段；rejudge_seq 默认为 0，始终走防护比较
- **#88** Nitro 代理加固：path 白名单 `/api/v1/`、headers 白名单透传、登录响应 `Cache-Control: no-store`
- `/:id/status` 走 AppError 体系（`throw NotFoundError`）
- adminMiddleware 抛 ForbiddenError
- noj-judge 移除 scopeguard + tracing EnvFilter（`RUST_LOG` 生效）

### Batch 2（新增 4 项）

| Issue | 模块 | 类型 | 工作量 |
|-------|------|------|--------|
| #3 | judge | bug（资源泄漏） | 1h |
| #4 | judge | bug（优雅关闭） | 4h |
| #14 | core | refactor | 30min |
| #16 | core | bug（韧性） | 1h |

- **#3** create_container 成功 + start_container 失败时清理 zombie 容器（`force: true` + warn 日志）
- **#4** 优雅关闭时显式 `abort()` + `join_all` + 5s timeout（避免 docker exec 在 daemon 侧残留）
- **#14** LANGUAGE_EXT_MAP 提到 `types/index.ts`，消除 submissions.ts:292/627 重复定义
- **#16** 移除 DB `_error` 永久缓存，启动期 DB 不可用 → 恢复后自动重连

## 验证

### 单元测试

```bash
$ cd noj-core && deno test -A --env-file=.env \
    tests/services/submissions.test.ts \
    tests/routes/submissions.test.ts \
    tests/routes/auth-admin.test.ts
ok | 60 passed | 0 failed (2s)

$ cd noj-judge && cargo test --lib
test result: ok. 42 passed; 0 failed
```

### 类型 / Lint / Fmt

- `deno fmt --check`：103 files OK
- `deno lint`：86 files OK
- `cargo build`：OK
- `cargo clippy -- -D warnings`：OK
- `cargo fmt --check`：OK

### GPG 签名

```
verified: true, reason: valid
verified_at: 2026-07-01T...
```

## 测试覆盖增量

| 文件 | 新增测试 |
|------|---------|
| `tests/services/submissions.test.ts` | +2（UPSERT + rejudge_seq 防护） |
| `tests/routes/submissions.test.ts` | +1（全局错误格式） |

## 文件清单（12 文件 +391/-67）

- `noj-core/src/db/connection.ts` (Batch 2)
- `noj-core/src/middleware/auth.ts` (Batch 1)
- `noj-core/src/routes/submissions.ts` (Batch 1)
- `noj-core/src/services/submissions.ts` (Batch 1+2)
- `noj-core/src/types/index.ts` (Batch 2)
- `noj-core/tests/routes/submissions.test.ts` (Batch 1)
- `noj-core/tests/services/submissions.test.ts` (Batch 1)
- `noj-judge/Cargo.{lock,toml}` (Batch 1)
- `noj-judge/src/main.rs` (Batch 1+2)
- `noj-judge/src/pool/mod.rs` (Batch 2)
- `noj-ui/server/api/[...slug].ts` (Batch 1)

## 关联

- Closes #86
- Closes #88
- Part of #85（tracking issue）