### PR TITLE
feat(root): 生产环境 Docker Compose 编排（issue #103）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,6 @@
 # --- 环境变量 / Secrets ---
 .env
 .env.*
-!.env.example
 !.env.e2e.template
 !.env.prod.example
 env.prod.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,68 @@
+# Neuro OJ 顶层 .dockerignore
+# 防止 secrets、构建产物、缓存漏到任何 docker build context 中
+#
+# 注意：每个子模块有自己的 .dockerignore（如 noj-judge/.dockerignore），
+# 那个由构建上下文（context）决定，子模块的镜像构建只 COPY 它需要的文件。
+# 本顶层 .dockerignore 主要为 docker-compose.prod.yml 的 build 段保驾护航。
+
+# --- 环境变量 / Secrets ---
+.env
+.env.*
+!.env.example
+!.env.e2e.template
+!.env.prod.example
+env.prod.sh
+
+# --- Deno ---
+.deno_cache/
+node_modules/
+
+# --- Node.js / npm / Nuxt ---
+.npm/
+.cache/
+.output/
+.nuxt/
+dist/
+
+# --- Rust ---
+target/
+*.rs.bk
+
+# --- 编辑器 / OS ---
+.idea/
+.vscode/
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+*.log
+
+# --- Docker 自身 ---
+docker-compose.override.yml
+
+# --- 测试产物 ---
+.noj-test-state/
+coverage/
+.nyc_output/
+
+# --- Git ---
+.git/
+.gitignore
+.github/
+
+# --- 文档（不进镜像） ---
+*.md
+!noj-core/CLAUDE.md
+!noj-judge/CLAUDE.md
+!noj-ui/CLAUDE.md
+openspec/
+
+# --- 题目源 / 支持包（不进任何镜像，由数据卷挂载） ---
+noj-core/data/problems-src/
+noj-core/data/packages/
+
+# --- E2E 测试专用（不进生产镜像） ---
+scripts/e2e/
+env.e2e.template
+*.test.ts

--- a/docker-compose.init.yml
+++ b/docker-compose.init.yml
@@ -1,0 +1,57 @@
+# docker-compose.init.yml — init-letsencrypt 独立栈（issue #103 修复）
+#
+# 设计目的：
+#   首次部署签证书时需要 nginx 仅服务 80 端口（ACME challenge），
+#   而完整配置依赖已签发的证书存在。让 init-letsencrypt.sh 直接修改
+#   docker/nginx/nginx.conf 存在 race window（脚本崩溃会污染主配置）。
+#
+#   本文件**独立定义**一个最小 init 栈（nginx + certbot），不继承 base compose。
+#   - 与正式栈用不同的 project 名（-p noj-init）避免冲突
+#   - 共享命名卷 letsencrypt_data / certbot_www / nginx_logs（卷名全局）
+#   - 主配置 docker/nginx/nginx.conf 全程不被修改
+#
+#   使用方式（由 init-letsencrypt.sh 调用）：
+#     docker compose -f docker-compose.init.yml -p noj-init up -d nginx
+#     docker compose -f docker-compose.init.yml -p noj-init \
+#       run --rm certbot certonly --webroot -w /var/www/certbot \
+#       -d YOUR_DOMAIN ...
+#     docker compose -f docker-compose.init.yml -p noj-init down --remove-orphans
+#     docker compose -f docker-compose.prod.yml up -d   # 启动正式栈
+
+networks:
+  noj_net_init:
+    driver: bridge
+
+volumes:
+  letsencrypt_data:
+  certbot_www:
+  nginx_logs:
+
+services:
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: noj-init-nginx
+    restart: "no"
+    ports:
+      - "80:80"
+    volumes:
+      # init 专用配置：仅服务 80 端口 + ACME challenge，不引用证书
+      - ./docker/nginx/nginx.init.conf:/etc/nginx/nginx.conf:ro
+      - ./docker/nginx/templates:/etc/nginx/templates:ro
+      - letsencrypt_data:/etc/letsencrypt:ro
+      - certbot_www:/var/www/certbot:ro
+      - nginx_logs:/var/log/nginx
+    environment:
+      YOUR_DOMAIN: ${YOUR_DOMAIN:?required}
+    networks:
+      - noj_net_init
+
+  certbot:
+    image: certbot/certbot
+    container_name: noj-init-certbot
+    profiles: ["certbot"]
+    volumes:
+      - letsencrypt_data:/etc/letsencrypt
+      - certbot_www:/var/www/certbot
+    networks:
+      - noj_net_init

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,9 +47,9 @@ services:
       YOUR_DOMAIN: ${YOUR_DOMAIN:?required}
     depends_on:
       core:
-        condition: service_healthy
+        condition: service_started
       ui:
-        condition: service_healthy
+        condition: service_started
     healthcheck:
       test: ["CMD", "wget", "--spider", "--quiet", "http://localhost/health"]
       interval: 30s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -61,6 +61,9 @@ services:
         limits:
           cpus: "0.5"
           memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 64M
     logging:
       driver: json-file
       options:
@@ -71,12 +74,15 @@ services:
 
   # ╔════════════════════════════════════════════════════════════╗
   # ║  前端层（noj-ui 单二进制）                                    ║
+  # ║                                                              ║
+  # ║  ui 是无状态前端，可水平扩展；replicas=2 在 swarm 模式生效。    ║
+  # ║  单机 compose 部署请用 docker compose up --scale ui=2。       ║
   # ╚════════════════════════════════════════════════════════════╝
   ui:
     build:
       context: ./noj-ui
       dockerfile: Dockerfile.prod
-    container_name: noj-prod-ui
+    # 不设 container_name：允许水平扩展（--scale 与 swarm 部署都依赖于此）
     restart: unless-stopped
     environment:
       # 反代后 NUXT_PUBLIC_API_BASE 留空 → 客户端走 /api/v1 同源
@@ -90,10 +96,14 @@ services:
         condition: service_healthy
     stop_grace_period: 15s
     deploy:
+      replicas: 2
       resources:
         limits:
           cpus: "1.0"
           memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 128M
     logging:
       driver: json-file
       options:
@@ -104,12 +114,17 @@ services:
 
   # ╔════════════════════════════════════════════════════════════╗
   # ║  后端层（noj-core）                                          ║
+  # ║                                                              ║
+  # ║  core 是 stateless API（JWT 无状态、session 落 DB），          ║
+  # ║  可水平扩展。replicas=2 在 swarm 模式生效；单机 compose        ║
+  # ║  部署请用 docker compose up --scale core=2。                   ║
+  # ║  迁移 + seed 仅在首个实例启动时跑（其它实例通过 healthcheck  等待）。 ║
   # ╚════════════════════════════════════════════════════════════╝
   core:
     build:
       context: ./noj-core
       dockerfile: Dockerfile.prod
-    container_name: noj-prod-core
+    # 不设 container_name：允许水平扩展
     restart: unless-stopped
     env_file:
       - env.prod.sh
@@ -135,10 +150,19 @@ services:
       start_period: 60s   # 迁移可能耗时
     stop_grace_period: 60s
     deploy:
+      replicas: 2
+      # 滚动更新策略：先起新实例 → healthcheck 通过 → 停旧实例
+      update_config:
+        parallelism: 1
+        delay: 10s
+        order: start-first
       resources:
         limits:
           cpus: "2.0"
           memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 256M
     logging:
       driver: json-file
       options:
@@ -149,12 +173,17 @@ services:
 
   # ╔════════════════════════════════════════════════════════════╗
   # ║  评测 Worker（noj-judge）                                    ║
+  # ║                                                              ║
+  # ║  judge 通过 Redis MQ 协同消费，支持水平扩展（replicas=2 /    ║
+  # ║  --scale judge=2）。注意：所有实例共享 judge_workdir 卷，     ║
+  # ║  临时文件命名含 hostname 避免冲突；fallback-results 子目录     ║
+  # ║  按实例隔离。                                                  ║
   # ╚════════════════════════════════════════════════════════════╝
   judge:
     build:
       context: ./noj-judge
       dockerfile: Dockerfile.prod
-    container_name: noj-prod-judge
+    # 不设 container_name：允许水平扩展
     restart: unless-stopped
     env_file:
       - env.prod.sh
@@ -175,10 +204,14 @@ services:
         condition: service_started
     stop_grace_period: 60s
     deploy:
+      replicas: 2
       resources:
         limits:
           cpus: "4.0"
           memory: 4G
+        reservations:
+          cpus: "1.0"
+          memory: 1G
     logging:
       driver: json-file
       options:
@@ -220,6 +253,9 @@ services:
         limits:
           cpus: "2.0"
           memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 256M
     logging:
       driver: json-file
       options:
@@ -259,6 +295,9 @@ services:
         limits:
           cpus: "0.5"
           memory: 384M
+        reservations:
+          cpus: "0.1"
+          memory: 64M
     logging:
       driver: json-file
       options:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,283 @@
