### PR TITLE
feat(core,ui): 审计日志：管理员操作记录（issue #101）

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,0 +1,35 @@
+# Subagent-Driven Development Progress Ledger
+
+**Branch:** feat/issue-101-audit-log
+**Base:** main @ 97cb2a5
+**Worktree:** .worktrees/feat-issue-101-audit-log
+**Plan:** docs/superpowers/plans/2026-07-04-audit-log.md
+
+## Task Status
+
+- [ ] Task 1: 准备工作
+- [ ] Task 2: DB 迁移
+- [ ] Task 3: Drizzle Schema
+- [ ] Task 4: 类型定义
+- [ ] Task 5: ALS RequestContext
+- [ ] Task 6: adminMiddleware 注入
+- [ ] Task 7: logAudit service (TDD)
+- [ ] Task 8: 埋点 promoteUser
+- [ ] Task 9: 埋点 banUser/unbanUser
+- [ ] Task 10: 埋点 deleteProblem
+- [ ] Task 11: 埋点 deleteCategory
+- [ ] Task 12: 埋点 rejudge
+- [ ] Task 13: 路由 GET /audit-logs
+- [ ] Task 14: main.ts retention
+- [ ] Task 15: 文档
+- [ ] Task 16: useAuditLogs composable
+- [ ] Task 17: audit-logs.vue 页面
+- [ ] Task 18: 侧栏入口
+- [ ] Task 19: 全量验证
+- [ ] Task 20: 提交 PR
+- [ ] Final whole-branch review
+
+## Notes
+
+- Plan + openspec 提案于分支初始化前 commit
+- 任何 Minor 级 reviewer 发现按发现顺序追加到文末

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -7,10 +7,10 @@
 
 ## Task Status
 
-- [ ] Task 1: 准备工作
-- [ ] Task 2: DB 迁移
-- [ ] Task 3: Drizzle Schema
-- [ ] Task 4: 类型定义
+- [x] Task 1: 准备工作 (verification only)
+- [x] Task 2: DB 迁移 (commit 5e885ad, review clean + 3 Minor notes)
+- [x] Task 3: Drizzle Schema (commit f282665, review clean, +ALL_TABLES bonus)
+- [x] Task 4: 类型定义 (commit 438da12, deno check 0 errors, 57 lines, AuditDetail discriminated union by action)
 - [ ] Task 5: ALS RequestContext
 - [ ] Task 6: adminMiddleware 注入
 - [ ] Task 7: logAudit service (TDD)
@@ -33,3 +33,8 @@
 
 - Plan + openspec 提案于分支初始化前 commit
 - 任何 Minor 级 reviewer 发现按发现顺序追加到文末
+
+## Minor findings (累加)
+
+- **T2-M1**: 索引命名风格不一致 — 既有 `idx_<table>_<col>` 又有 `<table>_<col>_idx` 两种风格并存，新代码跟随最近 0010 的 `<table>_<col>_idx` 风格。可在最终 review 时统一
+- **T2-M2**: Brief 原 `when: 1751600000` 是 Unix 秒但 journal 用毫秒，已修正为 `1783300000000` 并 amend commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,6 +579,7 @@ jj git push
 - 无速率限制 / IP 封禁 / CAPTCHA
 - 无 CSRF token（依赖 sameSite: 'lax'）
 - 注册存在 TOCTOU 竞争条件（DB 唯一约束为最终保障）
+- 审计日志保留 90 天（`AUDIT_LOG_RETENTION_DAYS` 可配置；0 = 禁用）
 
 ---
 

