### PR TITLE
feat(core): 题目导入导出（issue #28，走法 A）

### DIFF
--- a/noj-core/drizzle/0017_audit_logs_problem_io.sql
+++ b/noj-core/drizzle/0017_audit_logs_problem_io.sql
@@ -1,0 +1,15 @@
+-- 扩展审计日志 action CHECK 约束（issue #28），新增 problems.import 和 problems.export
+ALTER TABLE "audit_logs" DROP CONSTRAINT IF EXISTS "audit_logs_action_check";
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_action_check" CHECK ("action" IN (
+  'users.role_change',
+  'users.ban',
+  'users.unban',
+  'problems.delete',
+  'problems.import',
+  'problems.export',
+  'categories.delete',
+  'submissions.rejudge',
+  'settings.update',
+  'ip_ban.create',
+  'ip_ban.delete'
+));

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1783120000400,
       "tag": "0016_audit_logs_ip_ban_actions",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1784000000000,
+      "tag": "0017_audit_logs_problem_io",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/src/lib/samples.ts
+++ b/noj-core/src/lib/samples.ts
@@ -91,13 +91,3 @@ export function extractSamples(description: string): SamplePair[] {
   }
   return pairs;
 }
-
-/**
- * 移除 description 中的所有样例段，返回剩余文本。
- * 用于导入时防止重复拼接。
- */
-export function removeSamplesSection(description: string): string {
-  const hits = collectHits(description);
-  if (hits.length === 0) return description;
-  return description.slice(0, hits[0].start).trimEnd();
-}

--- a/noj-core/src/lib/samples.ts
+++ b/noj-core/src/lib/samples.ts
@@ -1,0 +1,103 @@
+/**
+ * 题目样例解析器（issue #28）。
+ *
+ * 题目 description 是 Markdown 文本，约定使用 `## 样例输入` / `## 样例输出`
+ * 段标记可见样例。导入导出场景需要单独抽取出这些段。
+ *
+ * 支持的 heading 形式（# 表示 1-3 个 `#`）：
+ * - `## 样例输入` / `## 样例输入 #1`
+ * - `### Sample Input` 同样识别（英文混排场景）
+ *
+ * 配对规则：按出现顺序，遇到 `样例输入` 后必须紧跟 `样例输出` 才能配对。
+ * 连续两个输入时第一个被丢弃；末尾孤立输入/输出被忽略。
+ */
+
+export interface SamplePair {
+  input: string;
+  output: string;
+}
+
+interface Hit {
+  /** "输入" 或 "输出" */
+  type: "输入" | "输出";
+  /** heading 在原文的起始位置（用于切片） */
+  start: number;
+  /** heading 行结束位置（用于取正文起点） */
+  headingEnd: number;
+}
+
+/**
+ * 匹配样例相关 heading（大小写不敏感）：
+ *   ## 样例输入 / ## 样例输出 / ## Sample Input / ## Sample Output 等。
+ * 捕获组为 input/output/输入/输出 之一。 可选尾随 " #N" 编号。
+ */
+const HEADING_RE =
+  /^#{1,3}\s*样例\s*(input|output|输入|输出)(?:\s*#\s*\d+)?\s*$/gim;
+
+const KEY_MAP: Record<string, "输入" | "输出"> = {
+  "输入": "输入",
+  "输出": "输出",
+  "input": "输入",
+  "output": "输出",
+};
+
+function collectHits(description: string): Hit[] {
+  const hits: Hit[] = [];
+  for (const m of description.matchAll(HEADING_RE)) {
+    const start = m.index ?? 0;
+    const key = (m[1] ?? "").toLowerCase();
+    const type = KEY_MAP[key];
+    if (!type) continue;
+    hits.push({
+      type,
+      start,
+      headingEnd: start + m[0].length,
+    });
+  }
+  return hits;
+}
+
+/**
+ * 从 description 抽取所有可见样例对。
+ * 不解析 Markdown 代码块——样例本身就是预格式化文本。
+ */
+export function extractSamples(description: string): SamplePair[] {
+  const hits = collectHits(description);
+  if (hits.length === 0) return [];
+
+  // 取第 i 个 heading 段的正文：从 headingEnd 到下一个 heading start
+  const sectionContent = (i: number): string => {
+    const hit = hits[i];
+    const nextStart = i + 1 < hits.length
+      ? hits[i + 1].start
+      : description.length;
+    return description.slice(hit.headingEnd, nextStart).trim();
+  };
+
+  // 按出现顺序配对：每个 "输入" 段配对其后第一个 "输出" 段
+  const pairs: SamplePair[] = [];
+  for (let i = 0; i < hits.length; i++) {
+    if (hits[i].type !== "输入") continue;
+    if (i + 1 >= hits.length) break;
+    if (hits[i + 1].type !== "输出") {
+      // 输入后紧跟另一个输入 → 跳过当前输入
+      continue;
+    }
+    pairs.push({
+      input: sectionContent(i),
+      output: sectionContent(i + 1),
+    });
+    i++; // 消耗已配对的输出
+  }
+  return pairs;
+}
+
+/**
+ * 移除 description 中的所有样例段，返回剩余文本。
+ * 用于导入时防止重复拼接。
+ */
+export function removeSamplesSection(description: string): string {
+  const hits = collectHits(description);
+  if (hits.length === 0) return description;
+  return description.slice(0, hits[0].start).trimEnd();
+}

--- a/noj-core/src/routes/admin.ts
+++ b/noj-core/src/routes/admin.ts
@@ -9,6 +9,7 @@ import {
   importProblems,
   listAllProblems,
 } from "../services/problems.ts";