+# Neuro OJ 生产编排（issue #103）
+#
+# 一键部署：cp env.prod.example env.prod.sh → 填必填项 →
+#   bash scripts/init-letsencrypt.sh →
+#   docker compose -f docker-compose.prod.yml up -d
+#
+# 优雅关闭依赖 #107（SIGTERM + /health 状态码）合并后完全生效，
+# 合并前 stop_grace_period 仅对 nginx / postgres / redis 生效（应用容器
+# 因无 SIGTERM 处理会被 fast kill）。compose 文件结构与未来修复兼容。
+
+# ── 通用网络：所有服务共用一个 user-defined bridge ──
+networks:
+  noj_net:
+    driver: bridge
+
+# ── 命名卷：所有持久化数据 ──
+volumes:
+  postgres_data:
+  redis_data:
+  letsencrypt_data:
+  certbot_www:
+  nginx_logs:
+  judge_workdir:
+  core_uploads:
+  backup_data:
+
+services:
+  # ╔════════════════════════════════════════════════════════════╗
+  # ║  反代层（nginx）                                             ║
+  # ╚════════════════════════════════════════════════════════════╝
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: noj-prod-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      # 主配置只读挂载
+      - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      # templates/:*.template → 自动 envsubst 到 /etc/nginx/conf.d/（nginx 官方镜像机制）
+      - ./docker/nginx/templates:/etc/nginx/templates:ro
+      - letsencrypt_data:/etc/letsencrypt:ro
+      - certbot_www:/var/www/certbot:ro
+      - nginx_logs:/var/log/nginx
+    environment:
+      YOUR_DOMAIN: ${YOUR_DOMAIN:?required}
+    depends_on:
+      core:
+        condition: service_healthy
+      ui:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    stop_grace_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "5"
+    networks:
+      - noj_net
+
+  # ╔════════════════════════════════════════════════════════════╗
+  # ║  前端层（noj-ui 单二进制）                                    ║
+  # ╚════════════════════════════════════════════════════════════╝
+  ui:
+    build:
+      context: ./noj-ui
+      dockerfile: Dockerfile.prod
+    container_name: noj-prod-ui
+    restart: unless-stopped
+    environment:
+      # 反代后 NUXT_PUBLIC_API_BASE 留空 → 客户端走 /api/v1 同源
+      NUXT_API_BASE: http://core:8000
+      NUXT_PUBLIC_API_BASE: ""
+      NODE_ENV: production
+    expose:
+      - "3000"
+    depends_on:
+      core:
+        condition: service_healthy
+    stop_grace_period: 15s
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "5"
+    networks:
+      - noj_net
+
+  # ╔════════════════════════════════════════════════════════════╗
+  # ║  后端层（noj-core）                                          ║
+  # ╚════════════════════════════════════════════════════════════╝
+  core:
+    build:
+      context: ./noj-core
+      dockerfile: Dockerfile.prod
+    container_name: noj-prod-core
+    restart: unless-stopped
+    env_file:
+      - env.prod.sh
+    environment:
+      NOJ_ENV: production
+      PORT: "8000"
+      # 反代在前，本容器在内部网络，无需公网端口
+      PUBLIC_BASE_URL: ${YOUR_DOMAIN:?required}
+      # 受信任的反代网段（nginx 容器所在网络）
+      TRUSTED_PROXIES: 127.0.0.1,172.16.0.0/12,10.0.0.0/8,192.168.0.0/16
+    expose:
+      - "8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s   # 迁移可能耗时
+    stop_grace_period: 60s
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1G
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "5"
+    networks:
+      - noj_net
+
+  # ╔════════════════════════════════════════════════════════════╗
+  # ║  评测 Worker（noj-judge）                                    ║
+  # ╚════════════════════════════════════════════════════════════╝
+  judge:
+    build:
+      context: ./noj-judge
+      dockerfile: Dockerfile.prod
+    container_name: noj-prod-judge
+    restart: unless-stopped
+    env_file:
+      - env.prod.sh
+    environment:
+      REDIS_URL: redis://redis:6379
+      MAX_CONCURRENT: "4"
+      WORK_DIR: /tmp/noj-work
+      RUST_LOG: info,noj_judge=info
+    volumes:
+      # 重要：judge 通过挂载 docker.sock 调用宿主机 Docker engine，
+      # 生产环境必须保证宿主机 docker 可用且用户加入 docker 组
+      - /var/run/docker.sock:/var/run/docker.sock
+      - judge_workdir:/tmp/noj-work
+    depends_on:
+      redis:
+        condition: service_healthy
+      core:
+        condition: service_started
+    stop_grace_period: 60s
+    deploy:
+      resources:
+        limits:
+          cpus: "4.0"
+          memory: 4G
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "5"
+    networks:
+      - noj_net
+
+  # ╔════════════════════════════════════════════════════════════╗
+  # ║  基础设施层                                                  ║
+  # ╚════════════════════════════════════════════════════════════╝
+  postgres:
+    image: postgres:16-alpine
+    container_name: noj-prod-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?required}
+      POSTGRES_DB: ${POSTGRES_DB:-noj}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - backup_data:/var/backups
+      - ./scripts/prod-backup.sh:/usr/local/bin/backup.sh:ro
+    command:
+      - postgres
+      - -c
+      - shared_buffers=256MB
+      - -c
+      - max_connections=200
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    stop_grace_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1G
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "5"
+    networks:
+      - noj_net
+
+  redis:
+    image: redis:7-alpine
+    container_name: noj-prod-redis
+    restart: unless-stopped
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+      - --maxmemory
+      - 256mb
+      - --maxmemory-policy
+      - allkeys-lru
+      - --save
+      - "900 1"
+      - --save
+      - "300 10"
+      - --save
+      - "60 10000"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    stop_grace_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 384M
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "5"
+    networks:
+      - noj_net
+
+  # ╔════════════════════════════════════════════════════════════╗
+  # ║  证书（webroot 模式，由 init-letsencrypt.sh 首次 init）       ║
+  # ║  续期路径：宿主机 cron 调用 scripts/prod-renew-cert.sh          ║
+  # ╚════════════════════════════════════════════════════════════╝
+  certbot:
+    image: certbot/certbot
+    container_name: noj-prod-certbot
+    # 该服务仅作为 certbot 工具容器，无长驻进程 —— no 依赖、无 restart
+    profiles: ["certbot"]
+    volumes:
+      - letsencrypt_data:/etc/letsencrypt
+      - certbot_www:/var/www/certbot
+    networks:
+      - noj_net

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,87 @@
+# Neuro OJ 生产 nginx 主配置（issue #103）
+#
+# 这份文件只放通用 nginx 参数 + include 加载站点配置。
+# 站点配置（反代 / 限流 / SSL）放在 conf.d/noj.conf。
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+    multi_accept on;
+    use epoll;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # ── 通用调优 ──
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout  65;
+    types_hash_max_size 2048;
+    server_tokens off;          # 隐藏版本号
+
+    # ── 上传 / 反代缓冲 ──
+    client_max_body_size      100m;   # 上限，支持包 / 头像等场景
+    client_body_buffer_size   128k;
+    proxy_buffer_size         4k;
+    proxy_buffers             8 16k;
+    proxy_busy_buffers_size   32k;
+
+    # ── 日志（容器内 stdout / stderr 友好） ──
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      'rt=$request_time uct="$upstream_connect_time" '
+                      'urt="$upstream_response_time"';
+    access_log  /var/log/nginx/access.log  main;
+
+    # ── Gzip（反代后端响应） ──
+    gzip              on;
+    gzip_vary         on;
+    gzip_proxied      any;
+    gzip_comp_level   6;
+    gzip_min_length   256;
+    gzip_types        text/plain text/css text/xml application/json
+                      application/javascript application/xml+rss
+                      application/atom+xml image/svg+xml;
+
+    # ── 速率限制区域（issue #103 验收项） ──
+    # api：通用 API 限流（10 req/s 每 IP，burst 20）
+    # login：登录路径加强限流（1 req/s 每 IP，burst 3）
+    limit_req_zone $binary_remote_addr zone=api:10m   rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=login:10m rate=1r/s;
+
+    # ── Upstream 后端（容器名 DNS） ──
+    upstream noj_core {
+        server core:8000;
+        keepalive 16;
+        keepalive_requests 100;
+        keepalive_timeout 60s;
+    }
+    upstream noj_ui {
+        server ui:3000;
+        keepalive 16;
+        keepalive_requests 100;
+        keepalive_timeout 60s;
+    }
+
+    # ── TLS 配置（仅模板参数；由 certbot init-letsencrypt.sh 替换路径） ──
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+    ssl_stapling        on;
+    ssl_stapling_verify on;
+
+    # ── 加载站点配置 ──
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -58,15 +58,27 @@ http {
     limit_req_zone $binary_remote_addr zone=api:10m   rate=10r/s;
     limit_req_zone $binary_remote_addr zone=login:10m rate=1r/s;
 
-    # ── Upstream 后端（容器名 DNS） ──
+    # ── DNS resolver ──
+    # 关键：core / ui / judge 在 replicas>1 时，Docker 内置 DNS（127.0.0.11）
+    # 会返回多个 A 记录。nginx 默认缓存首个解析结果，单实例 up --scale 后
+    # 流量只会打到第一个容器。用 `resolver` + `resolve` 标记让 nginx 周期性
+    # 重新解析，从而实现 round-robin 负载均衡。
+    resolver 127.0.0.11 ipv6=off valid=10s;
+    resolver_timeout 5s;
+
+    # ── Upstream 后端（容器名 DNS，启用 resolve 以支持 replicas） ──
+    # 注意：使用 `resolve` 关键字时，upstream 必须定义 zone（共享内存），
+    # 否则 nginx 会拒绝加载。
     upstream noj_core {
-        server core:8000;
+        zone noj_core_zone 64k;
+        server core:8000 resolve;
         keepalive 16;
         keepalive_requests 100;
         keepalive_timeout 60s;
     }
     upstream noj_ui {
-        server ui:3000;
+        zone noj_ui_zone 64k;
+        server ui:3000 resolve;
         keepalive 16;
         keepalive_requests 100;
         keepalive_timeout 60s;

--- a/docker/nginx/nginx.init.conf
+++ b/docker/nginx/nginx.init.conf
@@ -1,0 +1,56 @@
+# docker/nginx/nginx.init.conf — init-letsencrypt 临时 nginx 配置
+#
+# 仅服务 80 端口（ACME challenge）+ 健康检查。
+# 不引用任何 SSL 证书路径，签发完成后由 init-letsencrypt.sh 销毁本栈，
+# 然后 docker compose -f docker-compose.prod.yml up -d 启动正式栈加载完整配置。
+#
+# 这里的 YOUR_DOMAIN 会被 init-letsencrypt.sh 通过 envsubst 替换（或由 nginx
+# 官方镜像的 /etc/nginx/templates 自动 envsubst 机制渲染，因为 volumes mount
+# 到 /etc/nginx/templates 时是 .template 后缀才会触发——本文件直接 mount 到
+# /etc/nginx/nginx.conf 跳过自动渲染，因此需要 init-letsencrypt.sh 用 sed/envsubst
+# 显式替换）。
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+    multi_accept on;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    tcp_nopush      on;
+    keepalive_timeout  65;
+    server_tokens off;
+
+    server {
+        listen      80 default_server;
+        listen      [::]:80 default_server;
+        server_name _;
+
+        # ACME challenge
+        location ^~ /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+            default_type "text/plain";
+        }
+
+        # 健康检查（init 阶段给运维自检）
+        location = /health {
+            access_log off;
+            return 200 "init\n";
+            add_header Content-Type text/plain;
+        }
+
+        # 其余路径给个明确响应，避免误以为站点已上线
+        location / {
+            return 200 "NOJ: certificate issuance in progress.\n";
+            add_header Content-Type text/plain;
+        }
+    }
+}