--- a/docs/superpowers/plans/2026-07-04-audit-log.md
+++ b/docs/superpowers/plans/2026-07-04-audit-log.md
@@ -1,0 +1,1951 @@
+# 审计日志（Issue #101）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 NOJ 管理员操作提供完整的审计日志能力（同步直写 DB + ALS 自动捕获 IP + 7 类强类型 detail + 90 天保留 + admin UI 查看页），关闭 issue #101。
+
+**Architecture:** 在 `noj-core` service 层 7 处埋点调用 `logAudit()`，同步 INSERT `audit_logs` 表；admin middleware 通过 AsyncLocalStorage 注入 `RequestContext`（actorId / actorIp / actorRole）实现 service 函数零签名改动；后台 setInterval 任务每日清理过期记录；`noj-ui` 新增 `/admin/audit-logs` 页面按 action 类型渲染 detail 列。
+
+**Tech Stack:** Deno + Hono + Drizzle ORM + PostgreSQL 16；前端 Nuxt 4 + Vue 3 + Tailwind；TypeScript discriminated union；`node:async_hooks` (AsyncLocalStorage)。
+
+## Global Constraints
+
+- **GPG 签名**：所有 commit 必须 GPG 签名（CLAUDE.md §5 强制）
+- **提交规范**：Conventional Commits `<type>(<scope>): 中文描述`，description 中文（CLAUDE.md §5）
+- **格式 + Lint**：`deno fmt --check` + `deno lint` 必须通过；Rust 文件 `cargo fmt` + `cargo clippy` 必须通过
+- **数据库迁移**：使用 Drizzle 生成的 4 位序号 SQL 文件（`0012_*.sql`），追加到 `_journal.json`，**禁止改写已存在的 journal 条目**
+- **TypeScript 严格性**：`deno check` 必须通过；新代码不引入 `any`（除 `JSONB` 反序列化已知边界）
+- **测试隔离**：每个测试 `beforeEach` 清空 `audit_logs` 表
+- **OpenSpec 同步**：本实现必须 100% 覆盖 `openspec/changes/audit-log/specs/audit-log/spec.md` 的 8 Requirements + 20 Scenarios
+- **环境变量**：`AUDIT_LOG_RETENTION_DAYS` 默认 90，0 = 禁用清理
+- **依赖**：Deno 新增 0 依赖（`AsyncLocalStorage` 来自 `node:async_hooks` 内建）；Rust 无变更
+- **工作分支**：`feat/issue-101-audit-log`，从 `main` 拉出
+
+---
+
+## File Structure
+
+**Create:**
+- `noj-core/drizzle/0012_audit_logs.sql` — 迁移 SQL
+- `noj-core/src/types/audit-log.ts` — AuditAction / AuditDetail / AuditLogEntry
+- `noj-core/src/lib/requestContext.ts` — ALS 封装
+- `noj-core/src/services/audit-log.ts` — logAudit / listAuditLogs / cleanupOldAuditLogs / startAuditLogRetentionTask
+- `noj-core/tests/services/audit-log.test.ts` — service 单元测试
+- `noj-core/tests/routes/admin-audit-logs.test.ts` — 路由测试
+- `noj-ui/composables/useAuditLogs.ts` — 列表 + 筛选状态
+- `noj-ui/pages/admin/audit-logs.vue` — 审计日志查看页
+
+**Modify:**
+- `noj-core/drizzle/meta/_journal.json` — 追加 idx 12 条目
+- `noj-core/src/db/schema.ts` — 新增 auditLogs 表定义
+- `noj-core/src/db/schema-ddl.ts` — SCHEMA_DDL + SCHEMA_INDEXES 数组
+- `noj-core/src/middleware/auth.ts` — adminMiddleware 注入 ALS
+- `noj-core/src/services/auth.ts` — promoteUser 埋点
+- `noj-core/src/services/users.ts` — banUser / unbanUser 埋点
+- `noj-core/src/services/problems.ts` — deleteProblem 埋点
+- `noj-core/src/services/categories.ts` — deleteCategory 埋点
+- `noj-core/src/services/submissions.ts` — rejudgeSubmission / rejudgeProblemSubmissions 埋点
+- `noj-core/src/routes/admin.ts` — 新增 GET /audit-logs 端点
+- `noj-core/src/main.ts` — HTTP 启动后调用 startAuditLogRetentionTask
+- `noj-core/.env.example` — 新增 AUDIT_LOG_RETENTION_DAYS
+- `noj-core/AGENTS.md` — 环境变量表 + 审计说明
+- `noj-core/tests/services/auth.test.ts` — 加 audit 断言
+- `noj-core/tests/services/users.test.ts` — 加 audit 断言
+- `noj-core/tests/services/problems.test.ts` — 加 audit 断言
+- `noj-core/tests/services/categories.test.ts` — 加 audit 断言
+- `noj-core/tests/services/submissions.test.ts` — 加 audit 断言
+- `noj-ui/layouts/admin.vue` — navItems 新增"审计日志"
+- `AGENTS.md`（根）— 已知限制章节追加"审计日志保留 90 天"
+
+**Total:** 8 新文件 + 17 改动文件
+
+---
+
+## Task 1: 准备工作 — 分支 + 环境验证
+
+**Files:** 无
+
+- [ ] **Step 1: 从 main 拉新分支**
+
+```bash
+jj new main
+jj describe -m "feat(core,ui): 审计日志（issue #101）"
+# 或 git 用户：
+# git checkout main && git pull
+# git checkout -b feat/issue-101-audit-log
+```
+
+- [ ] **Step 2: 验证 GPG 配置**
+
+```bash
+gpg --list-secret-keys --keyid-format LONG | head -3
+jj config get signing.key 2>/dev/null || git config --global user.signingkey
+```
+
+Expected: 有可用 GPG key；若提示未配置，跳到 https://docs.github.com/en/authentication/managing-commit-signature-verification 生成新 key
+
+- [ ] **Step 3: 验证基础设施**
+
+```bash
+docker compose ps | grep -E "postgres|redis"
+cd noj-core && deno task test --help 2>&1 | head -5
+```
+
+Expected: postgres + redis 都在 UP；deno task 可执行
+
+- [ ] **Step 4: 验证基线测试通过**
+
+```bash
+cd noj-core && deno task test 2>&1 | tail -5
+```
+
+Expected: 全量 343+ passed, 0 failed
+
+---
+
+## Task 2: DB Migration — 0012_audit_logs.sql
+
+**Files:**
+- Create: `noj-core/drizzle/0012_audit_logs.sql`
+- Modify: `noj-core/drizzle/meta/_journal.json`
+
+- [ ] **Step 1: 创建迁移 SQL 文件**
+
+`noj-core/drizzle/0012_audit_logs.sql`：
+
+```sql
+-- 审计日志表（issue #101）
+CREATE TABLE "audit_logs" (
+  "id" TEXT PRIMARY KEY,
+  "admin_id" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "target_type" TEXT,
+  "target_id" TEXT,
+  "detail" JSONB NOT NULL DEFAULT '{}',
+  "ip_address" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  CONSTRAINT "audit_logs_admin_id_fk" FOREIGN KEY ("admin_id") REFERENCES "users"("id"),
+  CONSTRAINT "audit_logs_action_check" CHECK ("action" IN (
+    'users.role_change',
+    'users.ban',
+    'users.unban',
+    'problems.delete',
+    'categories.delete',
+    'submissions.rejudge',
+    'settings.update'
+  ))
+);
+
+CREATE INDEX "audit_logs_admin_id_idx" ON "audit_logs" ("admin_id");
+CREATE INDEX "audit_logs_created_at_idx" ON "audit_logs" ("created_at");
+CREATE INDEX "audit_logs_action_idx" ON "audit_logs" ("action");
+```
+
+- [ ] **Step 2: 追加到 _journal.json**
+
+打开 `noj-core/drizzle/meta/_journal.json`，在 `entries` 数组末尾追加（**不修改既有条目**）：
+
+```json
+{
+  "idx": 12,
+  "version": "6",
+  "when": 1751600000,
+  "tag": "0012_audit_logs",
+  "breakpoints": true
+}
+```
+
+- [ ] **Step 3: 验证迁移可执行**
+
+```bash
+cd noj-core && deno task migrate 2>&1 | tail -10
+```
+
+Expected: 输出包含 "applied 0012_audit_logs" 或 "already up to date"
+
+- [ ] **Step 4: 验证表结构**
+
+```bash
+docker compose exec -T postgres psql -U noj -d noj -c "\d audit_logs"
+```
+
+Expected: 列出所有列 + CHECK + 3 个 INDEX
+
+- [ ] **Step 5: 验证 CHECK 约束**
+
+```bash
+docker compose exec -T postgres psql -U noj -d noj -c \
+  "INSERT INTO audit_logs (id, admin_id, action, ip_address, created_at) VALUES ('test', '0', 'invalid.action', '127.0.0.1', '2026-07-04T00:00:00Z')"
+```
+
+Expected: ERROR — new row for relation "audit_logs" violates check constraint "audit_logs_action_check"
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add noj-core/drizzle/0012_audit_logs.sql noj-core/drizzle/meta/_journal.json
+jj describe -m "feat(core): 添加 audit_logs 表迁移（issue #101）"
+jj git push -b feat/issue-101-audit-log  # 首次推送
+```
+
+---
+
+## Task 3: Drizzle Schema 定义
+
+**Files:**
+- Modify: `noj-core/src/db/schema.ts`
+- Modify: `noj-core/src/db/schema-ddl.ts`
+
+- [ ] **Step 1: 在 schema.ts 顶部 import 增加 jsonb**
+
+修改 `noj-core/src/db/schema.ts` 顶部 import 块：
+
+```ts
+import {
+  boolean,
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  unique,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+```
+
+- [ ] **Step 2: 在 schema.ts 末尾追加 auditLogs 表定义**
+
+打开 `noj-core/src/db/schema.ts`，定位到最后一个 `export const ... = pgTable(...)` 之后，追加：
+
+```ts
+/**
+ * 审计日志表（issue #101）。
+ * 记录所有管理员操作的详细信息：admin_id、action、target、detail、ip、time。
+ * service 层通过 logAudit() 同步写入；后台任务定期清理过期记录。
+ */
+export const auditLogs = pgTable(
+  "audit_logs",
+  {
+    id: text("id").primaryKey(),
+    admin_id: text("admin_id").notNull().references(() => users.id),
+    action: text("action").notNull(),
+    target_type: text("target_type"),
+    target_id: text("target_id"),
+    detail: jsonb("detail").notNull().default({}),
+    ip_address: text("ip_address").notNull(),
+    created_at: text("created_at").notNull(),
+  },
+  (table) => ({
+    actionCheck: check(
+      "audit_logs_action_check",
+      sql`${table.action} IN (
+        'users.role_change',
+        'users.ban',
+        'users.unban',
+        'problems.delete',
+        'categories.delete',
+        'submissions.rejudge',
+        'settings.update'
+      )`,
+    ),
+    adminIdx: index("audit_logs_admin_id_idx").on(table.admin_id),
+    createdAtIdx: index("audit_logs_created_at_idx").on(table.created_at),
+    actionIdx: index("audit_logs_action_idx").on(table.action),
+  }),
+);
+```
+
+- [ ] **Step 3: 同步 schema-ddl.ts**
+
+打开 `noj-core/src/db/schema-ddl.ts`，在 `SCHEMA_DDL` 字符串末尾追加：
+
+```sql
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id TEXT PRIMARY KEY,
+  admin_id TEXT NOT NULL REFERENCES users(id),
+  action TEXT NOT NULL,
+  target_type TEXT,
+  target_id TEXT,
+  detail JSONB NOT NULL DEFAULT '{}',
+  ip_address TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  CONSTRAINT audit_logs_action_check CHECK (action IN (
+    'users.role_change','users.ban','users.unban',
+    'problems.delete','categories.delete','submissions.rejudge','settings.update'
+  ))
+);
+```
+
+在 `SCHEMA_INDEXES` 数组追加：
+
+```ts
+"CREATE INDEX IF NOT EXISTS audit_logs_admin_id_idx ON audit_logs (admin_id)",
+"CREATE INDEX IF NOT EXISTS audit_logs_created_at_idx ON audit_logs (created_at)",
+"CREATE INDEX IF NOT EXISTS audit_logs_action_idx ON audit_logs (action)",
+```
+
+- [ ] **Step 4: 验证 deno check 通过**
+
+```bash
+cd noj-core && deno check src/db/schema.ts 2>&1 | tail -10
+```
+
+Expected: 无错误
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add noj-core/src/db/schema.ts noj-core/src/db/schema-ddl.ts
+jj describe -m "feat(core): Drizzle schema 增加 auditLogs 表"
+```
+
+---
+
+## Task 4: AuditLog 类型定义
+
+**Files:**
+- Create: `noj-core/src/types/audit-log.ts`
+
+- [ ] **Step 1: 创建类型文件**
+
+`noj-core/src/types/audit-log.ts`：
+
+```ts
+/**
+ * 审计日志类型定义（issue #101）。
+ *
+ * `AuditAction` 限定 7 类合法操作，CHECK 约束保证 DB 层一致；
+ * `AuditDetail` 用 discriminated union 保证 detail 字段的类型安全。
+ */
+
+/** 审计 action 枚举（与 DB CHECK 约束一致） */
+export type AuditAction =
+  | "users.role_change"
+  | "users.ban"
+  | "users.unban"
+  | "problems.delete"
+  | "categories.delete"
+  | "submissions.rejudge"
+  | "settings.update";
+
+/** 按 action 强类型的 detail（discriminated union） */
+export type AuditDetail =
+  | { action: "users.role_change"; from: string; to: string }
+  | { action: "users.ban"; reason: string; until: string | null }
+  | { action: "users.unban" }
+  | { action: "problems.delete"; title: string; display_id: string }
+  | {
+    action: "categories.delete";
+    name: string;
+    slug: string;
+  }
+  | {
+    action: "submissions.rejudge";
+    submission_id?: string;
+    problem_id?: string;
+    count?: number;
+  }
+  | { action: "settings.update"; key: string; from: unknown; to: unknown };
+
+/** audit_logs 表的响应类型 */
+export interface AuditLogEntry {
+  id: string;
+  admin_id: string;
+  action: AuditAction;
+  target_type: string | null;
+  target_id: string | null;
+  detail: AuditDetail;
+  ip_address: string;
+  created_at: string;
+}
+
+/** 列表 API 查询参数 */
+export interface AuditLogListFilter {
+  page: number;
+  perPage: number;
+  admin_id?: string;
+  action?: AuditAction;
+  from?: string;
+  to?: string;
+}
+```
+
+- [ ] **Step 2: 验证类型检查**
+
+```bash
+cd noj-core && deno check src/types/audit-log.ts 2>&1
+```
+
+Expected: 无错误
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add noj-core/src/types/audit-log.ts
+jj describe -m "feat(core): 定义 AuditAction / AuditDetail 强类型"
+```
+
+---
+
+## Task 5: AsyncLocalStorage 上下文
+
+**Files:**
+- Create: `noj-core/src/lib/requestContext.ts`
+
+- [ ] **Step 1: 创建 requestContext.ts**
+
+`noj-core/src/lib/requestContext.ts`：
+
+```ts
+/**
+ * AsyncLocalStorage 上下文（issue #101）。
+ *
+ * adminMiddleware 在请求作用域注入 RequestContext，
+ * service 层通过 getRequestContext() 取用，避免污染函数签名。
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface RequestContext {
+  /** 当前用户 ID */
+  actorId: string;
+  /** 请求客户端 IP（X-Forwarded-For 优先） */
+  actorIp: string;
+  /** 当前用户角色 */
+  actorRole: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+/** 在指定 context 内运行 fn（adminMiddleware 内使用） */
+export function runWithContext<T>(ctx: RequestContext, fn: () => T): T {
+  return storage.run(ctx, fn);
+}
+
+/** 取当前请求的 context；缺失抛错（程序 bug 保护） */
+export function getRequestContext(): RequestContext {
+  const ctx = storage.getStore();
+  if (!ctx) {
+    throw new Error(
+      "RequestContext 未注入 — logAudit 仅允许在 admin 路由内调用",
+    );
+  }
+  return ctx;
+}
+
+/**
+ * 仅测试中使用：注入固定 context，service 层无需 Hono 中间件即可调用 logAudit。
+ * 与 runWithContext 不同，enterWith 影响后续所有异步调用，无需 await。
+ */
+export function enterTestContext(ctx: RequestContext): void {
+  storage.enterWith(ctx);
+}
+```
+
+- [ ] **Step 2: 验证类型检查**
+
+```bash
+cd noj-core && deno check src/lib/requestContext.ts 2>&1
+```
+
+Expected: 无错误
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add noj-core/src/lib/requestContext.ts
+jj describe -m "feat(core): 引入 RequestContext (AsyncLocalStorage)"
+```
+
+---
+
+## Task 6: adminMiddleware 注入 context
+
+**Files:**
+- Modify: `noj-core/src/middleware/auth.ts`
+
+- [ ] **Step 1: 阅读现有 adminMiddleware**
+
+```bash
+grep -n "adminMiddleware\|export function" noj-core/src/middleware/auth.ts | head -10
+```
+
+- [ ] **Step 2: 在文件顶部添加 import**
+
+修改 `noj-core/src/middleware/auth.ts` 顶部 import 块（保留其他 import）：
+
+```ts
+import { runWithContext } from "../lib/requestContext.ts";
+import { getClientIp } from "../lib/rateLimitEnv.ts";
+```
+
+- [ ] **Step 3: 改造 adminMiddleware**
+
+定位到 `adminMiddleware` 函数（应在 authMiddleware 之后定义），将现有实现替换为：
+
+```ts
+/**
+ * 管理员权限校验中间件。
+ *
+ * 必须在 authMiddleware 之后挂载。
+ * 注入 RequestContext 到 AsyncLocalStorage，使后续 service 层
+ * 通过 getRequestContext() 获取 actorId / actorIp / actorRole。
+ */
+export const adminMiddleware: MiddlewareHandler<{
+  Variables: { userId: string; userRole: string };
+}> = async (c, next) => {
+  const userRole = c.get("userRole");
+  if (userRole !== "admin") {
+    throw new ForbiddenError("需要管理员权限");
+  }
+
+  const ctx = {
+    actorId: c.get("userId"),
+    actorIp: getClientIp(c),
+    actorRole: userRole,
+  };
+
+  return await runWithContext(ctx, () => next());
+};
+```
+
+- [ ] **Step 4: 验证类型检查**
+
+```bash
+cd noj-core && deno check src/middleware/auth.ts 2>&1
+```
+
+Expected: 无错误（若 getClientIp 不存在见 Step 5）
+
+- [ ] **Step 5: 若 getClientIp 未导出，补 import**
+
+```bash
+grep -n "export function getClientIp" noj-core/src/lib/rateLimitEnv.ts
+```
+
+若不存在：
+
+```bash
+grep -n "xff\|X-Forwarded-For\|RemoteAddr" noj-core/src/middleware/rateLimit.ts | head -5
+```
+
+参照现有 IP 提取逻辑在 requestContext.ts 内实现独立 `extractClientIp(c)` 工具（避免循环依赖）。若 rateLimitEnv.ts 已导出 `getClientIp(c: Context)`，继续 Step 6。
+
+- [ ] **Step 6: 运行既有 admin 测试**
+
+```bash
+cd noj-core && deno test -A tests/routes/admin*.test.ts 2>&1 | tail -10
+```
+
+Expected: 既有测试全部通过（middleware 改造未改变对外行为）
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add noj-core/src/middleware/auth.ts
+jj describe -m "feat(core): adminMiddleware 注入 RequestContext"
+```
+
+---
+
+## Task 7: logAudit service 核心（TDD）
+
+**Files:**
+- Create: `noj-core/tests/services/audit-log.test.ts`
+- Create: `noj-core/src/services/audit-log.ts`
+
+- [ ] **Step 1: 写失败测试 — logAudit 写入字段映射**
+
+`noj-core/tests/services/audit-log.test.ts`：
+
+```ts
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { getDb } from "../../src/db/connection.ts";
+import { auditLogs } from "../../src/db/schema.ts";
+import { enterTestContext } from "../../src/lib/requestContext.ts";
+import {
+  cleanupOldAuditLogs,
+  listAuditLogs,
+  logAudit,
+} from "../../src/services/audit-log.ts";
+
+const TEST_CTX = {
+  actorId: "test-admin-uuid",
+  actorIp: "192.168.1.100",
+  actorRole: "admin",
+};
+
+// 每个测试前清空 audit_logs
+async function cleanAuditLogs() {
+  const db = getDb();
+  await db.delete(auditLogs);
+}
+
+Deno.test("logAudit 写入字段映射", async () => {
+  await cleanAuditLogs();
+  enterTestContext(TEST_CTX);
+
+  await logAudit(
+    "users.ban",
+    { action: "users.ban", reason: "spam", until: null },
+    { type: "user", id: "target-uuid" },
+  );
+
+  const db = getDb();
+  const rows = await db.select().from(auditLogs);
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].admin_id, "test-admin-uuid");
+  assertEquals(rows[0].action, "users.ban");
+  assertEquals(rows[0].ip_address, "192.168.1.100");
+  assertEquals(rows[0].target_type, "user");
+  assertEquals(rows[0].target_id, "target-uuid");
+  assertEquals(rows[0].detail, {
+    action: "users.ban",
+    reason: "spam",
+    until: null,
+  });
+  assertExists(rows[0].created_at);
+  assertExists(rows[0].id);
+});
+
+Deno.test("logAudit 失败仅 console.error，不抛业务错误", async () => {
+  await cleanAuditLogs();
+  enterTestContext(TEST_CTX);
+  // 不应抛错 — 业务继续
+  // 后续 Task 中会通过异常 detail 模拟；此处仅验证正常路径不抛错
+  await logAudit("users.unban", { action: "users.unban" }, {
+    type: "user",
+    id: "x",
+  });
+  // 若到达此处即通过
+});
+
+Deno.test("logAudit ALS 缺失抛错", async () => {
+  await cleanAuditLogs();
+  // 注意：未调 enterTestContext
+  let threw = false;
+  try {
+    await logAudit("users.unban", { action: "users.unban" });
+  } catch (e) {
+    threw = true;
+    assertEquals(
+      (e as Error).message.includes("RequestContext 未注入"),
+      true,
+    );
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("cleanupOldAuditLogs 删除过期记录", async () => {
+  await cleanAuditLogs();
+  enterTestContext(TEST_CTX);
+
+  const oldDate = new Date(Date.now() - 100 * 86400 * 1000).toISOString();
+  const recentDate = new Date().toISOString();
+
+  // 直接 INSERT 一条 100 天前的记录
+  const db = getDb();
+  await db.insert(auditLogs).values({
+    id: "old-1",
+    admin_id: TEST_CTX.actorId,
+    action: "users.unban",
+    ip_address: TEST_CTX.actorIp,
+    detail: { action: "users.unban" },
+    created_at: oldDate,
+  });
+  await db.insert(auditLogs).values({
+    id: "recent-1",
+    admin_id: TEST_CTX.actorId,
+    action: "users.unban",
+    ip_address: TEST_CTX.actorIp,
+    detail: { action: "users.unban" },
+    created_at: recentDate,
+  });
+
+  const deleted = await cleanupOldAuditLogs(90);
+  assertEquals(deleted, 1);
+
+  const rows = await db.select().from(auditLogs);
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].id, "recent-1");
+});
+
+Deno.test("listAuditLogs 默认排除 root (admin_id=0)", async () => {
+  await cleanAuditLogs();
+  const db = getDb();
+  await db.insert(auditLogs).values([
+    {
+      id: "by-root",
+      admin_id: "0",
+      action: "users.unban",
+      ip_address: "1.1.1.1",
+      detail: { action: "users.unban" },
+      created_at: new Date().toISOString(),
+    },
+    {
+      id: "by-admin",
+      admin_id: "test-admin-uuid",
+      action: "users.ban",
+      ip_address: "1.1.1.1",
+      detail: { action: "users.ban", reason: "x", until: null },
+      created_at: new Date().toISOString(),
+    },
+  ]);
+
+  const result = await listAuditLogs({ page: 1, perPage: 20 });
+  assertEquals(result.data.length, 1);
+  assertEquals(result.data[0].id, "by-admin");
+  assertEquals(result.pagination.total, 1);
+});
+
+Deno.test("listAuditLogs 按 action 筛选", async () => {
+  await cleanAuditLogs();
+  enterTestContext(TEST_CTX);
+  await logAudit("users.ban", {
+    action: "users.ban",
+    reason: "x",
+    until: null,
+  });
+  await logAudit("users.unban", { action: "users.unban" });
+
+  const result = await listAuditLogs({
+    page: 1,
+    perPage: 20,
+    action: "users.ban",
+  });
+  assertEquals(result.data.length, 1);
+  assertEquals(result.data[0].action, "users.ban");
+});
+
+Deno.test("listAuditLogs 按时间范围筛选", async () => {
+  await cleanAuditLogs();
+  enterTestContext(TEST_CTX);
+  await logAudit("users.unban", { action: "users.unban" });
+
+  const from = new Date(Date.now() - 60_000).toISOString();
+  const to = new Date(Date.now() + 60_000).toISOString();
+
+  const result = await listAuditLogs({
+    page: 1,
+    perPage: 20,
+    from,
+    to,
+  });
+  assertEquals(result.data.length, 1);
+});
+```
+
+- [ ] **Step 2: 运行测试 — 应全部失败（service 未实现）**
+
+```bash
+cd noj-core && deno test -A tests/services/audit-log.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL — 模块 `../../src/services/audit-log.ts` 不存在
+
+- [ ] **Step 3: 实现 service**
+
+`noj-core/src/services/audit-log.ts`：
+
+```ts
+/**
+ * 审计日志 service（issue #101）。
+ *
+ * 提供：
+ * - logAudit() —— service 层同步写入，失败仅 console.error
+ * - listAuditLogs() —— 分页 + 多维度筛选，默认排除 root
+ * - cleanupOldAuditLogs() —— 按 created_at 阈值删除
+ * - startAuditLogRetentionTask() —— 后台 setInterval 任务
+ */
+
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+import { auditLogs } from "../db/schema.ts";
+import { getRequestContext } from "../lib/requestContext.ts";
+import type {
+  AuditAction,
+  AuditDetail,
+  AuditLogEntry,
+  AuditLogListFilter,
+} from "../types/audit-log.ts";
+
+/**
+ * 记录一条审计日志。必须在 admin 路由内调用（依赖 RequestContext）。
+ * 失败仅 console.error，业务操作继续。
+ */
+export async function logAudit(
+  action: AuditAction,
+  detail: AuditDetail,
+  target?: { type: string; id: string },
+): Promise<void> {
+  try {
+    const ctx = getRequestContext();
+    const db = getDb();
+    await db.insert(auditLogs).values({
+      id: crypto.randomUUID(),
+      admin_id: ctx.actorId,
+      action,
+      target_type: target?.type ?? null,
+      target_id: target?.id ?? null,
+      detail: detail as unknown as Record<string, unknown>,
+      ip_address: ctx.actorIp,
+      created_at: new Date().toISOString(),
+    });
+  } catch (e) {
+    console.error(
+      `[audit] logAudit 失败 (action=${action}):`,
+      e instanceof Error ? e.message : String(e),
+    );
+  }
+}
+
+/** 审计日志分页列表 + 多维度筛选。默认排除 root (admin_id='0')。 */
+export async function listAuditLogs(
+  filter: AuditLogListFilter,
+): Promise<{ data: AuditLogEntry[]; pagination: { page: number; per_page: number; total: number } }> {
+  const { page, perPage, admin_id, action, from, to } = filter;
+  const db = getDb();
+
+  const conditions = [sql`${auditLogs.admin_id} != '0'`];
+  if (admin_id) conditions.push(eq(auditLogs.admin_id, admin_id));
+  if (action) conditions.push(eq(auditLogs.action, action));
+  if (from) conditions.push(gte(auditLogs.created_at, from));
+  if (to) conditions.push(lte(auditLogs.created_at, to));
+
+  const whereClause = and(...conditions);
+
+  const [rows, totalResult] = await Promise.all([
+    db.select()
+      .from(auditLogs)
+      .where(whereClause)
+      .orderBy(desc(auditLogs.created_at))
+      .limit(perPage)
+      .offset((page - 1) * perPage),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(auditLogs)
+      .where(whereClause),
+  ]);
+
+  return {
+    data: rows.map((r) => ({
+      id: r.id,
+      admin_id: r.admin_id,
+      action: r.action as AuditAction,
+      target_type: r.target_type,
+      target_id: r.target_id,
+      detail: r.detail as unknown as AuditDetail,
+      ip_address: r.ip_address,
+      created_at: r.created_at,
+    })),
+    pagination: {
+      page,
+      per_page: perPage,
+      total: totalResult[0]?.count ?? 0,
+    },
+  };
+}
+
+/** 按保留天数清理过期日志，返回删除行数 */
+export async function cleanupOldAuditLogs(
+  retentionDays: number,
+): Promise<number> {
+  if (retentionDays <= 0) return 0;
+  const cutoff = new Date(
+    Date.now() - retentionDays * 86400 * 1000,
+  ).toISOString();
+  const db = getDb();
+  const result = await db.delete(auditLogs).where(
+    lte(auditLogs.created_at, cutoff),
+  );
+  return result.rowCount ?? 0;
+}
+
+/** 启动后台保留任务（HTTP 启动后由 main.ts 调用） */
+export function startAuditLogRetentionTask(): void {
+  const days = parseInt(
+    Deno.env.get("AUDIT_LOG_RETENTION_DAYS") ?? "90",
+    10,
+  );
+  if (days <= 0) {
+    console.info("[audit] AUDIT_LOG_RETENTION_DAYS=0, 清理任务已禁用");
+    return;
+  }
+  // 启动立即跑一次
+  cleanupOldAuditLogs(days)
+    .then((n) => console.info(`[audit] 启动清理: 移除 ${n} 条过期日志`))
+    .catch((e) =>
+      console.error("[audit] 启动清理失败:", e instanceof Error ? e.message : String(e))
+    );
+  // 每 24h 重复
+  setInterval(() => {
+    cleanupOldAuditLogs(days)
+      .then((n) =>
+        n > 0
+          ? console.info(`[audit] 周期清理: 移除 ${n} 条过期日志`)
+          : undefined
+      )
+      .catch((e) =>
+        console.error(
+          "[audit] 周期清理失败:",
+          e instanceof Error ? e.message : String(e),
+        )
+      );
+  }, 86400 * 1000);
+  console.info(`[audit] 保留任务已启动: retention_days=${days}`);
+}
+```
+
+- [ ] **Step 4: 运行测试 — 应全部通过**
+
+```bash
+cd noj-core && deno test -A tests/services/audit-log.test.ts 2>&1 | tail -10
+```
+
+Expected: 7 passed, 0 failed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add noj-core/src/services/audit-log.ts noj-core/tests/services/audit-log.test.ts
+jj describe -m "feat(core): logAudit service 实现 + 单元测试"
+```
+
+---
+
+## Task 8: 埋点 — promoteUser (users.role_change)
+
+**Files:**
+- Modify: `noj-core/src/services/auth.ts`
+
+- [ ] **Step 1: 在 auth.ts 顶部 import logAudit**
+
+修改 `noj-core/src/services/auth.ts` 顶部（保留其他 import）：
+
+```ts
+import { logAudit } from "./audit-log.ts";
+```
+
+- [ ] **Step 2: 定位 promoteUser 函数**
+
+```bash
+grep -n "export async function promoteUser" noj-core/src/services/auth.ts
+```
+
+- [ ] **Step 3: 在 promoteUser 成功路径末尾加 logAudit**
+
+定位到 `promoteUser` 函数中"更新数据库角色"成功的代码之后、return 之前，插入：
+
+```ts
+// 审计：角色变更
+await logAudit(
+  "users.role_change",
+  { action: "users.role_change", from: <old_role>, to: <new_role> },
+  { type: "user", id: targetUserId },
+);
+```
+
+替换 `<old_role>` / `<new_role>` 为函数体内已有的变量名（查看函数签名 + 上下文确定）。
+
+- [ ] **Step 4: 验证 deno check**
+
+```bash
+cd noj-core && deno check src/services/auth.ts 2>&1
+```
+
+Expected: 无错误
+
+- [ ] **Step 5: 扩展 auth.test.ts 验证 audit**
+
+打开 `noj-core/tests/services/auth.test.ts`，找到 `promoteUser` 已有测试，在测试末尾追加：
+
+```ts
+// 验证审计日志被记录
+import { eq } from "drizzle-orm";
+import { getDb } from "../../src/db/connection.ts";
+import { auditLogs } from "../../src/db/schema.ts";
+import { enterTestContext } from "../../src/lib/requestContext.ts";
+
+Deno.test("promoteUser 写一条 role_change 审计", async () => {
+  enterTestContext({
+    actorId: "<admin-uuid>",
+    actorIp: "10.0.0.1",
+    actorRole: "admin",
+  });
+  await getDb().delete(auditLogs);
+
+  await promoteUser("<target-uuid>", "admin", "<admin-uuid>");
+
+  const rows = await getDb().select().from(auditLogs).where(
+    eq(auditLogs.action, "users.role_change"),
+  );
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].target_id, "<target-uuid>");
+  assertEquals(rows[0].ip_address, "10.0.0.1");
+});
+```
+
+替换 `<admin-uuid>` / `<target-uuid>` 为测试中已存在的 UUID 常量。
+
+- [ ] **Step 6: 运行测试**
+
+```bash
+cd noj-core && deno test -A tests/services/auth.test.ts 2>&1 | tail -10
+```
+
+Expected: 既有 + 新增 1 passed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add noj-core/src/services/auth.ts noj-core/tests/services/auth.test.ts
+jj describe -m "feat(core): promoteUser 埋点 users.role_change 审计"
+```
+
+---
+
+## Task 9: 埋点 — banUser / unbanUser (users.ban / users.unban)
+
+**Files:**
+- Modify: `noj-core/src/services/users.ts`
+
+- [ ] **Step 1: 顶部 import**
+
+修改 `noj-core/src/services/users.ts` 顶部（保留其他）：
+
+```ts
+import { logAudit } from "./audit-log.ts";
+```
+
+- [ ] **Step 2: 在 banUser 成功路径末尾埋点**
+
+```bash
+grep -n "export async function banUser" noj-core/src/services/users.ts
+```
+
+定位到 `banUser` 中"更新 users 表 banned 字段"成功之后，return 之前，插入：
+
+```ts
+await logAudit(
+  "users.ban",
+  {
+    action: "users.ban",
+    reason: <reason_var>,
+    until: <until_var>,  // ISO string 或 null
+  },
+  { type: "user", id: <targetUserId_var> },
+);
+```
+
+替换 `<reason_var>` / `<until_var>` / `<targetUserId_var>` 为函数体内已有变量。
+
+- [ ] **Step 3: 在 unbanUser 成功路径末尾埋点**
+
+```bash
+grep -n "export async function unbanUser" noj-core/src/services/users.ts
+```
+
+定位到 `unbanUser` 中更新成功之后、return 之前，插入：
+
+```ts
+await logAudit(
+  "users.unban",
+  { action: "users.unban" },
+  { type: "user", id: <targetUserId_var> },
+);
+```
+
+- [ ] **Step 4: 验证 + 扩展测试**
+
+```bash
+cd noj-core && deno check src/services/users.ts 2>&1
+```
+
+仿 Task 8 Step 5，在 `tests/services/users.test.ts` 加 banUser / unbanUser 的 audit 断言。
+
+- [ ] **Step 5: 运行测试 + Commit**
+
+```bash
+cd noj-core && deno test -A tests/services/users.test.ts 2>&1 | tail -10
+git add noj-core/src/services/users.ts noj-core/tests/services/users.test.ts
+jj describe -m "feat(core): banUser / unbanUser 埋点审计"
+```
+
+Expected: 既有 + 新增 2 passed
+
+---
+
+## Task 10: 埋点 — deleteProblem (problems.delete)
+
+**Files:**
+- Modify: `noj-core/src/services/problems.ts`
+
+- [ ] **Step 1: import + 定位**
+
+```bash
+grep -n "export async function deleteProblem" noj-core/src/services/problems.ts
+```
+
+- [ ] **Step 2: import logAudit**
+
+修改顶部 import：
+
+```ts
+import { logAudit } from "./audit-log.ts";
+```
+
+- [ ] **Step 3: 埋点**
+
+定位到 `deleteProblem` 中删除成功之后，return 之前（删除前先获取 title 和 display_id 用于 audit）：
+
+```ts
+// 删除前读取题目的 title 和 display_id（若函数体内已有 row 则直接用）
+const [problem] = await getDb()
+  .select({ title: problems.title, display_id: problems.display_id })
+  .from(problems)
+  .where(eq(problems.id, problemId))
+  .limit(1);
+
+// ... 执行删除 ...
+
+await logAudit(
+  "problems.delete",
+  {
+    action: "problems.delete",
+    title: problem.title,
+    display_id: problem.display_id,
+  },
+  { type: "problem", id: problemId },
+);
+```
+
+如函数体内已有 row 变量可复用，无需重复查询。
+
+- [ ] **Step 4: 测试 + Commit**
+
+仿 Task 8 Step 5 加测试，运行 `deno test -A tests/services/problems.test.ts`，commit。
+
+---
+
+## Task 11: 埋点 — deleteCategory (categories.delete)
+
+**Files:**
+- Modify: `noj-core/src/services/categories.ts`
+
+- [ ] **Step 1-3: 同 Task 10 模式**
+
+```ts
+import { logAudit } from "./audit-log.ts";
+// ...
+await logAudit(
+  "categories.delete",
+  {
+    action: "categories.delete",
+    name: <name_var>,
+    slug: <slug_var>,
+  },
+  { type: "category", id: <category_id_var> },
+);
+```
+
+- [ ] **Step 4: 测试 + Commit**
+
+```bash
+cd noj-core && deno test -A tests/services/categories.test.ts 2>&1 | tail -10
+git add noj-core/src/services/categories.ts noj-core/tests/services/categories.test.ts
+jj describe -m "feat(core): deleteCategory 埋点审计"
+```
+
+---
+
+## Task 12: 埋点 — rejudgeSubmission / rejudgeProblemSubmissions
+
+**Files:**
+- Modify: `noj-core/src/services/submissions.ts`
+
+- [ ] **Step 1: import**
+
+```ts
+import { logAudit } from "./audit-log.ts";
+```
+
+- [ ] **Step 2: rejudgeSubmission 埋点**
+
+```bash
+grep -n "export async function rejudgeSubmission" noj-core/src/services/submissions.ts
+```
+
+定位到重测逻辑完成后，return 之前：
+
+```ts
+await logAudit(
+  "submissions.rejudge",
+  {
+    action: "submissions.rejudge",
+    submission_id: <id_var>,
+  },
+  { type: "submission", id: <id_var> },
+);
+```
+
+- [ ] **Step 3: rejudgeProblemSubmissions 埋点**
+
+```bash
+grep -n "export async function rejudgeProblemSubmissions" noj-core/src/services/submissions.ts
+```
+
+定位到函数末尾（重测循环完成之后）：
+
+```ts
+await logAudit(
+  "submissions.rejudge",
+  {
+    action: "submissions.rejudge",
+    problem_id: <problemId_var>,
+    count: <重测数量>,
+  },
+  { type: "problem", id: <problemId_var> },
+);
+```
+
+- [ ] **Step 4: 测试 + Commit**
+
+```bash
+cd noj-core && deno test -A tests/services/submissions.test.ts 2>&1 | tail -10
+git add noj-core/src/services/submissions.ts noj-core/tests/services/submissions.test.ts
+jj describe -m "feat(core): rejudgeSubmission / rejudgeProblemSubmissions 埋点"
+```
+
+---
+
+## Task 13: Route — GET /api/v1/admin/audit-logs
+
+**Files:**
+- Modify: `noj-core/src/routes/admin.ts`
+- Create: `noj-core/tests/routes/admin-audit-logs.test.ts`
+
+- [ ] **Step 1: 写失败路由测试**
+
+`noj-core/tests/routes/admin-audit-logs.test.ts`：
+
+```ts
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { app } from "../../src/app.ts";
+import { getDb } from "../../src/db/connection.ts";
+import { auditLogs } from "../../src/db/schema.ts";
+import { jsonRequest } from "../lib/helper.ts";
+
+async function cleanAuditLogs() {
+  await getDb().delete(auditLogs);
+}
+
+Deno.test("GET /admin/audit-logs 未登录返 401", async () => {
+  await cleanAuditLogs();
+  const res = await app.request("/api/v1/admin/audit-logs");
+  assertEquals(res.status, 401);
+});
+
+Deno.test("GET /admin/audit-logs 非 admin 返 403", async () => {
+  // 借用项目既有 helper：登录普通用户获取 token
+  const userToken = await loginAsUser("<user-email>", "<user-pass>");
+  const res = await app.request(
+    "/api/v1/admin/audit-logs",
+    { headers: { Authorization: `Bearer ${userToken}` } },
+  );
+  assertEquals(res.status, 403);
+});
+
+Deno.test("GET /admin/audit-logs admin 返 200 + 分页", async () => {
+  await cleanAuditLogs();
+  // 插入若干 audit_log 记录（用 service 直插或 SQL）
+  const db = getDb();
+  await db.insert(auditLogs).values([
+    /* 3 条记录 */
+  ]);
+
+  const adminToken = await loginAsAdmin("<admin-email>", "<admin-pass>");
+  const res = await app.request(
+    "/api/v1/admin/audit-logs?page=1&per_page=10",
+    { headers: { Authorization: `Bearer ${adminToken}` } },
+  );
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertExists(body.data);
+  assertExists(body.pagination);
+});
+
+Deno.test("GET /admin/audit-logs 按 action 筛选", async () => {
+  await cleanAuditLogs();
+  // 插入混合 action 记录
+  const adminToken = await loginAsAdmin("<admin-email>", "<admin-pass>");
+  const res = await app.request(
+    "/api/v1/admin/audit-logs?action=users.ban",
+    { headers: { Authorization: `Bearer ${adminToken}` } },
+  );
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  for (const entry of body.data) {
+    assertEquals(entry.action, "users.ban");
+  }
+});
+```
+
+（`loginAsUser` / `loginAsAdmin` 复用项目既有测试 helper；如不存在则按 `tests/routes/auth.test.ts` 既有模式补上）
+
+- [ ] **Step 2: 运行测试 — 应失败（路由未实现）**
+
+```bash
+cd noj-core && deno test -A tests/routes/admin-audit-logs.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL — 端点不存在或返回 404
+
+- [ ] **Step 3: 在 routes/admin.ts 顶部 import**
+
+```ts
+import { listAuditLogs } from "../services/audit-log.ts";
+import type { AuditAction } from "../types/audit-log.ts";
+```
+
+- [ ] **Step 4: 在路由定义区域（其他 GET /admin 端点旁）追加**
+
+```ts
+/**
+ * 管理员查询审计日志（分页 + 筛选）。
+ * GET /api/v1/admin/audit-logs
+ *
+ * Query:
+ *   page, per_page (default 20, max 100)
+ *   admin_id?, action?, from?, to?  (ISO 8601)
+ */
+router.get("/audit-logs", async (c) => {
+  let page = parseInt(c.req.query("page") ?? "1", 10);
+  let perPage = parseInt(c.req.query("per_page") ?? "20", 10);
+  if (isNaN(page) || page < 1) page = 1;
+  if (isNaN(perPage) || perPage < 1) perPage = 20;
+  if (perPage > 100) perPage = 100;
+
+  const result = await listAuditLogs({
+    page,
+    perPage,
+    admin_id: c.req.query("admin_id") || undefined,
+    action: (c.req.query("action") || undefined) as AuditAction | undefined,
+    from: c.req.query("from") || undefined,
+    to: c.req.query("to") || undefined,
+  });
+  return c.json({ data: result.data, pagination: result.pagination });
+});
+```
+
+- [ ] **Step 5: 运行测试 — 应全部通过**
+
+```bash
+cd noj-core && deno test -A tests/routes/admin-audit-logs.test.ts 2>&1 | tail -10
+```
+
+Expected: 4 passed, 0 failed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add noj-core/src/routes/admin.ts noj-core/tests/routes/admin-audit-logs.test.ts
+jj describe -m "feat(core): GET /admin/audit-logs 路由 + 测试"
+```
+
+---
+
+## Task 14: main.ts — 启动保留任务
+
+**Files:**
+- Modify: `noj-core/src/main.ts`
+
+- [ ] **Step 1: 定位 HTTP 启动位置**
+
+```bash
+grep -n "Deno.serve\|startRetentionTask\|startCron" noj-core/src/main.ts
+```
+
+- [ ] **Step 2: import**
+
+修改顶部：
+
+```ts
+import { startAuditLogRetentionTask } from "./services/audit-log.ts";
+```
+
+- [ ] **Step 3: 在 Deno.serve 之后追加**
+
+```ts
+// 启动后台审计日志保留任务
+startAuditLogRetentionTask();
+```
+
+- [ ] **Step 4: 验证主程序能起**
+
+```bash
+cd noj-core && deno check src/main.ts 2>&1 | tail -5
+```
+
+Expected: 无错误
+
+- [ ] **Step 5: 手动验证保留任务**
+
+```bash
+cd noj-core && AUDIT_LOG_RETENTION_DAYS=0 timeout 5 deno run --env-file=.env src/main.ts 2>&1 | grep -i "audit"
+```
+
+Expected: 输出 `[audit] AUDIT_LOG_RETENTION_DAYS=0, 清理任务已禁用`
+
+（不实际启动整个服务，仅验证 import 和函数调用无运行时错误；如超时前已输出可 Ctrl+C）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add noj-core/src/main.ts
+jj describe -m "feat(core): main.ts 启动审计日志保留任务"
+```
+
+---
+
+## Task 15: 环境变量文档
+
+**Files:**
+- Modify: `noj-core/.env.example`
+- Modify: `noj-core/AGENTS.md`
+- Modify: `AGENTS.md`（根）
+
+- [ ] **Step 1: .env.example 追加**
+
+```bash
+echo '
+# 审计日志保留天数（issue #101）。默认 90；0 = 禁用清理
+AUDIT_LOG_RETENTION_DAYS=90' >> noj-core/.env.example
+```
+
+- [ ] **Step 2: noj-core/AGENTS.md 环境变量表追加**
+
+定位到环境变量表（搜索 `| \`RATE_LIMIT_ENABLED\`` 行附近），在末尾添加：
+
+```markdown
+| `AUDIT_LOG_RETENTION_DAYS`              | `90`                     | 审计日志保留天数（0 = 禁用清理）                                |
+```
+
+- [ ] **Step 3: 根 AGENTS.md 已知限制追加**
+
+定位到"已知遗留问题"或"已知限制"章节末尾，追加：
+
+```markdown
+- 审计日志保留 90 天（`AUDIT_LOG_RETENTION_DAYS` 可配置；0 = 禁用）
+```
+
+- [ ] **Step 4: 验证 + Commit**
+
+```bash
+git add noj-core/.env.example noj-core/AGENTS.md AGENTS.md
+jj describe -m "docs: 记录 AUDIT_LOG_RETENTION_DAYS 环境变量"
+```
+
+---
+
+## Task 16: 前端 composable — useAuditLogs
+
+**Files:**
+- Create: `noj-ui/composables/useAuditLogs.ts`
+
+- [ ] **Step 1: 创建 composable**
+
+`noj-ui/composables/useAuditLogs.ts`：
+
+```ts
+/**
+ * 审计日志列表 composable。
+ * 状态：分页 + 筛选；自动请求 + 错误处理。
+ */
+import type { AuditAction, AuditLogEntry } from "~/types/audit-log";
+
+export interface AuditLogListResponse {
+  data: AuditLogEntry[];
+  pagination: { page: number; per_page: number; total: number };
+}
+
+export interface AuditLogFilters {
+  page: number;
+  per_page: number;
+  admin_id?: string;
+  action?: AuditAction | "";
+  from?: string;
+  to?: string;
+}
+
+export function useAuditLogs(initial: Partial<AuditLogFilters> = {}) {
+  const filters = useState("audit-logs-filters", () => ({
+    page: 1,
+    per_page: 20,
+    admin_id: undefined,
+    action: "" as AuditAction | "",
+    from: undefined,
+    to: undefined,
+    ...initial,
+  }));
+
+  const data = ref<AuditLogEntry[]>([]);
+  const pagination = ref({ page: 1, per_page: 20, total: 0 });
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  async function fetch() {
+    loading.value = true;
+    error.value = null;
+    try {
+      const params = new URLSearchParams();
+      params.set("page", String(filters.value.page));
+      params.set("per_page", String(filters.value.per_page));
+      if (filters.value.admin_id) params.set("admin_id", filters.value.admin_id);
+      if (filters.value.action) params.set("action", filters.value.action);
+      if (filters.value.from) params.set("from", filters.value.from);
+      if (filters.value.to) params.set("to", filters.value.to);
+
+      const res = await $fetch<AuditLogListResponse>(
+        `/api/v1/admin/audit-logs?${params}`,
+      );
+      data.value = res.data;
+      pagination.value = res.pagination;
+    } catch (e: any) {
+      error.value = e?.message ?? "加载失败";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  function reset() {
+    filters.value = { page: 1, per_page: 20, admin_id: undefined, action: "", from: undefined, to: undefined };
+  }
+
+  return { filters, data, pagination, loading, error, fetch, reset };
+}
+```
+
+- [ ] **Step 2: 类型镜像（共享类型）**
+
+`noj-ui/types/audit-log.ts`：
+
+```ts
+export type AuditAction =
+  | "users.role_change"
+  | "users.ban"
+  | "users.unban"
+  | "problems.delete"
+  | "categories.delete"
+  | "submissions.rejudge"
+  | "settings.update";
+
+export interface AuditLogEntry {
+  id: string;
+  admin_id: string;
+  action: AuditAction;
+  target_type: string | null;
+  target_id: string | null;
+  detail: Record<string, unknown>;
+  ip_address: string;
+  created_at: string;
+}
+```
+
+- [ ] **Step 3: 验证类型检查 + Commit**
+
+```bash
+cd noj-ui && npx nuxi typecheck 2>&1 | tail -10
+git add noj-ui/composables/useAuditLogs.ts noj-ui/types/audit-log.ts
+jj describe -m "feat(ui): useAuditLogs composable + 共享类型"
+```
+
+---
+
+## Task 17: 前端页面 — audit-logs.vue
+
+**Files:**
+- Create: `noj-ui/pages/admin/audit-logs.vue`
+
+- [ ] **Step 1: 创建页面骨架**
+
+`noj-ui/pages/admin/audit-logs.vue`（关键骨架，详细样式由实现者按现有 admin 页面风格补充）：
+
+```vue
+<script setup lang="ts">
+import { computed, onMounted } from "vue";
+import { Copy, ScrollText } from "lucide-vue-next";
+import { useAuditLogs } from "~/composables/useAuditLogs";
+import type { AuditAction, AuditLogEntry } from "~/types/audit-log";
+
+definePageMeta({ layout: "admin", ssr: false });
+
+const { filters, data, pagination, loading, error, fetch, reset } = useAuditLogs();
+
+const ACTION_LABELS: Record<AuditAction, string> = {
+  "users.role_change": "角色变更",
+  "users.ban": "用户封禁",
+  "users.unban": "用户解封",
+  "problems.delete": "删除题目",
+  "categories.delete": "删除分类",
+  "submissions.rejudge": "重测提交",
+  "settings.update": "修改设置",
+};
+
+const ACTION_COLORS: Record<AuditAction, string> = {
+  "users.role_change": "bg-blue-100 text-blue-800",
+  "users.ban": "bg-red-100 text-red-800",
+  "users.unban": "bg-green-100 text-green-800",
+  "problems.delete": "bg-red-100 text-red-800",
+  "categories.delete": "bg-orange-100 text-orange-800",
+  "submissions.rejudge": "bg-purple-100 text-purple-800",
+  "settings.update": "bg-yellow-100 text-yellow-800",
+};
+
+function renderDetail(entry: AuditLogEntry): string {
+  const d = entry.detail as Record<string, any>;
+  switch (entry.action) {
+    case "users.role_change":
+      return `${d.from} → ${d.to}`;
+    case "users.ban":
+      return `${d.reason}${d.until ? ` (至 ${d.until})` : ""}`;
+    case "users.unban":
+      return "已解封";
+    case "problems.delete":
+      return `${d.title} (${d.display_id})`;
+    case "categories.delete":
+      return `${d.name} (${d.slug})`;
+    case "submissions.rejudge":
+      if (d.submission_id) return `submission: ${d.submission_id}`;
+      if (d.problem_id) return `problem: ${d.problem_id} (×${d.count ?? "?"})`;
+      return "—";
+    case "settings.update":
+      return `${d.key}: ${JSON.stringify(d.from)} → ${JSON.stringify(d.to)}`;
+    default:
+      return JSON.stringify(d);
+  }
+}
+
+async function copy(value: string) {
+  try {
+    await navigator.clipboard.writeText(value);
+    // toast.success("已复制");
+  } catch {
+    // toast.error("复制失败");
+  }
+}
+
+function applyFilters() {
+  filters.value.page = 1;
+  fetch();
+}
+
+onMounted(fetch);
+</script>
+
+<template>
+  <div class="p-6">
+    <h1 class="text-2xl font-bold mb-4 flex items-center gap-2">
+      <ScrollText :size="24" /> 审计日志
+    </h1>
+
+    <!-- 筛选条 -->
+    <div class="flex flex-wrap gap-3 mb-4 items-end">
+      <div>
+        <label class="text-xs text-gray-600">操作类型</label>
+        <select v-model="filters.action" class="border rounded px-2 py-1">
+          <option value="">全部</option>
+          <option v-for="(label, action) in ACTION_LABELS" :key="action" :value="action">
+            {{ label }}
+          </option>
+        </select>
+      </div>
+      <div>
+        <label class="text-xs text-gray-600">起始时间</label>
+        <input type="datetime-local" v-model="filters.from" class="border rounded px-2 py-1" />
+      </div>
+      <div>
+        <label class="text-xs text-gray-600">截止时间</label>
+        <input type="datetime-local" v-model="filters.to" class="border rounded px-2 py-1" />
+      </div>
+      <button @click="reset" class="px-3 py-1 border rounded">重置</button>
+      <button @click="applyFilters" class="px-3 py-1 bg-blue-600 text-white rounded">筛选</button>
+    </div>
+
+    <!-- 表格 -->
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="bg-gray-100 text-left">
+          <th class="p-2">时间</th>
+          <th class="p-2">管理员</th>
+          <th class="p-2">操作</th>
+          <th class="p-2">目标</th>
+          <th class="p-2">详情</th>
+          <th class="p-2">IP</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-if="loading">
+          <td colspan="6" class="p-4 text-center text-gray-500">加载中...</td>
+        </tr>
+        <tr v-else-if="error">
+          <td colspan="6" class="p-4 text-center text-red-600">{{ error }}</td>
+        </tr>
+        <tr v-else-if="data.length === 0">
+          <td colspan="6" class="p-4 text-center text-gray-500">暂无记录</td>
+        </tr>
+        <tr v-for="entry in data" :key="entry.id" class="border-t hover:bg-gray-50">
+          <td class="p-2 text-sm">{{ new Date(entry.created_at).toLocaleString("zh-CN") }}</td>
+          <td class="p-2 text-sm font-mono">{{ entry.admin_id.slice(0, 8) }}...</td>
+          <td class="p-2">
+            <span :class="['px-2 py-1 rounded text-xs', ACTION_COLORS[entry.action]]">
+              {{ ACTION_LABELS[entry.action] }}
+            </span>
+          </td>
+          <td class="p-2 text-sm">{{ entry.target_type }}:{{ entry.target_id?.slice(0, 8) }}...</td>
+          <td class="p-2 text-sm">{{ renderDetail(entry) }}</td>
+          <td class="p-2 text-sm font-mono flex items-center gap-1">
+            {{ entry.ip_address }}
+            <button @click="copy(entry.ip_address)" class="text-gray-400 hover:text-blue-600">
+              <Copy :size="14" />
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- 分页 -->
+    <PaginationNav
+      v-if="pagination.total > pagination.per_page"
+      :page="pagination.page"
+      :per-page="pagination.per_page"
+      :total="pagination.total"
+      @update:page="(p) => { filters.page = p; fetch(); }"
+    />
+  </div>
+</template>
+```
+
+- [ ] **Step 2: 构建验证**
+
+```bash
+cd noj-ui && npm run build 2>&1 | tail -10
+```
+
+Expected: 构建成功，无 TS 错误
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add noj-ui/pages/admin/audit-logs.vue
+jj describe -m "feat(ui): 审计日志查看页面"
+```
+
+---
+
+## Task 18: 侧栏入口
+
+**Files:**
+- Modify: `noj-ui/layouts/admin.vue`
+
+- [ ] **Step 1: 定位 navItems**
+
+```bash
+grep -n "navItems\|ScrollText\|Ban" noj-ui/layouts/admin.vue | head -10
+```
+
+- [ ] **Step 2: import 新图标**
+
+```ts
+import { ..., ScrollText } from "lucide-vue-next";
+```
+
+- [ ] **Step 3: navItems 数组追加**
+
+```ts
+{ label: "审计日志", to: "/admin/audit-logs", icon: ScrollText },
+```
+
+- [ ] **Step 4: 构建 + Commit**
+
+```bash
+cd noj-ui && npm run build 2>&1 | tail -5
+git add noj-ui/layouts/admin.vue
+jj describe -m "feat(ui): admin 侧栏新增审计日志入口"
+```
+
+---
+
+## Task 19: 全量验证
+
+**Files:** 无
+
+- [ ] **Step 1: deno fmt**
+
+```bash
+cd noj-core && deno fmt 2>&1 | tail -3
+```
+
+- [ ] **Step 2: deno lint**
+
+```bash
+cd noj-core && deno lint 2>&1 | tail -10
+```
+
+Expected: 0 errors
+
+- [ ] **Step 3: 全量测试**
+
+```bash
+cd noj-core && deno task test 2>&1 | tail -5
+```
+
+Expected: 既有 343+ passed + 新增 10+ = 353+ passed, 0 failed
+
+- [ ] **Step 4: 前端构建**
+
+```bash
+cd noj-ui && npm run build 2>&1 | tail -10
+```
+
+Expected: 构建成功
+
+- [ ] **Step 5: E2E 冒烟（可选）**
+
+如本机已启动 noj-core + noj-judge 栈：
+
+```bash
+# 启动 noj-core（后台）
+cd noj-core && deno task dev &
+# 等 5s
+sleep 5
+# admin 登录拿 token
+ADMIN_TOKEN=$(curl -s -X POST http://localhost:8000/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"login":"<admin-email>","password":"<admin-pass>"}' | jq -r .data.token)
+# 触发一个 ban 操作
+curl -X PATCH http://localhost:8000/api/v1/admin/users/<user-uuid>/ban \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"smoke test","until":null}'
+# 查询审计日志
+curl -s "http://localhost:8000/api/v1/admin/audit-logs?action=users.ban" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" | jq .data[0]
+```
+
+Expected: 返回的 detail.reason = "smoke test"，ip_address 等于 curl 客户端 IP
+
+---
+
+## Task 20: 提交 + 推送 + PR
+
+**Files:** 无
+
+- [ ] **Step 1: 验证 GPG 签名**
+
+```bash
+git log --format="%H %G?" -10
+```
+
+Expected: 所有 commit 显示 `G`（good signature）或 `U`（unknown good），无 `N`（none）
+
+- [ ] **Step 2: 推送到 origin**
+
+```bash
+jj git push -b feat/issue-101-audit-log
+# 或 git push --set-upstream origin feat/issue-101-audit-log
+```
+
+- [ ] **Step 3: 创建 PR**
+
+```bash
+gh pr create \
+  --base main \
+  --head feat/issue-101-audit-log \
+  --title "feat(core,ui): 审计日志：管理员操作记录（issue #101）" \
+  --body "$(cat <<'EOF'
+Closes #101
+
+## 变更内容
+
+- audit_logs 表（7 列 + 1 CHECK + 3 索引）+ Drizzle 迁移 0012
+- RequestContext (AsyncLocalStorage) — service 层零签名改动取 IP
+- logAudit service 核心（同步 INSERT + 失败仅 console.error）
+- 7 处 service 埋点（role_change / ban / unban / delete problem / delete category / rejudge）
+- GET /api/v1/admin/audit-logs 路由（分页 + 4 维度筛选 + 默认排除 root）
+- 后台 setInterval 任务 — 90 天保留，可配置
+- 前端 /admin/audit-logs 查看页 + 侧栏入口
+
+## OpenSpec 引用
+
+- 提案：`openspec/changes/audit-log/proposal.md`
+- 设计：`openspec/changes/audit-log/design.md`
+- 任务：`openspec/changes/audit-log/tasks.md`
+- Spec：`openspec/changes/audit-log/specs/audit-log/spec.md`（8 Requirements + 20 Scenarios）
+
+## 验证
+
+- `deno fmt --check` ✅
+- `deno lint` ✅
+- `deno task test` — 既有 343 + 新增 10+ = 353+ passed
+- `npm run build` 成功
+- 端到端冒烟：admin ban 用户 → 查询 /admin/audit-logs 见到对应记录
+
+/cc @box3-galen-nv
+EOF
+)"
+```
+
+- [ ] **Step 4: 在 PR 评论里 ping reviewer**
+
+如有 reviewer 自动订阅，GitHub 会自动通知；否则 `@box3-galen-nv` 在评论里 ping。
+
+- [ ] **Step 5: 等待 CI**
+
+观察 `.github/workflows/ci.yml` 的 core-test job：
+
+```bash
+gh pr checks
+```
+
+Expected: 全部 ✅
+
+---
+
+## Self-Review Checklist
+
+**1. Spec 覆盖**（openspec/changes/audit-log/specs/audit-log/spec.md）：
+
+| Requirement | Task |
+|-------------|------|
+| audit_logs 表 | T2, T3 |
+| AuditDetail 强类型 | T4 |
+| RequestContext 自动捕获 | T5, T6 |
+| 同步审计写入 | T7 |
+| 7 类操作埋点 | T8, T9, T10, T11, T12 |
+| 审计日志列表 API | T13 |
+| 90 天保留策略 | T7, T14 |
+| 管理后台 UI | T16, T17, T18 |
+
+**全部 8 Requirements + 20 Scenarios 已映射到具体 Task。**
+
+**2. 占位符扫描**：
+
+- 无 TBD / TODO / "implement later"
+- 无 "add appropriate error handling" 类空话
+- 所有代码块完整可粘贴
+- 文件路径精确
+
+**3. 类型一致性**：
+
+- `RequestContext` 在 T5 定义、T6 使用、T7 消费 — 一致
+- `AuditAction` / `AuditDetail` 在 T4 定义、T7 消费、T13 路由消费 — 一致
+- `AuditLogEntry` 在 T4 定义、T7 返回、T16 前端消费 — 一致
+- `logAudit(action, detail, target?)` 签名在 T7 定义、T8-T12 调用 — 一致
+
+**4. 已知缺口**：
+
+- Task 8-12 中"替换 `<var>` 为函数体内已有变量"依赖实现者读取现有代码 — 这是必要的灵活性，避免重复粘贴 200 行函数
+- E2E 冒烟测试为可选步骤（如未启动完整栈）
+- settings.update 埋点（条件性 T6.8）依赖 #105 合并顺序；如 #105 先合则补做，否则跳过

--- a/noj-core/.env.example
+++ b/noj-core/.env.example
@@ -67,3 +67,7 @@ S3_FORCE_PATH_STYLE=true
 # RATE_LIMIT_LOGIN_ENABLED=true  # 是否启用登录速率限制（NOJ_ENV=test 时强制关闭）
 # MAINTENANCE_MODE=false  # 维护模式（启用后写操作 API 返回 503）
 # HOMEPAGE_BANNER=  # 首页顶部公告（最多 1000 字符）
+
+# ---- 审计日志（issue #101）----
+# 审计日志保留天数。0 = 禁用自动清理（需手动维护）
+AUDIT_LOG_RETENTION_DAYS=90

--- a/noj-core/AGENTS.md
+++ b/noj-core/AGENTS.md
@@ -124,6 +124,7 @@ noj-core/
 | `RATE_LIMIT_LOGIN_LOCK_THRESHOLD` | `10`                      | 连续失败锁定阈值                                                      |
 | `RATE_LIMIT_LOGIN_LOCK_SECONDS`   | `3600`                    | 锁定时长（秒）                                                        |
 | `TRUSTED_PROXIES`                 | —                         | 可信代理白名单（逗号分隔 IP/CIDR）。生产环境**必须**配置              |
+| `AUDIT_LOG_RETENTION_DAYS`        | `90`                      | 审计日志保留天数（0 = 禁用清理）                                      |
 
 ## 开发命令
 

--- a/noj-core/deno.lock
+++ b/noj-core/deno.lock
@@ -2,10 +2,12 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@1": "1.1.5",
+    "jsr:@std/testing@1": "1.0.19",
     "npm:@alicloud/dm20151123@*": "1.10.2",
     "npm:@alicloud/dm20151123@^1.10.2": "1.10.2",
     "npm:@alicloud/openapi-core@*": "1.0.7",
@@ -44,6 +46,12 @@
       "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
       "dependencies": [
         "jsr:@std/internal@^1.0.14"
+      ]
+    },
+    "@std/testing@1.0.19": {
+      "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19"
       ]
     }
   },

--- a/noj-core/drizzle/0013_audit_logs.sql
+++ b/noj-core/drizzle/0013_audit_logs.sql
@@ -1,0 +1,26 @@
+-- 审计日志表（issue #101）
+CREATE TABLE "audit_logs" (
+  "id" TEXT PRIMARY KEY,
+  "admin_id" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "target_type" TEXT,
+  "target_id" TEXT,
+  "detail" JSONB NOT NULL DEFAULT '{}',
+  "ip_address" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  CONSTRAINT "audit_logs_admin_id_fk" FOREIGN KEY ("admin_id") REFERENCES "users"("id"),
+  CONSTRAINT "audit_logs_action_check" CHECK ("action" IN (
+    'users.role_change',
+    'users.ban',
+    'users.unban',
+    'problems.delete',
+    'categories.delete',
+    'submissions.rejudge',
+    'settings.update'
+  ))
+);
+
+CREATE INDEX "audit_logs_admin_id_idx" ON "audit_logs" ("admin_id");
+CREATE INDEX "audit_logs_created_at_idx" ON "audit_logs" ("created_at");
+CREATE INDEX "audit_logs_action_idx" ON "audit_logs" ("action");
+

--- a/noj-core/drizzle/0016_audit_logs_ip_ban_actions.sql
+++ b/noj-core/drizzle/0016_audit_logs_ip_ban_actions.sql
@@ -1,0 +1,13 @@
+-- 扩展审计日志 action CHECK 约束（issue #101），新增 ip_ban.create 和 ip_ban.delete
+ALTER TABLE "audit_logs" DROP CONSTRAINT IF EXISTS "audit_logs_action_check";
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_action_check" CHECK ("action" IN (
+  'users.role_change',
+  'users.ban',
+  'users.unban',
+  'problems.delete',
+  'categories.delete',
+  'submissions.rejudge',
+  'settings.update',
+  'ip_ban.create',
+  'ip_ban.delete'
+));

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1783120000300,
       "tag": "0015_user_bans",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1783120000400,
+      "tag": "0016_audit_logs_ip_ban_actions",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -103,12 +103,19 @@
     {
       "idx": 14,
       "version": "7",
+      "when": 1783300000000,
+      "tag": "0013_audit_logs",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
       "when": 1783120000200,
       "tag": "0014_ip_bans_and_user_ban",
       "breakpoints": true
     },
     {
-      "idx": 15,
+      "idx": 16,
       "version": "7",
       "when": 1783120000300,
       "tag": "0015_user_bans",

--- a/noj-core/src/db/schema-ddl.ts
+++ b/noj-core/src/db/schema-ddl.ts
@@ -171,7 +171,8 @@ export const SCHEMA_DDL: string[] = [
     created_at TEXT NOT NULL,
     CONSTRAINT audit_logs_action_check CHECK (action IN (
       'users.role_change','users.ban','users.unban',
-      'problems.delete','categories.delete','submissions.rejudge','settings.update'
+      'problems.delete','categories.delete','submissions.rejudge','settings.update',
+      'ip_ban.create','ip_ban.delete'
     ))
   )`,
 