+import { logAudit } from "../services/audit-log.ts";
 import {
   createJudgeImage,
   deleteJudgeImage,
@@ -162,7 +163,19 @@ router.post("/problems/export", async (c) => {
 
   const payload = await buildExportPayload(query, c.get("userId"));
 
-  const filename = `noj-problems-${Date.now()}.json`;
+  // 审计：导出是元数据读取，但同 admin 账号连续多次导出可能泄漏题库结构
+  await logAudit("problems.export", {
+    action: "problems.export",
+    mode: query.ids !== undefined ? "ids" : "type",
+    type: query.type,
+    count: payload.problems.length,
+    ids: query.ids,
+  });
+
+  // 文件名加随机后缀，避免同毫秒并发导出的浏览器下载冲突
+  const filename = `noj-problems-${Date.now()}-${
+    crypto.randomUUID().slice(0, 6)
+  }.json`;
   return c.body(JSON.stringify(payload, null, 2), 200, {
     "Content-Type": "application/json; charset=utf-8",
     "Content-Disposition": `attachment; filename="${filename}"`,
@@ -177,6 +190,19 @@ router.post("/problems/export", async (c) => {
  * 返回导入结果报告。
  */
 router.post("/problems/import", async (c) => {
+  // 路由层 payload 大小上限（issue #28 PR #116 review）
+  // - Content-Length 上限 5MB（避免恶意大 payload OOM 服务）
+  // - problems 数量上限 1000（单次导入批次上限）
+  const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024;
+  const MAX_PROBLEMS_PER_IMPORT = 1000;
+
+  const contentLength = parseInt(c.req.header("content-length") ?? "0", 10);
+  if (Number.isFinite(contentLength) && contentLength > MAX_PAYLOAD_BYTES) {
+    throw new BadRequestError(
+      `请求体过大（${contentLength} 字节），上限 ${MAX_PAYLOAD_BYTES} 字节`,
+    );
+  }
+
   const body = await parseJsonBody<{
     strategy: string;
     payload: unknown;
@@ -196,6 +222,17 @@ router.post("/problems/import", async (c) => {
   }
   if (body.payload === undefined || body.payload === null) {
     throw new ValidationError("缺少必填字段：payload");
+  }
+
+  // problems 数量上限提前检查（在 parseImportPayload 之前）
+  const pre = body.payload as { problems?: unknown };
+  if (
+    Array.isArray(pre?.problems) &&
+    pre.problems.length > MAX_PROBLEMS_PER_IMPORT
+  ) {
+    throw new BadRequestError(
+      `单次导入 problems 数量 ${pre.problems.length} 超过上限 ${MAX_PROBLEMS_PER_IMPORT}`,
+    );
   }
 
   const report = await importProblems(

--- a/noj-core/src/routes/admin.ts
+++ b/noj-core/src/routes/admin.ts
@@ -4,7 +4,11 @@ import { parseJsonBody } from "../lib/request.ts";
 import { BadRequestError, ValidationError } from "../lib/errors.ts";
 import { listUsers, promoteUser } from "../services/auth.ts";
 import { getDashboardStats } from "../services/dashboard.ts";
-import { listAllProblems } from "../services/problems.ts";
+import {
+  buildExportPayload,
+  importProblems,
+  listAllProblems,
+} from "../services/problems.ts";
 import {
   createJudgeImage,
   deleteJudgeImage,
@@ -13,6 +17,7 @@ import {
 } from "../services/judge-images.ts";
 import type {
   CreateJudgeImageInput,
+  ImportStrategy,
   UpdateJudgeImageInput,
 } from "../types/problems.ts";
 import {
@@ -124,6 +129,82 @@ router.get("/problems", async (c) => {
     page: result.page,
     limit: result.limit,
   });
+});
+
+// ─── 题目导入导出（issue #28）──────────────────────────────
+
+/**
+ * 管理员导出题目集合为 JSON。
+ * POST /api/v1/admin/problems/export
+ * body: { ids?: string[]; type?: "U" | "P" }
+ *
+ * 返回 application/json 文件下载，Content-Disposition 携带文件名。
+ */
+router.post("/problems/export", async (c) => {
+  const body = await parseJsonBody<{ ids?: string[]; type?: string }>(c);
+
+  const query: { ids?: string[]; type?: "U" | "P" } = {};
+  if (body.ids !== undefined) {
+    if (!Array.isArray(body.ids)) {
+      throw new BadRequestError("ids 必须为字符串数组");
+    }
+    if (body.ids.some((id) => typeof id !== "string" || id.length === 0)) {
+      throw new BadRequestError("ids 数组中不能包含空字符串或非字符串元素");
+    }
+    query.ids = body.ids;
+  }
+  if (body.type !== undefined) {
+    if (body.type !== "U" && body.type !== "P") {
+      throw new BadRequestError(`非法 type：${body.type}（仅允许 U/P）`);
+    }
+    query.type = body.type;
+  }
+
+  const payload = await buildExportPayload(query, c.get("userId"));
+
+  const filename = `noj-problems-${Date.now()}.json`;
+  return c.body(JSON.stringify(payload, null, 2), 200, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Disposition": `attachment; filename="${filename}"`,
+  });
+});
+
+/**
+ * 管理员导入题目集合。
+ * POST /api/v1/admin/problems/import
+ * body: { strategy: "create" | "overwrite" | "skip"; payload: ExportPayload }
+ *
+ * 返回导入结果报告。
+ */
+router.post("/problems/import", async (c) => {
+  const body = await parseJsonBody<{
+    strategy: string;
+    payload: unknown;
+  }>(c);
+
+  if (!body.strategy) {
+    throw new ValidationError("缺少必填字段：strategy");
+  }
+  if (
+    body.strategy !== "create" &&
+    body.strategy !== "overwrite" &&
+    body.strategy !== "skip"
+  ) {
+    throw new BadRequestError(
+      `非法 strategy：${body.strategy}（仅允许 create/overwrite/skip）`,
+    );
+  }
+  if (body.payload === undefined || body.payload === null) {
+    throw new ValidationError("缺少必填字段：payload");
+  }
+
+  const report = await importProblems(
+    body.payload,
+    body.strategy as ImportStrategy,
+    c.get("userId"),
+    c.get("userRole"),
+  );
+  return c.json({ data: report }, 200);
 });
 
 // ─── 提交管理 ───────────────────────────────────────────────

--- a/noj-core/src/services/problems.ts
+++ b/noj-core/src/services/problems.ts
@@ -25,6 +25,13 @@ import {
 import {
   type CreateProblemInput,
   DIFFICULTIES,
+  EXPORT_VERSION,
+  type ExportPayload,
+  type ExportProblem,
+  type ExportQuery,
+  type ImportItemResult,
+  type ImportReport,
+  type ImportStrategy,
   isValidDifficulty,
   isValidProblemType,
   type ProblemListQuery,
@@ -33,6 +40,8 @@ import {
 } from "../types/problems.ts";
 import { validateJudgeImage } from "./judge-images.ts";
 import { getStorageProvider } from "../lib/storage/mod.ts";
+import { extractSamples } from "../lib/samples.ts";
+import { listCategories } from "./categories.ts";
 import { logAudit } from "./audit-log.ts";
 
 export interface ProblemResponse {
@@ -739,4 +748,437 @@ export async function syncProblemCategories(
       })),
     );
   }
+}
+
+// ─── 题目导入导出（issue #28）─────────────────────────────────
+
+/**
+ * 校验 support_package_storage_url 格式合法。
+ *
+ * 走法 A 不做可达性检查——导出是元数据操作，不应因为临时 S3 故障
+ * 就让导出失败。如果 URL 真正坏掉，导入后 judge 端评测会自然报错。
+ * 这里只拦截明显错误的协议前缀，避免 round-trip 引入脏数据。
+ */
+function assertStorageUrlFormat(url: string | null): void {
+  if (!url) return;
+  if (
+    !url.startsWith("noj-storage://") &&
+    !url.startsWith("noj-download://")
+  ) {
+    throw new BadRequestError(
+      `支持包 URL 协议不受支持：${url}（仅支持 noj-storage:// 或 noj-download://）`,
+    );
+  }
+}
+
+/**
+ * 导出题目集合为标准 JSON 结构。
+ *
+ * 查询模式：
+ * - `ids` 优先：按指定 id 列表精确导出
+ * - `type`：按题目类型批量导出（U/P 全部）
+ * - 二者都未提供或都提供 → 拒绝
+ *
+ * 返回结构遵循 EXPORT_VERSION 约定的字段命名，round-trip 安全。
+ *
+ * @throws {BadRequestError} 查询参数非法 / 支持包 URL 校验失败
+ */
+export async function buildExportPayload(
+  query: ExportQuery,
+  exportedBy: string,
+): Promise<ExportPayload> {
+  const db = getDb();
+
+  // 互斥校验
+  const hasIds = query.ids !== undefined && query.ids.length > 0;
+  const hasType = query.type !== undefined;
+  if (hasIds && hasType) {
+    throw new BadRequestError("ids 和 type 互斥，请二选一");
+  }
+  if (!hasIds && !hasType) {
+    throw new BadRequestError("必须提供 ids 或 type 之一");
+  }
+  if (hasType && query.type !== undefined && !isValidProblemType(query.type)) {
+    throw new BadRequestError(
+      `非法题目类型：${query.type}，仅允许 U/P`,
+    );
+  }
+
+  // 查询题目
+  let rows: (typeof problems.$inferSelect)[];
+  if (hasIds) {
+    rows = await db
+      .select()
+      .from(problems)
+      .where(inArray(problems.id, query.ids!));
+  } else {
+    rows = await db
+      .select()
+      .from(problems)
+      .where(eq(problems.type, query.type!));
+  }
+
+  if (rows.length === 0) {
+    return {
+      version: EXPORT_VERSION,
+      exported_at: new Date().toISOString(),
+      exported_by: exportedBy,
+      problems: [],
+    };
+  }
+
+  // 注入分类信息
+  const catMap = await attachCategories(rows.map((r) => r.id));
+
+  // 校验所有 support_package URL 协议前缀合法
+  for (const row of rows) {
+    assertStorageUrlFormat(row.support_package_storage_url);
+  }
+
+  // 组装 ExportProblem
+  const exportedProblems: ExportProblem[] = rows.map((row) => {
+    const cats = catMap.get(row.id) ?? [];
+    return {
+      id: row.id,
+      display_id: `${row.type}${row.number}`,
+      type: row.type as "U" | "P",
+      number: row.number,
+      title: row.title,
+      description: row.description,
+      difficulty: row.difficulty,
+      categories: cats.map((c) => ({ name: c.name, slug: c.slug })),
+      // judge_images 暂时只暴露单值（与当前 schema 一致：1 道题 = 1 镜像）。
+      // 字段设计为数组是为未来多镜像留口。
+      judge_images: [row.judge_image],
+      judge_command: row.judge_command,
+      time_limit_ms: row.time_limit_ms,
+      memory_limit_mb: row.memory_limit_mb,
+      support_package_storage_url: row.support_package_storage_url,
+      test_cases_ref: row.support_package_storage_url,
+      samples: extractSamples(row.description),
+    };
+  });
+
+  return {
+    version: EXPORT_VERSION,
+    exported_at: new Date().toISOString(),
+    exported_by: exportedBy,
+    problems: exportedProblems,
+  };
+}
+
+// ─── 导入服务 ──────────────────────────────────────────────
+
+/**
+ * 导入 payload 类型守卫。
+ * 校验 version、problems 数组、每个 ExportProblem 的基本字段。
+ */
+function parseImportPayload(input: unknown): ExportPayload {
+  if (!input || typeof input !== "object") {
+    throw new BadRequestError("导入文件必须为 JSON 对象");
+  }
+  const obj = input as Record<string, unknown>;
+  if (obj.version !== EXPORT_VERSION) {
+    throw new BadRequestError(
+      `不支持的导入文件版本：${
+        String(obj.version)
+      }（当前仅支持 ${EXPORT_VERSION}）`,
+    );
+  }
+  if (!Array.isArray(obj.problems)) {
+    throw new BadRequestError("导入文件必须包含 problems 数组");
+  }
+  for (let i = 0; i < obj.problems.length; i++) {
+    const p = obj.problems[i] as Record<string, unknown> | null;
+    if (!p || typeof p !== "object") {
+      throw new BadRequestError(`problems[${i}] 不是合法对象`);
+    }
+    for (
+      const field of [
+        "id",
+        "title",
+        "description",
+        "judge_command",
+        "type",
+        "number",
+      ]
+    ) {
+      if (!(field in p)) {
+        throw new BadRequestError(
+          `problems[${i}] 缺少必填字段：${field}`,
+        );
+      }
+    }
+  }
+  return obj as unknown as ExportPayload;
+}
+
+/**
+ * 构建分类 name → id 映射（用于按 name 解析导入题目中的分类关联）。
+ *
+ * 走法 A 不支持自动创建分类——不存在的分类名会被忽略（warning），
+ * 由 admin 自行在导入前手动创建，避免脏数据。
+ */
+async function buildCategoryLookup(): Promise<Map<string, string>> {
+  const tree = await listCategories();
+  const map = new Map<string, string>();
+  const visit = (nodes: typeof tree) => {
+    for (const n of nodes) {
+      map.set(n.name, n.id);
+      if (n.children.length > 0) visit(n.children);
+    }
+  };
+  visit(tree);
+  return map;
+}
+
+/**
+ * 把单个 ExportProblem 落到数据库。
+ *
+ * 策略行为：
+ * - create: 已存在 → skip；不存在 → 新建
+ * - overwrite: 已存在 → 更新（type/number 不可变）；不存在 → 新建
+ * - skip: 已存在 → skip；不存在 → 新建
+ *
+ * 权限：
+ * - 仅 admin 可调用
+ * - 若 import 项的 type='P'，会校验 userRole
+ *
+ * @returns 该条目的处理结果（含写入后的 problem_id）
+ */
+async function importOne(
+  item: ExportProblem,
+  strategy: ImportStrategy,
+  userId: string,
+  userRole: string,
+  categoryLookup: Map<string, string>,
+): Promise<ImportItemResult> {
+  const baseResult: Omit<ImportItemResult, "action" | "problem_id"> = {
+    id: item.id,
+    display_id: item.display_id,
+  };
+
+  // 1. 难度值校验
+  if (!isValidDifficulty(item.difficulty)) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: `非法难度值：${item.difficulty}`,
+    };
+  }
+
+  // 2. 题目类型校验
+  if (!isValidProblemType(item.type)) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: `非法题目类型：${item.type}`,
+    };
+  }
+
+  // 3. P 型题需要 admin
+  if (item.type === "P" && userRole !== "admin") {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: "P 型题仅管理员可导入",
+    };
+  }
+
+  // 4. judge_images 校验（当前 schema 是 1:1，取第一个）
+  const judgeImage = item.judge_images[0];
+  if (!judgeImage) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: "judge_images 数组为空",
+    };
+  }
+  try {
+    await validateJudgeImage(judgeImage);
+  } catch (err) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: `judge_image 校验失败：${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+
+  // 5. support_package_storage_url 协议前缀校验
+  if (item.support_package_storage_url) {
+    if (
+      !item.support_package_storage_url.startsWith("noj-storage://") &&
+      !item.support_package_storage_url.startsWith("noj-download://")
+    ) {
+      return {
+        ...baseResult,
+        action: "failed",
+        reason: `支持包 URL 协议不受支持：${item.support_package_storage_url}`,
+      };
+    }
+  }
+
+  // 6. 分类解析（按 name 查；找不到的跳过）
+  const categoryIds: string[] = [];
+  const missingCategories: string[] = [];
+  for (const c of item.categories) {
+    const id = categoryLookup.get(c.name);
+    if (id) {
+      categoryIds.push(id);
+    } else {
+      missingCategories.push(c.name);
+    }
+  }
+
+  // 7. 检查目标问题是否存在（按 source id）
+  const db = getDb();
+  const existing = await db
+    .select()
+    .from(problems)
+    .where(eq(problems.id, item.id))
+    .limit(1);
+
+  if (existing.length > 0) {
+    // 目标已存在
+    if (strategy === "create" || strategy === "skip") {
+      return {
+        ...baseResult,
+        action: "skipped",
+        reason: strategy === "create"
+          ? "目标 id 已存在，create 策略跳过"
+          : "目标 id 已存在，skip 策略跳过",
+        problem_id: existing[0].id,
+      };
+    }
+    // overwrite：更新元数据
+    const updates: Record<string, unknown> = {
+      title: item.title,
+      description: item.description,
+      difficulty: item.difficulty,
+      judge_image: judgeImage,
+      judge_command: item.judge_command,
+      support_package_storage_url: item.support_package_storage_url,
+      time_limit_ms: item.time_limit_ms,
+      memory_limit_mb: item.memory_limit_mb,
+      updated_at: new Date().toISOString(),
+    };
+    await db.update(problems).set(updates).where(eq(problems.id, item.id));
+    await syncProblemCategories(item.id, categoryIds);
+    return {
+      ...baseResult,
+      action: "updated",
+      problem_id: item.id,
+    };
+  }
+
+  // 8. 目标不存在 → 新建
+  try {
+    const created = await createProblem(
+      {
+        title: item.title,
+        description: item.description,
+        difficulty: item.difficulty,
+        judge_image: judgeImage,
+        judge_command: item.judge_command,
+        support_package_storage_url: item.support_package_storage_url,
+        time_limit_ms: item.time_limit_ms,
+        memory_limit_mb: item.memory_limit_mb,
+        type: item.type,
+        number: item.number,
+        category_ids: categoryIds,
+      },
+      userId,
+      userRole,
+    );
+    const reasonSuffix = missingCategories.length > 0
+      ? `（注意：以下分类在当前 DB 不存在，已忽略：${
+        missingCategories.join("、")
+      }）`
+      : undefined;
+    return {
+      ...baseResult,
+      action: "created",
+      problem_id: created.id,
+      reason: reasonSuffix,
+    };
+  } catch (err) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: `创建失败：${err instanceof Error ? err.message : String(err)}${
+        missingCategories.length > 0
+          ? `；缺失分类：${missingCategories.join("、")}`
+          : ""
+      }`,
+    };
+  }
+}
+
+/**
+ * 批量导入题目。
+ *
+ * @param input 原始 JSON（来自请求体或文件）
+ * @param strategy 三种策略之一
+ * @param userId 当前 admin id
+ * @param userRole 当前 admin role
+ * @returns 导入结果报告（按 action 分桶）
+ */
+export async function importProblems(
+  input: unknown,
+  strategy: ImportStrategy,
+  userId: string,
+  userRole: string,
+): Promise<ImportReport> {
+  if (
+    strategy !== "create" && strategy !== "overwrite" && strategy !== "skip"
+  ) {
+    throw new BadRequestError(
+      `非法导入策略：${strategy}（仅支持 create/overwrite/skip）`,
+    );
+  }
+
+  const payload = parseImportPayload(input);
+
+  // 预构建分类查找表（一次查询，避免 N+1）
+  const categoryLookup = await buildCategoryLookup();
+
+  const created: ImportItemResult[] = [];
+  const updated: ImportItemResult[] = [];
+  const skipped: ImportItemResult[] = [];
+  const failed: ImportItemResult[] = [];
+
+  for (const item of payload.problems) {
+    const result = await importOne(
+      item,
+      strategy,
+      userId,
+      userRole,
+      categoryLookup,
+    );
+    switch (result.action) {
+      case "created":
+        created.push(result);
+        break;
+      case "updated":
+        updated.push(result);
+        break;
+      case "skipped":
+        skipped.push(result);
+        break;
+      case "failed":
+        failed.push(result);
+        break;
+    }
+  }
+
+  return {
+    strategy,
+    total: payload.problems.length,
+    created,
+    updated,
+    skipped,
+    failed,
+  };
 }

--- a/noj-core/src/services/problems.ts
+++ b/noj-core/src/services/problems.ts
@@ -870,14 +870,21 @@ export async function buildExportPayload(
 // ─── 导入服务 ──────────────────────────────────────────────
 
 /**
- * 导入 payload 类型守卫。
- * 校验 version、problems 数组、每个 ExportProblem 的基本字段。
+ * 导入 payload 类型守卫（issue #28 PR #116 review 强化）。
+ *
+ * 显式校验 ExportPayload 每个字段的类型，避免 silent cast。
+ * 任一字段非法都抛 BadRequestError，整体拒绝导入。
+ *
+ * 注意：返回的 ExportPayload 仍带 unknown 转换，但每一字段都已经在
+ * 此处经过类型校验——下游 importOne 可安全访问。
  */
 function parseImportPayload(input: unknown): ExportPayload {
   if (!input || typeof input !== "object") {
     throw new BadRequestError("导入文件必须为 JSON 对象");
   }
   const obj = input as Record<string, unknown>;
+
+  // ── 顶层字段 ──
   if (obj.version !== EXPORT_VERSION) {
     throw new BadRequestError(
       `不支持的导入文件版本：${
@@ -885,27 +892,149 @@ function parseImportPayload(input: unknown): ExportPayload {
       }（当前仅支持 ${EXPORT_VERSION}）`,
     );
   }
+  if (typeof obj.exported_at !== "string") {
+    throw new BadRequestError("exported_at 必须为字符串");
+  }
+  if (typeof obj.exported_by !== "string") {
+    throw new BadRequestError("exported_by 必须为字符串");
+  }
   if (!Array.isArray(obj.problems)) {
     throw new BadRequestError("导入文件必须包含 problems 数组");
   }
+
+  // ── problems[] 字段 ──
   for (let i = 0; i < obj.problems.length; i++) {
     const p = obj.problems[i] as Record<string, unknown> | null;
     if (!p || typeof p !== "object") {
       throw new BadRequestError(`problems[${i}] 不是合法对象`);
     }
+
+    // 字符串必填
     for (
       const field of [
         "id",
+        "display_id",
         "title",
         "description",
         "judge_command",
-        "type",
-        "number",
       ]
     ) {
-      if (!(field in p)) {
+      if (typeof p[field] !== "string" || (p[field] as string).length === 0) {
         throw new BadRequestError(
-          `problems[${i}] 缺少必填字段：${field}`,
+          `problems[${i}].${field} 必须为非空字符串`,
+        );
+      }
+    }
+
+    // type: U / P
+    if (p.type !== "U" && p.type !== "P") {
+      throw new BadRequestError(
+        `problems[${i}].type 必须为 "U" 或 "P"（当前：${String(p.type)}）`,
+      );
+    }
+
+    // number: 正整数
+    if (
+      typeof p.number !== "number" || !Number.isInteger(p.number) ||
+      p.number < 1
+    ) {
+      throw new BadRequestError(
+        `problems[${i}].number 必须为正整数（当前：${String(p.number)}）`,
+      );
+    }
+
+    // difficulty: 字符串 + 合法值
+    if (typeof p.difficulty !== "string" || !isValidDifficulty(p.difficulty)) {
+      throw new BadRequestError(
+        `problems[${i}].difficulty 非法（${String(p.difficulty)}）`,
+      );
+    }
+
+    // categories: 数组，元素 {name: string, slug: string}
+    if (!Array.isArray(p.categories)) {
+      throw new BadRequestError(`problems[${i}].categories 必须为数组`);
+    }
+    for (let j = 0; j < p.categories.length; j++) {
+      const c = p.categories[j] as Record<string, unknown> | null;
+      if (!c || typeof c !== "object") {
+        throw new BadRequestError(
+          `problems[${i}].categories[${j}] 不是合法对象`,
+        );
+      }
+      if (typeof c.name !== "string" || (c.name as string).length === 0) {
+        throw new BadRequestError(
+          `problems[${i}].categories[${j}].name 必须为非空字符串`,
+        );
+      }
+      if (typeof c.slug !== "string" || (c.slug as string).length === 0) {
+        throw new BadRequestError(
+          `problems[${i}].categories[${j}].slug 必须为非空字符串`,
+        );
+      }
+    }
+
+    // judge_images: 非空字符串数组
+    if (
+      !Array.isArray(p.judge_images) ||
+      p.judge_images.length === 0 ||
+      !p.judge_images.every((img) => typeof img === "string" && img.length > 0)
+    ) {
+      throw new BadRequestError(
+        `problems[${i}].judge_images 必须为非空字符串数组`,
+      );
+    }
+
+    // time_limit_ms / memory_limit_mb: 正整数
+    if (
+      typeof p.time_limit_ms !== "number" ||
+      !Number.isInteger(p.time_limit_ms) ||
+      p.time_limit_ms < 1
+    ) {
+      throw new BadRequestError(
+        `problems[${i}].time_limit_ms 必须为正整数`,
+      );
+    }
+    if (
+      typeof p.memory_limit_mb !== "number" ||
+      !Number.isInteger(p.memory_limit_mb) ||
+      p.memory_limit_mb < 1
+    ) {
+      throw new BadRequestError(
+        `problems[${i}].memory_limit_mb 必须为正整数`,
+      );
+    }
+
+    // support_package_storage_url: string | null
+    if (
+      p.support_package_storage_url !== null &&
+      typeof p.support_package_storage_url !== "string"
+    ) {
+      throw new BadRequestError(
+        `problems[${i}].support_package_storage_url 必须为字符串或 null`,
+      );
+    }
+
+    // test_cases_ref: string | null（语义占位，与 support_package_storage_url 同值）
+    if (
+      p.test_cases_ref !== null && typeof p.test_cases_ref !== "string"
+    ) {
+      throw new BadRequestError(
+        `problems[${i}].test_cases_ref 必须为字符串或 null`,
+      );
+    }
+
+    // samples: 数组，元素 {input: string, output: string}
+    if (!Array.isArray(p.samples)) {
+      throw new BadRequestError(`problems[${i}].samples 必须为数组`);
+    }
+    for (let j = 0; j < p.samples.length; j++) {
+      const s = p.samples[j] as Record<string, unknown> | null;
+      if (!s || typeof s !== "object") {
+        throw new BadRequestError(`problems[${i}].samples[${j}] 不是合法对象`);
+      }
+      if (typeof s.input !== "string" || typeof s.output !== "string") {
+        throw new BadRequestError(
+          `problems[${i}].samples[${j}].input/output 必须为字符串`,
         );
       }
     }
@@ -936,13 +1065,18 @@ async function buildCategoryLookup(): Promise<Map<string, string>> {
  * 把单个 ExportProblem 落到数据库。
  *
  * 策略行为：
- * - create: 已存在 → skip；不存在 → 新建
- * - overwrite: 已存在 → 更新（type/number 不可变）；不存在 → 新建
- * - skip: 已存在 → skip；不存在 → 新建
+ * - create: 不存在 → 新建；已存在 → skip（不报错）
+ * - overwrite: 不存在 → 新建；已存在 → 更新元数据（type/number 不可变）
+ * - skip: 不存在 → fail（docstring 与实现对齐）；已存在 → skip
  *
  * 权限：
  * - 仅 admin 可调用
  * - 若 import 项的 type='P'，会校验 userRole
+ *
+ * 幂等性：
+ * - 目标不存在路径使用 `crypto.randomUUID()` 重新生成 id，与导出时的
+ *   UUID 不一致——这是**快照语义**。若需要 round-trip 等价，请使用
+ *   overwrite 策略并在导入前确保目标已存在。
  *
  * @returns 该条目的处理结果（含写入后的 problem_id）
  */
@@ -958,7 +1092,7 @@ async function importOne(
     display_id: item.display_id,
   };
 
-  // 1. 难度值校验
+  // 1. 难度值校验（parseImportPayload 已校验，这里双保险）
   if (!isValidDifficulty(item.difficulty)) {
     return {
       ...baseResult,
@@ -1033,15 +1167,30 @@ async function importOne(
   }
 
   // 7. 检查目标问题是否存在（按 source id）
+  //    race-safe：单条 SQL 原子 UPDATE，不存在则 affectedRows=0；并发场景下
+  //    两条 SQL 串行执行不会丢更新。post-UPDATE 再 SELECT 拿到最新 id。
   const db = getDb();
-  const existing = await db
-    .select()
-    .from(problems)
-    .where(eq(problems.id, item.id))
-    .limit(1);
+  const now = new Date().toISOString();
+  const updates: Record<string, unknown> = {
+    title: item.title,
+    description: item.description,
+    difficulty: item.difficulty,
+    judge_image: judgeImage,
+    judge_command: item.judge_command,
+    support_package_storage_url: item.support_package_storage_url,
+    time_limit_ms: item.time_limit_ms,
+    memory_limit_mb: item.memory_limit_mb,
+    updated_at: now,
+  };
 
-  if (existing.length > 0) {
-    // 目标已存在
+  const updateResult = await db
+    .update(problems)
+    .set(updates)
+    .where(eq(problems.id, item.id))
+    .returning({ id: problems.id });
+
+  if (updateResult.length > 0) {
+    // 目标已存在 → UPDATE 成功
     if (strategy === "create" || strategy === "skip") {
       return {
         ...baseResult,
@@ -1049,31 +1198,29 @@ async function importOne(
         reason: strategy === "create"
           ? "目标 id 已存在，create 策略跳过"
           : "目标 id 已存在，skip 策略跳过",
-        problem_id: existing[0].id,
+        problem_id: updateResult[0].id,
       };
     }
-    // overwrite：更新元数据
-    const updates: Record<string, unknown> = {
-      title: item.title,
-      description: item.description,
-      difficulty: item.difficulty,
-      judge_image: judgeImage,
-      judge_command: item.judge_command,
-      support_package_storage_url: item.support_package_storage_url,
-      time_limit_ms: item.time_limit_ms,
-      memory_limit_mb: item.memory_limit_mb,
-      updated_at: new Date().toISOString(),
-    };
-    await db.update(problems).set(updates).where(eq(problems.id, item.id));
+    // overwrite：更新元数据 + 同步分类
     await syncProblemCategories(item.id, categoryIds);
     return {
       ...baseResult,
       action: "updated",
-      problem_id: item.id,
+      problem_id: updateResult[0].id,
     };
   }
 
-  // 8. 目标不存在 → 新建
+  // 8. UPDATE 命中 0 行 → 目标不存在
+  if (strategy === "skip") {
+    // skip 策略：docstring 承诺"不存在则新建失败"
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: "skip 策略：目标 id 不存在（按约定拒绝创建）",
+    };
+  }
+
+  // create / overwrite：新建
   try {
     const created = await createProblem(
       {
@@ -1172,6 +1319,20 @@ export async function importProblems(
         break;
     }
   }
+
+  // 审计日志：记录本次批量导入汇总（每条详情不进审计，避免膨胀）
+  await logAudit(
+    "problems.import",
+    {
+      action: "problems.import",
+      strategy,
+      total: payload.problems.length,
+      created: created.length,
+      updated: updated.length,
+      skipped: skipped.length,
+      failed: failed.length,
+    },
+  );
 
   return {
     strategy,

--- a/noj-core/src/types/audit-log.ts
+++ b/noj-core/src/types/audit-log.ts
@@ -11,6 +11,8 @@ export type AuditAction =
   | "users.ban"
   | "users.unban"
   | "problems.delete"
+  | "problems.import"
+  | "problems.export"
   | "categories.delete"
   | "submissions.rejudge"
   | "settings.update"
@@ -23,6 +25,22 @@ export type AuditDetail =
   | { action: "users.ban"; reason: string; until: string | null }
   | { action: "users.unban" }
   | { action: "problems.delete"; title: string; display_id: string }
+  | {
+    action: "problems.import";
+    strategy: "create" | "overwrite" | "skip";
+    total: number;
+    created: number;
+    updated: number;
+    skipped: number;
+    failed: number;
+  }
+  | {
+    action: "problems.export";
+    mode: "ids" | "type";
+    type?: "U" | "P";
+    count: number;
+    ids?: string[];
+  }
   | {
     action: "categories.delete";
     name: string;

--- a/noj-core/src/types/problems.ts
+++ b/noj-core/src/types/problems.ts
@@ -164,9 +164,16 @@ export const EXPORT_VERSION = "1.0" as const;
  * 导出单题结构。
  *
  * 字段命名约定：
- * - 蛇形命名（snake_case）保持与 DB 列一致，便于 round-trip
+ * - 蛇形命名（snake_case）保持与 DB 列一致
  * - 列表类字段（categories / judge_images / samples）按显示顺序排列
- * - display_id = `${type}${number}`，从 type+number 计算得出，导入时可任选其一
+ * - display_id = `${type}${number}`，从 type+number 计算得出
+ *
+ * **快照语义（PR #116 review 明确化）**：
+ * - `id` 字段是导出时刻的题目 UUID，**导入时不再保留**——create/overwrite
+ *   在目标不存在时由服务端重新生成 UUID。
+ * - 若需要 round-trip 等价（保留 id），应在导入前保证目标 id 已存在
+ *   并使用 overwrite 策略。
+ * - 删除 `id` 字段不影响导入路径（仅作 informational reference）。
  */
 export interface ExportProblem {
   id: string;
@@ -211,7 +218,7 @@ export interface ExportQuery {
  * 导入策略。
  * - create: 不存在则新建；存在则按 skip 处理（不报错）
  * - overwrite: 不存在则新建；存在则覆盖元数据（type/number 不可变）
- * - skip: 不存在则新建失败；存在则跳过
+ * - skip: 不存在则按 failed 报告；存在则跳过
  */
 export type ImportStrategy = "create" | "overwrite" | "skip";
 

--- a/noj-core/src/types/problems.ts
+++ b/noj-core/src/types/problems.ts
@@ -152,6 +152,96 @@ export interface JudgeImageResponse {
   updated_at: string;
 }
 
+// ─── 题目导入导出（issue #28）─────────────────────────────────
+
+/**
+ * 导出文件格式版本号。
+ * v1.0 = 走法 A：仅元数据 + support_package_storage_url 引用 + samples。
+ */
+export const EXPORT_VERSION = "1.0" as const;
+
+/**
+ * 导出单题结构。
+ *
+ * 字段命名约定：
+ * - 蛇形命名（snake_case）保持与 DB 列一致，便于 round-trip
+ * - 列表类字段（categories / judge_images / samples）按显示顺序排列
+ * - display_id = `${type}${number}`，从 type+number 计算得出，导入时可任选其一
+ */
+export interface ExportProblem {
+  id: string;
+  display_id: string;
+  type: "U" | "P";
+  number: number;
+  title: string;
+  description: string;
+  difficulty: string;
+  categories: { name: string; slug: string }[];
+  judge_images: string[];
+  judge_command: string;
+  time_limit_ms: number;
+  memory_limit_mb: number;
+  support_package_storage_url: string | null;
+  /** 引用支持包 URL（与 support_package_storage_url 同值，仅作为语义占位） */
+  test_cases_ref: string | null;
+  samples: { input: string; output: string }[];
+}
+
+/**
+ * 完整导出文件结构。
+ */
+export interface ExportPayload {
+  version: typeof EXPORT_VERSION;
+  exported_at: string;
+  exported_by: string;
+  problems: ExportProblem[];
+}
+
+/**
+ * 导出查询参数。
+ * - ids 与 type 互斥：ids 优先，type 用于批量筛选（U/P 全部）
+ * - 都未提供时拒绝（避免误操作全表导出）
+ */
+export interface ExportQuery {
+  ids?: string[];
+  type?: "U" | "P";
+}
+
+/**
+ * 导入策略。
+ * - create: 不存在则新建；存在则按 skip 处理（不报错）
+ * - overwrite: 不存在则新建；存在则覆盖元数据（type/number 不可变）
+ * - skip: 不存在则新建失败；存在则跳过
+ */
+export type ImportStrategy = "create" | "overwrite" | "skip";
+
+/**
+ * 导入单条结果。
+ */
+export interface ImportItemResult {
+  /** 来源 id（ExportProblem.id），便于追踪失败项 */
+  id: string;
+  display_id: string;
+  /** created / updated / skipped / failed */
+  action: "created" | "updated" | "skipped" | "failed";
+  /** 失败原因（仅 action=failed 时存在） */
+  reason?: string;
+  /** 写入后服务端 id（skipped 时为已存在题目 id，failed 时不存在） */
+  problem_id?: string;
+}
+
+/**
+ * 导入结果报告。
+ */
+export interface ImportReport {
+  strategy: ImportStrategy;
+  total: number;
+  created: ImportItemResult[];
+  updated: ImportItemResult[];
+  skipped: ImportItemResult[];
+  failed: ImportItemResult[];
+}
+
 /**
  * 校验 judge_image 是否与白名单匹配。
  * exact 模式：完全相等；all_versions 模式：镜像名去掉标签后匹配。

--- a/noj-core/tests/lib/samples.test.ts
+++ b/noj-core/tests/lib/samples.test.ts
@@ -5,7 +5,7 @@
  * 标记可见样例。导入导出时需要把这些段单独抽出来。
  */
 import { assertEquals } from "jsr:@std/assert@^1";
-import { extractSamples, removeSamplesSection } from "../../src/lib/samples.ts";
+import { extractSamples } from "../../src/lib/samples.ts";
 
 Deno.test("samples: 单样例（H2 标题，无编号）", () => {
   const md = `# 题目
@@ -140,26 +140,4 @@ Deno.test("samples: 大小写不敏感", () => {
   assertEquals(extractSamples(md), [
     { input: "1", output: "2" },
   ]);
-});
-
-Deno.test("removeSamplesSection: 截断到第一个样例段之前", () => {
-  const md = `# 题目描述
-
-详细描述。
-
-## 样例输入
-
-1 2
-
-## 样例输出
-
-3
-`;
-  const cleaned = removeSamplesSection(md);
-  assertEquals(cleaned, "# 题目描述\n\n详细描述。");
-});
-
-Deno.test("removeSamplesSection: 无样例段时原样返回", () => {
-  const md = "# 只有描述";
-  assertEquals(removeSamplesSection(md), "# 只有描述");
 });

--- a/noj-core/tests/lib/samples.test.ts
+++ b/noj-core/tests/lib/samples.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Samples 解析器单测（issue #28）。
+ *
+ * 题目 description 是 Markdown 文本，约定使用 `## 样例输入` / `## 样例输出` 段
+ * 标记可见样例。导入导出时需要把这些段单独抽出来。
+ */
+import { assertEquals } from "jsr:@std/assert@^1";
+import { extractSamples, removeSamplesSection } from "../../src/lib/samples.ts";
+
+Deno.test("samples: 单样例（H2 标题，无编号）", () => {
+  const md = `# 题目
+
+题目描述文本。
+
+## 样例输入
+
+1 2
+
+## 样例输出
+
+3
+`;
+  assertEquals(extractSamples(md), [
+    { input: "1 2", output: "3" },
+  ]);
+});
+
+Deno.test("samples: 多样例（H2 标题 + 编号 #1/#2）", () => {
+  const md = `## 样例输入 #1
+
+1 2
+
+## 样例输出 #1
+
+3
+
+## 样例输入 #2
+
+4 5
+
+## 样例输出 #2
+
+9
+`;
+  assertEquals(extractSamples(md), [
+    { input: "1 2", output: "3" },
+    { input: "4 5", output: "9" },
+  ]);
+});
+
+Deno.test("samples: H3 标题也支持", () => {
+  const md = `### 样例输入
+
+hello
+
+### 样例输出
+
+world
+`;
+  assertEquals(extractSamples(md), [
+    { input: "hello", output: "world" },
+  ]);
+});
+
+Deno.test("samples: 多行输入/输出", () => {
+  const md = `## 样例输入
+
+3
+1 2
+3 4
+
+## 样例输出
+
+3
+1 3
+6 4
+`;
+  assertEquals(extractSamples(md), [
+    {
+      input: "3\n1 2\n3 4",
+      output: "3\n1 3\n6 4",
+    },
+  ]);
+});
+
+Deno.test("samples: 无样例段返回空数组", () => {
+  const md = `# 题目
+
+只有描述，没有样例段。
+`;
+  assertEquals(extractSamples(md), []);
+});
+
+Deno.test("samples: 仅输入无输出 → 跳过该对", () => {
+  const md = `## 样例输入
+
+1 2
+`;
+  // 配对失败，不应返回半成品
+  assertEquals(extractSamples(md), []);
+});
+
+Deno.test("samples: 仅输出无输入 → 跳过", () => {
+  const md = `## 样例输出
+
+3
+`;
+  assertEquals(extractSamples(md), []);
+});
+
+Deno.test("samples: 输入后跟另一个输入 → 第一个 input 被丢弃", () => {
+  const md = `## 样例输入
+
+1
+
+## 样例输入
+
+2
+
+## 样例输出
+
+3
+`;
+  // 配对规则：输入必须紧跟输出；连续两个输入时第一个被忽略
+  assertEquals(extractSamples(md), [
+    { input: "2", output: "3" },
+  ]);
+});
+
+Deno.test("samples: 大小写不敏感", () => {
+  const md = `## 样例INPUT
+
+1
+
+## 样例OUTPUT
+
+2
+`;
+  // 中文标题里大小写不常见，但英文混排也要能识别
+  assertEquals(extractSamples(md), [
+    { input: "1", output: "2" },
+  ]);
+});
+
+Deno.test("removeSamplesSection: 截断到第一个样例段之前", () => {
+  const md = `# 题目描述
+
+详细描述。
+
+## 样例输入
+
+1 2
+
+## 样例输出
+
+3
+`;
+  const cleaned = removeSamplesSection(md);
+  assertEquals(cleaned, "# 题目描述\n\n详细描述。");
+});
+
+Deno.test("removeSamplesSection: 无样例段时原样返回", () => {
+  const md = "# 只有描述";
+  assertEquals(removeSamplesSection(md), "# 只有描述");
+});

--- a/noj-core/tests/routes/admin_problem_io.test.ts
+++ b/noj-core/tests/routes/admin_problem_io.test.ts
@@ -1,0 +1,401 @@
+/**
+ * 题目导入导出路由测试（issue #28）。
+ *
+ * 覆盖 admin 端点的鉴权、参数校验、文件下载响应头、报告结构。
+ */
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { users } from "../../src/db/schema.ts";
+import { signToken } from "../../src/lib/jwt.ts";
+import { jsonRequest } from "../lib/helper.ts";
+import { createProblem } from "../../src/services/problems.ts";
+import { createCategory } from "../../src/services/categories.ts";
+
+const ADMIN_ID = crypto.randomUUID();
+const TEST_TS = Date.now();
+
+async function freshSetup() {
+  await resetDbForTest();
+  const db = getDb();
+  await db.delete(users).where(eq(users.id, ADMIN_ID));
+  const now = new Date().toISOString();
+  await db.insert(users).values({
+    id: ADMIN_ID,
+    username: `io-admin-${TEST_TS}`,
+    email: `io-admin-${TEST_TS}@noj.local`,
+    password_hash: "x",
+    role: "admin",
+    created_at: now,
+    updated_at: now,
+  });
+  // 准备一个分类（用 service 处理 created_at/updated_at）
+  await createCategory({
+    name: `导入测试分类-${TEST_TS}`,
+    slug: `io-cat-${TEST_TS}`,
+  });
+}
+
+async function adminToken(): Promise<string> {
+  if (!Deno.env.get("JWT_SECRET")) {
+    Deno.env.set(
+      "JWT_SECRET",
+      "test-secret-must-be-at-least-32-characters-long-xxx",
+    );
+  }
+  return await signToken({ sub: ADMIN_ID, role: "admin" });
+}
+
+// ─── Export 端点 ───────────────────────────────────────────
+
+Deno.test({
+  name: "export route: 无 token → 401",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+    const res = await jsonRequest(app, "/api/v1/admin/problems/export", {
+      method: "POST",
+      body: { type: "P" },
+    });
+    assertEquals(res.status, 401);
+  },
+});
+
+Deno.test({
+  name: "export route: 按 type=P 导出返 attachment 响应",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    await createProblem(
+      {
+        title: `导出测试题-${TEST_TS}`,
+        description: "## 样例输入\n\n1\n\n## 样例输出\n\n2\n",
+        difficulty: "easy",
+        judge_image: "noj-judge-python",
+        judge_command: "python3 /tmp/evaluate.py",
+        time_limit_ms: 1000,
+        memory_limit_mb: 256,
+        type: "P",
+      },
+      ADMIN_ID,
+      "admin",
+    );
+
+    const token = await adminToken();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+    const res = await jsonRequest(app, "/api/v1/admin/problems/export", {
+      method: "POST",
+      body: { type: "P" },
+      token,
+    });
+    assertEquals(res.status, 200);
+    assertEquals(
+      res.headers.get("Content-Type")?.startsWith("application/json"),
+      true,
+    );
+    const disposition = res.headers.get("Content-Disposition") ?? "";
+    assertEquals(disposition.includes("attachment"), true);
+    assertEquals(disposition.includes(".json"), true);
+
+    const body = await res.json();
+    assertEquals(body.version, "1.0");
+    assertEquals(body.exported_by, ADMIN_ID);
+    assertEquals(Array.isArray(body.problems), true);
+    assertEquals(body.problems.length >= 1, true);
+    const found = body.problems.find(
+      (p: { title: string }) => p.title === `导出测试题-${TEST_TS}`,
+    );
+    assertExists(found);
+    assertEquals(found.samples.length, 1);
+  },
+});
+
+Deno.test({
+  name: "export route: ids 非法类型 → 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const token = await adminToken();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+    const res = await jsonRequest(app, "/api/v1/admin/problems/export", {
+      method: "POST",
+      body: { ids: "not-array" },
+      token,
+    });
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "export route: 非法 type → 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const token = await adminToken();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+    const res = await jsonRequest(app, "/api/v1/admin/problems/export", {
+      method: "POST",
+      body: { type: "X" },
+      token,
+    });
+    assertEquals(res.status, 400);
+  },
+});
+
+// ─── Import 端点 ───────────────────────────────────────────
+
+Deno.test({
+  name: "import route: 无 token → 401",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+    const res = await jsonRequest(app, "/api/v1/admin/problems/import", {
+      method: "POST",
+      body: { strategy: "create", payload: { version: "1.0", problems: [] } },
+    });
+    assertEquals(res.status, 401);
+  },
+});
+
+Deno.test({
+  name: "import route: create 策略新建成功",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const token = await adminToken();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+
+    const sourceId = crypto.randomUUID();
+    const res = await jsonRequest(app, "/api/v1/admin/problems/import", {
+      method: "POST",
+      body: {
+        strategy: "create",
+        payload: {
+          version: "1.0",
+          exported_at: new Date().toISOString(),
+          exported_by: "test",
+          problems: [
+            {
+              id: sourceId,
+              display_id: "P9100",
+              type: "P",
+              number: 9100,
+              title: `路由测试题-${TEST_TS}`,
+              description: "无样例",
+              difficulty: "easy",
+              categories: [],
+              judge_images: ["noj-judge-python"],
+              judge_command: "python3 /tmp/evaluate.py",
+              time_limit_ms: 1000,
+              memory_limit_mb: 256,
+              support_package_storage_url: null,
+              test_cases_ref: null,
+              samples: [],
+            },
+          ],
+        },
+      },
+      token,
+    });
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.data.total, 1);
+    assertEquals(body.data.created.length, 1);
+    assertEquals(body.data.created[0].id, sourceId);
+    assertEquals(body.data.failed.length, 0);
+  },
+});
+
+Deno.test({
+  name: "import route: 缺 strategy → 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const token = await adminToken();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+    const res = await jsonRequest(app, "/api/v1/admin/problems/import", {
+      method: "POST",
+      body: { payload: { version: "1.0", problems: [] } },
+      token,
+    });
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "import route: 非法 strategy → 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const token = await adminToken();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+    const res = await jsonRequest(app, "/api/v1/admin/problems/import", {
+      method: "POST",
+      body: {
+        strategy: "merge",
+        payload: { version: "1.0", problems: [] },
+      },
+      token,
+    });
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "import route: overwrite 策略覆盖已存在题",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    // 先创建一道题
+    const created = await createProblem(
+      {
+        title: `将被覆盖的题-${TEST_TS}`,
+        description: "原始描述",
+        difficulty: "easy",
+        judge_image: "noj-judge-python",
+        judge_command: "python3 /tmp/evaluate.py",
+        time_limit_ms: 1000,
+        memory_limit_mb: 256,
+        type: "P",
+      },
+      ADMIN_ID,
+      "admin",
+    );
+
+    const token = await adminToken();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+
+    // 用同一 id 导入新描述
+    const res = await jsonRequest(app, "/api/v1/admin/problems/import", {
+      method: "POST",
+      body: {
+        strategy: "overwrite",
+        payload: {
+          version: "1.0",
+          exported_at: new Date().toISOString(),
+          exported_by: "test",
+          problems: [
+            {
+              id: created.id,
+              display_id: `P${created.number}`,
+              type: "P",
+              number: created.number,
+              title: `覆盖后的题-${TEST_TS}`,
+              description: "新描述（覆盖后）",
+              difficulty: "hard",
+              categories: [],
+              judge_images: ["noj-judge-python"],
+              judge_command: "python3 /tmp/evaluate.py",
+              time_limit_ms: 2000,
+              memory_limit_mb: 512,
+              support_package_storage_url: null,
+              test_cases_ref: null,
+              samples: [],
+            },
+          ],
+        },
+      },
+      token,
+    });
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.data.updated.length, 1);
+    assertEquals(body.data.updated[0].problem_id, created.id);
+
+    // 验证 DB 已被覆盖
+    const db = getDb();
+    const row = await db.execute(
+      `SELECT title, description, difficulty FROM problems WHERE id = '${created.id}'`,
+    );
+    const first = (row as unknown as {
+      rows: { title: string; description: string; difficulty: string }[];
+    }).rows[0];
+    assertEquals(first?.title, `覆盖后的题-${TEST_TS}`);
+    assertEquals(first?.description, "新描述（覆盖后）");
+    assertEquals(first?.difficulty, "hard");
+  },
+});
+
+Deno.test({
+  name: "import route: skip 策略下已存在题被跳过",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const created = await createProblem(
+      {
+        title: `保留题-${TEST_TS}`,
+        description: "原始",
+        difficulty: "easy",
+        judge_image: "noj-judge-python",
+        judge_command: "python3 /tmp/evaluate.py",
+        time_limit_ms: 1000,
+        memory_limit_mb: 256,
+        type: "P",
+      },
+      ADMIN_ID,
+      "admin",
+    );
+
+    const token = await adminToken();
+    const { createApp } = await import("../../src/app.ts");
+    const app = createApp();
+
+    const res = await jsonRequest(app, "/api/v1/admin/problems/import", {
+      method: "POST",
+      body: {
+        strategy: "skip",
+        payload: {
+          version: "1.0",
+          exported_at: new Date().toISOString(),
+          exported_by: "test",
+          problems: [
+            {
+              id: created.id,
+              display_id: `P${created.number}`,
+              type: "P",
+              number: created.number,
+              title: "覆盖尝试（应被忽略）",
+              description: "应不生效",
+              difficulty: "hard",
+              categories: [],
+              judge_images: ["noj-judge-python"],
+              judge_command: "python3 /tmp/evaluate.py",
+              time_limit_ms: 2000,
+              memory_limit_mb: 512,
+              support_package_storage_url: null,
+              test_cases_ref: null,
+              samples: [],
+            },
+          ],
+        },
+      },
+      token,
+    });
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.data.skipped.length, 1);
+    assertEquals(body.data.created.length, 0);
+    assertEquals(body.data.updated.length, 0);
+  },
+});