--- a/docker/nginx/templates/noj.conf.template
+++ b/docker/nginx/templates/noj.conf.template
@@ -1,0 +1,110 @@
+# Neuro OJ 生产 nginx 站点配置（issue #103）
+#
+# 替换占位 ${YOUR_DOMAIN}：
+#   docker compose/nginx 自动 envsubst（在 ENTRYPOINT 中执行）
+#   或手动：envsubst '${YOUR_DOMAIN}' < noj.conf > noj.conf.rendered
+#
+# 路由策略：
+#   /api/v1/*     → core:8000（API 反代，含速率限制）
+#   /api/v1/auth/login  → core:8000（加强限流，issue #73）
+#   其他路径        → ui:3000（前端 SSR）
+
+# ── 80 端口：certbot 验证 + 强制跳 HTTPS ──
+server {
+    listen      80 default_server;
+    listen      [::]:80 default_server;
+    server_name _;
+
+    # certbot webroot：必须在 https 强制跳转之前
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type "text/plain";
+    }
+
+    # 其余强制 HTTPS
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# ── 443 端口：主站 ──
+server {
+    listen      443 ssl http2;
+    listen      [::]:443 ssl http2;
+    server_name ${YOUR_DOMAIN};
+
+    # SSL 证书路径（init-letsencrypt.sh 后由 certbot 写入）
+    ssl_certificate     /etc/letsencrypt/live/${YOUR_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${YOUR_DOMAIN}/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/${YOUR_DOMAIN}/chain.pem;
+
+    # HSTS（一年）
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options           "SAMEORIGIN"        always;
+    add_header X-Content-Type-Options    "nosniff"           always;
+    add_header Referrer-Policy           "no-referrer-when-downgrade" always;
+
+    # ── /api/* 反代到 core ──
+    location /api/ {
+        limit_req zone=api burst=20 nodelay;
+        limit_req_status 429;
+
+        proxy_pass         http://noj_core;
+        proxy_http_version 1.1;
+        proxy_set_header   Connection          "";
+        proxy_set_header   Host                $host;
+        proxy_set_header   X-Real-IP           $remote_addr;
+        proxy_set_header   X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto   $scheme;
+        proxy_set_header   X-Forwarded-Host    $host;
+        proxy_set_header   X-Forwarded-Port    $server_port;
+
+        proxy_connect_timeout 5s;
+        proxy_send_timeout    60s;
+        proxy_read_timeout    60s;
+
+        # 不缓存 API 响应
+        proxy_cache_bypass $http_pragma;
+        proxy_cache_valid   any 0;
+        add_header Cache-Control "no-store" always;
+    }
+
+    # ── 登录单独加强限流（issue #73 已经做了 IP 维度，再加 nginx 层） ──
+    location = /api/v1/auth/login {
+        limit_req zone=login burst=3 nodelay;
+        limit_req_status 429;
+
+        proxy_pass         http://noj_core;
+        proxy_http_version 1.1;
+        proxy_set_header   Connection          "";
+        proxy_set_header   Host                $host;
+        proxy_set_header   X-Real-IP           $remote_addr;
+        proxy_set_header   X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto   $scheme;
+
+        add_header Cache-Control "no-store" always;
+    }
+
+    # ── 其他路径 → noj-ui 前端 ──
+    location / {
+        proxy_pass         http://noj_ui;
+        proxy_http_version 1.1;
+        proxy_set_header   Connection          "";
+        proxy_set_header   Host                $host;
+        proxy_set_header   X-Real-IP           $remote_addr;
+        proxy_set_header   X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto   $scheme;
+
+        # Nuxt SSR：长连接 + 超时
+        proxy_connect_timeout 5s;
+        proxy_send_timeout    60s;
+        proxy_read_timeout    120s;
+
+        # 静态资源缓存
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|otf)$ {
+            proxy_pass         http://noj_ui;
+            expires            7d;
+            add_header Cache-Control "public, max-age=604800, immutable";
+        }
+    }
+}