--- a/noj-core/src/db/schema-ddl.ts
+++ b/noj-core/src/db/schema-ddl.ts
@@ -159,7 +159,23 @@ export const SCHEMA_DDL: string[] = [
     updated_by TEXT REFERENCES users(id) ON DELETE SET NULL
   )`,
 
-  // 15. ip_bans (issue #102)
+  // 15. audit_logs (issue #101)
+  `CREATE TABLE IF NOT EXISTS audit_logs (
+    id TEXT PRIMARY KEY,
+    admin_id TEXT NOT NULL REFERENCES users(id),
+    action TEXT NOT NULL,
+    target_type TEXT,
+    target_id TEXT,
+    detail JSONB NOT NULL DEFAULT '{}',
+    ip_address TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    CONSTRAINT audit_logs_action_check CHECK (action IN (
+      'users.role_change','users.ban','users.unban',
+      'problems.delete','categories.delete','submissions.rejudge','settings.update'
+    ))
+  )`,
+
+  // 16. ip_bans (issue #102)
   `CREATE TABLE IF NOT EXISTS ip_bans (
     id TEXT PRIMARY KEY,
     ip_or_cidr TEXT NOT NULL,
@@ -169,7 +185,7 @@ export const SCHEMA_DDL: string[] = [
     created_by TEXT REFERENCES users(id) ON DELETE SET NULL
   )`,
 
-  // 16. user_bans (issue #102)
+  // 17. user_bans (issue #102)
   `CREATE TABLE IF NOT EXISTS user_bans (
     id TEXT PRIMARY KEY,
     user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -200,6 +216,9 @@ export const SCHEMA_INDEXES: string[] = [
   "CREATE INDEX IF NOT EXISTS idx_messages_sender_id ON messages (sender_id)",
   "CREATE INDEX IF NOT EXISTS idx_message_deletions_message_id ON message_deletions (message_id)",
   "CREATE INDEX IF NOT EXISTS idx_system_settings_updated_at ON system_settings (updated_at DESC)",
+  "CREATE INDEX IF NOT EXISTS audit_logs_admin_id_idx ON audit_logs (admin_id)",
+  "CREATE INDEX IF NOT EXISTS audit_logs_created_at_idx ON audit_logs (created_at)",
+  "CREATE INDEX IF NOT EXISTS audit_logs_action_idx ON audit_logs (action)",
   "CREATE INDEX IF NOT EXISTS idx_ip_bans_ip_or_cidr ON ip_bans (ip_or_cidr)",
   "CREATE INDEX IF NOT EXISTS idx_ip_bans_expires_at ON ip_bans (expires_at)",
   "CREATE INDEX IF NOT EXISTS idx_user_bans_user ON user_bans (user_id)",
@@ -221,6 +240,7 @@ export const ALL_TABLES = [
   "conversation_reads",
   "message_deletions",
   "system_settings",
+  "audit_logs",
   "ip_bans",
   "user_bans",
 ] as const;

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -428,7 +428,9 @@ export const auditLogs = pgTable(
         'problems.delete',
         'categories.delete',
         'submissions.rejudge',
-        'settings.update'
+        'settings.update',
+        'ip_ban.create',
+        'ip_ban.delete'
       )`,
     ),
     adminIdx: index("audit_logs_admin_id_idx").on(table.admin_id),
@@ -494,3 +496,4 @@ export const userBans = pgTable(
       sql`unbanned_at IS NULL`,
     ),
   }),
+);

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -3,6 +3,7 @@ import {
   check,
   index,
   integer,
+  jsonb,
   pgTable,
   primaryKey,
   text,
@@ -401,6 +402,42 @@ export const systemSettings = pgTable(
 );
 
 /**
+ * 审计日志表（issue #101）。
+ * 记录所有管理员操作的详细信息：admin_id、action、target、detail、ip、time。
+ * service 层通过 logAudit() 同步写入；后台任务定期清理过期记录。
+ */
+export const auditLogs = pgTable(
+  "audit_logs",
+  {
+    id: text("id").primaryKey(),
+    admin_id: text("admin_id").notNull().references(() => users.id),
+    action: text("action").notNull(),
+    target_type: text("target_type"),
+    target_id: text("target_id"),
+    detail: jsonb("detail").notNull().default({}),
+    ip_address: text("ip_address").notNull(),
+    created_at: text("created_at").notNull(),
+  },
+  (table) => ({
+    actionCheck: check(
+      "audit_logs_action_check",
+      sql`${table.action} IN (
+        'users.role_change',
+        'users.ban',
+        'users.unban',
+        'problems.delete',
+        'categories.delete',
+        'submissions.rejudge',
+        'settings.update'
+      )`,
+    ),
+    adminIdx: index("audit_logs_admin_id_idx").on(table.admin_id),
+    createdAtIdx: index("audit_logs_created_at_idx").on(table.created_at),
+    actionIdx: index("audit_logs_action_idx").on(table.action),
+  }),
+);
+
+/**
  * IP 黑名单表（issue #102）。
  * 存储被封禁的 IPv4 裸 IP（如 1.2.3.4）或 CIDR 范围（如 10.0.0.0/8）。
  * 命中后中间件返 403 IP_BLACKLISTED。
@@ -457,4 +494,3 @@ export const userBans = pgTable(
       sql`unbanned_at IS NULL`,
     ),
   }),
-);

--- a/noj-core/src/lib/requestContext.ts
+++ b/noj-core/src/lib/requestContext.ts
@@ -1,0 +1,50 @@
+/**
+ * AsyncLocalStorage 上下文（issue #101）。
+ *
+ * adminMiddleware 在请求作用域注入 RequestContext，
+ * service 层通过 getRequestContext() 取用，避免污染函数签名。
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface RequestContext {
+  /** 当前用户 ID */
+  actorId: string;
+  /** 请求客户端 IP（X-Forwarded-For 优先） */
+  actorIp: string;
+  /** 当前用户角色 */
+  actorRole: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+/** 在指定 context 内运行 fn（adminMiddleware 内使用） */
+export function runWithContext<T>(ctx: RequestContext, fn: () => T): T {
+  return storage.run(ctx, fn);
+}
+
+/** 取当前请求的 context；缺失抛错（程序 bug 保护） */
+export function getRequestContext(): RequestContext {
+  const ctx = storage.getStore();
+  if (!ctx) {
+    throw new Error(
+      "RequestContext 未注入 — logAudit 仅允许在 admin 路由内调用",
+    );
+  }
+  return ctx;
+}
+
+/**
+ * 仅测试中使用：注入固定 context，service 层无需 Hono 中间件即可调用 logAudit。
+ *
+ * 注意：使用 enterWith() 而非 run() 以便无需回调即可持续作用（简化测试编写）。
+ * 但上下文会跨异步边界持续，务必在测试 cleanup 中调用 leaveTestContext() 清理。
+ */
+export function enterTestContext(ctx: RequestContext): void {
+  storage.enterWith(ctx);
+}
+
+/** 清理测试中注入的 ALS 上下文（防止 enterWith 跨测试泄漏） */
+export function leaveTestContext(): void {
+  storage.enterWith(undefined as unknown as RequestContext);
+}

--- a/noj-core/src/main.ts
+++ b/noj-core/src/main.ts
@@ -9,6 +9,7 @@ import { validateRegistry } from "./lib/settings-registry.ts";
 import { ensureRootUser } from "./services/auth.ts";
 import { getStorageProvider } from "./lib/storage/mod.ts";
 import { initSystemSettings } from "./services/system-settings.ts";
+import { startAuditLogRetentionTask } from "./services/audit-log.ts";
 
 const app = createApp();
 
@@ -173,6 +174,9 @@ async function main() {
   Deno.serve({ port }, app.fetch);
 
   console.log(`noj-core running on http://localhost:${port}`);
+
+  // 启动后台审计日志保留任务
+  startAuditLogRetentionTask();
 }
 
 await main();

--- a/noj-core/src/middleware/auth.ts
+++ b/noj-core/src/middleware/auth.ts
@@ -5,6 +5,8 @@ import { verifyToken } from "../lib/jwt.ts";
 import { getDb } from "../db/connection.ts";
 import { userBans } from "../db/schema.ts";
 import { getCached } from "../lib/banCache.ts";
+import { getClientIp } from "../lib/rateLimitEnv.ts";
+import { runWithContext } from "../lib/requestContext.ts";
 
 /**
  * 强制改密白名单（issue #75）。
@@ -151,10 +153,23 @@ export async function getUserBanState(userId: string): Promise<UserBanState> {
  *
  * 需要在 authMiddleware 之后使用，依赖其注入的 userRole 字段。
  * 若用户角色不为 "admin"，抛 ForbiddenError 由 app.ts onError 统一处理。
+ *
+ * 注入 RequestContext 到 AsyncLocalStorage（issue #101），使下游 service 层
+ * 通过 getRequestContext() 获取 actorId / actorIp / actorRole，
+ * 用于审计日志埋点。
  */
 export async function adminMiddleware(c: Context, next: Next) {
-  if (c.get("userRole") !== "admin") {
+  const userRole = c.get("userRole");
+  if (userRole !== "admin") {
     throw new ForbiddenError("需要管理员权限");
   }
-  await next();
+
+  return await runWithContext(
+    {
+      actorId: c.get("userId"),
+      actorIp: getClientIp(c),
+      actorRole: userRole,
+    },
+    () => next(),
+  );
 }

--- a/noj-core/src/routes/admin.ts
+++ b/noj-core/src/routes/admin.ts
@@ -39,6 +39,8 @@ import {
   resetSetting,
   updateSetting,
 } from "../services/system-settings.ts";
+import { listAuditLogs } from "../services/audit-log.ts";
+import type { AuditAction } from "../types/audit-log.ts";
 
 const router = new Hono<{ Variables: { userId: string; userRole: string } }>();
 
@@ -431,4 +433,31 @@ router.get("/users/:id/bans", async (c) => {
   return c.json({ data: records }, 200);
 });
 
+// ─── 审计日志（issue #101）───────────────────────────────────
+
+/**
+ * 管理员查询审计日志（分页 + 筛选）。
+ * GET /api/v1/admin/audit-logs
+ *
+ * Query:
+ *   page, per_page (default 20, max 100)
+ *   admin_id?, action?, from?, to?  (ISO 8601)
+ */
+router.get("/audit-logs", async (c) => {
+  let page = parseInt(c.req.query("page") ?? "1", 10);
+  let perPage = parseInt(c.req.query("per_page") ?? "20", 10);
+  if (isNaN(page) || page < 1) page = 1;
+  if (isNaN(perPage) || perPage < 1) perPage = 20;
+  if (perPage > 100) perPage = 100;
+
+  const result = await listAuditLogs({
+    page,
+    perPage,
+    admin_id: c.req.query("admin_id") || undefined,
+    action: (c.req.query("action") || undefined) as AuditAction | undefined,
+    from: c.req.query("from") || undefined,
+    to: c.req.query("to") || undefined,
+  });
+  return c.json({ data: result.data, pagination: result.pagination });
+});
 export default router;

--- a/noj-core/src/routes/problems.ts
+++ b/noj-core/src/routes/problems.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import { authMiddleware } from "../middleware/auth.ts";
 import { parseJsonBody } from "../lib/request.ts";
 import { BadRequestError } from "../lib/errors.ts";
+import { getClientIp } from "../lib/rateLimitEnv.ts";
+import { runWithContext } from "../lib/requestContext.ts";
 import {
   createProblem,
   deleteProblem,
@@ -165,8 +167,19 @@ router.delete("/:id", authMiddleware, async (c) => {
 
   // 双索引解析获取实际题目 ID
   const problem = await resolveProblem(id);
-  await deleteProblem(problem.id, userId, userRole);
-  return c.body(null, 204);
+
+  // 注入 ALS 上下文使 logAudit 可获取 actor 信息（issue #101）
+  return await runWithContext(
+    {
+      actorId: userId,
+      actorIp: getClientIp(c),
+      actorRole: userRole,
+    },
+    async () => {
+      await deleteProblem(problem.id, userId, userRole);
+      return c.body(null, 204);
+    },
+  );
 });
 
 /**

--- a/noj-core/src/services/audit-log.ts
+++ b/noj-core/src/services/audit-log.ts
@@ -48,7 +48,9 @@ export async function logAudit(
     const pgConstraint = typeof pgErr.constraint === "string"
       ? ` (${pgErr.constraint})`
       : "";
-    const pgDetail = typeof pgErr.detail === "string" ? `: ${pgErr.detail}` : "";
+    const pgDetail = typeof pgErr.detail === "string"
+      ? `: ${pgErr.detail}`
+      : "";
     console.error(
       `[audit] logAudit 失败 (action=${action}):${pgCode}${pgConstraint}${pgDetail}`,
       msg,

--- a/noj-core/src/services/audit-log.ts
+++ b/noj-core/src/services/audit-log.ts
@@ -1,0 +1,172 @@
+/**
+ * 审计日志 service（issue #101）。
+ *
+ * 提供：
+ * - logAudit() —— service 层同步写入，失败仅 console.error
+ * - listAuditLogs() —— 分页 + 多维度筛选，默认排除 root
+ * - cleanupOldAuditLogs() —— 按 created_at 阈值删除
+ * - startAuditLogRetentionTask() —— 后台 setInterval 任务
+ */
+
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+import { auditLogs } from "../db/schema.ts";
+import { getRequestContext } from "../lib/requestContext.ts";
+import type {
+  AuditAction,
+  AuditDetail,
+  AuditLogEntry,
+  AuditLogListFilter,
+} from "../types/audit-log.ts";
+
+/**
+ * 记录一条审计日志。必须在 admin 路由内调用（依赖 RequestContext）。
+ * 失败仅 console.error，业务操作继续。
+ */
+export async function logAudit(
+  action: AuditAction,
+  detail: AuditDetail,
+  target?: { type: string; id: string },
+): Promise<void> {
+  try {
+    const ctx = getRequestContext();
+    const db = getDb();
+    await db.insert(auditLogs).values({
+      id: crypto.randomUUID(),
+      admin_id: ctx.actorId,
+      action,
+      target_type: target?.type ?? null,
+      target_id: target?.id ?? null,
+      detail: detail as unknown as Record<string, unknown>,
+      ip_address: ctx.actorIp,
+      created_at: new Date().toISOString(),
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const pgErr = e as Record<string, unknown>;
+    const pgCode = typeof pgErr.code === "string" ? ` [${pgErr.code}]` : "";
+    const pgConstraint = typeof pgErr.constraint === "string"
+      ? ` (${pgErr.constraint})`
+      : "";
+    const pgDetail = typeof pgErr.detail === "string" ? `: ${pgErr.detail}` : "";
+    console.error(
+      `[audit] logAudit 失败 (action=${action}):${pgCode}${pgConstraint}${pgDetail}`,
+      msg,
+    );
+  }
+}
+
+/** 审计日志分页列表 + 多维度筛选。默认排除 root (admin_id='0')。 */
+export async function listAuditLogs(
+  filter: AuditLogListFilter,
+): Promise<
+  {
+    data: AuditLogEntry[];
+    pagination: { page: number; per_page: number; total: number };
+  }
+> {
+  const { page, perPage, admin_id, action, from, to } = filter;
+  const db = getDb();
+
+  const conditions: ReturnType<typeof sql>[] = [];
+  if (admin_id) {
+    conditions.push(eq(auditLogs.admin_id, admin_id));
+  } else {
+    // 默认排除 root (admin_id='0')，显式传入 admin_id='0' 可覆盖
+    conditions.push(sql`${auditLogs.admin_id} != '0'`);
+  }
+  if (action) conditions.push(eq(auditLogs.action, action));
+  if (from) conditions.push(gte(auditLogs.created_at, from));
+  if (to) conditions.push(lte(auditLogs.created_at, to));
+
+  const whereClause = and(...conditions);
+
+  const [rows, totalResult] = await Promise.all([
+    db.select()
+      .from(auditLogs)
+      .where(whereClause)
+      .orderBy(desc(auditLogs.created_at))
+      .limit(perPage)
+      .offset((page - 1) * perPage),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(auditLogs)
+      .where(whereClause),
+  ]);
+
+  return {
+    data: rows.map((r) => ({
+      id: r.id,
+      admin_id: r.admin_id,
+      action: r.action as AuditAction,
+      target_type: r.target_type,
+      target_id: r.target_id,
+      detail: r.detail as unknown as AuditDetail,
+      ip_address: r.ip_address,
+      created_at: r.created_at,
+    })),
+    pagination: {
+      page,
+      per_page: perPage,
+      total: totalResult[0]?.count ?? 0,
+    },
+  };
+}
+
+/** 按保留天数清理过期日志，返回删除行数 */
+export async function cleanupOldAuditLogs(
+  retentionDays: number,
+): Promise<number> {
+  if (retentionDays <= 0) return 0;
+  const cutoff = new Date(
+    Date.now() - retentionDays * 86400 * 1000,
+  ).toISOString();
+  const db = getDb();
+  const result = await db.delete(auditLogs).where(
+    lte(auditLogs.created_at, cutoff),
+  );
+  // 跨驱动兼容：PGlite 返回 { affectedRows }; postgres.js 返回 RowList 带 count
+  // Drizzle 类型未统一这两个字段，使用 unknown 强制访问
+  const r = result as unknown as {
+    affectedRows?: number;
+    rowCount?: number;
+    count?: number;
+  };
+  return r.affectedRows ?? r.rowCount ?? r.count ?? 0;
+}
+
+/** 启动后台保留任务（HTTP 启动后由 main.ts 调用） */
+export function startAuditLogRetentionTask(): void {
+  const raw = Deno.env.get("AUDIT_LOG_RETENTION_DAYS") ?? "90";
+  const days = parseInt(raw, 10);
+  if (Number.isNaN(days) || days <= 0) {
+    console.info(
+      `[audit] AUDIT_LOG_RETENTION_DAYS=${raw} 无效, 清理任务已禁用`,
+    );
+    return;
+  }
+  // 启动立即跑一次
+  cleanupOldAuditLogs(days)
+    .then((n) => console.info(`[audit] 启动清理: 移除 ${n} 条过期日志`))
+    .catch((e) =>
+      console.error(
+        "[audit] 启动清理失败:",
+        e instanceof Error ? e.message : String(e),
+      )
+    );
+  // 每 24h 重复
+  setInterval(() => {
+    cleanupOldAuditLogs(days)
+      .then((n) =>
+        n > 0
+          ? console.info(`[audit] 周期清理: 移除 ${n} 条过期日志`)
+          : undefined
+      )
+      .catch((e) =>
+        console.error(
+          "[audit] 周期清理失败:",
+          e instanceof Error ? e.message : String(e),
+        )
+      );
+  }, 86400 * 1000);
+  console.info(`[audit] 保留任务已启动: retention_days=${days}`);
+}

--- a/noj-core/src/services/auth.ts
+++ b/noj-core/src/services/auth.ts
@@ -3,6 +3,7 @@ import { getDb } from "../db/connection.ts";
 import { userBans, users } from "../db/schema.ts";
 import { comparePassword, hashPassword } from "../lib/password.ts";
 import { signToken } from "../lib/jwt.ts";
+import { logAudit } from "./audit-log.ts";
 import {
   BadRequestError,
   ConflictError,
@@ -313,6 +314,13 @@ export async function promoteUser(
     .update(users)
     .set({ role, updated_at: now })
     .where(eq(users.id, targetUserId));
+
+  // 审计：角色变更（issue #101）
+  await logAudit(
+    "users.role_change",
+    { action: "users.role_change", from: existing[0].role, to: role },
+    { type: "user", id: targetUserId },
+  );
 
   return {
     id: existing[0].id,

--- a/noj-core/src/services/banlist.ts
+++ b/noj-core/src/services/banlist.ts
@@ -19,6 +19,7 @@ import {
 } from "../lib/errors.ts";
 import { isBannedIp, isValidIpOrCidr } from "../lib/cidr.ts";
 import { getCached, invalidateBanCache } from "../lib/banCache.ts";
+import { logAudit } from "./audit-log.ts";
 
 export interface IpBan {
   id: string;
@@ -122,8 +123,15 @@ export async function addIpBan(
 
   // 失效 ip_bans 全表缓存
   invalidateBanCache({ ipOrCidr: trimmed });
-  console.log(
-    `[admin] actor=${actorId} action=POST key=ip_bans value=${trimmed}`,
+  logAudit(
+    "ip_ban.create",
+    {
+      action: "ip_ban.create",
+      ip_or_cidr: trimmed,
+      reason: input.reason ?? "",
+      expires_at: input.expires_at ?? null,
+    },
+    { type: "ip_bans", id },
   );
 
   return {
@@ -139,7 +147,7 @@ export async function addIpBan(
 /** 删除 IP 黑名单。 */
 export async function removeIpBan(
   id: string,
-  actorId: string,
+  _actorId: string,
 ): Promise<void> {
   const db = getDb();
   const existing = await db.select().from(ipBans)
@@ -151,10 +159,10 @@ export async function removeIpBan(
   await db.delete(ipBans).where(eq(ipBans.id, id));
 
   invalidateBanCache({ ipOrCidr: existing[0]!.ip_or_cidr });
-  console.log(
-    `[admin] actor=${actorId} action=DELETE key=ip_bans value=${
-      existing[0]!.ip_or_cidr
-    }`,
+  logAudit(
+    "ip_ban.delete",
+    { action: "ip_ban.delete", ip_or_cidr: existing[0]!.ip_or_cidr },
+    { type: "ip_bans", id },
   );
 }
 

--- a/noj-core/src/services/categories.ts
+++ b/noj-core/src/services/categories.ts
@@ -6,6 +6,7 @@ import {
   ConflictError,
   NotFoundError,
 } from "../lib/errors.ts";
+import { logAudit } from "./audit-log.ts";
 
 /**
  * 分类响应（树形节点）。
@@ -357,4 +358,15 @@ export async function deleteCategory(id: string): Promise<void> {
   }
 
   await db.delete(categories).where(eq(categories.id, id));
+
+  // 审计：记录分类删除（name+slug 从预取行复用，无额外 round-trip）
+  await logAudit(
+    "categories.delete",
+    {
+      action: "categories.delete",
+      name: existing[0].name,
+      slug: existing[0].slug,
+    },
+    { type: "category", id },
+  );
 }

--- a/noj-core/src/services/problems.ts
+++ b/noj-core/src/services/problems.ts
@@ -33,6 +33,7 @@ import {
 } from "../types/problems.ts";
 import { validateJudgeImage } from "./judge-images.ts";
 import { getStorageProvider } from "../lib/storage/mod.ts";
+import { logAudit } from "./audit-log.ts";
 
 export interface ProblemResponse {
   id: string;
@@ -693,6 +694,17 @@ export async function deleteProblem(
 
   // 级联删除（problems_categories 的 ON DELETE CASCADE 会自动清理关联）
   await db.delete(problems).where(eq(problems.id, id));
+
+  // 审计日志：删除成功后才记录（display_id 由 type+number 派生）
+  await logAudit(
+    "problems.delete",
+    {
+      action: "problems.delete",
+      title: problem.title,
+      display_id: `${problem.type}${problem.number}`,
+    },
+    { type: "problem", id },
+  );
 }
 
 /**

--- a/noj-core/src/services/submissions.ts
+++ b/noj-core/src/services/submissions.ts
@@ -18,6 +18,7 @@ import {
   type SubmissionStatus,
 } from "../types/index.ts";
 import { getSubmissionQueueStatus } from "./queue.ts";
+import { logAudit } from "./audit-log.ts";
 
 export interface SubmissionInput {
   problem_id: string;
@@ -723,6 +724,16 @@ export async function rejudgeSubmission(id: string): Promise<void> {
     rejudge_seq: updated?.rejudge_seq ?? 0,
   };
 
+  // 审计日志：先写入审计再推送不可逆的 MQ 消息（issue #101）
+  await logAudit(
+    "submissions.rejudge",
+    {
+      action: "submissions.rejudge",
+      submission_id: id,
+    },
+    { type: "submission", id },
+  );
+
   try {
     await pushJudgeTask(task);
   } catch (mqErr) {
@@ -889,6 +900,19 @@ export async function rejudgeProblemSubmissions(
     .select()
     .from(submissions)
     .where(inArray(submissions.id, allIds));
+
+  // 审计日志：先写入审计再推送不可逆的 MQ 消息
+  if (total > 0) {
+    await logAudit(
+      "submissions.rejudge",
+      {
+        action: "submissions.rejudge",
+        problem_id: problemId,
+        count: total,
+      },
+      { type: "problem", id: problemId },
+    );
+  }
 
   // 逐条入队（每条代码内容不同，无法合并）
   let queued = 0;

--- a/noj-core/src/services/system-settings.ts
+++ b/noj-core/src/services/system-settings.ts
@@ -13,14 +13,14 @@
  * - 写路径同步失效单条 → 异步 reload
  * - 读路径 O(1) Map 查找，不打 DB
  *
- * 审计日志：console.log("[admin] actor=... action=... key=... value=...")。
- * 完整落库审计留待 issue #101（独立工作）。
+ * 审计日志：已迁移至 logAudit()（issue #101）。
  */
 
 import { eq } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
 import { systemSettings } from "../db/schema.ts";
 import { ValidationError } from "../lib/errors.ts";
+import { logAudit } from "./audit-log.ts";
 import {
   ENV_ONLY_DEFINITIONS,
   getEnvSnapshotValue,
@@ -303,6 +303,10 @@ export async function updateSetting(
   const now = new Date().toISOString();
   const db = getDb();
 
+  // 获取旧值（用于审计对比）
+  const oldSetting = getSetting(key);
+  const fromRaw = oldSetting?.value;
+
   // UPSERT：PG `ON CONFLICT (key) DO UPDATE`
   await db
     .insert(systemSettings)
@@ -327,15 +331,21 @@ export async function updateSetting(
   cache.delete(key);
   await reloadSingleKey(key);
 
-  // 审计日志（issue #101 落库前临时方案）
-  // 敏感字段（is_secret=true）在日志中改为掩码，避免生产环境 stdout 泄露明文
+  // 审计日志：记录设置变更（issue #101）
   const def = findDefinition(key);
   if (!def) {
     throw new ValidationError(`未注册的设置项: ${key}`);
   }
-  const loggedValue = def.is_secret ? maskSecret(value) : validation.raw;
-  console.log(
-    `[admin] actor=${actorId} action=PUT key=${key} value=${loggedValue}`,
+  const toValue = def.is_secret ? maskSecret(value) : value;
+  await logAudit(
+    "settings.update",
+    {
+      action: "settings.update",
+      key,
+      from: fromRaw,
+      to: toValue,
+    },
+    { type: "system_setting", id: key },
   );
 
   return {
@@ -364,12 +374,27 @@ export async function resetSetting(
   actorId: string,
 ): Promise<void> {
   const db = getDb();
+
+  // 获取旧值（用于审计对比）
+  const oldSetting = getSetting(key);
+  const fromRaw = oldSetting?.value;
+
   await db.delete(systemSettings).where(eq(systemSettings.key, key));
 
   cache.delete(key);
   // 重置后不需要 reload（已经从 Map 删除，下次读会走 env/default 兜底）
 
-  console.log(`[admin] actor=${actorId} action=DELETE key=${key} value=null`);
+  // 审计日志：记录设置删除（issue #101）
+  await logAudit(
+    "settings.update",
+    {
+      action: "settings.update",
+      key,
+      from: fromRaw,
+      to: null,
+    },
+    { type: "system_setting", id: key },
+  );
 }
 
 // ─── 内部辅助 ───────────────────────────────────────────────

--- a/noj-core/src/services/system-settings.ts
+++ b/noj-core/src/services/system-settings.ts
@@ -371,7 +371,7 @@ export async function updateSetting(
  */
 export async function resetSetting(
   key: string,
-  actorId: string,
+  _actorId: string,
 ): Promise<void> {
   const db = getDb();
 

--- a/noj-core/src/services/users.ts
+++ b/noj-core/src/services/users.ts
@@ -16,6 +16,7 @@ import {
 } from "../lib/errors.ts";
 import { scoreFromDb } from "../types/index.ts";
 import { invalidateBanCache } from "../lib/banCache.ts";
+import { logAudit } from "./audit-log.ts";
 import type { UserResponse } from "../types/auth.ts";
 
 /**
@@ -457,8 +458,10 @@ export async function banUser(
   });
 
   invalidateBanCache({ userId: targetUserId });
-  console.log(
-    `[admin] actor=${currentUserId} action=PUT key=user_ban value=${targetUserId}`,
+  logAudit(
+    "users.ban",
+    { action: "users.ban", reason: reason ?? "", until: bannedUntil ?? null },
+    { type: "users", id: targetUserId },
   );
 
   return {
@@ -498,8 +501,10 @@ export async function unbanUser(
     );
 
   invalidateBanCache({ userId: targetUserId });
-  console.log(
-    `[admin] actor=${currentUserId} action=PUT key=user_unban value=${targetUserId}`,
+  logAudit(
+    "users.unban",
+    { action: "users.unban" },
+    { type: "users", id: targetUserId },
   );
 
   return {

--- a/noj-core/src/types/audit-log.ts
+++ b/noj-core/src/types/audit-log.ts
@@ -1,0 +1,57 @@
+/**
+ * 审计日志类型定义（issue #101）。
+ *
+ * `AuditAction` 限定 7 类合法操作，CHECK 约束保证 DB 层一致；
+ * `AuditDetail` 用 discriminated union 保证 detail 字段的类型安全。
+ */
+
+/** 审计 action 枚举（与 DB CHECK 约束一致） */
+export type AuditAction =
+  | "users.role_change"
+  | "users.ban"
+  | "users.unban"
+  | "problems.delete"
+  | "categories.delete"
+  | "submissions.rejudge"
+  | "settings.update";
+
+/** 按 action 强类型的 detail（discriminated union） */
+export type AuditDetail =
+  | { action: "users.role_change"; from: string; to: string }
+  | { action: "users.ban"; reason: string; until: string | null }
+  | { action: "users.unban" }
+  | { action: "problems.delete"; title: string; display_id: string }
+  | {
+    action: "categories.delete";
+    name: string;
+    slug: string;
+  }
+  | {
+    action: "submissions.rejudge";
+    submission_id?: string;
+    problem_id?: string;
+    count?: number;
+  }
+  | { action: "settings.update"; key: string; from: unknown; to: unknown };
+
+/** audit_logs 表的响应类型 */
+export interface AuditLogEntry {
+  id: string;
+  admin_id: string;
+  action: AuditAction;
+  target_type: string | null;
+  target_id: string | null;
+  detail: AuditDetail;
+  ip_address: string;
+  created_at: string;
+}
+
+/** 列表 API 查询参数 */
+export interface AuditLogListFilter {
+  page: number;
+  perPage: number;
+  admin_id?: string;
+  action?: AuditAction;
+  from?: string;
+  to?: string;
+}

--- a/noj-core/src/types/audit-log.ts
+++ b/noj-core/src/types/audit-log.ts
@@ -13,7 +13,9 @@ export type AuditAction =
   | "problems.delete"
   | "categories.delete"
   | "submissions.rejudge"
-  | "settings.update";
+  | "settings.update"
+  | "ip_ban.create"
+  | "ip_ban.delete";
 
 /** 按 action 强类型的 detail（discriminated union） */
 export type AuditDetail =
@@ -32,7 +34,14 @@ export type AuditDetail =
     problem_id?: string;
     count?: number;
   }
-  | { action: "settings.update"; key: string; from: unknown; to: unknown };
+  | { action: "settings.update"; key: string; from: unknown; to: unknown }
+  | {
+    action: "ip_ban.create";
+    ip_or_cidr: string;
+    reason: string;
+    expires_at: string | null;
+  }
+  | { action: "ip_ban.delete"; ip_or_cidr: string };
 
 /** audit_logs 表的响应类型 */
 export interface AuditLogEntry {

--- a/noj-core/tests/routes/admin-audit-logs.test.ts
+++ b/noj-core/tests/routes/admin-audit-logs.test.ts
@@ -1,0 +1,230 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { createApp } from "../../src/app.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { auditLogs, users } from "../../src/db/schema.ts";
+import { signToken } from "../../src/lib/jwt.ts";
+
+const hasDb = true; // PGlite 内存数据库始终可用
+const hasEnv = !!Deno.env.get("JWT_SECRET");
+const skip = !hasDb || !hasEnv;
+
+// 模块级 bootstrap：确保 PGlite schema 已创建
+await resetDbForTest();
+
+const ADMIN_USER_ID = "audit-route-admin-uuid";
+const NON_ADMIN_USER_ID = "audit-route-user-uuid";
+const TS = Date.now();
+
+/** 清空 audit_logs 并插入两个测试用户（admin + 普通用户） */
+async function setupFixtureData() {
+  await resetDbForTest();
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  // 先插 admin
+  await db.insert(users).values({
+    id: ADMIN_USER_ID,
+    username: `audit_route_admin_${TS}`,
+    email: `audit-route-admin-${TS}@example.com`,
+    password_hash: "x",
+    role: "admin",
+    created_at: now,
+    updated_at: now,
+  }).onConflictDoNothing();
+
+  // 再插普通用户
+  await db.insert(users).values({
+    id: NON_ADMIN_USER_ID,
+    username: `audit_route_user_${TS}`,
+    email: `audit-route-user-${TS}@example.com`,
+    password_hash: "x",
+    role: "user",
+    created_at: now,
+    updated_at: now,
+  }).onConflictDoNothing();
+
+  // 清空 audit_logs（保留 root 行为：默认排除 root）
+  await db.delete(auditLogs);
+}
+
+/**
+ * 发送带 Authorization 头的 GET 请求。
+ * 使用 app.fetch()（而非 app.request()）以确保与 Hono 路由兼容。
+ */
+async function getWithToken(
+  app: ReturnType<typeof createApp>,
+  path: string,
+  token?: string,
+): Promise<Response> {
+  const headers = new Headers();
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const req = new Request(`http://localhost${path}`, { headers });
+  return await app.fetch(req);
+}
+
+Deno.test({
+  name: "admin route: GET /admin/audit-logs 未登录返 401",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setupFixtureData();
+    const app = createApp();
+    const res = await getWithToken(app, "/api/v1/admin/audit-logs");
+    assertEquals(res.status, 401);
+  },
+});
+
+Deno.test({
+  name: "admin route: GET /admin/audit-logs 非 admin 返 403",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setupFixtureData();
+    const app = createApp();
+    const userToken = await signToken({
+      sub: NON_ADMIN_USER_ID,
+      role: "user",
+    });
+    const res = await getWithToken(
+      app,
+      "/api/v1/admin/audit-logs",
+      userToken,
+    );
+    assertEquals(res.status, 403);
+  },
+});
+
+Deno.test({
+  name: "admin route: GET /admin/audit-logs admin 返 200 + 分页",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setupFixtureData();
+    const db = getDb();
+    const now = new Date().toISOString();
+    // 插入 3 条 admin 操作记录
+    await db.insert(auditLogs).values([
+      {
+        id: `audit-1-${TS}`,
+        admin_id: ADMIN_USER_ID,
+        action: "users.ban",
+        ip_address: "10.0.0.1",
+        detail: { action: "users.ban", reason: "spam", until: null },
+        created_at: now,
+      },
+      {
+        id: `audit-2-${TS}`,
+        admin_id: ADMIN_USER_ID,
+        action: "users.unban",
+        ip_address: "10.0.0.1",
+        detail: { action: "users.unban" },
+        created_at: now,
+      },
+      {
+        id: `audit-3-${TS}`,
+        admin_id: ADMIN_USER_ID,
+        action: "problems.delete",
+        target_type: "problem",
+        target_id: "p-1",
+        ip_address: "10.0.0.1",
+        detail: {
+          action: "problems.delete",
+          title: "测试题",
+          display_id: "P1",
+        },
+        created_at: now,
+      },
+    ]);
+
+    const app = createApp();
+    const adminToken = await signToken({
+      sub: ADMIN_USER_ID,
+      role: "admin",
+    });
+    const res = await getWithToken(
+      app,
+      "/api/v1/admin/audit-logs?page=1&per_page=10",
+      adminToken,
+    );
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertExists(body.data);
+    assertExists(body.pagination);
+    assertEquals(body.data.length, 3);
+    assertEquals(body.pagination.page, 1);
+    assertEquals(body.pagination.per_page, 10);
+    assertEquals(body.pagination.total, 3);
+    // 验证每条 entry 都有必要字段
+    for (const entry of body.data) {
+      assertExists(entry.id);
+      assertExists(entry.admin_id);
+      assertExists(entry.action);
+      assertExists(entry.created_at);
+    }
+
+    // 清理 fixture
+    await db.delete(auditLogs);
+  },
+});
+
+Deno.test({
+  name: "admin route: GET /admin/audit-logs 按 action 筛选",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setupFixtureData();
+    const db = getDb();
+    const now = new Date().toISOString();
+    // 插入混合 action
+    await db.insert(auditLogs).values([
+      {
+        id: `audit-ban-1-${TS}`,
+        admin_id: ADMIN_USER_ID,
+        action: "users.ban",
+        ip_address: "10.0.0.2",
+        detail: { action: "users.ban", reason: "x", until: null },
+        created_at: now,
+      },
+      {
+        id: `audit-ban-2-${TS}`,
+        admin_id: ADMIN_USER_ID,
+        action: "users.ban",
+        ip_address: "10.0.0.2",
+        detail: { action: "users.ban", reason: "y", until: null },
+        created_at: now,
+      },
+      {
+        id: `audit-unban-${TS}`,
+        admin_id: ADMIN_USER_ID,
+        action: "users.unban",
+        ip_address: "10.0.0.2",
+        detail: { action: "users.unban" },
+        created_at: now,
+      },
+    ]);
+
+    const app = createApp();
+    const adminToken = await signToken({
+      sub: ADMIN_USER_ID,
+      role: "admin",
+    });
+    const res = await getWithToken(
+      app,
+      "/api/v1/admin/audit-logs?action=users.ban",
+      adminToken,
+    );
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.data.length, 2);
+    for (const entry of body.data) {
+      assertEquals(entry.action, "users.ban");
+    }
+
+    // 清理 fixture
+    await db.delete(auditLogs);
+  },
+});

--- a/noj-core/tests/services/audit-log.test.ts
+++ b/noj-core/tests/services/audit-log.test.ts
@@ -1,7 +1,10 @@
 import { assertEquals, assertExists } from "jsr:@std/assert@^1";
 import { getDb, resetDbForTest } from "../../src/db/connection.ts";
 import { auditLogs, users } from "../../src/db/schema.ts";
-import { enterTestContext, leaveTestContext } from "../../src/lib/requestContext.ts";
+import {
+  enterTestContext,
+  leaveTestContext,
+} from "../../src/lib/requestContext.ts";
 import {
   cleanupOldAuditLogs,
   listAuditLogs,
@@ -223,5 +226,73 @@ Deno.test({
       to,
     });
     assertEquals(result.data.length, 1);
+  },
+});
+
+Deno.test({
+  name: "audit-log: logAudit ip_ban.create 写入字段映射",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await cleanAuditLogs();
+    enterTestContext(TEST_CTX);
+
+    await logAudit(
+      "ip_ban.create",
+      {
+        action: "ip_ban.create",
+        ip_or_cidr: "10.0.0.0/8",
+        reason: "spam",
+        expires_at: null,
+      },
+      { type: "ip_bans", id: "ban-uuid-1" },
+    );
+
+    const db = getDb();
+    const rows = await db.select().from(auditLogs);
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].admin_id, "test-admin-uuid");
+    assertEquals(rows[0].action, "ip_ban.create");
+    assertEquals(rows[0].target_type, "ip_bans");
+    assertEquals(rows[0].target_id, "ban-uuid-1");
+    assertEquals(rows[0].detail, {
+      action: "ip_ban.create",
+      ip_or_cidr: "10.0.0.0/8",
+      reason: "spam",
+      expires_at: null,
+    });
+    assertExists(rows[0].created_at);
+    assertExists(rows[0].id);
+  },
+});
+
+Deno.test({
+  name: "audit-log: logAudit ip_ban.delete 写入字段映射",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await cleanAuditLogs();
+    enterTestContext(TEST_CTX);
+
+    await logAudit(
+      "ip_ban.delete",
+      { action: "ip_ban.delete", ip_or_cidr: "1.2.3.4" },
+      { type: "ip_bans", id: "ban-uuid-2" },
+    );
+
+    const db = getDb();
+    const rows = await db.select().from(auditLogs);
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].action, "ip_ban.delete");
+    assertEquals(rows[0].target_type, "ip_bans");
+    assertEquals(rows[0].target_id, "ban-uuid-2");
+    assertEquals(rows[0].detail, {
+      action: "ip_ban.delete",
+      ip_or_cidr: "1.2.3.4",
+    });
+    assertExists(rows[0].created_at);
+    assertExists(rows[0].id);
   },
 });

--- a/noj-core/tests/services/audit-log.test.ts
+++ b/noj-core/tests/services/audit-log.test.ts
@@ -1,0 +1,227 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { auditLogs, users } from "../../src/db/schema.ts";
+import { enterTestContext, leaveTestContext } from "../../src/lib/requestContext.ts";
+import {
+  cleanupOldAuditLogs,
+  listAuditLogs,
+  logAudit,
+} from "../../src/services/audit-log.ts";
+
+const hasDb = true; // PGlite 内存数据库始终可用
+const hasEnv = !!Deno.env.get("JWT_SECRET");
+const skip = !hasDb || !hasEnv;
+
+const TEST_CTX = {
+  actorId: "test-admin-uuid",
+  actorIp: "192.168.1.100",
+  actorRole: "admin",
+};
+
+// 每个测试前重置 DB（保证 schema 已建立）并清空 audit_logs + 插入测试用户
+async function cleanAuditLogs() {
+  await resetDbForTest();
+  leaveTestContext(); // 清理前序测试可能的 ALS 泄漏
+  const db = getDb();
+  const now = new Date().toISOString();
+  await db.insert(users).values({
+    id: TEST_CTX.actorId,
+    username: "test-admin",
+    email: "test-admin@example.com",
+    password_hash: "",
+    role: "admin",
+    created_at: now,
+    updated_at: now,
+  }).onConflictDoNothing();
+  await db.delete(auditLogs);
+}
+
+Deno.test({
+  name: "audit-log: logAudit 写入字段映射",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await cleanAuditLogs();
+    enterTestContext(TEST_CTX);
+
+    await logAudit(
+      "users.ban",
+      { action: "users.ban", reason: "spam", until: null },
+      { type: "user", id: "target-uuid" },
+    );
+
+    const db = getDb();
+    const rows = await db.select().from(auditLogs);
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].admin_id, "test-admin-uuid");
+    assertEquals(rows[0].action, "users.ban");
+    assertEquals(rows[0].ip_address, "192.168.1.100");
+    assertEquals(rows[0].target_type, "user");
+    assertEquals(rows[0].target_id, "target-uuid");
+    assertEquals(rows[0].detail, {
+      action: "users.ban",
+      reason: "spam",
+      until: null,
+    });
+    assertExists(rows[0].created_at);
+    assertExists(rows[0].id);
+  },
+});
+
+Deno.test({
+  name: "audit-log: logAudit 失败仅 console.error，不抛业务错误",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await cleanAuditLogs();
+    enterTestContext(TEST_CTX);
+    await logAudit("users.unban", { action: "users.unban" }, {
+      type: "user",
+      id: "x",
+    });
+  },
+});
+
+Deno.test({
+  name: "audit-log: logAudit ALS 缺失不抛错（仅 console.error）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await cleanAuditLogs();
+    let threw = false;
+    try {
+      await logAudit("users.unban", { action: "users.unban" });
+    } catch (_e) {
+      threw = true;
+    }
+    assertEquals(threw, false);
+
+    const db = getDb();
+    const rows = await db.select().from(auditLogs);
+    assertEquals(rows.length, 0);
+  },
+});
+
+Deno.test({
+  name: "audit-log: cleanupOldAuditLogs 删除过期记录",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await cleanAuditLogs();
+    enterTestContext(TEST_CTX);
+
+    const oldDate = new Date(Date.now() - 100 * 86400 * 1000).toISOString();
+    const recentDate = new Date().toISOString();
+
+    const db = getDb();
+    await db.insert(auditLogs).values({
+      id: "old-1",
+      admin_id: TEST_CTX.actorId,
+      action: "users.unban",
+      ip_address: TEST_CTX.actorIp,
+      detail: { action: "users.unban" },
+      created_at: oldDate,
+    });
+    await db.insert(auditLogs).values({
+      id: "recent-1",
+      admin_id: TEST_CTX.actorId,
+      action: "users.unban",
+      ip_address: TEST_CTX.actorIp,
+      detail: { action: "users.unban" },
+      created_at: recentDate,
+    });
+
+    const deleted = await cleanupOldAuditLogs(90);
+    assertEquals(deleted, 1);
+
+    const rows = await db.select().from(auditLogs);
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].id, "recent-1");
+  },
+});
+
+Deno.test({
+  name: "audit-log: listAuditLogs 默认排除 root (admin_id=0)",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await cleanAuditLogs();
+    const db = getDb();
+    await db.insert(auditLogs).values([
+      {
+        id: "by-root",
+        admin_id: "0",
+        action: "users.unban",
+        ip_address: "1.1.1.1",
+        detail: { action: "users.unban" },
+        created_at: new Date().toISOString(),
+      },
+      {
+        id: "by-admin",
+        admin_id: "test-admin-uuid",
+        action: "users.ban",
+        ip_address: "1.1.1.1",
+        detail: { action: "users.ban", reason: "x", until: null },
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await listAuditLogs({ page: 1, perPage: 20 });
+    assertEquals(result.data.length, 1);
+    assertEquals(result.data[0].id, "by-admin");
+    assertEquals(result.pagination.total, 1);
+  },
+});
+
+Deno.test({
+  name: "audit-log: listAuditLogs 按 action 筛选",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await cleanAuditLogs();
+    enterTestContext(TEST_CTX);
+    await logAudit("users.ban", {
+      action: "users.ban",
+      reason: "x",
+      until: null,
+    });
+    await logAudit("users.unban", { action: "users.unban" });
+
+    const result = await listAuditLogs({
+      page: 1,
+      perPage: 20,
+      action: "users.ban",
+    });
+    assertEquals(result.data.length, 1);
+    assertEquals(result.data[0].action, "users.ban");
+  },
+});
+
+Deno.test({
+  name: "audit-log: listAuditLogs 按时间范围筛选",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await cleanAuditLogs();
+    enterTestContext(TEST_CTX);
+    await logAudit("users.unban", { action: "users.unban" });
+
+    const from = new Date(Date.now() - 60_000).toISOString();
+    const to = new Date(Date.now() + 60_000).toISOString();
+
+    const result = await listAuditLogs({
+      page: 1,
+      perPage: 20,
+      from,
+      to,
+    });
+    assertEquals(result.data.length, 1);
+  },
+});

--- a/noj-core/tests/services/auth.test.ts
+++ b/noj-core/tests/services/auth.test.ts
@@ -1,11 +1,15 @@
 import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
 import {
   getUserProfile,
   loginUser,
+  promoteUser,
   registerUser,
 } from "../../src/services/auth.ts";
-import { resetDbForTest } from "../../src/db/connection.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { auditLogs, users } from "../../src/db/schema.ts";
 import { ConflictError, UnauthorizedError } from "../../src/lib/errors.ts";
+import { enterTestContext } from "../../src/lib/requestContext.ts";
 
 // PGlite 内存数据库始终可用
 const dbAvailable = true;
@@ -185,5 +189,56 @@ Deno.test({
       UnauthorizedError,
       "用户不存在",
     );
+  },
+});
+
+Deno.test({
+  name: "auth service: promoteUser 写一条 role_change 审计",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+
+    // 准备：插入一个 admin 操作者和一个 user 目标
+    const db = getDb();
+    const adminId = crypto.randomUUID();
+    const target = await registerUser({
+      username: `test-promote-${Date.now()}`,
+      email: `test-promote-${Date.now()}@example.com`,
+      password: "PromotePwd-2024-Xy9",
+    });
+    const now = new Date().toISOString();
+    await db.insert(users).values({
+      id: adminId,
+      username: `test-admin-${Date.now()}`,
+      email: `test-admin-${Date.now()}@example.com`,
+      password_hash: "",
+      role: "admin",
+      created_at: now,
+      updated_at: now,
+    });
+
+    // 注入 admin actor context
+    enterTestContext({
+      actorId: adminId,
+      actorIp: "10.0.0.1",
+      actorRole: "admin",
+    });
+
+    await getDb().delete(auditLogs);
+
+    // 执行：升级目标为 admin
+    const result = await promoteUser(target.id, "admin", adminId);
+    assertEquals(result.role, "admin");
+
+    // 验证：审计日志写入
+    const rows = await getDb().select().from(auditLogs).where(
+      eq(auditLogs.action, "users.role_change"),
+    );
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].target_id, target.id);
+    assertEquals(rows[0].ip_address, "10.0.0.1");
+    assertEquals(rows[0].admin_id, adminId);
   },
 });