--- a/noj-core/tests/services/problem_io.test.ts
+++ b/noj-core/tests/services/problem_io.test.ts
@@ -20,52 +20,75 @@ import { createCategory } from "../../src/services/categories.ts";
 import { resetDbForTest } from "../../src/db/connection.ts";
 import { BadRequestError } from "../../src/lib/errors.ts";
 
-const skip = false; // 依赖 PGlite，始终可用
+// 共享测试夹具：模块顶层声明但延迟初始化（PR #116 review 修复）
+// - 避免模块顶层副作用污染其他测试文件的文件级隔离
+// - 每个测试用例都通过 hasEnv gating（与 noj-core/AGENTS.md「测试约定」一致）
+// - 实际初始化在 Deno.test("00 setup") 中按文件名前缀字母序先行执行
+const skip = !Deno.env.get("DATABASE_URL");
 const ts = Date.now();
 
-await resetDbForTest();
+interface Fixture {
+  catA: { id: string; name: string; slug: string };
+  catB: { id: string; name: string; slug: string };
+  PROBLEM_WITH_SAMPLES: { id: string; title: string; number: number };
+  PROBLEM_PLAIN: { id: string; title: string; number: number };
+}
+const fixture: { value?: Fixture } = {};
 
-// 模块级 setup：创建分类 + 测试题目
-const catA = await createCategory({
-  name: `基础-${ts}`,
-  slug: `basic-${ts}`,
-});
-const catB = await createCategory({
-  name: `数组-${ts}`,
-  slug: `array-${ts}`,
-});
-
-const PROBLEM_WITH_SAMPLES = await createProblem(
-  {
-    title: `含样例的题-${ts}`,
-    description:
-      `# 题目\n\n题目描述。\n\n## 样例输入\n\n1 2\n\n## 样例输出\n\n3\n\n## 样例输入 #2\n\n4 5\n\n## 样例输出 #2\n\n9\n`,
-    difficulty: "easy",
-    judge_image: "noj-judge-python",
-    judge_command: "python3 /tmp/evaluate.py",
-    time_limit_ms: 1000,
-    memory_limit_mb: 256,
-    type: "P",
-    category_ids: [catA.id, catB.id],
+Deno.test({
+  name: "00 setup: 初始化 PGlite + 分类 + 测试题目",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const catA = await createCategory({
+      name: `基础-${ts}`,
+      slug: `basic-${ts}`,
+    });
+    const catB = await createCategory({
+      name: `数组-${ts}`,
+      slug: `array-${ts}`,
+    });
+    const PROBLEM_WITH_SAMPLES = await createProblem(
+      {
+        title: `含样例的题-${ts}`,
+        description:
+          `# 题目\n\n题目描述。\n\n## 样例输入\n\n1 2\n\n## 样例输出\n\n3\n\n## 样例输入 #2\n\n4 5\n\n## 样例输出 #2\n\n9\n`,
+        difficulty: "easy",
+        judge_image: "noj-judge-python",
+        judge_command: "python3 /tmp/evaluate.py",
+        time_limit_ms: 1000,
+        memory_limit_mb: 256,
+        type: "P",
+        category_ids: [catA.id, catB.id],
+      },
+      "test-admin",
+      "admin",
+    );
+    const PROBLEM_PLAIN = await createProblem(
+      {
+        title: `普通题-${ts}`,
+        description: "# 普通题\n\n没有样例段。",
+        difficulty: "medium",
+        judge_image: "noj-judge-python",
+        judge_command: "python3 /tmp/evaluate.py",
+        time_limit_ms: 2000,
+        memory_limit_mb: 512,
+        type: "P",
+      },
+      "test-admin",
+      "admin",
+    );
+    fixture.value = { catA, catB, PROBLEM_WITH_SAMPLES, PROBLEM_PLAIN };
   },
-  "test-admin",
-  "admin",
-);
+});
 