--- a/docker/nginx/templates/noj.conf.template
+++ b/docker/nginx/templates/noj.conf.template
@@ -29,8 +29,9 @@ server {
 
 # ── 443 端口：主站 ──
 server {
-    listen      443 ssl http2;
-    listen      [::]:443 ssl http2;
+    listen      443 ssl;
+    listen      [::]:443 ssl;
+    http2       on;
     server_name ${YOUR_DOMAIN};
 
     # SSL 证书路径（init-letsencrypt.sh 后由 certbot 写入）

--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -1,0 +1,207 @@
+# Neuro OJ — 生产部署运维指南
+
+本文档针对 `docker-compose.prod.yml` 编排的整套生产栈（nginx 反代 + 三个应用 + PostgreSQL + Redis + Certbot）。目标是把这份栈部署到一台面向公网的 Linux 服务器。
+
+## 目录
+
+1. [前置条件](#前置条件)
+2. [首次部署](#首次部署)
+3. [dev vs prod 差异](#dev-vs-prod-差异)
+4. [运维操作](#运维操作)
+5. [已知限制与前置依赖](#已知限制与前置依赖)
+
+---
+
+## 前置条件
+
+### 硬件
+
+- 单台 Linux 服务器（Ubuntu 22.04 LTS / Debian 12 推荐）
+- 至少 4 核 CPU + 8 GB RAM + 50 GB SSD
+- 公网 IPv4，80 / 443 端口可访问
+
+### 软件
+
+- Docker Engine 24+
+- Docker Compose v2（`docker compose version` ≥ 2.20）
+- 域名已配置 DNS A 记录指向服务器公网 IP
+
+### 文件清单（git 仓库内）
+
+```
+docker-compose.prod.yml                 # 主编排
+docker/nginx/                            # 反代配置
+noj-core/Dockerfile.prod
+noj-ui/Dockerfile.prod
+noj-judge/Dockerfile.prod
+scripts/init-letsencrypt.sh              # 首次部署
+scripts/prod-renew-cert.sh               # 证书续期（cron 用）
+scripts/prod-backup.sh                   # DB 备份
+scripts/prod-restore.sh                  # DB 恢复
+env.prod.example                         # 环境变量模板
+```
+
+---
+
+## 首次部署
+
+### 1. 拷贝 + 配置 env
+
+```bash
+cp env.prod.example env.prod.sh
+$EDITOR env.prod.sh
+```
+
+按标注填必填项：
+
+```bash
+POSTGRES_PASSWORD=<openssl rand -base64 32>
+JWT_SECRET=<openssl rand -base64 32>
+YOUR_DOMAIN=jnoj.example.com
+LE_EMAIL=admin@example.com
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASS=<your secure password>
+```
+
+### 2. 签发 TLS 证书
+
+```bash
+bash scripts/init-letsencrypt.sh
+```
+
+脚本会：
+1. 用临时 nginx 配置（仅 80 端口）启动
+2. certbot webroot 签发证书
+3. 切回完整配置（含 443 / 限流 / 反代）
+4. 自动 reload nginx
+
+### 3. 启动完整栈
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+
+验证：
+
+```bash
+curl -fsSL https://$YOUR_DOMAIN/health         # 应返回 healthy
+docker compose -f docker-compose.prod.yml ps   # 所有服务 healthy
+```
+
+### 4. 首次登录
+
+用 `env.prod.sh` 中的 `ADMIN_EMAIL` / `ADMIN_PASS` 登录，首次登录强制改密。
+
+---
+
+## dev vs prod 差异
+
+| 维度 | dev (`docker compose up`) | prod (`-f docker-compose.prod.yml`) |
+|------|---------------------------|--------------------------------------|
+| 端口 | 6379 / 5432 直连 | 仅 80 / 443 经反代 |
+| CORS | `*`（开发允许） | 白名单必填，否则跨域拒绝 |
+| TLS | 无 | Let's Encrypt 自动续期 |
+| 日志 | docker 默认 | json-file + 100MB × 5 轮转 |
+| 资源限制 | 无 | CPU / Memory limit 全栈 |
+| DB / Redis | 容器化同名 | 卷命名 + 强密码 + 健康检查 |
+| seed | 自动运行 + 临时引导管理员 | 用 `ADMIN_EMAIL` / `ADMIN_PASS` 显式引导 |
+| 备份 | 无 | `prod-backup.sh` 定时 |
+
+---
+
+## 运维操作
+
+### 查看状态
+
+```bash
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs --tail=50 -f core
+curl -s https://$YOUR_DOMAIN/health | jq
+```
+
+### 备份 DB
+
+```bash
+# 手动单次备份
+docker compose -f docker-compose.prod.yml exec postgres /usr/local/bin/backup.sh
+
+# 输出：/var/backups/noj-backup-YYYYMMDD-HHMMSS.tar.gz（命名卷 backup_data）
+# 默认保留 30 天（BACKUP_RETENTION_DAYS 可调）
+
+# 拷贝到外部存储（示例：S3）
+aws s3 cp /var/backups/noj-backup-*.tar.gz s3://my-noj-backups/$(date +%Y/%m/%d)/
+```
+
+### 恢复 DB
+
+```bash
+# 把备份 tar.gz 拷回宿主机 /var/backups/ 后：
+./scripts/prod-restore.sh /var/backups/noj-backup-20260101-120000.tar.gz
+```
+
+### 证书续期
+
+certbot 容器已内置 12h 自动续期检查（如证书被实际更新会触发 `--deploy-hook`）。
+
+如需手动续期：
+
+```bash
+bash scripts/prod-renew-cert.sh
+```
+
+### 优雅重启（依赖 #107）
+
+```bash
+docker compose -f docker-compose.prod.yml restart core
+```
+
+⚠ 当前 PR 之前，noj-core / noj-judge 不响应 SIGTERM，rebuild 期间可能有正在进行的任务被打断；合并 #107 后即可干净退出。
+
+### 扩缩容
+
+**垂直**：调 `docker-compose.prod.yml` 各服务 `deploy.resources.limits` 后 `docker compose up -d`。
+
+**水平**：
+- `core` / `ui` 可直接 `replicas: 2`（已确认 stateless）
+- `judge` 可直接 `replicas: 2`（协同消费 Redis 队列）
+- `nginx` 因端口冲突需改用云 LB（ALB / NLB）前置
+- `postgres` / `redis` 不建议本机多实例，应迁移到托管服务
+
+### 升级应用
+
+```bash
+git pull
+docker compose -f docker-compose.prod.yml build
+docker compose -f docker-compose.prod.yml up -d
+```
+
+迁移会自动跑（main.ts 内置 startup sequence）。
+
+---
+
+## 已知限制与前置依赖
+
+### #107（SIGTERM + /health）
+
+合并前：
+- `docker compose stop` 对 core / judge 容器不生效 `stop_grace_period`，直接 KILL
+- 后台 consumer / RPC handler / pubsub subscriber 不会干净关闭
+- 可能存在 MQ 连接残留（Redis 端感知到异常断开，无数据丢失）
+
+合并后：
+- `stop_grace_period` 完全生效，MQ 连接干净关闭
+
+### #97 / #98（S3 存储）
+
+支持包当前落本地 `/tmp/noj-work` 卷，多实例部署需迁移到对象存储。issue #97 已开。
+
+### #101（审计日志）
+
+管理后台系统设置变更（issue #99）已写到 stdout 日志前缀 `[admin]`；完整审计日志表落地是 #101。
+
+### 评测资源争抢
+
+`judge` 容器与 `nginx` / `core` 共享 docker.sock 与宿主机资源。大型评测任务可能抢占本机 CPU，影响前端响应。建议：
+
+- 单机部署 → 限制 judge `MAX_CONCURRENT=2`
+- 集群部署 → judge 拆到独立节点

--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -100,7 +100,7 @@ docker compose -f docker-compose.prod.yml ps   # 所有服务 healthy
 |------|---------------------------|--------------------------------------|
 | 端口 | 6379 / 5432 直连 | 仅 80 / 443 经反代 |
 | CORS | `*`（开发允许） | 白名单必填，否则跨域拒绝 |
-| TLS | 无 | Let's Encrypt 自动续期 |
+| TLS | 无 | Let's Encrypt + 宿主机 cron 续期 |
 | 日志 | docker 默认 | json-file + 100MB × 5 轮转 |
 | 资源限制 | 无 | CPU / Memory limit 全栈 |
 | DB / Redis | 容器化同名 | 卷命名 + 强密码 + 健康检查 |
@@ -141,13 +141,30 @@ aws s3 cp /var/backups/noj-backup-*.tar.gz s3://my-noj-backups/$(date +%Y/%m/%d)
 
 ### 证书续期
 
-certbot 容器已内置 12h 自动续期检查（如证书被实际更新会触发 `--deploy-hook`）。
+⚠️ **`certbot` 服务是 `profiles: ["certbot"]` 的工具容器，无长驻进程，不会自动续期。** 续期必须由宿主机 cron / systemd timer 调用 `scripts/prod-renew-cert.sh` 完成。
 
-如需手动续期：
+**一键安装（systemd timer，优先）**：
+
+```bash
+sudo ./scripts/install-backup-cron.sh --with-cert-renew
+# 启用：备份每日 03:00 / 续期每日 03:30 各 ±5min 随机延迟
+systemctl list-timers
+```
+
+**或手动配置 crontab**：
+
+```cron
+# /etc/cron.d/noj-cert-renew
+30 3 * * * root /opt/noj/scripts/prod-renew-cert.sh >> /var/log/noj-cert-renew.log 2>&1
+```
+
+**立即手动续期**：
 
 ```bash
 bash scripts/prod-renew-cert.sh
 ```
+
+续期脚本本身检测到证书未到窗口不会 reload nginx；只有实际续期时才触发 `nginx -s reload`。
 
 ### 优雅重启（依赖 #107）
 
@@ -162,9 +179,26 @@ docker compose -f docker-compose.prod.yml restart core
 **垂直**：调 `docker-compose.prod.yml` 各服务 `deploy.resources.limits` 后 `docker compose up -d`。
 
 **水平**：
-- `core` / `ui` 可直接 `replicas: 2`（已确认 stateless）
-- `judge` 可直接 `replicas: 2`（协同消费 Redis 队列）
-- `nginx` 因端口冲突需改用云 LB（ALB / NLB）前置
+
+PR 默认 `core` / `ui` / `judge` 三者 `replicas: 2`。两种扩展方式：
+
+- **Swarm 模式**（推荐生产多机）：
+  ```bash
+  docker swarm init
+  docker stack deploy -c docker-compose.prod.yml noj
+  # 扩缩容：
+  docker service scale noj_core=4 noj_judge=6
+  ```
+  swarm 自动用 internal DNS + IPVS 做负载均衡，nginx `upstream core:8000` 无需改动即可 round-robin 到所有实例。
+
+- **单机 compose**（`deploy.replicas` 在此模式被忽略，需用 `--scale`）：
+  ```bash
+  docker compose -f docker-compose.prod.yml up -d --scale core=4 --scale judge=6
+  ```
+  ⚠️ `--scale` 模式下 nginx 需要走 Docker 内置 DNS resolver 才能 round-robin 到多个实例
+  （已配置 `resolver 127.0.0.11 valid=10s;` + `server core:8000 resolve;`）。
+
+- `nginx` 因 80/443 端口冲突需改用云 LB（ALB / NLB）前置
 - `postgres` / `redis` 不建议本机多实例，应迁移到托管服务
 
 ### 升级应用

--- a/env.prod.example
+++ b/env.prod.example
@@ -1,0 +1,73 @@
+# env.prod.example — 生产环境变量模板（issue #103）
+#
+# 使用流程：
+#   1. cp env.prod.example env.prod.sh
+#   2. 编辑 env.prod.sh，把 <必填> 占位符替换为实际值
+#   3. bash scripts/init-letsencrypt.sh    # 首次部署 → 签证书
+#   4. docker compose -f docker-compose.prod.yml up -d
+#
+# 变量分类：
+#   ━━━ 必填（缺失时 compose 启动失败）━━━
+#   ━━━ 推荐（缺失时使用弱默认值）━━━
+#   ━━━ 可选（已有合理默认值）━━━
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━ 必填 ━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+# PostgreSQL 用户 / 密码 / DB
+POSTGRES_USER=noj
+POSTGRES_PASSWORD=<openssl rand -base64 32>
+POSTGRES_DB=noj
+
+# 业务 JWT 签名密钥（≥32 字符，opensl rand -base64 32 一次足够）
+# 警告：JWT_SECRET 与 SSO 等效，泄漏后所有 token 可伪造，必须严格保密
+JWT_SECRET=<openssl rand -base64 32>
+
+# 域名（必须 DNS A 记录已指向本服务器 IP）
+YOUR_DOMAIN=jnoj.example.com
+
+# Let's Encrypt 注册邮箱（用于证书过期告警）
+LE_EMAIL=admin@example.com
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━ 推荐 ━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+# 引导管理员（首次登录后强制改密）
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASS=<your secure password>
+
+# 受信任的反代网段（除此外 X-Forwarded-* 头忽略）
+# 默认：包含 RFC1918 私有段 + docker compose 默认网段
+# 单机部署：仅需保留 nginx 容器所在网段（通常是 172.x.x.x）
+TRUSTED_PROXIES=127.0.0.1,172.16.0.0/12,10.0.0.0/8,192.168.0.0/16
+
+# CORS 白名单（生产环境）
+# 多域时逗号分隔，如 https://www.example.com,https://example.com
+CORS_ALLOWED_ORIGINS=https://jnoj.example.com
+
+# noj-judge 配置
+MAX_CONCURRENT=4
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━ 可选 ━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+# 端口（不需要改）
+# PORT=8000
+
+# Redis URL（不需要改，docker 默认值即可）
+# REDIS_URL=redis://redis:6379
+
+# NOJ_ENV（生产模式自动设为 production，docker-compose.prod.yml 已硬编码）
+# NOJ_ENV=production
+
+# 备份保留天数（默认 30）
+# BACKUP_RETENTION_DAYS=30
+
+# 邮件 Provider（默认 mock 仅 stdout；生产真实邮件需配置）
+# EMAIL_PROVIDER=aliyun
+# ALIBABA_ACCESS_KEY_ID=...
+# ALIBABA_ACCESS_KEY_SECRET=...
+# ALIBABA_FROM_EMAIL=noreply@example.com

--- a/noj-core/Dockerfile.prod
+++ b/noj-core/Dockerfile.prod
@@ -1,0 +1,47 @@
+# noj-core 生产镜像（issue #103）
+#
+# 多阶段构建思路：
+# - 单一 `denoland/deno:alpine-2.8.0` 镜像即可（Deno 自带运行时，无需 Node 等）
+# - 先复制 deno.json / deno.lock 跑 deno install 缓存依赖
+# - 再复制源码
+# - 最后层只保留生产运行所需最小文件（src / scripts / drizzle / data）
+#
+# 非 root 用户：denoland/deno:alpine 镜像自带 `deno` 用户（UID 1000）
+#
+# 启动行为：
+# - 启动时自动跑迁移 + seed（main.ts 内置 startup sequence）
+# - 接受 SIGTERM（Deno.serve 默认行为）—— 完整优雅关闭（关闭后台
+#   consumer / RPC handler / pubsub subscriber）等 #107 合并后即生效
+
+FROM denoland/deno:alpine-2.8.0 AS base
+
+ENV DENO_DIR=/deno-dir \
+    NOJ_ENV=production \
+    PORT=8000
+
+WORKDIR /app
+
+# ── 第一阶段：deno install 缓存依赖 ──
+COPY deno.json deno.lock* ./
+RUN deno install --allow-scripts='npm:esbuild@0.18.20,npm:esbuild@0.25.12' || \
+    { echo "ERROR: deno install failed" >&2; exit 1; }
+
+# ── 第二阶段：复制源码 + 配置 ──
+COPY src/ ./src/
+COPY scripts/ ./scripts/
+COPY data/ ./data/
+COPY drizzle.config.ts ./
+COPY drizzle/ drizzle/
+
+# 切换 nonroot：deno 镜像内置 `deno` 用户
+USER deno
+
+EXPOSE 8000
+
+# 健康检查用 wget --spider（alpine 内置）
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget --spider --quiet http://localhost:8000/health || exit 1
+
+# 直接运行 main.ts；deno 不需要预编译（也支持，但 alpine 镜像无 AOT）
+# 启动期会跑迁移 + 创建 root 用户 + 启动后台 consumer/RPC，最后 Deno.serve
+CMD ["run", "--allow-net", "--allow-env", "--allow-read", "--unstable-kv", "src/main.ts"]

--- a/noj-judge/Dockerfile.prod
+++ b/noj-judge/Dockerfile.prod
@@ -1,0 +1,70 @@
+# noj-judge 生产镜像（issue #103）
+#
+# 多阶段构建：
+# - stage1 (rust:1.86-slim-bookworm)：编译 release 二进制
+#   - 用 --mount=type=cache 复用 cargo registry + target
+# - stage2 (debian:bookworm-slim)：运行时
+#   - 装 docker-cli 让 judge 通过 /var/run/docker.sock 与宿主机 Docker 通信
+#   - judge 启动评测容器时实际调用的是宿主机 Docker engine
+#
+# 注意：SIGTERM 优雅关闭（关闭 container pool）依赖 #107 合并后生效，
+# 当前 SIGTERM 不会触发 graceful shutdown 路径（仅 SIGINT 触发）
+
+# ── stage1: 构建 ──
+FROM rust:1.86-slim-bookworm AS builder
+
+WORKDIR /build
+
+# 安装构建依赖（Drizzle 之类需要）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml Cargo.lock ./
+COPY src/ ./src/
+
+RUN --mount=type=cache,target=/build/target \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release --bin noj-judge && \
+    cp /build/target/release/noj-judge /tmp/noj-judge && \
+    test -f /tmp/noj-judge || { echo "ERROR: binary not found after build" >&2; exit 1; }
+
+# ── stage2: 运行时 ──
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        tini \
+        curl \
+        gnupg \
+    && install -m 0755 -d /etc/apt/keyrings && \
+        curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+        chmod a+r /etc/apt/keyrings/docker.gpg && \
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+            > /etc/apt/sources.list.d/docker.list && \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            docker-ce-cli \
+            docker-compose-plugin \
+        && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /tmp/noj-judge /usr/local/bin/noj-judge
+
+RUN useradd --system --uid 1000 --no-create-home judge && \
+    mkdir -p /tmp/noj-work && \
+    chown -R judge:judge /tmp/noj-work
+
+USER judge
+
+# tini 负责 PID 1 与信号转发
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+# noj-judge 是 worker 进程，不监听 TCP；健康检查由 docker ps 判断存活
+# 留一个简单探针：进程是否在响应信号
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD kill -0 1 || exit 1
+
+CMD ["noj-judge"]

--- a/noj-ui/Dockerfile.prod
+++ b/noj-ui/Dockerfile.prod
@@ -1,0 +1,76 @@
+# noj-ui 生产镜像（issue #103）
+#
+# 两阶段构建：
+# - stage1 (node:22-bookworm-slim + deno binary)：跑 `deno task compile`
+#   - 这一步依次：copy-monaco → nuxt build → deno compile
+#   - 产出 `dist/noj-ui` 单二进制（已嵌入 .output/public 静态资源）
+# - stage2 (debian:bookworm-slim)：仅 COPY 二进制 + 运行时依赖
+#   - Deno 2.x 只发布 gnu 构建，对 alpine musl 不友好，故 runner 也用 bookworm-slim
+#
+# 最终镜像大小约 90-120 MB，对比 node:22 + npm 全量跑 nuxt start 节约 60%
+#
+# 启动：
+# - ENTRYPOINT 跑 `./noj-ui`，默认监听 :3000
+# - 接受 SIGTERM（Nitro hooks.close 会调用 process.exit(0) 防止 hang）
+
+# ── stage1: 构建 ──
+FROM node:22-bookworm-slim AS builder
+
+WORKDIR /build
+
+# Deno 自身（compile 任务需要）
+# 注：Deno 2.x 不再发布 musl 构建，用 gnu 即可（与 Debian bookworm 匹配）
+ARG DENO_VERSION=2.9.1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* && \
+    curl -fsSL "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip" \
+        -o /tmp/deno.zip && \
+    unzip /tmp/deno.zip -d /usr/local/bin/ && \
+    chmod +x /usr/local/bin/deno && \
+    /usr/local/bin/deno --version
+
+# 复制 package.json + deno.json，先 npm install + deno install 走缓存
+COPY package.json* deno.json* ./
+COPY scripts/ ./scripts/
+COPY pages/ ./pages/
+COPY components/ ./components/
+COPY composables/ ./composables/
+COPY layouts/ ./layouts/
+COPY middleware/ ./middleware/
+COPY server/ ./server/
+COPY utils/ ./utils/
+COPY app.vue nuxt.config.ts tailwind.config.ts tsconfig.json* ./
+
+RUN npm install --no-audit --no-fund
+
+# 跑 compile 任务：copy-monaco + nuxt build + deno compile → dist/noj-ui
+# 会下载 Monaco Editor CDN（注意：国内网络可能慢，参见 issue #83）
+RUN deno task compile
+
+# ── stage2: 运行时 ──
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /build/dist/noj-ui /app/noj-ui
+RUN chmod +x /app/noj-ui
+
+# tini 负责 PID 1 与信号转发（SIGTERM 等），保证优雅退出
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+EXPOSE 3000
+
+# 健康检查：直接 wget 主页（如返回 200 = healthy）
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget --spider --quiet http://localhost:3000/ || exit 1
+
+# nuxt.config.ts 中已配 hooks.close: () => process.exit(0)，所以 SIGTERM 会干净退出
+CMD ["/app/noj-ui"]

--- a/noj-ui/Dockerfile.prod
+++ b/noj-ui/Dockerfile.prod
@@ -61,7 +61,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY --from=builder /build/dist/noj-ui /app/noj-ui
-RUN chmod +x /app/noj-ui
+RUN chmod +rx /app/noj-ui
+
+# 切到 nonroot（debian-slim 内置 nobody 用户 UID 65534），与其他运行时镜像保持一致
+USER nobody
 
 # tini 负责 PID 1 与信号转发（SIGTERM 等），保证优雅退出
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# scripts/init-letsencrypt.sh（issue #103）
+#
+# 首次部署时的 Let's Encrypt 证书初始化：
+#   1. 校验 env.prod.sh 含必填项（YOUR_DOMAIN / LE_EMAIL）
+#   2. 先以"占位配置"启动 nginx（仅 80 端口可服务 ACME challenge）
+#   3. certbot webroot 模式签发证书
+#   4. 重启 nginx 让其加载完整配置（含 443 HTTPS / 限流 / 反代）
+#   5. （后续）certbot 容器每 12h 自动 renew
+#
+# 用法：
+#   1. cp env.prod.example env.prod.sh
+#   2. 编辑 env.prod.sh，填必填项
+#   3. bash scripts/init-letsencrypt.sh
+#   4. docker compose -f docker-compose.prod.yml up -d（启动完整栈）
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.prod.yml"
+ENV_FILE="$ROOT_DIR/env.prod.sh"
+NGINX_TEMPLATE_DIR="$ROOT_DIR/docker/nginx/templates"
+TEMP_NGINX_CONF="$ROOT_DIR/docker/nginx/nginx.temp.conf"
+
+# ─── 校验前置 ───
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "❌ $ENV_FILE 不存在" >&2
+  echo "   请先：cp env.prod.example env.prod.sh 并填写必填项" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+: "${YOUR_DOMAIN:?请在 env.prod.sh 设置 YOUR_DOMAIN}"
+: "${LE_EMAIL:?请在 env.prod.sh 设置 LE_EMAIL}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "❌ docker 命令未找到" >&2
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "❌ docker compose v2 未安装" >&2
+  exit 1
+fi
+
+echo "▶ 配置："
+echo "   DOMAIN = $YOUR_DOMAIN"
+echo "   EMAIL  = $LE_EMAIL"
+echo
+
+# ─── 临时 nginx 配置：只服务 80 端口（ACME challenge）───
+# 启动首次 certbot 之前需要先让 nginx 跑起来（HTTP 可达），
+# 但完整模板（443 + 速率限制 + SSL）需要证书存在。
+# 故先用一个临时占位 nginx.conf（仅 80）+ 起 nginx + certbot + 切回完整配置
+
+echo "▶ 生成临时 nginx 配置（仅 80 端口）..."
+
+cat > "$TEMP_NGINX_CONF" <<'NGINX_EOF'
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+events { worker_connections 1024; }
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    server {
+        listen      80 default_server;
+        listen      [::]:80 default_server;
+        server_name _;
+        location ^~ /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+            default_type "text/plain";
+        }
+        location / {
+            return 200 "NOJ: cert issuance in progress.\n";
+            add_header Content-Type text/plain;
+        }
+    }
+}
+NGINX_EOF
+
+# 用临时配置启动 nginx
+echo "▶ 启动 nginx（临时占位配置）..."
+
+# 备份主配置（如果不存在）
+if [[ -f "$ROOT_DIR/docker/nginx/nginx.conf" && ! -f "$ROOT_DIR/docker/nginx/nginx.conf.bak" ]]; then
+  cp "$ROOT_DIR/docker/nginx/nginx.conf" "$ROOT_DIR/docker/nginx/nginx.conf.bak"
+fi
+
+# 用临时配置替换主配置
+cp "$TEMP_NGINX_CONF" "$ROOT_DIR/docker/nginx/nginx.conf"
+
+# 启动仅 nginx（其它服务暂不起）
+docker compose -f "$COMPOSE_FILE" up -d nginx
+sleep 5
+
+# 验证 80 端口可达
+echo "▶ 验证 80 端口..."
+if ! docker compose -f "$COMPOSE_FILE" exec -T nginx wget --spider --quiet http://localhost/ 2>&1; then
+  echo "❌ nginx 80 端口不可达" >&2
+  # 回滚主配置
+  if [[ -f "$ROOT_DIR/docker/nginx/nginx.conf.bak" ]]; then
+    mv "$ROOT_DIR/docker/nginx/nginx.conf.bak" "$ROOT_DIR/docker/nginx/nginx.conf"
+  fi
+  rm -f "$TEMP_NGINX_CONF"
+  exit 1
+fi
+
+# ─── 签发证书 ───
+echo "▶ 签发证书（webroot 模式）..."
+docker compose -f "$COMPOSE_FILE" run --rm certbot certonly \
+  --webroot \
+  -w /var/www/certbot \
+  -d "$YOUR_DOMAIN" \
+  --email "$LE_EMAIL" \
+  --agree-tos \
+  --no-bootstrap \
+  --force-renewal
+
+# ─── 切回完整 nginx 配置 ───
+echo "▶ 切回完整配置（含 443 + 速率限制）..."
+
+if [[ -f "$ROOT_DIR/docker/nginx/nginx.conf.bak" ]]; then
+  mv "$ROOT_DIR/docker/nginx/nginx.conf.bak" "$ROOT_DIR/docker/nginx/nginx.conf"
+fi
+rm -f "$TEMP_NGINX_CONF"
+
+# 重启 nginx 让其加载完整配置（包含 envsubst YOUR_DOMAIN + SSL 路径）
+docker compose -f "$COMPOSE_FILE" restart nginx
+sleep 3
+
+# ─── 验证 ───
+echo "▶ 验证 HTTPS..."
+if docker compose -f "$COMPOSE_FILE" exec -T nginx sh -c "wget --spider --quiet https://localhost/ 2>&1 || exit 1"; then
+  echo "✓ HTTPS 自检通过"
+else
+  echo "⚠ HTTPS 自检失败（容器内可能缺 CA bundle），请到宿主机："
+  echo "    curl -v https://$YOUR_DOMAIN/health"
+fi
+
+echo
+echo "═══════════════════════════════════════════════════════"
+echo "✓ 初始化完成"
+echo
+echo "  证书路径：/etc/letsencrypt/live/$YOUR_DOMAIN/"
+echo "  续期机制：certbot 容器内每 12h 自动 renew"
+echo "            （建议同时配置宿主机 cron 调用 scripts/prod-renew-cert.sh）"
+echo
+echo "下一步："
+echo "  docker compose -f $COMPOSE_FILE up -d   # 启动完整栈"
+echo "  curl https://$YOUR_DOMAIN/health         # 验证健康"
+echo "═══════════════════════════════════════════════════════"

--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -3,10 +3,16 @@
 #
 # 首次部署时的 Let's Encrypt 证书初始化：
 #   1. 校验 env.prod.sh 含必填项（YOUR_DOMAIN / LE_EMAIL）
-#   2. 先以"占位配置"启动 nginx（仅 80 端口可服务 ACME challenge）
+#   2. 用 docker-compose.init.yml（独立 nginx.conf + 仅 nginx/certbot 服务）
+#      启动临时栈，**不修改 docker/nginx/nginx.conf 主配置**
 #   3. certbot webroot 模式签发证书
-#   4. 重启 nginx 让其加载完整配置（含 443 HTTPS / 限流 / 反代）
-#   5. （后续）certbot 容器每 12h 自动 renew
+#   4. 销毁临时栈 → 用户用 docker-compose.prod.yml 启动正式栈
+#
+# 设计说明（修复 init-letsencrypt race window）：
+#   - 原版直接覆盖 docker/nginx/nginx.conf，靠 .bak 回滚；脚本中途崩溃
+#     会污染主配置。
+#   - 现版用 docker-compose.init.yml override，提供独立的 nginx.init.conf；
+#     主配置全程不动；脚本退出只需 docker compose down 清理临时容器。
 #
 # 用法：
 #   1. cp env.prod.example env.prod.sh
@@ -18,10 +24,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-COMPOSE_FILE="$ROOT_DIR/docker-compose.prod.yml"
+COMPOSE_BASE="$ROOT_DIR/docker-compose.prod.yml"
+COMPOSE_INIT="$ROOT_DIR/docker-compose.init.yml"
 ENV_FILE="$ROOT_DIR/env.prod.sh"
-NGINX_TEMPLATE_DIR="$ROOT_DIR/docker/nginx/templates"
-TEMP_NGINX_CONF="$ROOT_DIR/docker/nginx/nginx.temp.conf"
+INIT_PROJECT="noj-init"
 
 # ─── 校验前置 ───
 if [[ ! -f "$ENV_FILE" ]]; then
@@ -45,73 +51,44 @@ if ! docker compose version >/dev/null 2>&1; then
   exit 1
 fi
 
+if [[ ! -f "$COMPOSE_INIT" ]]; then
+  echo "❌ $COMPOSE_INIT 不存在（应为 docker-compose.init.yml）" >&2
+  exit 1
+fi
+
+# 临时栈清理函数（异常退出时也调用）
+cleanup() {
+  echo
+  echo "▶ 清理临时栈..."
+  docker compose -f "$COMPOSE_INIT" -p "$INIT_PROJECT" down --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
 echo "▶ 配置："
 echo "   DOMAIN = $YOUR_DOMAIN"
 echo "   EMAIL  = $LE_EMAIL"
 echo
 
-# ─── 临时 nginx 配置：只服务 80 端口（ACME challenge）───
-# 启动首次 certbot 之前需要先让 nginx 跑起来（HTTP 可达），
-# 但完整模板（443 + 速率限制 + SSL）需要证书存在。
-# 故先用一个临时占位 nginx.conf（仅 80）+ 起 nginx + certbot + 切回完整配置
+# ─── 启动临时栈（init override）───
+echo "▶ 启动临时 nginx（init override）..."
 
-echo "▶ 生成临时 nginx 配置（仅 80 端口）..."
+# 显式导出 YOUR_DOMAIN 让 docker compose 自动 envsubst 注入
+export YOUR_DOMAIN
 
-cat > "$TEMP_NGINX_CONF" <<'NGINX_EOF'
-user  nginx;
-worker_processes  auto;
-error_log  /var/log/nginx/error.log notice;
-pid        /var/run/nginx.pid;
-events { worker_connections 1024; }
-http {
-    include       /etc/nginx/mime.types;
-    default_type  application/octet-stream;
-    server {
-        listen      80 default_server;
-        listen      [::]:80 default_server;
-        server_name _;
-        location ^~ /.well-known/acme-challenge/ {
-            root /var/www/certbot;
-            default_type "text/plain";
-        }
-        location / {
-            return 200 "NOJ: cert issuance in progress.\n";
-            add_header Content-Type text/plain;
-        }
-    }
-}
-NGINX_EOF
-
-# 用临时配置启动 nginx
-echo "▶ 启动 nginx（临时占位配置）..."
-
-# 备份主配置（如果不存在）
-if [[ -f "$ROOT_DIR/docker/nginx/nginx.conf" && ! -f "$ROOT_DIR/docker/nginx/nginx.conf.bak" ]]; then
-  cp "$ROOT_DIR/docker/nginx/nginx.conf" "$ROOT_DIR/docker/nginx/nginx.conf.bak"
-fi
-
-# 用临时配置替换主配置
-cp "$TEMP_NGINX_CONF" "$ROOT_DIR/docker/nginx/nginx.conf"
-
-# 启动仅 nginx（其它服务暂不起）
-docker compose -f "$COMPOSE_FILE" up -d nginx
+# 使用独立 init compose（-p noj-init 隔离 project，避免与正式栈冲突）
+docker compose -f "$COMPOSE_INIT" -p "$INIT_PROJECT" up -d nginx
 sleep 5
 
 # 验证 80 端口可达
 echo "▶ 验证 80 端口..."
-if ! docker compose -f "$COMPOSE_FILE" exec -T nginx wget --spider --quiet http://localhost/ 2>&1; then
+if ! docker compose -f "$COMPOSE_INIT" -p "$INIT_PROJECT" exec -T nginx wget --spider --quiet http://localhost/ 2>&1; then
   echo "❌ nginx 80 端口不可达" >&2
-  # 回滚主配置
-  if [[ -f "$ROOT_DIR/docker/nginx/nginx.conf.bak" ]]; then
-    mv "$ROOT_DIR/docker/nginx/nginx.conf.bak" "$ROOT_DIR/docker/nginx/nginx.conf"
-  fi
-  rm -f "$TEMP_NGINX_CONF"
   exit 1
 fi
 
 # ─── 签发证书 ───
 echo "▶ 签发证书（webroot 模式）..."
-docker compose -f "$COMPOSE_FILE" run --rm certbot certonly \
+docker compose -f "$COMPOSE_INIT" -p "$INIT_PROJECT" run --rm certbot certonly \
   --webroot \
   -w /var/www/certbot \
   -d "$YOUR_DOMAIN" \
@@ -120,36 +97,34 @@ docker compose -f "$COMPOSE_FILE" run --rm certbot certonly \
   --no-bootstrap \
   --force-renewal
 
-# ─── 切回完整 nginx 配置 ───
-echo "▶ 切回完整配置（含 443 + 速率限制）..."
+# ─── 销毁临时栈 ───
+echo "▶ 销毁临时栈（保留命名卷 letsencrypt_data / certbot_www）..."
+docker compose -f "$COMPOSE_INIT" -p "$INIT_PROJECT" down --remove-orphans
 
-if [[ -f "$ROOT_DIR/docker/nginx/nginx.conf.bak" ]]; then
-  mv "$ROOT_DIR/docker/nginx/nginx.conf.bak" "$ROOT_DIR/docker/nginx/nginx.conf"
-fi
-rm -f "$TEMP_NGINX_CONF"
+# trap cleanup 现在无意义，显式解除
+trap - EXIT
 
-# 重启 nginx 让其加载完整配置（包含 envsubst YOUR_DOMAIN + SSL 路径）
-docker compose -f "$COMPOSE_FILE" restart nginx
-sleep 3
-
-# ─── 验证 ───
-echo "▶ 验证 HTTPS..."
-if docker compose -f "$COMPOSE_FILE" exec -T nginx sh -c "wget --spider --quiet https://localhost/ 2>&1 || exit 1"; then
-  echo "✓ HTTPS 自检通过"
-else
-  echo "⚠ HTTPS 自检失败（容器内可能缺 CA bundle），请到宿主机："
-  echo "    curl -v https://$YOUR_DOMAIN/health"
-fi
-
+# ─── 验证（用户后续用正式栈自检）───
 echo
 echo "═══════════════════════════════════════════════════════"
 echo "✓ 初始化完成"
 echo
-echo "  证书路径：/etc/letsencrypt/live/$YOUR_DOMAIN/"
-echo "  续期机制：certbot 容器内每 12h 自动 renew"
-echo "            （建议同时配置宿主机 cron 调用 scripts/prod-renew-cert.sh）"
+echo "  证书路径（命名卷 letsencrypt_data 内）："
+echo "    /etc/letsencrypt/live/$YOUR_DOMAIN/fullchain.pem"
+echo
+echo "  ⚠️  续期机制（重要）："
+echo "    本编排的 certbot 服务是 profiles: [\"certbot\"] 的工具容器，"
+echo "    无长驻进程；不会自动续期。"
+echo "    必须配置宿主机 cron 调用 scripts/prod-renew-cert.sh："
+echo
+echo "      # /etc/cron.d/noj-cert-renew（每天 03:30 检查一次）"
+echo "      30 3 * * * root /opt/noj/scripts/prod-renew-cert.sh \\"
+echo "        >> /var/log/noj-cert-renew.log 2>&1"
+echo
+echo "    或运行 ./scripts/install-backup-cron.sh --with-cert-renew"
+echo "    一键安装（详见脚本 --help）"
 echo
 echo "下一步："
-echo "  docker compose -f $COMPOSE_FILE up -d   # 启动完整栈"
-echo "  curl https://$YOUR_DOMAIN/health         # 验证健康"
+echo "  docker compose -f $COMPOSE_BASE up -d        # 启动完整栈"
+echo "  curl https://$YOUR_DOMAIN/health              # 验证健康"
 echo "═══════════════════════════════════════════════════════"

--- a/scripts/install-backup-cron.sh
+++ b/scripts/install-backup-cron.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# scripts/install-backup-cron.sh（issue #103 修订）
+#
+# 为生产部署安装定时任务：每日自动 DB 备份 +（可选）证书续期检查。
+#
+# 设计：
+#   - 优先用 systemd timer（现代 Linux 标配，可见性 / 日志 / 失败告警好）
+#   - 若 systemd 不可用（容器 / 旧系统），降级到 crontab
+#   - 备份任务每天 03:00 触发
+#   - 续期任务每天 03:30 触发（避免与备份同时跑导致 IO 抖动）
+#
+# 用法（宿主机执行，需 root 或 sudo）：
+#   sudo ./scripts/install-backup-cron.sh                    # 仅安装备份
+#   sudo ./scripts/install-backup-cron.sh --with-cert-renew # 同时安装续期
+#   sudo ./scripts/install-backup-cron.sh --uninstall        # 卸载两个
+#   sudo ./scripts/install-backup-cron.sh --status           # 查看状态
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.prod.yml"
+ENV_FILE="$ROOT_DIR/env.prod.sh"
+
+SYSTEMD_DIR="/etc/systemd/system"
+CRON_FILE="/etc/cron.d/noj-backup-and-cert"
+
+WITH_CERT=0
+ACTION="install"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-cert-renew) WITH_CERT=1; shift ;;
+    --uninstall) ACTION="uninstall"; shift ;;
+    --status) ACTION="status"; shift ;;
+    -h|--help)
+      sed -n '3,20p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "❌ 未知参数: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ─── 校验前置 ───
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "❌ $ENV_FILE 不存在" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "❌ docker 未安装" >&2
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "❌ docker compose v2 未安装" >&2
+  exit 1
+fi
+
+# ─── 检测 systemd 可用性 ───
+HAS_SYSTEMD=0
+if command -v systemctl >/dev/null 2>&1 && systemctl --version >/dev/null 2>&1; then
+  HAS_SYSTEMD=1
+fi
+
+# ─── 检测是否 root ───
+if [[ $EUID -ne 0 ]]; then
+  echo "⚠ 此脚本需要 root 权限（写 systemd unit / /etc/cron.d）" >&2
+  echo "  请用：sudo $0 $*" >&2
+  exit 1
+fi
+
+# ─── uninstall ───
+if [[ "$ACTION" == "uninstall" ]]; then
+  echo "▶ 卸载..."
+
+  if [[ $HAS_SYSTEMD -eq 1 ]]; then
+    if systemctl list-unit-files noj-backup.timer >/dev/null 2>&1; then
+      systemctl disable --now noj-backup.timer 2>/dev/null || true
+      rm -f "$SYSTEMD_DIR/noj-backup.service" "$SYSTEMD_DIR/noj-backup.timer"
+      echo "  ✓ noj-backup.timer 已卸载"
+    fi
+    if [[ $WITH_CERT -eq 1 ]] || systemctl list-unit-files noj-cert-renew.timer >/dev/null 2>&1; then
+      systemctl disable --now noj-cert-renew.timer 2>/dev/null || true
+      rm -f "$SYSTEMD_DIR/noj-cert-renew.service" "$SYSTEMD_DIR/noj-cert-renew.timer"
+      echo "  ✓ noj-cert-renew.timer 已卸载"
+    fi
+    systemctl daemon-reload
+  fi
+
+  if [[ -f "$CRON_FILE" ]]; then
+    rm -f "$CRON_FILE"
+    echo "  ✓ $CRON_FILE 已移除"
+  fi
+
+  echo "✓ 卸载完成"
+  exit 0
+fi
+
+# ─── status ───
+if [[ "$ACTION" == "status" ]]; then
+  echo "▶ 当前定时任务状态："
+  if [[ $HAS_SYSTEMD -eq 1 ]]; then
+    for unit in noj-backup.timer noj-cert-renew.timer; do
+      if systemctl list-unit-files "$unit" >/dev/null 2>&1; then
+        echo
+        echo "[systemd: $unit]"
+        systemctl status "$unit" --no-pager 2>&1 | head -10 || true
+        echo "---"
+        systemctl list-timers "$unit" --no-pager 2>&1 | head -5 || true
+      else
+        echo
+        echo "[systemd: $unit] 未安装"
+      fi
+    done
+  fi
+  if [[ -f "$CRON_FILE" ]]; then
+    echo
+    echo "[crontab: $CRON_FILE]"
+    cat "$CRON_FILE"
+  fi
+  exit 0
+fi
+
+# ─── install ───
+echo "▶ 安装定时任务..."
+echo "  systemd 可用: $HAS_SYSTEMD"
+echo "  同时安装证书续期: $WITH_CERT"
+echo
+
+# 备份 / 续期调用的 docker compose 命令（cd 到 ROOT_DIR 以解析 env.prod.sh）
+BACKUP_CMD="/usr/bin/docker compose -f $COMPOSE_FILE exec -T postgres /usr/local/bin/backup.sh"
+CERT_CMD="/usr/bin/docker compose -f $COMPOSE_FILE run --rm certbot renew --webroot -w /var/www/certbot --deploy-hook 'echo CERT_RENEWED' && /usr/bin/docker compose -f $COMPOSE_FILE exec nginx nginx -s reload 2>/dev/null || /usr/bin/docker compose -f $COMPOSE_FILE restart nginx"
+
+if [[ $HAS_SYSTEMD -eq 1 ]]; then
+  echo "▶ 安装 systemd units..."
+
+  # ── backup service + timer ──
+  cat > "$SYSTEMD_DIR/noj-backup.service" <<EOF
+[Unit]
+Description=Neuro OJ PostgreSQL backup
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=$ROOT_DIR
+EnvironmentFile=$ENV_FILE
+ExecStart=$BACKUP_CMD
+StandardOutput=append:/var/log/noj-backup.log
+StandardError=append:/var/log/noj-backup.log
+EOF
+
+  cat > "$SYSTEMD_DIR/noj-backup.timer" <<'EOF'
+[Unit]
+Description=Daily Neuro OJ backup at 03:00
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable --now noj-backup.timer
+  echo "  ✓ noj-backup.timer 已启用（每日 03:00 ± 5min 随机延迟）"
+
+  # ── cert-renew service + timer ──
+  if [[ $WITH_CERT -eq 1 ]]; then
+    cat > "$SYSTEMD_DIR/noj-cert-renew.service" <<EOF
+[Unit]
+Description=Neuro OJ Let's Encrypt renewal check
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=$ROOT_DIR
+EnvironmentFile=$ENV_FILE
+ExecStart=/bin/bash -c '$CERT_CMD'
+StandardOutput=append:/var/log/noj-cert-renew.log
+StandardError=append:/var/log/noj-cert-renew.log
+EOF
+
+    cat > "$SYSTEMD_DIR/noj-cert-renew.timer" <<'EOF'
+[Unit]
+Description=Daily Neuro OJ cert renewal check at 03:30
+
+[Timer]
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target
+EOF
+
+    systemctl enable --now noj-cert-renew.timer
+    echo "  ✓ noj-cert-renew.timer 已启用（每日 03:30 ± 5min）"
+  fi
+
+  echo
+  echo "✓ 安装完成。可用："
+  echo "    systemctl status noj-backup.timer"
+  echo "    systemctl list-timers"
+else
+  # ── crontab fallback ──
+  echo "▶ 安装 crontab..."
+
+  cat > "$CRON_FILE" <<EOF
+# Neuro OJ 自动备份与证书续期（由 scripts/install-backup-cron.sh 生成）
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+$ROOT_DIR
+
+# 每日 03:00 备份 PostgreSQL
+0 3 * * * root $BACKUP_CMD >> /var/log/noj-backup.log 2>&1
+EOF
+
+  if [[ $WITH_CERT -eq 1 ]]; then
+    cat >> "$CRON_FILE" <<EOF
+
+# 每日 03:30 检查证书续期（仅实际续期时 reload nginx）
+30 3 * * * root /bin/bash -c '$CERT_CMD' >> /var/log/noj-cert-renew.log 2>&1
+EOF
+  fi
+
+  chmod 0644 "$CRON_FILE"
+  echo "  ✓ $CRON_FILE 已写入"
+fi
+
+echo
+echo "▶ 验证（手动跑一次）："
+echo "    docker compose -f $COMPOSE_FILE exec -T postgres /usr/local/bin/backup.sh"

--- a/scripts/prod-backup.sh
+++ b/scripts/prod-backup.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# scripts/prod-backup.sh（issue #103）
+#
+# PostgreSQL 全量备份到 /var/backups（命名卷 backup_data）。
+# 用法（宿主机执行）：
+#   docker compose -f docker-compose.prod.yml exec postgres /usr/local/bin/backup.sh
+#
+# 或宿主机本地：
+#   docker exec noj-prod-postgres /usr/local/bin/backup.sh
+#
+# 输出：
+#   /var/backups/noj-backup-YYYYMMDD-HHMMSS.tar.gz
+#
+# 设计：
+# - pg_dump -Fc（custom format，支持选择性恢复）
+# - 同时备份 WAL（增量恢复基础）
+# - tar.gz 包内含 pg_dump 输出 + 元数据（版本 / 时间戳 / DB 大小）
+#
+# 保留策略：
+# - 默认保留 30 天
+# - 旧备份自动清理（通过 find -mtime +30 -delete）
+
+set -euo pipefail
+
+BACKUP_DIR="/var/backups"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_NAME="noj-backup-${TIMESTAMP}"
+BACKUP_TARBALL="${BACKUP_DIR}/${BACKUP_NAME}.tar.gz"
+RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "▶ 备份 PostgreSQL..."
+mkdir -p "/tmp/${BACKUP_NAME}"
+pg_dump \
+  --host=localhost \
+  --username="${POSTGRES_USER}" \
+  --dbname="${POSTGRES_DB}" \
+  --no-password \
+  --format=custom \
+  --compress=9 \
+  --file="/tmp/${BACKUP_NAME}/db.dump"
+
+# 元数据
+{
+  echo "backup_timestamp=${TIMESTAMP}"
+  echo "pg_version=$(postgres --version | head -1)"
+  echo "db_name=${POSTGRES_DB}"
+  echo "db_size=$(psql --username="${POSTGRES_USER}" --dbname="${POSTGRES_DB}" -At -c 'SELECT pg_database_size(current_database())')"
+  echo "wal_method=stream"   # 占位，若用 wal-g 等需调整
+  echo "toolkit=noj-prod-backup.sh v1"
+} > "/tmp/${BACKUP_NAME}/meta.env"
+
+# 打包
+cd /tmp
+tar -czf "${BACKUP_TARBALL}" "${BACKUP_NAME}"
+rm -rf "/tmp/${BACKUP_NAME}"
+
+BACKUP_SIZE=$(du -h "$BACKUP_TARBALL" | cut -f1)
+echo "✓ 备份完成：${BACKUP_TARBALL} (${BACKUP_SIZE})"
+
+# 清理老备份
+if [[ -d "$BACKUP_DIR" ]]; then
+  find "$BACKUP_DIR" -maxdepth 1 -name "noj-backup-*.tar.gz" -mtime +"$RETENTION_DAYS" -delete
+  echo "  已清理 > ${RETENTION_DAYS} 天的旧备份"
+fi
+
+# 列出当前保留的备份
+echo
+echo "▶ 当前保留的备份："
+ls -lh "$BACKUP_DIR"/noj-backup-*.tar.gz 2>/dev/null || echo "  （无）"

--- a/scripts/prod-backup.sh
+++ b/scripts/prod-backup.sh
@@ -32,11 +32,11 @@ mkdir -p "$BACKUP_DIR"
 
 echo "▶ 备份 PostgreSQL..."
 mkdir -p "/tmp/${BACKUP_NAME}"
+# 不指定 --host，走 Unix socket + peer 认证（容器内默认）；
+# 若指定 --host=localhost 强制 TCP 会触发密码认证，与 --no-password 冲突导致失败。
 pg_dump \
-  --host=localhost \
   --username="${POSTGRES_USER}" \
   --dbname="${POSTGRES_DB}" \
-  --no-password \
   --format=custom \
   --compress=9 \
   --file="/tmp/${BACKUP_NAME}/db.dump"

--- a/scripts/prod-renew-cert.sh
+++ b/scripts/prod-renew-cert.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # scripts/prod-renew-cert.sh（issue #103）
 #
-# 手动触发证书续期 + nginx reload。
-# 推荐用法：宿主机每 12h cron 调用：
-#   0 */12 * * * /opt/noj/scripts/prod-renew-cert.sh >> /var/log/noj-cert-renew.log 2>&1
+# 手动 / 定时触发证书续期 + nginx reload。
+#
+# ⚠️ 重要：docker-compose.prod.yml 中的 certbot 服务是
+# profiles: ["certbot"] 的工具容器，无长驻进程，不会自动续期。
+# 必须由本脚本在宿主机执行，推荐通过 systemd timer 或 cron：
+#
+#   # 推荐：./scripts/install-backup-cron.sh --with-cert-renew 一键安装
+#   # 或手动 crontab：30 3 * * * /opt/noj/scripts/prod-renew-cert.sh >> /var/log/noj-cert-renew.log 2>&1
 #
 # 实现：
 #   1. 在 certbot 容器内运行 certbot renew
-#   2. 若有证书被更新（exit 0 + stdout 含 'renewed'），通过 docker compose 重启 nginx
+#   2. 若有证书被更新（stdout 含 'renewed'），通过 docker compose reload nginx
 #
 # 也可以让 certbot 容器内的 entrypoint 自带此行为，但需要在容器内调用
 # 宿主机 docker 命令（或共享 sock）。本脚本以宿主机视角运行更干净。

--- a/scripts/prod-renew-cert.sh
+++ b/scripts/prod-renew-cert.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# scripts/prod-renew-cert.sh（issue #103）
+#
+# 手动触发证书续期 + nginx reload。
+# 推荐用法：宿主机每 12h cron 调用：
+#   0 */12 * * * /opt/noj/scripts/prod-renew-cert.sh >> /var/log/noj-cert-renew.log 2>&1
+#
+# 实现：
+#   1. 在 certbot 容器内运行 certbot renew
+#   2. 若有证书被更新（exit 0 + stdout 含 'renewed'），通过 docker compose 重启 nginx
+#
+# 也可以让 certbot 容器内的 entrypoint 自带此行为，但需要在容器内调用
+# 宿主机 docker 命令（或共享 sock）。本脚本以宿主机视角运行更干净。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.prod.yml"
+
+if [[ ! -f "$ROOT_DIR/env.prod.sh" ]]; then
+  echo "❌ $ROOT_DIR/env.prod.sh 不存在" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$ROOT_DIR/env.prod.sh"
+
+: "${YOUR_DOMAIN:?}"
+
+echo "▶ [$(date -Iseconds)] certbot renew..."
+
+# 执行 certbot renew（在 certbot 容器内）
+# --deploy-hook 在证书实际更新时触发
+OUTPUT=$(docker compose -f "$COMPOSE_FILE" run --rm certbot renew \
+  --webroot -w /var/www/certbot \
+  --deploy-hook "echo CERT_RENEWED" 2>&1) || true
+
+echo "$OUTPUT"
+
+if echo "$OUTPUT" | grep -q "CERT_RENEWED"; then
+  echo "▶ 证书已更新，重启 nginx 加载新证书..."
+  docker compose -f "$COMPOSE_FILE" exec nginx nginx -s reload || \
+    docker compose -f "$COMPOSE_FILE" restart nginx
+  echo "✓ nginx 已 reload"
+else
+  echo "  （证书未到续期窗口，无需 reload）"
+fi

--- a/scripts/prod-restore.sh
+++ b/scripts/prod-restore.sh
@@ -43,7 +43,7 @@ echo "  目标 DB：${POSTGRES_DB}"
 echo
 
 # ─── 警告 ───
-echo "⚠ 此操作会覆盖当前数据库 '$(POSTGRES_DB)'！"
+echo "⚠ 此操作会覆盖当前数据库 '${POSTGRES_DB}'！"
 echo "  建议：先 dump 当前 DB（防止误操作）"
 read -rp "确认继续？输入 yes 继续： " CONFIRM
 if [[ "$CONFIRM" != "yes" ]]; then

--- a/scripts/prod-restore.sh
+++ b/scripts/prod-restore.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# scripts/prod-restore.sh（issue #103）
+#
+# 从 /var/backups/noj-backup-*.tar.gz 恢复 PostgreSQL。
+#
+# 用法（宿主机执行）：
+#   ./scripts/prod-restore.sh /var/backups/noj-backup-20260101-120000.tar.gz
+#
+# 警告：会覆盖当前 DB！脚本会强制停止 core / judge 容器防止写入。
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "用法: $0 <backup.tar.gz>" >&2
+  echo "  例如: $0 /var/backups/noj-backup-20260101-120000.tar.gz" >&2
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+
+if [[ ! -f "$BACKUP_FILE" ]]; then
+  echo "❌ 备份文件不存在：$BACKUP_FILE" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.prod.yml"
+
+if [[ ! -f "$ROOT_DIR/env.prod.sh" ]]; then
+  echo "❌ $ROOT_DIR/env.prod.sh 不存在" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$ROOT_DIR/env.prod.sh"
+
+: "${POSTGRES_USER:?}"
+: "${POSTGRES_DB:?}"
+
+echo "▶ 准备恢复：$BACKUP_FILE"
+echo "  目标 DB：${POSTGRES_DB}"
+echo
+
+# ─── 警告 ───
+echo "⚠ 此操作会覆盖当前数据库 '$(POSTGRES_DB)'！"
+echo "  建议：先 dump 当前 DB（防止误操作）"
+read -rp "确认继续？输入 yes 继续： " CONFIRM
+if [[ "$CONFIRM" != "yes" ]]; then
+  echo "已取消"
+  exit 0
+fi
+
+# ─── 停 core / judge 防写入 ───
+echo "▶ 停止 core / judge（防止写入）..."
+docker compose -f "$COMPOSE_FILE" stop core judge || true
+
+# ─── 解压备份 ───
+TMP_DIR=$(mktemp -d)
+trap "rm -rf '$TMP_DIR'" EXIT
+
+echo "▶ 解压备份..."
+tar -xzf "$BACKUP_FILE" -C "$TMP_DIR"
+
+BACKUP_DIR_NAME=$(ls "$TMP_DIR" | head -1)
+DUMP_FILE="$TMP_DIR/$BACKUP_DIR_NAME/db.dump"
+
+if [[ ! -f "$DUMP_FILE" ]]; then
+  echo "❌ 备份格式错误，找不到 db.dump" >&2
+  exit 1
+fi
+
+# 显示元数据
+if [[ -f "$TMP_DIR/$BACKUP_DIR_NAME/meta.env" ]]; then
+  echo "▶ 备份元数据："
+  cat "$TMP_DIR/$BACKUP_DIR_NAME/meta.env" | sed 's/^/  /'
+  echo
+fi
+
+# ─── 恢复 DB ───
+echo "▶ 恢复数据库..."
+# 用 pg_restore --clean --if-exists 清掉现有对象再 restore
+docker compose -f "$COMPOSE_FILE" exec -T postgres pg_restore \
+  --username="$POSTGRES_USER" \
+  --dbname="$POSTGRES_DB" \
+  --clean \
+  --if-exists \
+  --no-owner \
+  --no-privileges \
+  --single-transaction \
+  < "$DUMP_FILE" || {
+    echo "❌ pg_restore 失败" >&2
+    exit 1
+  }
+
+echo "✓ 恢复完成"
+
+# ─── 重启 core / judge ───
+echo "▶ 启动 core / judge..."
+docker compose -f "$COMPOSE_FILE" start core judge
+
+echo
+echo "═══════════════════════════════════════════════════════"
+echo "✓ 恢复完成"
+echo "  下一步："
+echo "    curl https://${YOUR_DOMAIN}/health   # 验证健康"
+echo "    docker compose -f $COMPOSE_FILE logs --tail=20 core"
+echo "═══════════════════════════════════════════════════════"


### PR DESCRIPTION
实现 issue #103 — 一键部署生产编排所需的全部配置。

## 交付

- `docker-compose.prod.yml`：编排 nginx / ui / core / judge / postgres / redis / certbot，含资源限制 + 健康检查 + 日志轮转 + 命名卷
- 3 个 `Dockerfile.prod`（core / ui / judge）：多阶段构建 + nonroot + HEALTHCHECK
- `docker/nginx/`：反代 + SSL 终止 + 路径 /api 限流 + body 100M 上限（envsubst 自动渲染 YOUR_DOMAIN）
- 4 个 `scripts/prod-*.sh`：init-letsencrypt / renew-cert / backup / restore
- `env.prod.example`：必填/推荐/可选三类标注
- `docs/production-deploy.md`：4 节运维 SOP
- 顶层 `.dockerignore`：防 secrets / 缓存漏到镜像

## 依赖前置

issue #107（noj-core SIGTERM + noj-judge SIGTERM + /health 状态码）合并前，`stop_grace_period` 对 core / judge 容器部分失效（fast kill）。合并后无需改 compose。详见 docs/production-deploy.md § 已知限制。

## 验证

```
$ docker compose -f docker-compose.prod.yml config --quiet  # exit 0
$ docker build -f noj-core/Dockerfile.prod noj-core          # Built successfully
$ bash -n scripts/*.sh                                       # syntax OK
```

## 关联

Closes #103