### PR TITLE
chore(root): 修复 noj-core/AGENTS.md markdown 表格列宽对齐

### DIFF
--- a/noj-core/AGENTS.md
+++ b/noj-core/AGENTS.md
@@ -252,21 +252,21 @@ docker compose down     # 停止
 
 ## 数据库 Schema 设计
 
-| 表                    | 关键列                                                                                                                    | 约束 / 索引                                                    |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `users`               | `id`(UUID), `username`(unique), `email`(unique), `password_hash`, `role`(user/admin), `bio`, `must_change_password`(bool) | PK, UK(username), UK(email)                                    |
-| `problems`            | `id`(UUID), `type`(U/P), `number`(int), `display_id`(unique), `title`, `difficulty`, `owner_id`                           | PK, UK(display_id), UK(type,number), FK→users                  |
-| `categories`          | `id`(UUID), `name`, `parent_id`, `level`(缓存深度)                                                                        | PK, FK→categories(parent_id) ON DELETE SET NULL                |
-| `problems_categories` | `problem_id`, `category_id`                                                                                               | FK→problems ON DELETE CASCADE, FK→categories ON DELETE CASCADE |
-| `submissions`         | `id`(UUID), `user_id`, `problem_id`, `status`, `language`, `code`                                                         | PK, FK→users, FK→problems, idx(user_id,created_at)             |
-| `evaluation_results`  | `id`(UUID), `submission_id`(unique), `status`, `score`(INTEGER×100), `output`, `time_ms`, `memory_kb`                     | PK, UK(submission_id), FK→submissions                          |
-| `check_ins`           | `id`(UUID), `user_id`, `checkin_date`(YYYY-MM-DD UTC), `streak`                                                           | PK, FK→users, UK(user_id,checkin_date)                         |
-| `judge_images`        | `id`(UUID), `image`(text), `enabled`(bool)                                                                                   | PK, UK(image)                                                   |
-| `password_reset_tokens` | `id`(UUID), `user_id`, `token_hash`(text), `expires_at`(text), `used`(bool)                                                 | PK, FK→users, UK(token_hash)                                    |
-| `conversations`        | `id`(UUID), `participant_a_id`, `participant_b_id`, `last_message_at`(text)                                                 | PK, FK→users, UK(participant_a,participant_b)                   |
-| `messages`             | `id`(UUID), `conversation_id`, `sender_id`, `content`(text), `created_at`(text)                                             | PK, FK→conversations, idx(conversation_id,created_at)           |
-| `conversation_reads`   | `id`(UUID), `conversation_id`, `user_id`, `last_read_at`(text)                                                              | PK, FK→conversations, FK→users, UK(conversation_id,user_id)     |
-| `message_deletions`    | `id`(UUID), `message_id`, `user_id`, `deleted_at`(text)                                                                     | PK, FK→messages, FK→users                                      |
+| 表                      | 关键列                                                                                                                    | 约束 / 索引                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `users`                 | `id`(UUID), `username`(unique), `email`(unique), `password_hash`, `role`(user/admin), `bio`, `must_change_password`(bool) | PK, UK(username), UK(email)                                    |
+| `problems`              | `id`(UUID), `type`(U/P), `number`(int), `display_id`(unique), `title`, `difficulty`, `owner_id`                           | PK, UK(display_id), UK(type,number), FK→users                  |
+| `categories`            | `id`(UUID), `name`, `parent_id`, `level`(缓存深度)                                                                        | PK, FK→categories(parent_id) ON DELETE SET NULL                |
+| `problems_categories`   | `problem_id`, `category_id`                                                                                               | FK→problems ON DELETE CASCADE, FK→categories ON DELETE CASCADE |
+| `submissions`           | `id`(UUID), `user_id`, `problem_id`, `status`, `language`, `code`                                                         | PK, FK→users, FK→problems, idx(user_id,created_at)             |
+| `evaluation_results`    | `id`(UUID), `submission_id`(unique), `status`, `score`(INTEGER×100), `output`, `time_ms`, `memory_kb`                     | PK, UK(submission_id), FK→submissions                          |
+| `check_ins`             | `id`(UUID), `user_id`, `checkin_date`(YYYY-MM-DD UTC), `streak`                                                           | PK, FK→users, UK(user_id,checkin_date)                         |
+| `judge_images`          | `id`(UUID), `image`(text), `enabled`(bool)                                                                                | PK, UK(image)                                                  |
+| `password_reset_tokens` | `id`(UUID), `user_id`, `token_hash`(text), `expires_at`(text), `used`(bool)                                               | PK, FK→users, UK(token_hash)                                   |
+| `conversations`         | `id`(UUID), `participant_a_id`, `participant_b_id`, `last_message_at`(text)                                               | PK, FK→users, UK(participant_a,participant_b)                  |
+| `messages`              | `id`(UUID), `conversation_id`, `sender_id`, `content`(text), `created_at`(text)                                           | PK, FK→conversations, idx(conversation_id,created_at)          |
+| `conversation_reads`    | `id`(UUID), `conversation_id`, `user_id`, `last_read_at`(text)                                                            | PK, FK→conversations, FK→users, UK(conversation_id,user_id)    |
+| `message_deletions`     | `id`(UUID), `message_id`, `user_id`, `deleted_at`(text)                                                                   | PK, FK→messages, FK→users                                      |
 
 **设计要点**：
 


### PR DESCRIPTION
## 背景

CI `deno fmt --check` 在 `noj-core/AGENTS.md` 第 §11 "数据库 Schema 设计"
markdown 表格报告列宽未对齐（13 行表格）。本次仅对齐 markdown 字符数，
**无任何语义修改**，纯文本表格对齐。

## 改动

`noj-core/AGENTS.md` 表 § 数据库 Schema 设计：
- 列宽对齐，使所有 13 行表格列宽一致
- `deno fmt --check` 通过

## 验证

- [x] `cd noj-core && deno fmt --check` 退出码 0（122 文件全部格式合规）
- [x] 表头 / 分隔线 / 数据行 列宽一致

## 影响

仅 1 文件 30 行（增 15 / 改 15），文本表格对齐。

Refs #105