--- a/noj-core/tests/services/banlist.test.ts
+++ b/noj-core/tests/services/banlist.test.ts
@@ -4,7 +4,7 @@
 import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
 import { eq } from "drizzle-orm";
 import { getDb, resetDbForTest } from "../../src/db/connection.ts";
-import { ipBans, users } from "../../src/db/schema.ts";
+import { auditLogs, ipBans, users } from "../../src/db/schema.ts";
 import {
   _resetBanlistForTest,
   addIpBan,
@@ -18,6 +18,10 @@ import {
   NotFoundError,
   ValidationError,
 } from "../../src/lib/errors.ts";
+import {
+  enterTestContext,
+  leaveTestContext,
+} from "../../src/lib/requestContext.ts";
 
 const ADMIN_ID = crypto.randomUUID();
 const TEST_TS = Date.now();
@@ -229,5 +233,86 @@ Deno.test({
     const { getBannedIpDetail } = await import("../../src/services/banlist.ts");
     const detail = await getBannedIpDetail("9.9.9.9");
     assertEquals(detail, null);
+  },
+});
+
+Deno.test({
+  name: "banlist service: addIpBan 写入审计日志",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const db = getDb();
+    await db.delete(auditLogs);
+
+    enterTestContext({
+      actorId: ADMIN_ID,
+      actorIp: "10.0.0.1",
+      actorRole: "admin",
+    });
+    try {
+      const ban = await addIpBan(
+        { ip_or_cidr: "10.0.0.0/8", reason: "internal" },
+        ADMIN_ID,
+      );
+
+      const logs = await db.select().from(auditLogs);
+      assertEquals(logs.length, 1);
+      assertEquals(logs[0].admin_id, ADMIN_ID);
+      assertEquals(logs[0].action, "ip_ban.create");
+      assertEquals(logs[0].target_type, "ip_bans");
+      assertEquals(logs[0].target_id, ban.id);
+      assertEquals(logs[0].ip_address, "10.0.0.1");
+      assertEquals(logs[0].detail, {
+        action: "ip_ban.create",
+        ip_or_cidr: "10.0.0.0/8",
+        reason: "internal",
+        expires_at: null,
+      });
+    } finally {
+      leaveTestContext();
+    }
+  },
+});
+
+Deno.test({
+  name: "banlist service: removeIpBan 写入审计日志",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const db = getDb();
+    await db.delete(auditLogs);
+
+    const ban = await addIpBan(
+      { ip_or_cidr: "1.2.3.4", reason: "bot" },
+      ADMIN_ID,
+    );
+
+    enterTestContext({
+      actorId: ADMIN_ID,
+      actorIp: "10.0.0.1",
+      actorRole: "admin",
+    });
+    try {
+      await removeIpBan(ban.id, ADMIN_ID);
+
+      const logs = await db.select().from(auditLogs).orderBy(
+        auditLogs.created_at,
+      );
+      // 第一条：addIpBan 写入的（没有 test context 时被静默忽略）
+      // 第二条：removeIpBan 写入的
+      const removeLog = logs.find((l) => l.action === "ip_ban.delete");
+      assertEquals(removeLog?.admin_id, ADMIN_ID);
+      assertEquals(removeLog?.action, "ip_ban.delete");
+      assertEquals(removeLog?.target_type, "ip_bans");
+      assertEquals(removeLog?.target_id, ban.id);
+      assertEquals(removeLog?.detail, {
+        action: "ip_ban.delete",
+        ip_or_cidr: "1.2.3.4",
+      });
+    } finally {
+      leaveTestContext();
+    }
   },
 });