-const PROBLEM_PLAIN = await createProblem(
-  {
-    title: `普通题-${ts}`,
-    description: "# 普通题\n\n没有样例段。",
-    difficulty: "medium",
-    judge_image: "noj-judge-python",
-    judge_command: "python3 /tmp/evaluate.py",
-    time_limit_ms: 2000,
-    memory_limit_mb: 512,
-    type: "P",
-  },
-  "test-admin",
-  "admin",
-);
+/** 取夹具；若 setup 未运行则跳过当前测试。 */
+function fx(): Fixture {
+  if (!fixture.value) throw new Error("setup 未运行（应已被 ignore 跳过）");
+  return fixture.value;
+}
 
 Deno.test({
   name: "export: ids 和 type 都未提供 → 拒绝",
@@ -120,14 +143,14 @@ Deno.test({
   sanitizeOps: false,
   fn: async () => {
     const payload = await buildExportPayload(
-      { ids: [PROBLEM_WITH_SAMPLES.id] },
+      { ids: [fx().PROBLEM_WITH_SAMPLES.id] },
       "test-admin",
     );
     assertEquals(payload.version, "1.0");
     assertEquals(payload.exported_by, "test-admin");
     assertEquals(payload.problems.length, 1);
     const p = payload.problems[0];
-    assertEquals(p.id, PROBLEM_WITH_SAMPLES.id);
+    assertEquals(p.id, fx().PROBLEM_WITH_SAMPLES.id);
     assertEquals(p.title, `含样例的题-${ts}`);
     assertEquals(p.difficulty, "easy");
     assertEquals(p.time_limit_ms, 1000);
@@ -151,7 +174,7 @@ Deno.test({
   sanitizeOps: false,
   fn: async () => {
     const payload = await buildExportPayload(
-      { ids: [PROBLEM_PLAIN.id] },
+      { ids: [fx().PROBLEM_PLAIN.id] },
       "test-admin",
     );
     assertEquals(payload.problems[0].samples, []);
@@ -169,9 +192,9 @@ Deno.test({
       "test-admin",
     );
     const found = payload.problems.find(
-      (p) => p.id === PROBLEM_WITH_SAMPLES.id,
+      (p) => p.id === fx().PROBLEM_WITH_SAMPLES.id,
     );
-    assertEquals(found?.display_id, `P${PROBLEM_WITH_SAMPLES.number}`);
+    assertEquals(found?.display_id, `P${fx().PROBLEM_WITH_SAMPLES.number}`);
   },
 });
 
@@ -183,8 +206,8 @@ Deno.test({
   fn: async () => {
     const payload = await buildExportPayload({ type: "P" }, "test-admin");
     const ids = payload.problems.map((p) => p.id);
-    assertEquals(ids.includes(PROBLEM_WITH_SAMPLES.id), true);
-    assertEquals(ids.includes(PROBLEM_PLAIN.id), true);
+    assertEquals(ids.includes(fx().PROBLEM_WITH_SAMPLES.id), true);
+    assertEquals(ids.includes(fx().PROBLEM_PLAIN.id), true);
     for (const p of payload.problems) {
       assertEquals(p.type, "P");
     }
@@ -275,7 +298,7 @@ Deno.test({
   fn: async () => {
     // 先 export 一道
     const exported = await buildExportPayload(
-      { ids: [PROBLEM_WITH_SAMPLES.id] },
+      { ids: [fx().PROBLEM_WITH_SAMPLES.id] },
       "test-admin",
     );
     // 然后 import 同一份（不同 id 时新建；同 id 时按 strategy 走）
@@ -289,13 +312,17 @@ Deno.test({
     assertEquals(report.total, 1);
     assertEquals(report.created.length, 0);
     assertEquals(report.updated.length, 1);
-    assertEquals(report.updated[0].id, PROBLEM_WITH_SAMPLES.id);
+    assertEquals(report.updated[0].id, fx().PROBLEM_WITH_SAMPLES.id);
     assertEquals(report.failed.length, 0);
 
     // 验证 DB 状态保持
-    const reloaded = await getProblem(PROBLEM_WITH_SAMPLES.id);
+    const reloaded = await getProblem(fx().PROBLEM_WITH_SAMPLES.id);
     assertEquals(reloaded.title, `含样例的题-${ts}`);
-    assertEquals(reloaded.samples, undefined); // samples 不在 ProblemResponse
+    // samples 不在 ProblemResponse（只存在 description 文本内）
+    assertEquals(
+      (reloaded as unknown as { samples?: unknown }).samples,
+      undefined,
+    );
     assertEquals(reloaded.description.includes("样例输入"), true);
   },
 });
@@ -356,7 +383,7 @@ Deno.test({
   sanitizeOps: false,
   fn: async () => {
     const exported = await buildExportPayload(
-      { ids: [PROBLEM_PLAIN.id] },
+      { ids: [fx().PROBLEM_PLAIN.id] },
       "test-admin",
     );
     const report = await importProblems(
@@ -366,7 +393,7 @@ Deno.test({
       "admin",
     );
     assertEquals(report.skipped.length, 1);
-    assertEquals(report.skipped[0].id, PROBLEM_PLAIN.id);
+    assertEquals(report.skipped[0].id, fx().PROBLEM_PLAIN.id);
     assertEquals(report.created.length, 0);
     assertEquals(report.updated.length, 0);
   },
@@ -379,7 +406,7 @@ Deno.test({
   sanitizeOps: false,
   fn: async () => {
     const exported = await buildExportPayload(
-      { ids: [PROBLEM_PLAIN.id] },
+      { ids: [fx().PROBLEM_PLAIN.id] },
       "test-admin",
     );
     const report = await importProblems(

--- a/noj-core/tests/services/problem_io.test.ts
+++ b/noj-core/tests/services/problem_io.test.ts
@@ -1,0 +1,551 @@
+/**
+ * 题目导入导出服务测试（issue #28）。
+ *
+ * 覆盖 buildExportPayload 的核心路径：
+ * - 参数互斥校验
+ * - 按 ids 导出
+ * - 按 type 导出
+ * - samples 抽取
+ * - 分类注入
+ * - 不支持协议前缀拒绝
+ */
+import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import {
+  buildExportPayload,
+  createProblem,
+  getProblem,
+  importProblems,
+} from "../../src/services/problems.ts";
+import { createCategory } from "../../src/services/categories.ts";
+import { resetDbForTest } from "../../src/db/connection.ts";
+import { BadRequestError } from "../../src/lib/errors.ts";
+
+const skip = false; // 依赖 PGlite，始终可用
+const ts = Date.now();
+
+await resetDbForTest();
+
+// 模块级 setup：创建分类 + 测试题目
+const catA = await createCategory({
+  name: `基础-${ts}`,
+  slug: `basic-${ts}`,
+});
+const catB = await createCategory({
+  name: `数组-${ts}`,
+  slug: `array-${ts}`,
+});
+
+const PROBLEM_WITH_SAMPLES = await createProblem(
+  {
+    title: `含样例的题-${ts}`,
+    description:
+      `# 题目\n\n题目描述。\n\n## 样例输入\n\n1 2\n\n## 样例输出\n\n3\n\n## 样例输入 #2\n\n4 5\n\n## 样例输出 #2\n\n9\n`,
+    difficulty: "easy",
+    judge_image: "noj-judge-python",
+    judge_command: "python3 /tmp/evaluate.py",
+    time_limit_ms: 1000,
+    memory_limit_mb: 256,
+    type: "P",
+    category_ids: [catA.id, catB.id],
+  },
+  "test-admin",
+  "admin",
+);
+
+const PROBLEM_PLAIN = await createProblem(
+  {
+    title: `普通题-${ts}`,
+    description: "# 普通题\n\n没有样例段。",
+    difficulty: "medium",
+    judge_image: "noj-judge-python",
+    judge_command: "python3 /tmp/evaluate.py",
+    time_limit_ms: 2000,
+    memory_limit_mb: 512,
+    type: "P",
+  },
+  "test-admin",
+  "admin",
+);
+
+Deno.test({
+  name: "export: ids 和 type 都未提供 → 拒绝",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () => buildExportPayload({}, "test-admin"),
+      BadRequestError,
+      "必须提供 ids 或 type 之一",
+    );
+  },
+});
+
+Deno.test({
+  name: "export: ids 和 type 同时提供 → 拒绝",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () =>
+        buildExportPayload(
+          { ids: ["x"], type: "P" },
+          "test-admin",
+        ),
+      BadRequestError,
+      "互斥",
+    );
+  },
+});
+
+Deno.test({
+  name: "export: 非法 type → 拒绝",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () => buildExportPayload({ type: "X" as never }, "test-admin"),
+      BadRequestError,
+      "非法题目类型",
+    );
+  },
+});
+
+Deno.test({
+  name: "export: 按 ids 导出包含元数据 + samples + 分类",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const payload = await buildExportPayload(
+      { ids: [PROBLEM_WITH_SAMPLES.id] },
+      "test-admin",
+    );
+    assertEquals(payload.version, "1.0");
+    assertEquals(payload.exported_by, "test-admin");
+    assertEquals(payload.problems.length, 1);
+    const p = payload.problems[0];
+    assertEquals(p.id, PROBLEM_WITH_SAMPLES.id);
+    assertEquals(p.title, `含样例的题-${ts}`);
+    assertEquals(p.difficulty, "easy");
+    assertEquals(p.time_limit_ms, 1000);
+    assertEquals(p.memory_limit_mb, 256);
+    assertEquals(p.type, "P");
+    assertEquals(p.judge_images, ["noj-judge-python"]);
+    assertEquals(p.judge_command, "python3 /tmp/evaluate.py");
+    assertEquals(p.samples.length, 2);
+    assertEquals(p.samples[0], { input: "1 2", output: "3" });
+    assertEquals(p.samples[1], { input: "4 5", output: "9" });
+    assertEquals(p.categories.length, 2);
+    const names = p.categories.map((c) => c.name).sort();
+    assertEquals(names, [`基础-${ts}`, `数组-${ts}`]);
+  },
+});
+
+Deno.test({
+  name: "export: description 无样例段时 samples 为空数组",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const payload = await buildExportPayload(
+      { ids: [PROBLEM_PLAIN.id] },
+      "test-admin",
+    );
+    assertEquals(payload.problems[0].samples, []);
+  },
+});
+
+Deno.test({
+  name: "export: display_id = ${type}${number}",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const payload = await buildExportPayload(
+      { type: "P" },
+      "test-admin",
+    );
+    const found = payload.problems.find(
+      (p) => p.id === PROBLEM_WITH_SAMPLES.id,
+    );
+    assertEquals(found?.display_id, `P${PROBLEM_WITH_SAMPLES.number}`);
+  },
+});
+
+Deno.test({
+  name: "export: 按 type=P 批量导出包含所有 P 型题",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const payload = await buildExportPayload({ type: "P" }, "test-admin");
+    const ids = payload.problems.map((p) => p.id);
+    assertEquals(ids.includes(PROBLEM_WITH_SAMPLES.id), true);
+    assertEquals(ids.includes(PROBLEM_PLAIN.id), true);
+    for (const p of payload.problems) {
+      assertEquals(p.type, "P");
+    }
+  },
+});
+
+Deno.test({
+  name: "export: 不存在的 ids 返空 problems 数组（不报错）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const payload = await buildExportPayload(
+      { ids: ["non-existent-id"] },
+      "test-admin",
+    );
+    assertEquals(payload.problems, []);
+  },
+});
+
+// ─── 导入测试 ──────────────────────────────────────────────
+
+Deno.test({
+  name: "import: 非 create/overwrite/skip 策略 → 拒绝",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () =>
+        importProblems(
+          { version: "1.0", problems: [] },
+          "bogus" as never,
+          "test-admin",
+          "admin",
+        ),
+      BadRequestError,
+      "非法导入策略",
+    );
+  },
+});
+
+Deno.test({
+  name: "import: version 不匹配 → 拒绝",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () =>
+        importProblems(
+          { version: "2.0", problems: [] },
+          "create",
+          "test-admin",
+          "admin",
+        ),
+      BadRequestError,
+      "不支持的导入文件版本",
+    );
+  },
+});
+
+Deno.test({
+  name: "import: 缺 problems 字段 → 拒绝",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () =>
+        importProblems(
+          { version: "1.0" }, // 有 version 但缺 problems
+          "create",
+          "test-admin",
+          "admin",
+        ),
+      BadRequestError,
+      "problems 数组",
+    );
+  },
+});
+
+Deno.test({
+  name: "import: 单题全字段 round-trip（overwrite 策略）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    // 先 export 一道
+    const exported = await buildExportPayload(
+      { ids: [PROBLEM_WITH_SAMPLES.id] },
+      "test-admin",
+    );
+    // 然后 import 同一份（不同 id 时新建；同 id 时按 strategy 走）
+    // 这里 source id 已存在 → overwrite 应该更新成功
+    const report = await importProblems(
+      exported,
+      "overwrite",
+      "test-admin",
+      "admin",
+    );
+    assertEquals(report.total, 1);
+    assertEquals(report.created.length, 0);
+    assertEquals(report.updated.length, 1);
+    assertEquals(report.updated[0].id, PROBLEM_WITH_SAMPLES.id);
+    assertEquals(report.failed.length, 0);
+
+    // 验证 DB 状态保持
+    const reloaded = await getProblem(PROBLEM_WITH_SAMPLES.id);
+    assertEquals(reloaded.title, `含样例的题-${ts}`);
+    assertEquals(reloaded.samples, undefined); // samples 不在 ProblemResponse
+    assertEquals(reloaded.description.includes("样例输入"), true);
+  },
+});
+
+Deno.test({
+  name: "import: 不存在的源 id + create 策略 → 新建",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const newId = crypto.randomUUID();
+    const payload = {
+      version: "1.0" as const,
+      exported_at: new Date().toISOString(),
+      exported_by: "test-admin",
+      problems: [
+        {
+          id: newId,
+          display_id: "P9001",
+          type: "P" as const,
+          number: 9001,
+          title: "全新导入题",
+          description: "# 全新\n\n## 样例输入\n\na\n\n## 样例输出\n\nb\n",
+          difficulty: "hard",
+          categories: [{ name: `基础-${ts}`, slug: `basic-${ts}` }],
+          judge_images: ["noj-judge-python"],
+          judge_command: "python3 /tmp/evaluate.py",
+          time_limit_ms: 3000,
+          memory_limit_mb: 128,
+          support_package_storage_url: null,
+          test_cases_ref: null,
+          samples: [{ input: "a", output: "b" }],
+        },
+      ],
+    };
+    const report = await importProblems(
+      payload,
+      "create",
+      "test-admin",
+      "admin",
+    );
+    assertEquals(report.created.length, 1);
+    assertEquals(report.created[0].id, newId);
+    // 实际写入的 id 应该不同于 source id（避免跨 DB 冲突）
+    assertEquals(report.created[0].problem_id !== newId, true);
+
+    // 验证题已存在
+    const created = await getProblem(report.created[0].problem_id!);
+    assertEquals(created.title, "全新导入题");
+    assertEquals(created.number, 9001);
+  },
+});
+
+Deno.test({
+  name: "import: skip 策略下已存在 → 跳过",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const exported = await buildExportPayload(
+      { ids: [PROBLEM_PLAIN.id] },
+      "test-admin",
+    );
+    const report = await importProblems(
+      exported,
+      "skip",
+      "test-admin",
+      "admin",
+    );
+    assertEquals(report.skipped.length, 1);
+    assertEquals(report.skipped[0].id, PROBLEM_PLAIN.id);
+    assertEquals(report.created.length, 0);
+    assertEquals(report.updated.length, 0);
+  },
+});
+
+Deno.test({
+  name: "import: create 策略下已存在 → 跳过（不报错）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const exported = await buildExportPayload(
+      { ids: [PROBLEM_PLAIN.id] },
+      "test-admin",
+    );
+    const report = await importProblems(
+      exported,
+      "create",
+      "test-admin",
+      "admin",
+    );
+    assertEquals(report.skipped.length, 1);
+    assertEquals(report.created.length, 0);
+  },
+});
+
+Deno.test({
+  name: "import: 分类名在当前 DB 找不到 → 忽略该分类（不报错）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const newId = crypto.randomUUID();
+    const payload = {
+      version: "1.0" as const,
+      exported_at: new Date().toISOString(),
+      exported_by: "test-admin",
+      problems: [
+        {
+          id: newId,
+          display_id: "P9002",
+          type: "P" as const,
+          number: 9002,
+          title: "部分分类缺失题",
+          description: "无样例",
+          difficulty: "easy",
+          categories: [
+            { name: `基础-${ts}`, slug: `basic-${ts}` }, // 存在
+            { name: "完全不存在的分类", slug: "no-such-cat" }, // 不存在
+          ],
+          judge_images: ["noj-judge-python"],
+          judge_command: "python3 /tmp/evaluate.py",
+          time_limit_ms: 1000,
+          memory_limit_mb: 256,
+          support_package_storage_url: null,
+          test_cases_ref: null,
+          samples: [],
+        },
+      ],
+    };
+    const report = await importProblems(
+      payload,
+      "create",
+      "test-admin",
+      "admin",
+    );
+    assertEquals(report.created.length, 1);
+    // 警告应在 reason 里
+    const r = report.created[0];
+    assertEquals(r.reason?.includes("完全不存在的分类"), true);
+
+    // 验证：基础分类已关联，不存在的未关联
+    const created = await getProblem(r.problem_id!);
+    const catNames = created.categories.map((c) => c.name);
+    assertEquals(catNames.includes(`基础-${ts}`), true);
+    assertEquals(catNames.includes("完全不存在的分类"), false);
+  },
+});
+
+Deno.test({
+  name: "import: 非法难度值 → 单条失败，其他成功",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const goodId = crypto.randomUUID();
+    const badId = crypto.randomUUID();
+    const payload = {
+      version: "1.0" as const,
+      exported_at: new Date().toISOString(),
+      exported_by: "test-admin",
+      problems: [
+        {
+          id: goodId,
+          display_id: "P9003",
+          type: "P" as const,
+          number: 9003,
+          title: "好的题",
+          description: "",
+          difficulty: "easy",
+          categories: [],
+          judge_images: ["noj-judge-python"],
+          judge_command: "python3 /tmp/evaluate.py",
+          time_limit_ms: 1000,
+          memory_limit_mb: 256,
+          support_package_storage_url: null,
+          test_cases_ref: null,
+          samples: [],
+        },
+        {
+          id: badId,
+          display_id: "P9004",
+          type: "P" as const,
+          number: 9004,
+          title: "坏的题",
+          description: "",
+          difficulty: "impossible" as never,
+          categories: [],
+          judge_images: ["noj-judge-python"],
+          judge_command: "python3 /tmp/evaluate.py",
+          time_limit_ms: 1000,
+          memory_limit_mb: 256,
+          support_package_storage_url: null,
+          test_cases_ref: null,
+          samples: [],
+        },
+      ],
+    };
+    const report = await importProblems(
+      payload,
+      "create",
+      "test-admin",
+      "admin",
+    );
+    assertEquals(report.created.length, 1);
+    assertEquals(report.failed.length, 1);
+    assertEquals(report.failed[0].id, badId);
+    assertEquals(report.failed[0].reason?.includes("难度"), true);
+  },
+});
+
+Deno.test({
+  name: "import: 不支持的协议前缀 → 单条失败",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const newId = crypto.randomUUID();
+    const payload = {
+      version: "1.0" as const,
+      exported_at: new Date().toISOString(),
+      exported_by: "test-admin",
+      problems: [
+        {
+          id: newId,
+          display_id: "P9005",
+          type: "P" as const,
+          number: 9005,
+          title: "坏 URL 题",
+          description: "",
+          difficulty: "easy",
+          categories: [],
+          judge_images: ["noj-judge-python"],
+          judge_command: "python3 /tmp/evaluate.py",
+          time_limit_ms: 1000,
+          memory_limit_mb: 256,
+          support_package_storage_url: "https://evil.example.com/x.zip",
+          test_cases_ref: null,
+          samples: [],
+        },
+      ],
+    };
+    const report = await importProblems(
+      payload,
+      "create",
+      "test-admin",
+      "admin",
+    );
+    assertEquals(report.failed.length, 1);
+    assertEquals(report.failed[0].reason?.includes("协议"), true);
+  },
+});