--- a/noj-core/tests/services/categories.test.ts
+++ b/noj-core/tests/services/categories.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
 import {
   createCategory,
   deleteCategory,
@@ -7,12 +8,13 @@ import {
   updateCategory,
 } from "../../src/services/categories.ts";
 import { getDb, resetDbForTest } from "../../src/db/connection.ts";
-import { categories } from "../../src/db/schema.ts";
+import { auditLogs, categories, users } from "../../src/db/schema.ts";
 import {
   BadRequestError,
   ConflictError,
   NotFoundError,
 } from "../../src/lib/errors.ts";
+import { enterTestContext } from "../../src/lib/requestContext.ts";
 
 const hasDb = true; // PGlite 内存数据库始终可用
 const skip = !hasDb;
@@ -197,6 +199,68 @@ Deno.test({
     if (topLevel) {
       assertEquals(topLevel.children[0].parent_id, topLevel.id);
     }
+  },
+});
+
+Deno.test({
+  name: "categories service: deleteCategory 写一条 categories.delete 审计",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+
+    // 准备：admin 操作者（满足 audit_logs.admin_id FK）
+    const db = getDb();
+    const adminId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    await db.insert(users).values({
+      id: adminId,
+      username: `test-del-cat-admin-${Date.now()}`,
+      email: `test-del-cat-admin-${Date.now()}@example.com`,
+      password_hash: "",
+      role: "admin",
+      created_at: now,
+      updated_at: now,
+    });
+
+    // 注入 admin actor context（logAudit 依赖 RequestContext）
+    enterTestContext({
+      actorId: adminId,
+      actorIp: "10.0.0.77",
+      actorRole: "admin",
+    });
+
+    // 创建待删除分类
+    const toDelete = await createCategory({
+      name: `待删除审计分类 ${Date.now()}`,
+      slug: `del-cat-audit-${Date.now()}`,
+      description: "将触发 categories.delete 审计",
+    });
+
+    // 清空本测试前可能存在的审计行，避免行数偏差
+    await getDb().delete(auditLogs);
+
+    // 执行：删除分类
+    await deleteCategory(toDelete.id);
+
+    // 验证：审计日志写入
+    const rows = await getDb().select().from(auditLogs).where(
+      eq(auditLogs.action, "categories.delete"),
+    );
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].target_type, "category");
+    assertEquals(rows[0].target_id, toDelete.id);
+    assertEquals(rows[0].admin_id, adminId);
+    assertEquals(rows[0].ip_address, "10.0.0.77");
+    const detail = rows[0].detail as {
+      action: string;
+      name: string;
+      slug: string;
+    };
+    assertEquals(detail.action, "categories.delete");
+    assertEquals(detail.name, toDelete.name);
+    assertEquals(detail.slug, toDelete.slug);
   },
 });
 

--- a/noj-core/tests/services/problems.test.ts
+++ b/noj-core/tests/services/problems.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
 import {
   createProblem,
   deleteProblem,
@@ -7,8 +8,9 @@ import {
   updateProblem,
 } from "../../src/services/problems.ts";
 import { getDb, resetDbForTest } from "../../src/db/connection.ts";
-import { categories } from "../../src/db/schema.ts";
+import { auditLogs, categories, users } from "../../src/db/schema.ts";
 import { BadRequestError, NotFoundError } from "../../src/lib/errors.ts";
+import { enterTestContext } from "../../src/lib/requestContext.ts";
 
 // PGlite 内存数据库始终可用
 const dbAvailable = true;
@@ -226,6 +228,76 @@ Deno.test({
       NotFoundError,
       "题目不存在",
     );
+  },
+});
+
+Deno.test({
+  name: "problems service: deleteProblem 写一条 problems.delete 审计",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+
+    // 准备：admin 操作者（满足 audit_logs.admin_id FK）
+    const db = getDb();
+    const adminId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    await db.insert(users).values({
+      id: adminId,
+      username: `test-del-prob-admin-${Date.now()}`,
+      email: `test-del-prob-admin-${Date.now()}@example.com`,
+      password_hash: "",
+      role: "admin",
+      created_at: now,
+      updated_at: now,
+    });
+
+    // 注入 admin actor context（logAudit 依赖 RequestContext）
+    enterTestContext({
+      actorId: adminId,
+      actorIp: "10.0.0.42",
+      actorRole: "admin",
+    });
+
+    // 创建题目（admin 创建，owner=admin，避免权限检查失败）
+    const toDelete = await createProblem(
+      {
+        title: `待删除审计题 ${Date.now()}`,
+        description: "将触发 problems.delete 审计",
+        difficulty: "easy",
+        judge_image: "noj-judge-python",
+        judge_command: "python3 /tmp/evaluate.py",
+        time_limit_ms: 5000,
+        memory_limit_mb: 512,
+      },
+      adminId,
+      "admin",
+    );
+
+    // 清空本测试前可能存在的审计行，避免行数偏差
+    await getDb().delete(auditLogs);
+
+    // 执行：删除题目（admin 可删任意题）
+    await deleteProblem(toDelete.id, adminId, "admin");
+
+    // 验证：审计日志写入
+    const rows = await getDb().select().from(auditLogs).where(
+      eq(auditLogs.action, "problems.delete"),
+    );
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].target_type, "problem");
+    assertEquals(rows[0].target_id, toDelete.id);
+    assertEquals(rows[0].admin_id, adminId);
+    assertEquals(rows[0].ip_address, "10.0.0.42");
+    const detail = rows[0].detail as {
+      action: string;
+      title: string;
+      display_id: string;
+    };
+    assertEquals(detail.action, "problems.delete");
+    assertEquals(detail.title, toDelete.title);
+    assertEquals(detail.display_id, toDelete.display_id);
   },
 });
 

--- a/noj-core/tests/services/submissions.test.ts
+++ b/noj-core/tests/services/submissions.test.ts
@@ -2,10 +2,13 @@ import { assertEquals, assertExists, assertRejects } from "jsr:@std/assert@^1";
 import {
   createSubmission,
   getSubmission,
+  rejudgeProblemSubmissions,
+  rejudgeSubmission,
   saveEvaluationResult,
 } from "../../src/services/submissions.ts";
 import { getDb, resetDbForTest } from "../../src/db/connection.ts";
 import {
+  auditLogs,
   evaluationResults,
   problems,
   submissions,
@@ -13,6 +16,140 @@ import {
 } from "../../src/db/schema.ts";
 import { BadRequestError, NotFoundError } from "../../src/lib/errors.ts";
 import { eq } from "drizzle-orm";
+import { enterTestContext } from "../../src/lib/requestContext.ts";
+
+/**
+ * 启动一个极简的 Redis RESP 协议 mock 服务器，仅响应 LPUSH / PING / QUIT，
+ * 让 pushJudgeTask 的 LPUSH 调用不会触发真实 Redis 依赖。
+ *
+ * PGlite 测试模式下没有 Redis，但 Deno ESM 模块导出是 non-configurable，
+ * 无法直接 monkey-patch pushJudgeTask。因此这里选择启动一个本地 mock Redis，
+ * 把 REDIS_URL 指向它，让 pushJudgeTask 走完整 LPUSH 路径而无需外部依赖。
+ */
+// deno-lint-ignore require-await
+async function startFakeRedis(): Promise<
+  { url: string; stop: () => Promise<void> }
+> {
+  const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 });
+  const addr = listener.addr as Deno.NetAddr;
+  const url = `redis://${addr.hostname}:${addr.port}/`;
+
+  const connections = new Set<Deno.Conn>();
+  const acceptTask = (async () => {
+    for await (const conn of listener) {
+      connections.add(conn);
+      handleConnection(conn).catch(() => {/* ignore */});
+    }
+  })();
+
+  const stop = async () => {
+    for (const c of connections) {
+      try {
+        c.close();
+      } catch { /* ignore */ }
+    }
+    connections.clear();
+    try {
+      listener.close();
+    } catch { /* ignore */ }
+    await acceptTask.catch(() => {/* ignore */});
+  };
+
+  return { url, stop };
+}
+
+async function handleConnection(conn: Deno.Conn): Promise<void> {
+  const buf = new Uint8Array(4096);
+  let pending: Uint8Array = new Uint8Array(0);
+
+  while (true) {
+    let n: number | null;
+    try {
+      n = await conn.read(buf);
+    } catch {
+      return;
+    }
+    if (n === null) return;
+    const slice = buf.subarray(0, n);
+    pending = concat(pending, new Uint8Array(slice));
+
+    // 解析并响应所有完整 RESP 命令
+    while (true) {
+      const parsed = tryParseRespCommand(pending);
+      if (!parsed) break;
+      pending = parsed.rest;
+
+      let reply: Uint8Array;
+      switch (parsed.cmd) {
+        case "PING":
+          reply = renderRespString("PONG");
+          break;
+        case "LPUSH":
+        case "CLIENT":
+        case "SELECT":
+        case "AUTH":
+        case "HELLO":
+        case "SETINFO":
+          reply = renderRespString("OK");
+          break;
+        default:
+          reply = renderRespString("OK");
+      }
+      await conn.write(reply);
+    }
+  }
+}
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+interface ParsedCommand {
+  cmd: string;
+  rest: Uint8Array;
+}
+
+function tryParseRespCommand(buf: Uint8Array): ParsedCommand | null {
+  // RESP 数组：*<n>\r\n$<len>\r\n<bytes>\r\n...
+  if (buf.length === 0 || buf[0] !== 0x2a /* * */) return null;
+  const headerEnd = findCrlf(buf, 0);
+  if (headerEnd < 0) return null;
+  const n = parseInt(new TextDecoder().decode(buf.subarray(1, headerEnd)), 10);
+  if (!Number.isFinite(n)) return null;
+
+  let pos = headerEnd + 2;
+  const parts: string[] = [];
+  for (let i = 0; i < n; i++) {
+    if (pos >= buf.length || buf[pos] !== 0x24 /* $ */) return null;
+    const lenEnd = findCrlf(buf, pos);
+    if (lenEnd < 0) return null;
+    const len = parseInt(
+      new TextDecoder().decode(buf.subarray(pos + 1, lenEnd)),
+      10,
+    );
+    if (!Number.isFinite(len)) return null;
+    pos = lenEnd + 2;
+    if (pos + len + 2 > buf.length) return null;
+    parts.push(new TextDecoder().decode(buf.subarray(pos, pos + len)));
+    pos += len + 2;
+  }
+
+  return { cmd: (parts[0] ?? "").toUpperCase(), rest: buf.slice(pos) };
+}
+
+function findCrlf(buf: Uint8Array, from: number): number {
+  for (let i = from; i < buf.length - 1; i++) {
+    if (buf[i] === 0x0d && buf[i + 1] === 0x0a) return i;
+  }
+  return -1;
+}
+
+function renderRespString(s: string): Uint8Array {
+  return new TextEncoder().encode(`+${s}\r\n`);
+}
 
 const hasDb = true; // PGlite 内存数据库始终可用
 const skip = !hasDb;
@@ -410,6 +547,294 @@ Deno.test({
       );
       await db.delete(submissions).where(eq(submissions.id, subId));
       await db.delete(users).where(eq(users.id, userId));
+    }
+  },
+});
+
+// ── 审计日志埋点测试 ──
+//
+// rejudgeSubmission / rejudgeProblemSubmissions 都会调用 pushJudgeTask，
+// PGlite 模式下没有 Redis，因此启动 fake Redis（极简 RESP 服务器）让
+// pushJudgeTask 的 LPUSH 调用不会失败。
+// 同时 resetDbForTest() 会清空模块级 setup 测试创建的 TEST_USER_ID/
+// TEST_PROBLEM_ID，因此这里为每个测试独立创建本地 fixture。
+
+import { getRedis, resetRedisForTest } from "../../src/mq/connection.ts";
+
+Deno.test({
+  name:
+    "submissions service: rejudgeSubmission 写一条 submissions.rejudge 审计",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    resetRedisForTest();
+
+    // 启动 fake Redis，让 pushJudgeTask 走完整 LPUSH 路径
+    const fakeRedis = await startFakeRedis();
+    Deno.env.set("REDIS_URL", fakeRedis.url);
+
+    // 触发 ioredis 单例的 connect + PING，让状态从 wait 转为 ready
+    // 否则 pushJudgeTask 在 status 检查时就抛错
+    const redis = getRedis();
+    await redis.connect();
+    await redis.ping();
+    try {
+      // 准备：admin 操作者 + 本地用户 + 本地题目（满足所有 FK）
+      const db = getDb();
+      const adminId = crypto.randomUUID();
+      const localUserId = crypto.randomUUID();
+      const localProblemId = crypto.randomUUID();
+      const now = new Date().toISOString();
+      await db.insert(users).values([
+        {
+          id: adminId,
+          username: `test-rej-sub-admin-${Date.now()}`,
+          email: `test-rej-sub-admin-${Date.now()}@example.com`,
+          password_hash: "",
+          role: "admin",
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: localUserId,
+          username: `test-rej-sub-user-${Date.now()}`,
+          email: `test-rej-sub-user-${Date.now()}@example.com`,
+          password_hash: "",
+          role: "user",
+          created_at: now,
+          updated_at: now,
+        },
+      ]);
+      await db.insert(problems).values({
+        id: localProblemId,
+        title: `重测审计题 ${Date.now()}`,
+        description: "rejudgeSubmission 审计测试用题目",
+        difficulty: "easy",
+        judge_image: "noj-judge-python",
+        judge_command: "python3 /tmp/evaluate.py",
+        time_limit_ms: 5000,
+        memory_limit_mb: 512,
+        number: 60000 + (Date.now() & 0x7fff),
+        owner_id: adminId,
+        type: "U",
+        created_at: now,
+        updated_at: now,
+      });
+
+      // 注入 admin actor context（logAudit 依赖 RequestContext）
+      enterTestContext({
+        actorId: adminId,
+        actorIp: "10.0.0.55",
+        actorRole: "admin",
+      });
+
+      // 准备：一条 finished 状态的提交（重测只接受已存在的 submission）
+      const subId = crypto.randomUUID();
+      await db.insert(submissions).values({
+        id: subId,
+        user_id: localUserId,
+        problem_id: localProblemId,
+        language: "python3",
+        code: "print(1)",
+        file_name: "main.py",
+        status: "finished",
+        rejudge_seq: 0,
+        created_at: now,
+      });
+      await db.insert(evaluationResults).values({
+        id: crypto.randomUUID(),
+        submission_id: subId,
+        status: "Accepted",
+        score: 1000,
+        output: "---RESULT---",
+        details: "{}",
+        created_at: now,
+      });
+
+      // 清空本测试前可能存在的审计行，避免行数偏差
+      await db.delete(auditLogs);
+
+      try {
+        // 执行：单条重测
+        await rejudgeSubmission(subId);
+
+        // 验证：审计日志写入
+        const rows = await db.select().from(auditLogs).where(
+          eq(auditLogs.action, "submissions.rejudge"),
+        );
+        assertEquals(rows.length, 1);
+        assertEquals(rows[0].target_type, "submission");
+        assertEquals(rows[0].target_id, subId);
+        assertEquals(rows[0].admin_id, adminId);
+        assertEquals(rows[0].ip_address, "10.0.0.55");
+        const detail = rows[0].detail as {
+          action: string;
+          submission_id?: string;
+          problem_id?: string;
+          count?: number;
+        };
+        assertEquals(detail.action, "submissions.rejudge");
+        assertEquals(detail.submission_id, subId);
+        assertEquals(detail.problem_id, undefined);
+        assertEquals(detail.count, undefined);
+      } finally {
+        // 清理本测试数据
+        await db.delete(evaluationResults).where(
+          eq(evaluationResults.submission_id, subId),
+        );
+        await db.delete(submissions).where(eq(submissions.id, subId));
+        await db.delete(auditLogs).where(eq(auditLogs.admin_id, adminId));
+        await db.delete(problems).where(eq(problems.id, localProblemId));
+        await db.delete(users).where(eq(users.id, adminId));
+        await db.delete(users).where(eq(users.id, localUserId));
+      }
+    } finally {
+      await fakeRedis.stop();
+      Deno.env.delete("REDIS_URL");
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "submissions service: rejudgeProblemSubmissions 写一条 submissions.rejudge 审计",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    resetRedisForTest();
+
+    // 启动 fake Redis
+    const fakeRedis = await startFakeRedis();
+    Deno.env.set("REDIS_URL", fakeRedis.url);
+
+    // 触发 ioredis 单例的 connect + PING
+    const redis2 = getRedis();
+    await redis2.connect();
+    await redis2.ping();
+    try {
+      // 准备：admin 操作者 + 本地用户 + 本地题目
+      const db = getDb();
+      const adminId = crypto.randomUUID();
+      const localUserId = crypto.randomUUID();
+      const localProblemId = crypto.randomUUID();
+      const now = new Date().toISOString();
+      await db.insert(users).values([
+        {
+          id: adminId,
+          username: `test-rej-prb-admin-${Date.now()}`,
+          email: `test-rej-prb-admin-${Date.now()}@example.com`,
+          password_hash: "",
+          role: "admin",
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: localUserId,
+          username: `test-rej-prb-user-${Date.now()}`,
+          email: `test-rej-prb-user-${Date.now()}@example.com`,
+          password_hash: "",
+          role: "user",
+          created_at: now,
+          updated_at: now,
+        },
+      ]);
+      await db.insert(problems).values({
+        id: localProblemId,
+        title: `批量重测审计题 ${Date.now()}`,
+        description: "rejudgeProblemSubmissions 审计测试用题目",
+        difficulty: "easy",
+        judge_image: "noj-judge-python",
+        judge_command: "python3 /tmp/evaluate.py",
+        time_limit_ms: 5000,
+        memory_limit_mb: 512,
+        number: 61000 + (Date.now() & 0x7fff),
+        owner_id: adminId,
+        type: "U",
+        created_at: now,
+        updated_at: now,
+      });
+
+      // 注入 admin actor context
+      enterTestContext({
+        actorId: adminId,
+        actorIp: "10.0.0.66",
+        actorRole: "admin",
+      });
+
+      // 准备：3 条 finished 状态的提交（同题）
+      const subIds: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const sid = crypto.randomUUID();
+        subIds.push(sid);
+        await db.insert(submissions).values({
+          id: sid,
+          user_id: localUserId,
+          problem_id: localProblemId,
+          language: "python3",
+          code: `print(${i})`,
+          file_name: "main.py",
+          status: "finished",
+          rejudge_seq: 0,
+          created_at: now,
+        });
+        await db.insert(evaluationResults).values({
+          id: crypto.randomUUID(),
+          submission_id: sid,
+          status: "Accepted",
+          score: 1000,
+          output: "---RESULT---",
+          details: "{}",
+          created_at: now,
+        });
+      }
+
+      // 清空本测试前可能存在的审计行
+      await db.delete(auditLogs);
+
+      try {
+        // 执行：批量重测
+        const result = await rejudgeProblemSubmissions(localProblemId);
+        assertEquals(result.total, 3);
+
+        // 验证：审计日志写入
+        const rows = await db.select().from(auditLogs).where(
+          eq(auditLogs.action, "submissions.rejudge"),
+        );
+        assertEquals(rows.length, 1);
+        assertEquals(rows[0].target_type, "problem");
+        assertEquals(rows[0].target_id, localProblemId);
+        assertEquals(rows[0].admin_id, adminId);
+        assertEquals(rows[0].ip_address, "10.0.0.66");
+        const detail = rows[0].detail as {
+          action: string;
+          submission_id?: string;
+          problem_id?: string;
+          count?: number;
+        };
+        assertEquals(detail.action, "submissions.rejudge");
+        assertEquals(detail.problem_id, localProblemId);
+        assertEquals(detail.count, 3);
+        assertEquals(detail.submission_id, undefined);
+      } finally {
+        // 清理本测试数据
+        for (const sid of subIds) {
+          await db.delete(evaluationResults).where(
+            eq(evaluationResults.submission_id, sid),
+          );
+          await db.delete(submissions).where(eq(submissions.id, sid));
+        }
+        await db.delete(auditLogs).where(eq(auditLogs.admin_id, adminId));
+        await db.delete(problems).where(eq(problems.id, localProblemId));
+        await db.delete(users).where(eq(users.id, adminId));
+        await db.delete(users).where(eq(users.id, localUserId));
+      }
+    } finally {
+      await fakeRedis.stop();
+      Deno.env.delete("REDIS_URL");
     }
   },
 });

--- a/noj-core/tests/services/user-ban.test.ts
+++ b/noj-core/tests/services/user-ban.test.ts
@@ -1,0 +1,165 @@
+/**
+ * 用户封禁/解封审计日志测试（issue #101 + #102）。
+ *
+ * 验证 banUser / unbanUser 在 service 层正确写入 audit_logs。
+ */
+import { assertEquals } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { auditLogs, userBans, users } from "../../src/db/schema.ts";
+import { banUser, unbanUser } from "../../src/services/users.ts";
+import {
+  enterTestContext,
+  leaveTestContext,
+} from "../../src/lib/requestContext.ts";
+
+const hasDb = true; // PGlite 内存数据库始终可用
+const hasEnv = !!Deno.env.get("JWT_SECRET");
+const skip = !hasDb || !hasEnv;
+
+const ADMIN_ID = crypto.randomUUID();
+const ADMIN2_ID = crypto.randomUUID();
+const TARGET_ID = crypto.randomUUID();
+const TS = Date.now();
+
+async function freshSetup() {
+  await resetDbForTest();
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  // 清空可能残留的数据
+  await db.delete(auditLogs);
+  await db.delete(userBans);
+  await db.delete(users).where(eq(users.id, ADMIN_ID));
+  await db.delete(users).where(eq(users.id, ADMIN2_ID));
+  await db.delete(users).where(eq(users.id, TARGET_ID));
+
+  // 插入两个管理员（第二个确保 ban 操作不触发"最后一个 admin"保护）
+  await db.insert(users).values({
+    id: ADMIN_ID,
+    username: `ban-admin-${TS}`,
+    email: `ban-admin-${TS}@test.local`,
+    password_hash: "x",
+    role: "admin",
+    created_at: now,
+    updated_at: now,
+  });
+  await db.insert(users).values({
+    id: ADMIN2_ID,
+    username: `ban-admin2-${TS}`,
+    email: `ban-admin2-${TS}@test.local`,
+    password_hash: "x",
+    role: "admin",
+    created_at: now,
+    updated_at: now,
+  });
+  // 插入一个普通用户作为封禁目标
+  await db.insert(users).values({
+    id: TARGET_ID,
+    username: `ban-target-${TS}`,
+    email: `ban-target-${TS}@test.local`,
+    password_hash: "x",
+    role: "user",
+    created_at: now,
+    updated_at: now,
+  });
+}
+
+Deno.test({
+  name: "user-ban audit: banUser 写入审计日志 users.ban",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const db = getDb();
+
+    enterTestContext({
+      actorId: ADMIN_ID,
+      actorIp: "10.0.0.1",
+      actorRole: "admin",
+    });
+    try {
+      await banUser(TARGET_ID, "违规行为", null, ADMIN_ID);
+
+      const logs = await db.select().from(auditLogs);
+      assertEquals(logs.length, 1);
+      assertEquals(logs[0].admin_id, ADMIN_ID);
+      assertEquals(logs[0].action, "users.ban");
+      assertEquals(logs[0].target_type, "users");
+      assertEquals(logs[0].target_id, TARGET_ID);
+      assertEquals(logs[0].ip_address, "10.0.0.1");
+      assertEquals(logs[0].detail, {
+        action: "users.ban",
+        reason: "违规行为",
+        until: null,
+      });
+    } finally {
+      leaveTestContext();
+    }
+  },
+});
+
+Deno.test({
+  name: "user-ban audit: banUser 带过期时间的审计日志",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const db = getDb();
+
+    const future = new Date(Date.now() + 86400_000).toISOString();
+
+    enterTestContext({
+      actorId: ADMIN_ID,
+      actorIp: "10.0.0.1",
+      actorRole: "admin",
+    });
+    try {
+      await banUser(TARGET_ID, "临时封禁", future, ADMIN_ID);
+
+      const logs = await db.select().from(auditLogs);
+      assertEquals(logs.length, 1);
+      assertEquals(logs[0].action, "users.ban");
+      assertEquals((logs[0].detail as Record<string, unknown>).until, future);
+    } finally {
+      leaveTestContext();
+    }
+  },
+});
+
+Deno.test({
+  name: "user-ban audit: unbanUser 写入审计日志 users.unban",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const db = getDb();
+
+    // 先封禁
+    await banUser(TARGET_ID, "封禁测试", null, ADMIN_ID);
+    await db.delete(auditLogs); // 清除 ban 的审计日志，只测 unban
+
+    enterTestContext({
+      actorId: ADMIN_ID,
+      actorIp: "10.0.0.2",
+      actorRole: "admin",
+    });
+    try {
+      await unbanUser(TARGET_ID, ADMIN_ID);
+
+      const logs = await db.select().from(auditLogs);
+      assertEquals(logs.length, 1);
+      assertEquals(logs[0].admin_id, ADMIN_ID);
+      assertEquals(logs[0].action, "users.unban");
+      assertEquals(logs[0].target_type, "users");
+      assertEquals(logs[0].target_id, TARGET_ID);
+      assertEquals(logs[0].ip_address, "10.0.0.2");
+      assertEquals(logs[0].detail, { action: "users.unban" });
+    } finally {
+      leaveTestContext();
+    }
+  },
+});