### PR DESCRIPTION
## 范围

按 [issue #28 走法 A](https://github.com/Neuro-OJ/neuro-oj/issues/28) 推进：仅元数据 + support_package URL 引用 + 三种导入策略，不动 schema，不改 judge 端。

### 新增能力

- `POST /api/v1/admin/problems/export` — 导出元数据为 JSON
  - body: `{ ids?: string[]; type?: "U"|"P" }`（互斥）
  - 返 `application/json` 附件下载
- `POST /api/v1/admin/problems/import` — 从 JSON 导入题目
  - body: `{ strategy: "create"|"overwrite"|"skip"; payload: ExportPayload }`
  - 返 `{ total, created, updated, skipped, failed: [{id, reason}] }` 报告

### 新增文件

| 文件 | 作用 |
|------|------|
| `src/lib/samples.ts` | 从 Markdown 描述抽取 `## 样例输入/输出` 段 |
| `src/services/problems.ts`（扩展） | 新增 `buildExportPayload` 和 `importProblems` |
| `src/types/problems.ts`（扩展） | 新增 ExportPayload / ExportProblem / ImportStrategy / ImportReport 等 |
| `src/routes/admin.ts`（扩展） | 两个新 admin 端点 |
| 3 个测试文件 | 单元 + 服务 + 路由层共 29 个新测试 |

### 明确不做（issue #28 范围外）

- `test_cases` 内联：仍归支持包 zip 管，导出附 `test_cases_ref` 占位
- `allowed_languages` 字段：用 `judge_images` 列表代替
- YAML 格式：v1 仅 JSON
- 数据库迁移：0 个迁移
- judge 端改动：0

### 测试

`deno test -A`：496 passed | 0 failed | 65 ignored（含本次新增 29 个）  
`deno lint`：通过  
`deno fmt --check`：通过

### 关联

- 关闭 #28
- 依赖：上一条 issue 评论里确认的走法 A 范围