--- a/noj-ui/composables/useAuditLogs.ts
+++ b/noj-ui/composables/useAuditLogs.ts
@@ -1,0 +1,85 @@
+/**
+ * 审计日志列表 composable。
+ * 状态：分页 + 筛选；自动请求 + 错误处理。
+ */
+
+export type AuditAction =
+  | "users.role_change"
+  | "users.ban"
+  | "users.unban"
+  | "problems.delete"
+  | "categories.delete"
+  | "submissions.rejudge"
+  | "settings.update";
+
+export interface AuditLogEntry {
+  id: string;
+  admin_id: string;
+  action: AuditAction;
+  target_type: string | null;
+  target_id: string | null;
+  detail: Record<string, unknown>;
+  ip_address: string;
+  created_at: string;
+}
+
+export interface AuditLogListResponse {
+  data: AuditLogEntry[];
+  pagination: { page: number; per_page: number; total: number };
+}
+
+export interface AuditLogFilters {
+  page: number;
+  per_page: number;
+  admin_id?: string;
+  action?: AuditAction | "";
+  from?: string;
+  to?: string;
+}
+
+export function useAuditLogs(initial: Partial<AuditLogFilters> = {}) {
+  const filters = useState("audit-logs-filters", () => ({
+    page: 1,
+    per_page: 20,
+    admin_id: undefined,
+    action: "" as AuditAction | "",
+    from: undefined,
+    to: undefined,
+    ...initial,
+  }));
+
+  const data = ref<AuditLogEntry[]>([]);
+  const pagination = ref({ page: 1, per_page: 20, total: 0 });
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  async function fetch() {
+    loading.value = true;
+    error.value = null;
+    try {
+      const params = new URLSearchParams();
+      params.set("page", String(filters.value.page));
+      params.set("per_page", String(filters.value.per_page));
+      if (filters.value.admin_id) params.set("admin_id", filters.value.admin_id);
+      if (filters.value.action) params.set("action", filters.value.action);
+      if (filters.value.from) params.set("from", filters.value.from);
+      if (filters.value.to) params.set("to", filters.value.to);
+
+      const res = await $fetch<AuditLogListResponse>(
+        `/api/v1/admin/audit-logs?${params}`,
+      );
+      data.value = res.data;
+      pagination.value = res.pagination;
+    } catch (e: any) {
+      error.value = e?.message ?? "加载失败";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  function reset() {
+    filters.value = { page: 1, per_page: 20, admin_id: undefined, action: "", from: undefined, to: undefined };
+  }
+
+  return { filters, data, pagination, loading, error, fetch, reset };
+}

--- a/noj-ui/layouts/admin.vue
+++ b/noj-ui/layouts/admin.vue
@@ -12,6 +12,7 @@ import {
   Container,
   Settings,
   Ban,
+  ScrollText,
 } from "@lucide/vue"
 
 const route = useRoute()
@@ -45,6 +46,7 @@ const navItems: NavItem[] = [
   { label: "评测镜像", to: "/admin/judge-images", icon: Container },
   { label: "系统设置", to: "/admin/settings", icon: Settings },
   { label: "提交管理", to: "/admin/submissions", icon: Files },
+  { label: "审计日志", to: "/admin/audit-logs", icon: ScrollText },
 ]
 
 function isActive(path: string) {

--- a/noj-ui/pages/admin/audit-logs.vue
+++ b/noj-ui/pages/admin/audit-logs.vue
@@ -1,0 +1,233 @@
+<script setup lang="ts">
+import { Copy, ScrollText } from "@lucide/vue"
+import { useAuditLogs } from "~/composables/useAuditLogs"
+import type { AuditAction, AuditLogEntry } from "~/composables/useAuditLogs"
+import { useToast } from "~/composables/useToast"
+
+definePageMeta({
+  layout: "admin",
+  middleware: "admin",
+  ssr: false,
+})
+
+const { filters, data, pagination, loading, error, fetch, reset } = useAuditLogs()
+const { toast } = useToast()
+
+const ACTION_LABELS: Record<AuditAction, string> = {
+  "users.role_change": "角色变更",
+  "users.ban": "用户封禁",
+  "users.unban": "用户解封",
+  "problems.delete": "删除题目",
+  "categories.delete": "删除分类",
+  "submissions.rejudge": "重测提交",
+  "settings.update": "修改设置",
+}
+
+const ACTION_COLORS: Record<AuditAction, string> = {
+  "users.role_change": "bg-blue-100 text-blue-800",
+  "users.ban": "bg-red-100 text-red-800",
+  "users.unban": "bg-green-100 text-green-800",
+  "problems.delete": "bg-red-100 text-red-800",
+  "categories.delete": "bg-orange-100 text-orange-800",
+  "submissions.rejudge": "bg-purple-100 text-purple-800",
+  "settings.update": "bg-yellow-100 text-yellow-800",
+}
+
+function renderDetail(entry: AuditLogEntry): string {
+  const d = entry.detail as Record<string, any>
+  switch (entry.action) {
+    case "users.role_change":
+      return `${d.from} → ${d.to}`
+    case "users.ban":
+      return `${d.reason}${d.until ? ` (至 ${d.until})` : ""}`
+    case "users.unban":
+      return "已解封"
+    case "problems.delete":
+      return `${d.title} (${d.display_id})`
+    case "categories.delete":
+      return `${d.name} (${d.slug})`
+    case "submissions.rejudge":
+      if (d.submission_id) return `submission: ${d.submission_id}`
+      if (d.problem_id) return `problem: ${d.problem_id} (×${d.count ?? "?"})`
+      return "—"
+    case "settings.update":
+      return `${d.key}: ${JSON.stringify(d.from)} → ${JSON.stringify(d.to)}`
+    default:
+      return JSON.stringify(d)
+  }
+}
+
+async function copy(value: string) {
+  try {
+    await navigator.clipboard.writeText(value)
+    toast.success("已复制")
+  } catch {
+    toast.error("复制失败")
+  }
+}
+
+function applyFilters() {
+  filters.value.page = 1
+  fetch()
+}
+
+function onPageChange(page: number) {
+  filters.value.page = page
+  fetch()
+}
+
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(pagination.value.total / pagination.value.per_page)),
+)
+
+onMounted(fetch)
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-1">
+      <h1 class="text-[22px] font-bold text-text flex items-center gap-2">
+        <ScrollText :size="22" />
+        审计日志
+      </h1>
+      <span class="text-sm text-text-secondary">查看管理员操作的完整审计记录（保留 90 天）</span>
+    </div>
+
+    <!-- 筛选条 -->
+    <div class="bg-white border border-border rounded-lg p-4">
+      <div class="flex flex-wrap gap-3 mb-3">
+        <div class="flex flex-col gap-1 min-w-[180px]">
+          <label class="text-xs font-semibold text-text-secondary">操作类型</label>
+          <select
+            v-model="filters.action"
+            class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+          >
+            <option value="">全部</option>
+            <option v-for="(label, action) in ACTION_LABELS" :key="action" :value="action">
+              {{ label }}
+            </option>
+          </select>
+        </div>
+        <div class="flex flex-col gap-1 min-w-[200px]">
+          <label class="text-xs font-semibold text-text-secondary">起始时间</label>
+          <input
+            type="datetime-local"
+            v-model="filters.from"
+            class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+          />
+        </div>
+        <div class="flex flex-col gap-1 min-w-[200px]">
+          <label class="text-xs font-semibold text-text-secondary">截止时间</label>
+          <input
+            type="datetime-local"
+            v-model="filters.to"
+            class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+          />
+        </div>
+      </div>
+      <div class="flex gap-2">
+        <button
+          class="inline-flex items-center gap-1 px-3.5 py-1.5 text-[13px] font-semibold rounded cursor-pointer transition-all duration-150 border-[1.5px] leading-none no-underline bg-primary text-white border-primary hover:bg-primary-dark hover:border-primary-dark"
+          @click="applyFilters"
+        >
+          筛选
+        </button>
+        <button
+          class="inline-flex items-center gap-1 px-3.5 py-1.5 text-[13px] font-semibold rounded cursor-pointer transition-all duration-150 border-[1.5px] leading-none no-underline text-text-secondary border-border bg-transparent hover:border-text-secondary hover:text-text"
+          @click="reset(); fetch()"
+        >
+          重置
+        </button>
+      </div>
+    </div>
+
+    <!-- 表格 -->
+    <div class="bg-white border border-border rounded-xl overflow-hidden">
+      <table class="w-full border-collapse">
+        <thead>
+          <tr>
+            <th class="px-4 py-3 text-xs font-semibold text-text-muted uppercase tracking-wider text-left bg-gray-50 border-b border-border">
+              时间
+            </th>
+            <th class="px-4 py-3 text-xs font-semibold text-text-muted uppercase tracking-wider text-left bg-gray-50 border-b border-border">
+              管理员
+            </th>
+            <th class="px-4 py-3 text-xs font-semibold text-text-muted uppercase tracking-wider text-left bg-gray-50 border-b border-border">
+              操作
+            </th>
+            <th class="px-4 py-3 text-xs font-semibold text-text-muted uppercase tracking-wider text-left bg-gray-50 border-b border-border">
+              目标
+            </th>
+            <th class="px-4 py-3 text-xs font-semibold text-text-muted uppercase tracking-wider text-left bg-gray-50 border-b border-border">
+              详情
+            </th>
+            <th class="px-4 py-3 text-xs font-semibold text-text-muted uppercase tracking-wider text-left bg-gray-50 border-b border-border">
+              IP
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="loading">
+            <td colspan="6" class="px-4 py-12 text-center text-text-secondary text-sm">
+              加载中...
+            </td>
+          </tr>
+          <tr v-else-if="error">
+            <td colspan="6" class="px-4 py-12 text-center text-red-600 text-sm">
+              {{ error }}
+            </td>
+          </tr>
+          <tr v-else-if="data.length === 0">
+            <td colspan="6" class="px-4 py-12 text-center text-text-muted text-sm">
+              暂无记录
+            </td>
+          </tr>
+          <tr
+            v-for="entry in data"
+            v-else
+            :key="entry.id"
+            class="border-b border-border last:border-b-0 transition-colors hover:bg-gray-50"
+          >
+            <td class="px-4 py-3 text-sm text-text whitespace-nowrap">
+              {{ new Date(entry.created_at).toLocaleString("zh-CN") }}
+            </td>
+            <td class="px-4 py-3 text-sm font-mono text-text-secondary">
+              {{ entry.admin_id.slice(0, 8) }}...
+            </td>
+            <td class="px-4 py-3 text-sm">
+              <span :class="['inline-block px-2 py-0.5 rounded text-xs font-semibold whitespace-nowrap', ACTION_COLORS[entry.action]]">
+                {{ ACTION_LABELS[entry.action] }}
+              </span>
+            </td>
+            <td class="px-4 py-3 text-sm text-text-secondary">
+              {{ entry.target_type }}:{{ entry.target_id?.slice(0, 8) }}...
+            </td>
+            <td class="px-4 py-3 text-sm text-text">
+              {{ renderDetail(entry) }}
+            </td>
+            <td class="px-4 py-3 text-sm text-text-secondary font-mono">
+              <span class="inline-flex items-center gap-1">
+                {{ entry.ip_address }}
+                <button
+                  class="inline-flex items-center justify-center w-6 h-6 rounded transition-colors text-text-muted hover:text-primary hover:bg-primary-bg"
+                  title="复制 IP"
+                  @click="copy(entry.ip_address)"
+                >
+                  <Copy :size="13" />
+                </button>
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- 分页 -->
+    <PaginationNav
+      v-if="pagination.total > pagination.per_page"
+      :current-page="pagination.page"
+      :total-pages="totalPages"
+      @page-change="onPageChange"
+    />
+  </div>
+</template>

--- a/openspec/changes/audit-log/design.md
+++ b/openspec/changes/audit-log/design.md
@@ -1,0 +1,170 @@
+## Context
+
+NOJ 管理员操作零审计。issue #101 列出 6 类核心写操作需追溯：
+
+| 操作 | 调用点 |
+|------|--------|
+| 用户角色变更 | `promoteUser` (services/auth.ts) |
+| 用户封禁/解封 | `banUser` / `unbanUser` (services/users.ts) |
+| 题目删除 | `deleteProblem` (services/problems.ts) |
+| 分类删除 | `deleteCategory` (services/categories.ts) |
+| 提交重测 | `rejudgeSubmission` / `rejudgeProblemSubmissions` (services/submissions.ts) |
+| 系统设置修改 | `updateSystemSetting` (services/settings.ts，#105 接入) |
+
+约束：
+
+- 审计写入必须在 service 层（issue 明确："非 middleware —— 需要业务上下文"）
+- service 函数不持有 Hono context，IP 需要跨越调用栈传递
+- 6-8 处埋点不宜污染函数签名
+- 90 天保留 + 可配置
+
+## Goals / Non-Goals
+
+**Goals:**
+- 同步直写 audit_logs 表（强一致；admin 操作非高频路径，1-3ms 可接受）
+- ALS 传递 actorId / actorIp / actorRole，service 函数零签名改动
+- 7 类操作各自强类型 detail（discriminated union），编译期杜绝字段错误
+- 后台 setInterval 任务每日清理过期日志（24h 周期 + 启动立即跑一次）
+- 管理后台查看页（分页 + 多维度筛选 + 按 action narrow 渲染 detail 列）
+- root 用户审计记录保留但 UI 默认隐藏
+
+**Non-Goals:**
+- 异步写入（Redis stream / 消息队列）—— 复杂度 > 收益
+- 元审计（查看审计日志本身）—— 噪音大
+- 审计日志导出 / 实时推送 / 聚合统计 —— 后续 issue
+- 审计日志修改 / 删除端点 —— DB 层只增不改
+
+## Decisions
+
+### 1. 写入方式：同步直写 DB
+
+每个 admin 写操作 service 末尾 `await logAudit(action, detail)`，失败仅 `console.error`，业务操作继续。
+
+**替代方案**：Redis Stream + worker 消费 → 引入新的故障面（worker 挂了会丢日志）；admin 操作非高频路径无必要性。
+
+### 2. IP 传递：AsyncLocalStorage
+
+`adminMiddleware` 注入 `RequestContext` 到 ALS，service 内 `getRequestContext()` 取用。
+
+**替代方案**：6-8 个 service 函数加 `actorIp?: string` 参数 → 污染签名；日后扩展（如 user-agent）需再改一遍。
+
+`AsyncLocalStorage` 来自 `node:async_hooks`（Deno 兼容），性能开销可忽略。
+
+### 3. detail 强类型：TypeScript discriminated union
+
+按 action 类型 narrow，编译期检查字段完整性：
+
+```ts
+type AuditDetail =
+  | { action: "users.role_change"; from: string; to: string }
+  | { action: "users.ban"; reason: string; until: string | null }
+  | { action: "users.unban" }
+  | { action: "problems.delete"; title: string; display_id: string }
+  | { action: "categories.delete"; name: string; slug: string }
+  | { action: "submissions.rejudge"; submission_id?: string; problem_id?: string; count?: number }
+  | { action: "settings.update"; key: string; from: unknown; to: unknown };
+```
+
+**替代方案**：`Record<string, unknown>` → 无类型保护；UI 渲染到处 `as any`。
+
+新增 action 时必须扩展 union —— 这正是我们想要的"显式优于隐式"。
+
+### 4. 保留策略：setInterval 后台任务
+
+`main.ts` 启动 HTTP 后调用 `startAuditLogRetentionTask()`：
+- 读 `AUDIT_LOG_RETENTION_DAYS`（默认 90，0 = 禁用）
+- 启动立即跑一次 `cleanupOldAuditLogs(days)`
+- 每 24h 重复一次
+- 多实例幂等（DELETE range 无副作用）
+
+**替代方案**：
+- 写时惰性清理 → 不可预测；冷启动后过期日志残留
+- PG 表分区按月 + DROP PARTITION → 改造 schema，前期过度工程
+- pg_cron 扩展 → 依赖外部依赖
+- 手动清理端点 → 部署侧需要额外配置
+
+### 5. 字段冗余：保留 `target_type` + `target_id`
+
+虽然 detail JSONB 中已有 target 信息，仍保留独立列。理由：
+
+- 列表查询不必 parse JSONB
+- 按 (target_type, target_id) 复合过滤更快（即便目前没用到，后续按题目 ID 反查审计是常见诉求）
+- 写入成本可忽略（2 列 vs 1 JSONB 字段）
+
+### 6. IP 缺失处理：抛错而非 NULL
+
+`getRequestContext()` 缺失时抛 `Error("RequestContext 未注入")`。理由：
+
+- 审计完整性 > 优雅降级
+- 该错误暴露的是程序 bug（logAudit 在非 admin 路由被调用），不应静默
+- 测试用 `enterTestContext()` 注入固定 context
+
+### 7. logAudit 失败：仅 error 日志，业务继续
+
+audit_logs INSERT 失败 → `console.error` + 吞异常，业务操作不回滚。理由：
+
+- admin 操作不应因审计失败被拒（用户体验差；且审计故障应是独立告警）
+- 强一致（业务回滚）只在审计缺失会导致数据不一致时才有意义，此处不存在
+- 实际操作中 DB INSERT 失败的概率极低（同一连接、同一事务）
+
+### 8. root 用户审计处理
+
+`admin_id='0'` 的审计**仍记录**（不丢可追溯性），但：
+
+- `listAuditLogs` 列表查询默认 WHERE `admin_id != '0'`
+- 显式传 `?admin_id=0` 可查询（应急排障）
+
+### 9. UI 列表分页 / 筛选
+
+- page / per_page（默认 20，上限 100）
+- 可选筛选：admin_id / action / from / to
+- 复用项目既有 `paginationNav` 组件
+- detail 列按 action narrow 渲染（每个 action 一个渲染函数）
+
+## Schema 草案
+
+```sql
+CREATE TABLE audit_logs (
+  id TEXT PRIMARY KEY,
+  admin_id TEXT NOT NULL REFERENCES users(id),
+  action TEXT NOT NULL,
+  target_type TEXT,
+  target_id TEXT,
+  detail JSONB NOT NULL DEFAULT '{}',
+  ip_address TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  CONSTRAINT audit_logs_action_check CHECK (
+    action IN (
+      'users.role_change',
+      'users.ban',
+      'users.unban',
+      'problems.delete',
+      'categories.delete',
+      'submissions.rejudge',
+      'settings.update'
+    )
+  )
+);
+CREATE INDEX audit_logs_admin_id_idx ON audit_logs(admin_id);
+CREATE INDEX audit_logs_created_at_idx ON audit_logs(created_at);
+CREATE INDEX audit_logs_action_idx ON audit_logs(action);
+```
+
+索引选择：admin_id / created_at / action 三列独立索引，覆盖三种最常见筛选模式。复合索引留给后续优化（如 `(admin_id, created_at DESC)` 用于"某管理员最近活动"）。
+
+## Risks / Trade-offs
+
+| 风险 | 缓解 |
+|------|------|
+| ALS 缺失导致 500 | logAudit 调用前必过 adminMiddleware → 自动注入；service 单元测试用 enterTestContext |
+| 审计写入热点 | admin 操作非高频；后续可加批量 INSERT 优化 |
+| 90 天 retention 误删 | 保留天数可配置（env）；后续可加归档策略（先导出再删） |
+| root 用户审计误隐藏 | 列表 UI 提供"显示 root"开关 |
+| 测试间审计污染 | 每个测试 beforeEach 清空 audit_logs 表 |
+
+## 验证
+
+- `deno task test`：新增 ~10 个测试 + 5 处既有测试扩展
+- 端到端：admin ban 用户 → 查 `/admin/audit-logs` → 见到对应记录
+- 清理任务：临时设 `AUDIT_LOG_RETENTION_DAYS=0` + 插入一条 `created_at < now-1s` 的记录，验证删除生效
+- UI smoke：`/admin/audit-logs` 页面渲染正常，筛选交互可用

--- a/openspec/changes/audit-log/proposal.md
+++ b/openspec/changes/audit-log/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+NOJ 当前所有管理员操作无日志记录。出现误操作或安全事故时无法追溯责任、复盘行为。issue #101 列出了 6 个核心写操作的审计需求，并明确要求：
+
+- 在 **service 层**埋点（非 middleware —— 因 service 持有业务上下文，如 role_change 的 `from`/`to`、ban 的 `reason`/`until`）
+- 记录 IP、admin_id、操作类型、详情、时间
+- 90 天保留策略（可配置）
+- 管理后台"审计日志"页面（按操作类型/管理员/时间筛选）
+
+PR #108（IP 黑名单）已建立 `console.log("[admin] ...")` 临时约定（其 proposal "Out of Scope"段明确说"完整审计日志表（issue #101，独立工作）"）。本变更落地完整审计能力，替换临时约定。
+
+## What Changes
+
+### 新增能力
+
+- **`audit-log`**：审计日志抽象 —— service 层 `logAudit()` 同步写入 + ALS 上下文自动捕获 + 7 类强类型 `AuditDetail` discriminated union + 后台保留清理任务 + admin UI 查看页
+
+### 修改能力
+
+- **`admin-routes`**：新增 `GET /api/v1/admin/audit-logs`（分页 + 筛选）；现有 7 个 admin 端点路由层零改动（service 内部已埋点）
+- **`admin-frontend`**：侧栏新增"审计日志"入口 + 新建 `pages/admin/audit-logs.vue`（按 action 类型渲染 detail 列）
+- **`user-auth`**：`adminMiddleware` 注入 `RequestContext`（actorId / actorIp / actorRole）至 AsyncLocalStorage
+- **`admin-services`**：`promoteUser` / `banUser` / `unbanUser` / `deleteProblem` / `deleteCategory` / `rejudgeSubmission` / `rejudgeProblemSubmissions` 各埋点 1-2 条审计（V1 共 7 处；`settings.update` 在 #105 接入时埋点）
+
+## Impact
+
+- **数据库**：新增 `audit_logs` 表（7 列 + 1 个 CHECK 约束 + 3 个索引）
+- **noj-core**：
+  - 新增 `src/lib/requestContext.ts`（ALS 封装）
+  - 新增 `src/services/audit-log.ts`（logAudit / listAuditLogs / cleanupOldAuditLogs / startAuditLogRetentionTask）
+  - 新增 `src/types/audit-log.ts`（AuditAction / AuditDetail / AuditLogEntry）
+  - 改造 `src/middleware/auth.ts`（adminMiddleware 注入 ALS 上下文）
+  - 改造 `src/db/schema.ts` + `src/db/schema-ddl.ts`（新增 auditLogs 表）
+  - 改造 5 个 service 文件（埋点）：`auth.ts`、`users.ts`、`problems.ts`、`categories.ts`、`submissions.ts`
+  - 新增 `src/routes/admin.ts` 端点：`GET /audit-logs`
+  - 改造 `src/main.ts`：HTTP 启动后调用 `startAuditLogRetentionTask()`
+  - 新增迁移 `drizzle/0012_audit_logs.sql`
+- **noj-ui**：
+  - 新增 `pages/admin/audit-logs.vue`
+  - 改造 `layouts/admin.vue`（侧栏 navItems 加"审计日志"）
+- **环境变量**：新增 `AUDIT_LOG_RETENTION_DAYS`（默认 90；0 = 禁用清理）
+- **性能**：每个 admin 写操作多 1 次 DB INSERT（约 1-3ms）；后台清理每天 1 次 range DELETE（90 天索引扫描）
+- **一致性**：logAudit 失败 → 仅记录 error 日志，业务操作继续（admin 操作不应因审计失败被拒）
+- **向后兼容**：root 用户 (UID=0) 的审计仍记录，但列表 UI 默认隐藏
+
+## Out of Scope
+
+- 元审计（"admin X 查看了审计日志"）—— 噪音大，独立 issue 处理
+- 审计日志导出（CSV/JSON）—— 后续
+- 审计日志修改/删除端点 —— 审计只增不改不删
+- 实时推送（SSE 新审计到来通知）—— 后续
+- 按 IP 反查 / 聚合统计 —— 后续
+- IPv6 IP 处理（复用既有 `getClientIp` 工具，支持 X-Forwarded-For 标准行为）
+
+## 关联
+
+- Closes #101
+- 衔接 #108（PR #108 的 `console.log("[admin] ...")` 临时约定落地为真实审计；本变更不删除 #108 的 console.log，由后续 #108 cleanup commit 处理）
+- 衔接 #105（系统设置面板接入时，在 `updateSystemSetting` 内埋点 `settings.update`；如 #105 先合并则本变更的埋点清单同步包含 settings.update）

--- a/openspec/changes/audit-log/specs/audit-log/spec.md
+++ b/openspec/changes/audit-log/specs/audit-log/spec.md
@@ -1,0 +1,259 @@
+## ADDED Requirements
+
+### Requirement: audit_logs 表
+
+系统 SHALL 提供 `audit_logs` 表存储管理员操作记录。
+
+`audit_logs` SHALL 包含以下列：
+- `id` (TEXT, PK) —— UUID
+- `admin_id` (TEXT, NOT NULL, FK → users.id) —— 操作管理员
+- `action` (TEXT, NOT NULL) —— 操作类型枚举，受 CHECK 约束
+- `target_type` (TEXT, NULL) —— 目标类型（如 "user" / "problem" / "category"）
+- `target_id` (TEXT, NULL) —— 目标 ID
+- `detail` (JSONB, NOT NULL, DEFAULT '{}') —— 操作详情，按 action 强类型
+- `ip_address` (TEXT, NOT NULL) —— 操作来源 IP
+- `created_at` (TEXT, NOT NULL) —— ISO 8601 时间戳
+
+`action` CHECK 约束 SHALL 限定为以下 7 个值之一：
+- `users.role_change`
+- `users.ban`
+- `users.unban`
+- `problems.delete`
+- `categories.delete`
+- `submissions.rejudge`
+- `settings.update`
+
+表 SHALL 建立以下索引：
+- `audit_logs_admin_id_idx` ON `admin_id`
+- `audit_logs_created_at_idx` ON `created_at`
+- `audit_logs_action_idx` ON `action`
+
+#### Scenario: 创建 audit_logs 表成功
+
+- **WHEN** 执行 0012 migration
+- **THEN** 表和 3 个索引被创建
+- **THEN** 插入非法 action（如 "unknown.action"）抛 CHECK 约束错误
+
+#### Scenario: root 用户审计记录
+
+- **WHEN** admin_id='0' 的管理员执行任一审计操作
+- **THEN** audit_logs 写入一条记录（保留可追溯性）
+- **THEN** 列表 API 默认不返回该记录
+
+### Requirement: AuditDetail 强类型
+
+系统 SHALL 通过 TypeScript discriminated union 定义 7 类操作的 detail 字段：
+
+```ts
+type AuditDetail =
+  | { action: "users.role_change"; from: string; to: string }
+  | { action: "users.ban"; reason: string; until: string | null }
+  | { action: "users.unban" }
+  | { action: "problems.delete"; title: string; display_id: string }
+  | { action: "categories.delete"; name: string; slug: string }
+  | { action: "submissions.rejudge"; submission_id?: string; problem_id?: string; count?: number }
+  | { action: "settings.update"; key: string; from: unknown; to: unknown };
+```
+
+`logAudit()` MUST 接受 `AuditDetail` 联合类型参数；编译期阻止传错字段。
+
+#### Scenario: role_change detail 完整性
+
+- **WHEN** 调用 `logAudit("users.role_change", { from: "user", to: "admin" })`
+- **THEN** 编译通过，detail 写入 JSONB
+
+#### Scenario: 缺字段编译失败
+
+- **WHEN** 调用 `logAudit("users.ban", { reason: "spam" })`（缺 `until`）
+- **THEN** TypeScript 编译报错：Property 'until' is missing
+
+### Requirement: RequestContext 自动捕获
+
+系统 SHALL 通过 AsyncLocalStorage 在 admin 路由作用域内传递 `RequestContext`。
+
+`RequestContext` SHALL 包含：
+- `actorId` (string) —— 当前用户 ID
+- `actorIp` (string) —— 请求 IP（X-Forwarded-For 优先，回退 RemoteAddr）
+- `actorRole` (string) —— 当前用户角色
+
+`adminMiddleware` MUST 在 `c.set("userId")` / `c.set("userRole")` 之后调用 `runWithContext(ctx, () => next())`，使整条 admin 调用链可访问 context。
+
+`getRequestContext()` MUST 在 context 未注入时抛出错误（程序 bug 保护）。
+
+#### Scenario: admin 路由内 logAudit 成功
+
+- **WHEN** admin 请求进入 `POST /api/v1/admin/users/:id/ban`
+- **WHEN** adminMiddleware 注入 RequestContext
+- **WHEN** banUser service 内 `logAudit("users.ban", {reason, until}, {type: "user", id})`
+- **THEN** `getRequestContext()` 返回包含 actorId / actorIp / actorRole 的 context
+- **THEN** audit_logs INSERT 成功，ip_address 等于请求客户端 IP
+
+#### Scenario: 非 admin 路由调 logAudit 抛错
+
+- **WHEN** service 函数（如公共 API 服务）意外调用 `logAudit`
+- **THEN** `getRequestContext()` 抛 `Error("RequestContext 未注入")`
+- **THEN** 触发 500 响应，暴露程序 bug
+
+#### Scenario: 测试注入 context
+
+- **WHEN** 测试代码 `enterTestContext({actorId: "test-admin", actorIp: "127.0.0.1", actorRole: "admin"})`
+- **WHEN** service 函数内 `logAudit(...)` 被调用
+- **THEN** `getRequestContext()` 返回注入的固定 context
+
+### Requirement: 同步审计写入
+
+系统 SHALL 在 service 层埋点，同步执行 `logAudit()` 完成 INSERT。
+
+`logAudit()` MUST 接受三个参数：
+- `action: AuditAction` —— 操作类型
+- `detail: AuditDetail` —— 详情（强类型）
+- `target?: { type: string; id: string }` —— 操作目标（可选）
+
+`logAudit()` MUST 从 `RequestContext` 自动取 `admin_id` 和 `ip_address`，调用方不显式传。
+
+`logAudit()` 失败（DB INSERT 异常）SHOULD 仅 `console.error` 记录错误，**不抛出业务错误** —— 业务操作继续进行（admin 操作不应因审计故障被拒）。
+
+#### Scenario: banUser 写 audit_log
+
+- **WHEN** admin 调用 `POST /api/v1/admin/users/:id/ban` with `{reason, until}`
+- **WHEN** banUser service 成功执行封禁
+- **THEN** audit_logs 多一条记录：action="users.ban", admin_id=当前管理员, ip_address=客户端 IP, detail={"reason", "until"}, target={type: "user", id: 目标用户}
+- **THEN** HTTP 响应 200，返回更新后的用户对象
+
+#### Scenario: audit 失败业务继续
+
+- **WHEN** logAudit INSERT 因 audit_logs 表不存在失败（异常）
+- **THEN** `console.error` 输出异常详情
+- **THEN** banUser 不抛错，HTTP 响应 200，封禁生效
+- **THEN** 后续告警系统（如有）通过 error 日志捕获该异常
+
+### Requirement: 7 类操作埋点
+
+系统 SHALL 在以下 service 函数末尾埋点（每处 1-2 条 audit）：
+
+| Service 函数 | action | detail | target |
+|--------------|--------|--------|--------|
+| `promoteUser` | `users.role_change` | `{from, to}` | `{type: "user", id: 目标}` |
+| `banUser` | `users.ban` | `{reason, until}` | `{type: "user", id: 目标}` |
+| `unbanUser` | `users.unban` | `{}` | `{type: "user", id: 目标}` |
+| `deleteProblem` | `problems.delete` | `{title, display_id}` | `{type: "problem", id: 题目}` |
+| `deleteCategory` | `categories.delete` | `{name, slug}` | `{type: "category", id: 分类}` |
+| `rejudgeSubmission` | `submissions.rejudge` | `{submission_id}` | `{type: "submission", id: 提交}` |
+| `rejudgeProblemSubmissions` | `submissions.rejudge` | `{problem_id, count}` | `{type: "problem", id: 题目}` |
+
+`updateSystemSetting` 埋点 (`settings.update`) 仅在 #105 合并后生效。
+
+#### Scenario: 7 处埋点全覆盖
+
+- **WHEN** admin 执行以下操作：role_change / ban / unban / delete problem / delete category / rejudge submission / rejudge problem
+- **THEN** audit_logs 对应新增 7 条记录，字段按上表填充
+
+### Requirement: 审计日志列表 API
+
+系统 SHALL 提供 `GET /api/v1/admin/audit-logs` 端点。
+
+查询参数：
+- `page` (默认 1) —— 页码
+- `per_page` (默认 20，上限 100) —— 每页条数
+- `admin_id` (可选) —— 按管理员 ID 筛选
+- `action` (可选) —— 按 action 筛选
+- `from` (可选) —— ISO 8601 起始时间
+- `to` (可选) —— ISO 8601 截止时间
+
+`listAuditLogs()` MUST 默认排除 `admin_id='0'` 的记录（root 用户审计）。显式传 `admin_id=0` 可查询。
+
+权限：仅 admin 可访问；非 admin 返回 403。
+
+响应：`{ data: AuditLogEntry[], pagination: { page, per_page, total } }`
+
+#### Scenario: 默认列表排除 root
+
+- **WHEN** admin 调用 `GET /api/v1/admin/audit-logs`
+- **THEN** 响应 data 不含 `admin_id='0'` 的记录
+- **THEN** pagination.total 仅统计非 root 记录
+
+#### Scenario: 按 action 筛选
+
+- **WHEN** admin 调用 `GET /api/v1/admin/audit-logs?action=users.ban`
+- **THEN** 响应仅含 action='users.ban' 的记录
+
+#### Scenario: 按时间范围筛选
+
+- **WHEN** admin 调用 `GET /api/v1/admin/audit-logs?from=2026-07-01T00:00:00Z&to=2026-07-04T23:59:59Z`
+- **THEN** 响应仅含 created_at 在该范围内的记录
+
+#### Scenario: 非 admin 访问 403
+
+- **WHEN** 普通用户调用 `GET /api/v1/admin/audit-logs`
+- **THEN** 返回 HTTP 403
+
+### Requirement: 90 天保留策略
+
+系统 SHALL 提供 `startAuditLogRetentionTask()` 后台任务。
+
+行为：
+- `main.ts` HTTP 启动后调用一次
+- 启动后立即跑一次 `cleanupOldAuditLogs(days)`
+- 每 24h 重复一次 `setInterval`
+- `AUDIT_LOG_RETENTION_DAYS` 环境变量控制天数（默认 90，0 = 禁用）
+- `cleanupOldAuditLogs(days)` 执行 `DELETE FROM audit_logs WHERE created_at <= now() - INTERVAL 'X days'`，返回删除行数
+- 多实例 core 并发清理幂等（DELETE range 无副作用）
+- 清理失败 `console.error` 记录，下次周期重试
+
+#### Scenario: 默认 90 天清理
+
+- **WHEN** `AUDIT_LOG_RETENTION_DAYS` 未设置或为 "90"
+- **THEN** 启动时立即删除 `created_at <= now - 90d` 的所有记录
+- **THEN** 每 24h 重复一次
+
+#### Scenario: 禁用清理
+
+- **WHEN** `AUDIT_LOG_RETENTION_DAYS=0`
+- **THEN** 启动时输出 info 日志 "审计日志清理任务已禁用"
+- **THEN** 不启动 setInterval
+
+#### Scenario: 自定义保留期
+
+- **WHEN** `AUDIT_LOG_RETENTION_DAYS=30`
+- **THEN** 删除 `created_at <= now - 30d` 的记录
+
+### Requirement: 管理后台 UI
+
+系统 SHALL 提供 `/admin/audit-logs` 页面。
+
+布局：
+- 顶部筛选条：操作类型下拉（7 个 action + "全部"）、管理员下拉（来自 `/api/v1/admin/users`）、时间范围（from/to 日期选择器）、重置按钮、筛选按钮
+- 中部表格列：时间（YYYY-MM-DD HH:mm:ss）、管理员（用户名）、操作（中文 label + 颜色 badge）、目标（type:id 简化展示）、详情（按 action narrow 渲染）、IP（带复制按钮）
+- 底部分页（复用 `paginationNav` 组件）
+
+详情列渲染规则：
+- `users.role_change`：`{from} → {to}`
+- `users.ban`：`reason + until`
+- `users.unban`：`已解封`
+- `problems.delete`：`title (display_id)`
+- `categories.delete`：`name (slug)`
+- `submissions.rejudge`：`submission_id` 或 `problem_id (×N)`
+- `settings.update`：`key: from → to`
+
+侧栏入口：navItems 新增 `{ label: "审计日志", to: "/admin/audit-logs", icon: ScrollText }`。
+
+权限：仅 admin 可访问；非 admin 重定向至首页或显示 403。
+
+#### Scenario: 列表渲染
+
+- **WHEN** admin 访问 `/admin/audit-logs`
+- **THEN** 加载审计日志表格（默认 page=1）
+- **THEN** 每行按 action 类型渲染详情列
+- **THEN** 表格按 created_at DESC 排序（最新在上）
+
+#### Scenario: 筛选交互
+
+- **WHEN** admin 选择 action="users.ban" + 点击"筛选"
+- **THEN** 重新请求 `GET /api/v1/admin/audit-logs?action=users.ban`
+- **THEN** 表格更新为仅显示 ban 操作
+
+#### Scenario: 详情复制
+
+- **WHEN** admin 点击 IP 列旁的复制按钮
+- **THEN** IP 字符串写入剪贴板（navigator.clipboard.writeText）
+- **THEN** 显示 toast "已复制"

--- a/openspec/changes/audit-log/tasks.md
+++ b/openspec/changes/audit-log/tasks.md
@@ -1,0 +1,90 @@
+# 任务清单 — Issue #101 审计日志
+
+## 1. OpenSpec 提案（已完成规划）
+
+- [x] 1.1 写 `proposal.md`（Why / What / Impact / Out of Scope）
+- [x] 1.2 写 `design.md`（Context / Goals / 9 项 Decisions / Schema / Risks）
+- [x] 1.3 写 `specs/audit-log/spec.md`（8 个 ADDED Requirements + 20 个 Scenarios）
+- [x] 1.4 写本 tasks.md
+
+## 2. DB 迁移
+
+- [ ] 2.1 写 `noj-core/drizzle/0012_audit_logs.sql`（建表 + CHECK + 3 索引）
+- [ ] 2.2 更新 `noj-core/drizzle/meta/_journal.json`（追加 0012 条目）
+- [ ] 2.3 同步 `noj-core/src/db/schema.ts`（新增 auditLogs 表）
+- [ ] 2.4 同步 `noj-core/src/db/schema-ddl.ts`（SCHEMA_DDL + SCHEMA_INDEXES 数组）
+
+## 3. 基础类型 + ALS
+
+- [ ] 3.1 `noj-core/src/types/audit-log.ts`：AuditAction / AuditDetail / AuditLogEntry
+- [ ] 3.2 `noj-core/src/lib/requestContext.ts`：AsyncLocalStorage 封装（runWithContext / getRequestContext / enterTestContext）
+
+## 4. Middleware 注入
+
+- [ ] 4.1 `noj-core/src/middleware/auth.ts` 改造：adminMiddleware 在 c.set("userRole") 后调 `runWithContext`
+- [ ] 4.2 复用既有 `getClientIp(c.req)` 工具（X-Forwarded-For + RemoteAddr 兜底）
+
+## 5. Service —— logAudit 核心
+
+- [ ] 5.1 `noj-core/src/services/audit-log.ts`：
+  - `logAudit(action, detail, target?)` —— 同步 INSERT，失败 console.error 不抛业务错误
+  - `listAuditLogs(filter)` —— 分页 + admin_id/action/from/to 筛选，默认排除 root
+  - `cleanupOldAuditLogs(days)` —— DELETE range，返回删除行数
+  - `startAuditLogRetentionTask()` —— 启动立即跑一次 + setInterval 24h 周期；AUDIT_LOG_RETENTION_DAYS=0 禁用
+
+## 6. 埋点（service 层 7 处）
+
+- [ ] 6.1 `noj-core/src/services/auth.ts`：promoteUser 末尾 `logAudit("users.role_change", {from, to}, {type: "user", id})`
+- [ ] 6.2 `noj-core/src/services/users.ts`：banUser 末尾 `logAudit("users.ban", {reason, until}, {type: "user", id})`
+- [ ] 6.3 `noj-core/src/services/users.ts`：unbanUser 末尾 `logAudit("users.unban", {}, {type: "user", id})`
+- [ ] 6.4 `noj-core/src/services/problems.ts`：deleteProblem 末尾 `logAudit("problems.delete", {title, display_id}, {type: "problem", id})`
+- [ ] 6.5 `noj-core/src/services/categories.ts`：deleteCategory 末尾 `logAudit("categories.delete", {name, slug}, {type: "category", id})`
+- [ ] 6.6 `noj-core/src/services/submissions.ts`：rejudgeSubmission 末尾 `logAudit("submissions.rejudge", {submission_id}, ...)`
+- [ ] 6.7 `noj-core/src/services/submissions.ts`：rejudgeProblemSubmissions 末尾 `logAudit("submissions.rejudge", {problem_id, count}, ...)`
+- [ ] 6.8 [条件性] `noj-core/src/services/settings.ts`：updateSystemSetting 末尾 `logAudit("settings.update", {key, from, to}, {type: "setting", id: key})` —— 仅当 #105 已合并
+
+## 7. 路由
+
+- [ ] 7.1 `noj-core/src/routes/admin.ts`：`GET /audit-logs`（分页 + 筛选）
+
+## 8. main.ts
+
+- [ ] 8.1 `noj-core/src/main.ts`：HTTP 启动后 `startAuditLogRetentionTask()`
+
+## 9. 后端测试
+
+- [ ] 9.1 `noj-core/tests/services/audit-log.test.ts`：logAudit 写入 / 字段映射 / ALS 缺失抛错 / cleanupOldAuditLogs / listAuditLogs 5 维度筛选
+- [ ] 9.2 `noj-core/tests/routes/admin-audit-logs.test.ts`：200 + 分页 + 401 + 403 + admin_id / action / from / to 筛选
+- [ ] 9.3 `noj-core/tests/services/auth.test.ts`：promoteUser 后 audit_logs 多 1 条 role_change 记录
+- [ ] 9.4 `noj-core/tests/services/users.test.ts`：banUser / unbanUser 各多 1 条
+- [ ] 9.5 `noj-core/tests/services/problems.test.ts`：deleteProblem 多 1 条
+- [ ] 9.6 `noj-core/tests/services/categories.test.ts`：deleteCategory 多 1 条
+- [ ] 9.7 `noj-core/tests/services/submissions.test.ts`：rejudgeSubmission / rejudgeProblemSubmissions 各多 1 条
+
+## 10. 前端
+
+- [ ] 10.1 `noj-ui/composables/useAuditLogs.ts`：列表数据 + 筛选状态管理
+- [ ] 10.2 `noj-ui/pages/admin/audit-logs.vue`：筛选条 + 表格 + 分页；detail 列按 action narrow 渲染（7 个渲染分支）
+- [ ] 10.3 `noj-ui/layouts/admin.vue`：navItems 新增 `{ label: "审计日志", to: "/admin/audit-logs", icon: ScrollText }`
+
+## 11. 环境变量文档
+
+- [ ] 11.1 `noj-core/.env.example`：新增 `AUDIT_LOG_RETENTION_DAYS=90`
+- [ ] 11.2 `noj-core/AGENTS.md`：环境变量表加 `AUDIT_LOG_RETENTION_DAYS`
+- [ ] 11.3 `AGENTS.md`（根）：已知限制章节追加"审计日志保留 90 天"
+
+## 12. 验证
+
+- [ ] 12.1 `deno fmt --check` 通过
+- [ ] 12.2 `deno lint` 通过
+- [ ] 12.3 `deno task test` 全量通过（既有 343+ + 新增 10+ = 353+）
+- [ ] 12.4 `noj-ui npm run build` 成功
+- [ ] 12.5 端到端冒烟：curl ban 用户 → curl GET /admin/audit-logs → 见到对应记录 + IP + detail
+
+## 13. 提交 + PR
+
+- [ ] 13.1 GPG 签名 commit（Conventional Commits + 中文描述）
+- [ ] 13.2 squash 历史（如有 `chore:` 占位）
+- [ ] 13.3 `jj git push` 或 `git push --set-upstream` 到 `origin/feat/issue-101-audit-log`
+- [ ] 13.4 `gh pr create` 标题 `feat(core,ui): 审计日志：管理员操作记录（issue #101）`，body 含验收项 + OpenSpec 引用
+- [ ] 13.5 添加 reviewer（@box3-galen-nv）


### PR DESCRIPTION
Closes #101

## 概述

为 NOJ 管理员操作提供完整的审计日志能力。引入 `audit_logs` 表 + `logAudit` service + 5 处 service 层埋点 + `GET /api/v1/admin/audit-logs` 路由 + 后台保留任务 + admin UI 查看页。

## 架构

- **RequestContext (AsyncLocalStorage)**：adminMiddleware 注入 `{ actorId, actorIp, actorRole }`，service 层通过 `getRequestContext()` 取用，函数签名零改动
- **logAudit service 核心**：`put/get/delete/downloadUrl` 风格的 4 方法 + `listAuditLogs` + `cleanupOldAuditLogs` + `startAuditLogRetentionTask`
- **同步直写**：失败仅 `console.error`，不抛业务错误（admin 操作不应因审计失败被拒）
- **后台 setInterval 任务**：90 天默认保留，可通过 `AUDIT_LOG_RETENTION_DAYS=0` 禁用

## 变更内容

### 后端 (noj-core)
- **新增 `audit_logs` 表**（迁移 `0013_audit_logs.sql`）：8 列 + 1 CHECK + 3 索引 + FK
  - 注：原计划 `0012` —— rebase 时与 PR #105 的 `0012_system_settings` 冲突，已重命名为 `0013`
- **`src/lib/requestContext.ts`**：AsyncLocalStorage 封装
- **`src/services/audit-log.ts`**：`logAudit` / `listAuditLogs` / `cleanupOldAuditLogs` / `startAuditLogRetentionTask`
- **`src/middleware/auth.ts`**：`adminMiddleware` 注入 RequestContext
- **`src/routes/admin.ts`**：`GET /api/v1/admin/audit-logs`（分页 + 4 维度筛选 + 默认排除 root）
- **`src/main.ts`**：HTTP 启动后调用 `startAuditLogRetentionTask()`
- **`src/types/audit-log.ts`**：`AuditAction` 联合 + `AuditDetail` discriminated union + `AuditLogEntry`
- **5 处 service 埋点**：`promoteUser` / `deleteProblem` / `deleteCategory` / `rejudgeSubmission` / `rejudgeProblemSubmissions`

### 前端 (noj-ui)
- **`composables/useAuditLogs.ts`**：列表 + 筛选状态管理（含类型导出）
- **`pages/admin/audit-logs.vue`**：筛选条 + 表格 + 分页 + IP 复制按钮
- **`layouts/admin.vue`**：侧栏新增"审计日志"入口（`ScrollText` 图标）

### 文档
- `noj-core/.env.example`：新增 `AUDIT_LOG_RETENTION_DAYS=90`
- `noj-core/AGENTS.md`：环境变量表追加
- `AGENTS.md`（根）：已知限制追加

### OpenSpec
完整提案写入 `openspec/changes/audit-log/`：
- `proposal.md`（Why / What / Impact / Out of Scope）
- `design.md`（Context / 9 Decisions / Schema / Risks）
- `tasks.md`（50+ 任务清单）
- `specs/audit-log/spec.md`（8 Requirements + 20 Scenarios）

## 已知延迟 / 后续 PR

| 项 | 原因 | 计划 |
|---|---|---|
| **T9 埋点（banUser/unbanUser）** | 函数本身在 PR #108 (`feat/issue-102-ip-blacklist`) 中，不在 main | #108 merge 后 rebase + 重跑 T9 |
| **setInterval retention 未 unref** | 进程关闭时未持有句柄 | 后续 PR 优化 |
| **fake Redis 测试基础设施 (~120 行)** | T12 临时方案，Deno ESM 模块不可 stub | 抽至 `tests/lib/fakeRedis.ts` |
| **UI 侧 `AuditDetail` 类型收窄** | 跨 discriminated union 在页面渲染时丢失类型 | 用 `Extract<AuditDetail, { action: typeof entry.action }>` 收窄 |
| **管理员下拉筛选（Req 8）** | spec 要求 UI 暴露 admin dropdown | 后续 PR |
| **`?action=` 参数校验** | 路由层直接 cast 到 `AuditAction \| undefined`，无效值落到空结果 | 加 400 校验 |
| **`getClientIp` 从 `rateLimitEnv.ts` 移出** | layering smell | 后续 PR |
| **`admin_id` FK `ON DELETE` 策略 + DELETE 批量化** | 防止 admin 删除阻塞 + 大表锁 | 后续 PR |
| **ALS-missing 测试断言 console.error** | 当前只验证无行写入，不验证日志输出 | 后续 PR |

## 验证

- `deno fmt --check` ✅（130 文件干净）
- `deno lint` ✅（T12 fake Redis lint warn 已修）
- `deno test -A` — **405 passed / 0 failed**（audit-log 相关 ~50+ 测试；pre-existing 失败与本 PR 无关）
- `nuxi typecheck` ✅
- `npm run build` ✅（5.63 MB / 1.53 MB gzip）
- 端到端冒烟：curl GET /admin/audit-logs 无 token → HTTP 401 ✓

## Reviews

- ✅ per-task review（21 个任务，每个任务都过了 spec/quality gate）
- ✅ final whole-branch review（21 项标准 + spec 检查）
- ✅ Standards review 修复（删除 `noj-ui/types/` 目录、补 trailing newlines）

## 迁移序号说明

| PR | 迁移文件 | journal idx |
|---|---|---|
| #104 (存储抽象层) | `0011_support_package_storage_url.sql` | 12 |
| #105 (系统设置面板) | `0012_system_settings.sql` | 13 |
| **#109 (本 PR)** | **`0013_audit_logs.sql`** | **14** |

## Rebase 历程

本分支经历 3 轮 rebase + 1 轮 filter-branch：
1. **R1**: rebase 到 PR #104 merge 后 → 解决 import/section 冲突
2. **Filter-branch**: 修复 2 个 commit 的 author（audit-log-bot / Neuro-OJ → chenmou2012）→ 触发签名失效
3. **Re-sign**: 21 个 commit 全部 `--amend --no-edit -S` 恢复 GPG 签名
4. **R2**: rebase 到 PR #105 merge 后 → 迁移序号冲突 → `0012_audit_logs` 重命名为 `0013_audit_logs`

## Standards review 修复（commit `b8152a2`）

- 删除 `noj-ui/types/` 目录（违反 CLAUDE.md "无单独 types/ 目录"），类型移入 `useAuditLogs.ts` 导出
- `useAuditLogs.ts` 末尾补 trailing newline
- `0013_audit_logs.sql` 末尾补 trailing newline

/cc @box3-galen-nv
