### PR TITLE
feat(judge,core): 双容器 Evaluator/Solution 评测运行时（issue #118）

### DIFF
--- a/noj-core/drizzle/0016_audit_logs_ip_ban_actions.sql
+++ b/noj-core/drizzle/0016_audit_logs_ip_ban_actions.sql
@@ -1,10 +1,12 @@
 -- 扩展审计日志 action CHECK 约束（issue #101），新增 ip_ban.create 和 ip_ban.delete
+-- 后续：双容器 RuntimeConfig 改动审计（openspec/changes/dual-container-judge §8）
 ALTER TABLE "audit_logs" DROP CONSTRAINT IF EXISTS "audit_logs_action_check";
 ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_action_check" CHECK ("action" IN (
   'users.role_change',
   'users.ban',
   'users.unban',
   'problems.delete',
+  'problems.runtime_config_changed',
   'categories.delete',
   'submissions.rejudge',
   'settings.update',

--- a/noj-core/drizzle/0017_problem_runtime_config.sql
+++ b/noj-core/drizzle/0017_problem_runtime_config.sql
@@ -1,0 +1,19 @@
+-- 双容器 RuntimeConfig 存储（openspec/changes/dual-container-judge §4）
+--
+-- problems 表新增 runtime_config JSONB 列：
+--   - NULL：单容器题目（旧路径，向后兼容）
+--   - 非 NULL：双容器题目（evaluator + solution 各自 RuntimeConfig）
+--
+-- 历史数据：所有现存题目 runtime_config = NULL（保持单容器路径）。
+-- 结构校验仅做最基础的 jsonb_typeof 检查；语义校验由 admin API 完成。
+
+ALTER TABLE "problems" ADD COLUMN "runtime_config" jsonb;
+
+-- 约束：runtime_config 必须为 NULL 或 JSON object
+ALTER TABLE "problems" ADD CONSTRAINT "problems_runtime_config_check"
+  CHECK ("runtime_config" IS NULL OR jsonb_typeof("runtime_config") = 'object');
+
+-- 索引：按 runtime_config IS NOT NULL 过滤（任务分流时常用）
+CREATE INDEX "problems_runtime_config_present_idx"
+  ON "problems" (id)
+  WHERE "runtime_config" IS NOT NULL;

--- a/noj-core/drizzle/0018_judge_images_kind.sql
+++ b/noj-core/drizzle/0018_judge_images_kind.sql
@@ -1,0 +1,17 @@
+-- 双容器 Evaluator/Solution 镜像分类（openspec/changes/dual-container-judge §5）
+--
+-- `judge_images` 表新增 `kind` 字段，区分镜像用途：
+--   - 'evaluator'：单容器 / 双容器 Evaluator 角色
+--   - 'solution' ：双容器 Solution 角色
+--
+-- 历史记录迁移：所有现存镜像默认为 'evaluator'。
+-- admin 应在迁移后手动将 `noj-solution-*` 镜像的 kind 改为 'solution'。
+
+ALTER TABLE "judge_images" ADD COLUMN "kind" text NOT NULL DEFAULT 'evaluator';
+
+-- 旧 CHECK 约束被替换（如果存在）
+ALTER TABLE "judge_images" DROP CONSTRAINT IF EXISTS "judge_images_mode_check";
+ALTER TABLE "judge_images" ADD CONSTRAINT "judge_images_kind_check" CHECK ("kind" IN ('evaluator', 'solution'));
+
+-- 历史数据全部标记为 'evaluator'（DEFAULT 已覆盖；显式 UPDATE 一次以保证）
+UPDATE "judge_images" SET "kind" = 'evaluator' WHERE "kind" IS NULL;

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1783120000400,
       "tag": "0016_audit_logs_ip_ban_actions",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1783900000000,
+      "tag": "0018_judge_images_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -132,6 +132,13 @@
       "idx": 18,
       "version": "7",
       "when": 1783900000000,
+      "tag": "0017_problem_runtime_config",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1784000000000,
       "tag": "0018_judge_images_kind",
       "breakpoints": true
     }

--- a/noj-core/src/db/schema-ddl.ts
+++ b/noj-core/src/db/schema-ddl.ts
@@ -28,6 +28,7 @@ export const SCHEMA_DDL: string[] = [
     support_package_storage_url TEXT,
     time_limit_ms INTEGER NOT NULL DEFAULT 5000,
     memory_limit_mb INTEGER NOT NULL DEFAULT 512,
+    runtime_config JSONB CHECK (runtime_config IS NULL OR jsonb_typeof(runtime_config) = 'object'),
     number INTEGER NOT NULL,
     owner_id TEXT NOT NULL DEFAULT '0',
     type TEXT NOT NULL DEFAULT 'U' CHECK (type IN ('U', 'P')),
@@ -172,7 +173,7 @@ export const SCHEMA_DDL: string[] = [
     created_at TEXT NOT NULL,
     CONSTRAINT audit_logs_action_check CHECK (action IN (
       'users.role_change','users.ban','users.unban',
-      'problems.delete','categories.delete','submissions.rejudge','settings.update',
+      'problems.delete','problems.runtime_config_changed','categories.delete','submissions.rejudge','settings.update',
       'ip_ban.create','ip_ban.delete'
     ))
   )`,

--- a/noj-core/src/db/schema-ddl.ts
+++ b/noj-core/src/db/schema-ddl.ts
@@ -40,6 +40,7 @@ export const SCHEMA_DDL: string[] = [
     id TEXT PRIMARY KEY,
     image TEXT NOT NULL,
     mode TEXT NOT NULL DEFAULT 'exact' CHECK (mode IN ('exact', 'all_versions')),
+    kind TEXT NOT NULL DEFAULT 'evaluator' CHECK (kind IN ('evaluator', 'solution')),
     description TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -59,6 +59,12 @@ export const problems = pgTable(
     support_package_storage_url: text("support_package_storage_url"),
     time_limit_ms: integer("time_limit_ms").notNull().default(5000),
     memory_limit_mb: integer("memory_limit_mb").notNull().default(512),
+    /**
+     * 双容器 Runtime 配置（dual-container-judge §4）。
+     * - NULL：单容器题目（向后兼容）
+     * - 非 NULL：双容器题目（evaluator + solution 各自 RuntimeConfig）
+     */
+    runtime_config: jsonb("runtime_config"),
     /** 题号（同一 type 内独立自增） */
     number: integer("number").notNull(),
     /** 题目所有者 ID，默认 root (UID=0) */
@@ -74,6 +80,10 @@ export const problems = pgTable(
       table.number,
     ),
     typeCheck: check("problems_type_check", sql`${table.type} IN ('U', 'P')`),
+    runtimeConfigCheck: check(
+      "problems_runtime_config_check",
+      sql`${table.runtime_config} IS NULL OR jsonb_typeof(${table.runtime_config}) = 'object'`,
+    ),
   }),
 );
 
@@ -438,6 +448,7 @@ export const auditLogs = pgTable(
         'users.ban',
         'users.unban',
         'problems.delete',
+        'problems.runtime_config_changed',
         'categories.delete',
         'submissions.rejudge',
         'settings.update',

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -89,6 +89,14 @@ export const judgeImages = pgTable(
     id: text("id").primaryKey(),
     image: text("image").notNull(),
     mode: text("mode").notNull().default("exact"),
+    /**
+     * 镜像用途分类（dual-container-judge §5）。
+     * - 'evaluator'：单容器 / 双容器 Evaluator 角色
+     * - 'solution' ：双容器 Solution 角色
+     *
+     * 历史数据迁移时默认 'evaluator'。
+     */
+    kind: text("kind").notNull().default("evaluator"),
     /** 管理员配置的介绍，在题目编辑器下拉中展示 */
     description: text("description").notNull().default(""),
     created_at: text("created_at").notNull(),
@@ -98,6 +106,10 @@ export const judgeImages = pgTable(
     modeCheck: check(
       "judge_images_mode_check",
       sql`${table.mode} IN ('exact', 'all_versions')`,
+    ),
+    kindCheck: check(
+      "judge_images_kind_check",
+      sql`${table.kind} IN ('evaluator', 'solution')`,
     ),
   }),
 );

--- a/noj-core/src/mq/judge-rpc.ts
+++ b/noj-core/src/mq/judge-rpc.ts
@@ -47,16 +47,34 @@ function createResponse(
 
 /**
  * 处理 get_image_allowlist 请求。
- * 从数据库查询所有 judge_images 记录。
+ *
+ * 从数据库查询所有 judge_images 记录；返回结构包含 `kind` 与 `mode` 字段
+ * （dual-container-judge §5），供 judge 端按 kind 分池预热。
  */
 async function handleGetImageAllowlist(): Promise<
-  { images: { image: string; tag: string }[] }
+  {
+    images: {
+      image: string;
+      kind: "evaluator" | "solution";
+      mode: "exact" | "all_versions";
+    }[];
+  }
 > {
   const rows = await getDb()
-    .select({ image: judgeImages.image })
+    .select({
+      image: judgeImages.image,
+      kind: judgeImages.kind,
+      mode: judgeImages.mode,
+    })
     .from(judgeImages);
 
-  return { images: rows.map((r) => ({ image: r.image, tag: "latest" })) };
+  return {
+    images: rows.map((r) => ({
+      image: r.image,
+      kind: r.kind as "evaluator" | "solution",
+      mode: r.mode as "exact" | "all_versions",
+    })),
+  };
 }
 
 /** 方法名到处理函数的映射 */

--- a/noj-core/src/services/judge-images.ts
+++ b/noj-core/src/services/judge-images.ts
@@ -2,7 +2,11 @@ import { eq } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
 import { judgeImages } from "../db/schema.ts";
 import { NotFoundError, ValidationError } from "../lib/errors.ts";
-import { isImageInWhitelist } from "../types/problems.ts";
+import {
+  isImageInWhitelist,
+  isValidJudgeImageKind,
+  type JudgeImageKind,
+} from "../types/problems.ts";
 import type {
   CreateJudgeImageInput,
   JudgeImageResponse,
@@ -21,6 +25,7 @@ function toResponse(
     id: row.id,
     image: row.image,
     mode: row.mode,
+    kind: row.kind as JudgeImageKind,
     description: row.description,
     created_at: row.created_at,
     updated_at: row.updated_at,
@@ -37,9 +42,19 @@ export async function listJudgeImages(): Promise<JudgeImageResponse[]> {
 }
 
 /**
+ * 按 kind 过滤白名单条目（dual-container-judge §5）。
+ */
+export async function listJudgeImagesByKind(
+  kind: JudgeImageKind,
+): Promise<JudgeImageResponse[]> {
+  const all = await listJudgeImages();
+  return all.filter((img) => img.kind === kind);
+}
+
+/**
  * 新增白名单条目。
  *
- * @throws {ValidationError} mode 非法
+ * @throws {ValidationError} mode / kind 非法
  */
 export async function createJudgeImage(
   input: CreateJudgeImageInput,
@@ -52,6 +67,11 @@ export async function createJudgeImage(
       `mode 仅允许 ${VALID_MODES.join("/")}，收到: ${input.mode}`,
     );
   }
+  if (!isValidJudgeImageKind(input.kind)) {
+    throw new ValidationError(
+      `kind 仅允许 evaluator/solution，收到: ${input.kind}`,
+    );
+  }
 
   const db = getDb();
   const now = new Date().toISOString();
@@ -61,6 +81,7 @@ export async function createJudgeImage(
     id,
     image: input.image.trim(),
     mode: input.mode,
+    kind: input.kind,
     description: input.description?.trim() ?? "",
     created_at: now,
     updated_at: now,
@@ -79,7 +100,7 @@ export async function createJudgeImage(
  * 更新白名单条目。
  *
  * @throws {NotFoundError} 条目不存在
- * @throws {ValidationError} mode 非法
+ * @throws {ValidationError} mode / kind 非法
  */
 export async function updateJudgeImage(
   id: string,
@@ -102,10 +123,16 @@ export async function updateJudgeImage(
       `mode 仅允许 ${VALID_MODES.join("/")}，收到: ${input.mode}`,
     );
   }
+  if (input.kind !== undefined && !isValidJudgeImageKind(input.kind)) {
+    throw new ValidationError(
+      `kind 仅允许 evaluator/solution，收到: ${input.kind}`,
+    );
+  }
 
   const updates: Record<string, unknown> = {};
   if (input.image !== undefined) updates.image = input.image.trim();
   if (input.mode !== undefined) updates.mode = input.mode;
+  if (input.kind !== undefined) updates.kind = input.kind;
   if (input.description !== undefined) {
     updates.description = input.description.trim();
   }
@@ -163,6 +190,57 @@ export async function validateJudgeImage(image: string): Promise<boolean> {
   if (!isImageInWhitelist(image, rows)) {
     throw new ValidationError(
       `评测镜像 '${image}' 不在允许列表中`,
+    );
+  }
+
+  return true;
+}
+
+/**
+ * 校验 judge_image + kind 组合（dual-container-judge §5）。
+ *
+ * 用于 admin API 在创建/更新题目时校验 `runtime_config` 中的镜像：
+ * - `runtime_config.evaluator.image` 必须 kind='evaluator'
+ * - `runtime_config.solution.image` 必须 kind='solution'
+ *
+ * @throws {ValidationError} kind 不匹配或镜像不在白名单
+ */
+export async function validateJudgeImageWithKind(
+  image: string,
+  expectedKind: JudgeImageKind,
+): Promise<boolean> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      image: judgeImages.image,
+      mode: judgeImages.mode,
+      kind: judgeImages.kind,
+    })
+    .from(judgeImages);
+
+  if (rows.length === 0) {
+    throw new ValidationError(
+      "系统尚未配置允许的评测镜像，请联系管理员",
+    );
+  }
+
+  // 1. 检查白名单
+  if (!isImageInWhitelist(image, rows)) {
+    throw new ValidationError(
+      `评测镜像 '${image}' 不在允许列表中`,
+    );
+  }
+
+  // 2. 检查 kind 匹配
+  const matched = rows.find((r) => isImageInWhitelist(image, [r]));
+  if (!matched) {
+    throw new ValidationError(
+      `评测镜像 '${image}' 未匹配任何白名单条目`,
+    );
+  }
+  if (matched.kind !== expectedKind) {
+    throw new ValidationError(
+      `image kind mismatch: 期望 ${expectedKind}，镜像 '${image}' 实际为 ${matched.kind}`,
     );
   }
 

--- a/noj-core/src/services/problems.ts
+++ b/noj-core/src/services/problems.ts
@@ -25,14 +25,24 @@ import {
 import {
   type CreateProblemInput,
   DIFFICULTIES,
+  EXPORT_VERSION,
+  type ExportPayload,
+  type ExportProblem,
+  type ExportQuery,
+  type ImportItemResult,
+  type ImportReport,
+  type ImportStrategy,
   isValidDifficulty,
   isValidProblemType,
   type ProblemListQuery,
   type ProblemResponseWithCategories,
+  type RuntimeConfig,
   type UpdateProblemInput,
 } from "../types/problems.ts";
-import { validateJudgeImage } from "./judge-images.ts";
+import { validateJudgeImage, validateJudgeImageWithKind } from "./judge-images.ts";
 import { getStorageProvider } from "../lib/storage/mod.ts";
+import { extractSamples } from "../lib/samples.ts";
+import { listCategories } from "./categories.ts";
 import { logAudit } from "./audit-log.ts";
 
 export interface ProblemResponse {
@@ -46,6 +56,7 @@ export interface ProblemResponse {
   has_support_package: boolean;
   time_limit_ms: number;
   memory_limit_mb: number;
+  runtime_config: RuntimeConfig | null;
   number: number;
   owner_id: string;
   type: string;
@@ -93,6 +104,54 @@ export interface AdminProblemListResponse {
 /**
  * 将数据库行转换为题目响应。
  */
+/**
+ * 校验 runtime_config 结构（不涉及白名单 / kind，调用方负责）。
+ *
+ * @throws {BadRequestError} 缺字段、类型错、值越界
+ */
+export function validateRuntimeConfig(rc: RuntimeConfig): void {
+  if (!rc.evaluator || typeof rc.evaluator !== "object") {
+    throw new BadRequestError("runtime_config.evaluator 必须是对象");
+  }
+  if (!rc.solution || typeof rc.solution !== "object") {
+    throw new BadRequestError("runtime_config.solution 必须是对象");
+  }
+
+  const e = rc.evaluator;
+  if (typeof e.image !== "string" || !e.image.trim()) {
+    throw new BadRequestError("runtime_config.evaluator.image 必须是非空字符串");
+  }
+  if (typeof e.command !== "string" || !e.command.trim()) {
+    throw new BadRequestError("runtime_config.evaluator.command 必须是非空字符串");
+  }
+  if (typeof e.time_limit_ms !== "number" || e.time_limit_ms <= 0) {
+    throw new BadRequestError("runtime_config.evaluator.time_limit_ms 必须为正整数");
+  }
+  if (typeof e.memory_limit_mb !== "number" || e.memory_limit_mb <= 0) {
+    throw new BadRequestError("runtime_config.evaluator.memory_limit_mb 必须为正整数");
+  }
+
+  const s = rc.solution;
+  if (typeof s.image !== "string" || !s.image.trim()) {
+    throw new BadRequestError("runtime_config.solution.image 必须是非空字符串");
+  }
+  if (typeof s.entry !== "string" || !s.entry.trim()) {
+    throw new BadRequestError("runtime_config.solution.entry 必须是非空字符串");
+  }
+  // entry 安全校验：禁止路径分隔符与 ..
+  if (s.entry.includes("/") || s.entry.includes("\\") || s.entry.includes("..")) {
+    throw new BadRequestError(
+      `runtime_config.solution.entry 含非法字符：${s.entry}`,
+    );
+  }
+  if (typeof s.call_timeout_ms !== "number" || s.call_timeout_ms <= 0) {
+    throw new BadRequestError("runtime_config.solution.call_timeout_ms 必须为正整数");
+  }
+  if (typeof s.memory_limit_mb !== "number" || s.memory_limit_mb <= 0) {
+    throw new BadRequestError("runtime_config.solution.memory_limit_mb 必须为正整数");
+  }
+}
+
 function toProblemResponse(
   row: typeof problems.$inferSelect,
 ): ProblemResponse {
@@ -107,6 +166,7 @@ function toProblemResponse(
     has_support_package: row.support_package_storage_url !== null,
     time_limit_ms: row.time_limit_ms,
     memory_limit_mb: row.memory_limit_mb,
+    runtime_config: (row.runtime_config as RuntimeConfig | null) ?? null,
     number: row.number,
     owner_id: row.owner_id,
     type: row.type,
@@ -453,6 +513,22 @@ export async function createProblem(
     await validateJudgeImage(input.judge_image);
   }
 
+  // 校验 runtime_config（仅 admin 可设置；非空时校验结构 + 镜像 + kind）
+  if (input.runtime_config !== undefined && input.runtime_config !== null) {
+    if (userRole !== "admin") {
+      throw new ForbiddenError("仅管理员可配置双容器 runtime_config");
+    }
+    validateRuntimeConfig(input.runtime_config);
+    await validateJudgeImageWithKind(
+      input.runtime_config.evaluator.image,
+      "evaluator",
+    );
+    await validateJudgeImageWithKind(
+      input.runtime_config.solution.image,
+      "solution",
+    );
+  }
+
   // 题目主键统一由服务端生成 UUID，避免客户端注入字符串 id
   // 影响 display_id 双索引路由解析
   const id = crypto.randomUUID();
@@ -503,6 +579,7 @@ export async function createProblem(
         support_package_storage_url: input.support_package_storage_url ?? null,
         time_limit_ms: input.time_limit_ms ?? 5000,
         memory_limit_mb: input.memory_limit_mb ?? 512,
+        runtime_config: input.runtime_config ?? null,
         number,
         owner_id: ownerId,
         type,
@@ -593,6 +670,25 @@ export async function updateProblem(
     await validateJudgeImage(input.judge_image);
   }
 
+  // 校验 runtime_config（仅 admin 可设置；非空时校验结构 + 镜像 + kind）
+  //   undefined → 不变；null → 清空（回退单容器）；object → 校验并写入
+  if (input.runtime_config !== undefined) {
+    if (userRole !== "admin") {
+      throw new ForbiddenError("仅管理员可配置双容器 runtime_config");
+    }
+    if (input.runtime_config !== null) {
+      validateRuntimeConfig(input.runtime_config);
+      await validateJudgeImageWithKind(
+        input.runtime_config.evaluator.image,
+        "evaluator",
+      );
+      await validateJudgeImageWithKind(
+        input.runtime_config.solution.image,
+        "solution",
+      );
+    }
+  }
+
   // 防御性忽略 type 和 number（spec 承诺这两个字段不可变更）
   delete (input as Record<string, unknown>)["type"];
   delete (input as Record<string, unknown>)["number"];
@@ -614,6 +710,9 @@ export async function updateProblem(
   if (input.memory_limit_mb !== undefined) {
     updates.memory_limit_mb = input.memory_limit_mb;
   }
+  if (input.runtime_config !== undefined) {
+    updates.runtime_config = input.runtime_config;
+  }
   updates.updated_at = new Date().toISOString();
 
   await db.update(problems).set(updates).where(eq(problems.id, id));
@@ -621,6 +720,25 @@ export async function updateProblem(
   // 处理分类关联
   if (input.category_ids !== undefined) {
     await syncProblemCategories(id, input.category_ids);
+  }
+
+  // 审计日志：runtime_config 变更
+  if (input.runtime_config !== undefined) {
+    const oldHas = problem.runtime_config !== null;
+    const newHas = input.runtime_config !== null;
+    if (oldHas !== newHas || JSON.stringify(problem.runtime_config) !== JSON.stringify(input.runtime_config)) {
+      await logAudit(
+        "problems.runtime_config_changed",
+        {
+          action: "problems.runtime_config_changed",
+          title: problem.title,
+          display_id: `${problem.type}${problem.number}`,
+          old_has_runtime_config: oldHas,
+          new_has_runtime_config: newHas,
+        },
+        { type: "problem", id },
+      );
+    }
   }
 
   return getProblem(id);
@@ -739,4 +857,441 @@ export async function syncProblemCategories(
       })),
     );
   }
+}
+
+// ─── 题目导入导出（issue #28）─────────────────────────────────
+
+/**
+ * 校验 support_package_storage_url 格式合法。
+ *
+ * 走法 A 不做可达性检查——导出是元数据操作，不应因为临时 S3 故障
+ * 就让导出失败。如果 URL 真正坏掉，导入后 judge 端评测会自然报错。
+ * 这里只拦截明显错误的协议前缀，避免 round-trip 引入脏数据。
+ */
+function assertStorageUrlFormat(url: string | null): void {
+  if (!url) return;
+  if (
+    !url.startsWith("noj-storage://") &&
+    !url.startsWith("noj-download://")
+  ) {
+    throw new BadRequestError(
+      `支持包 URL 协议不受支持：${url}（仅支持 noj-storage:// 或 noj-download://）`,
+    );
+  }
+}
+
+/**
+ * 导出题目集合为标准 JSON 结构。
+ *
+ * 查询模式：
+ * - `ids` 优先：按指定 id 列表精确导出
+ * - `type`：按题目类型批量导出（U/P 全部）
+ * - 二者都未提供或都提供 → 拒绝
+ *
+ * 返回结构遵循 EXPORT_VERSION 约定的字段命名，round-trip 安全。
+ *
+ * @throws {BadRequestError} 查询参数非法 / 支持包 URL 校验失败
+ */
+export async function buildExportPayload(
+  query: ExportQuery,
+  exportedBy: string,
+): Promise<ExportPayload> {
+  const db = getDb();
+
+  // 互斥校验
+  const hasIds = query.ids !== undefined && query.ids.length > 0;
+  const hasType = query.type !== undefined;
+  if (hasIds && hasType) {
+    throw new BadRequestError("ids 和 type 互斥，请二选一");
+  }
+  if (!hasIds && !hasType) {
+    throw new BadRequestError("必须提供 ids 或 type 之一");
+  }
+  if (hasType && query.type !== undefined && !isValidProblemType(query.type)) {
+    throw new BadRequestError(
+      `非法题目类型：${query.type}，仅允许 U/P`,
+    );
+  }
+
+  // 查询题目
+  let rows: (typeof problems.$inferSelect)[];
+  if (hasIds) {
+    rows = await db
+      .select()
+      .from(problems)
+      .where(inArray(problems.id, query.ids!));
+  } else {
+    rows = await db
+      .select()
+      .from(problems)
+      .where(eq(problems.type, query.type!));
+  }
+
+  if (rows.length === 0) {
+    return {
+      version: EXPORT_VERSION,
+      exported_at: new Date().toISOString(),
+      exported_by: exportedBy,
+      problems: [],
+    };
+  }
+
+  // 注入分类信息
+  const catMap = await attachCategories(rows.map((r) => r.id));
+
+  // 校验所有 support_package URL 协议前缀合法
+  for (const row of rows) {
+    assertStorageUrlFormat(row.support_package_storage_url);
+  }
+
+  // 组装 ExportProblem
+  const exportedProblems: ExportProblem[] = rows.map((row) => {
+    const cats = catMap.get(row.id) ?? [];
+    return {
+      id: row.id,
+      display_id: `${row.type}${row.number}`,
+      type: row.type as "U" | "P",
+      number: row.number,
+      title: row.title,
+      description: row.description,
+      difficulty: row.difficulty,
+      categories: cats.map((c) => ({ name: c.name, slug: c.slug })),
+      // judge_images 暂时只暴露单值（与当前 schema 一致：1 道题 = 1 镜像）。
+      // 字段设计为数组是为未来多镜像留口。
+      judge_images: [row.judge_image],
+      judge_command: row.judge_command,
+      time_limit_ms: row.time_limit_ms,
+      memory_limit_mb: row.memory_limit_mb,
+      support_package_storage_url: row.support_package_storage_url,
+      test_cases_ref: row.support_package_storage_url,
+      runtime_config: (row.runtime_config as RuntimeConfig | null) ?? null,
+      samples: extractSamples(row.description),
+    };
+  });
+
+  return {
+    version: EXPORT_VERSION,
+    exported_at: new Date().toISOString(),
+    exported_by: exportedBy,
+    problems: exportedProblems,
+  };
+}
+
+// ─── 导入服务 ──────────────────────────────────────────────
+
+/**
+ * 导入 payload 类型守卫。
+ * 校验 version、problems 数组、每个 ExportProblem 的基本字段。
+ */
+function parseImportPayload(input: unknown): ExportPayload {
+  if (!input || typeof input !== "object") {
+    throw new BadRequestError("导入文件必须为 JSON 对象");
+  }
+  const obj = input as Record<string, unknown>;
+  if (obj.version !== EXPORT_VERSION) {
+    throw new BadRequestError(
+      `不支持的导入文件版本：${
+        String(obj.version)
+      }（当前仅支持 ${EXPORT_VERSION}）`,
+    );
+  }
+  if (!Array.isArray(obj.problems)) {
+    throw new BadRequestError("导入文件必须包含 problems 数组");
+  }
+  for (let i = 0; i < obj.problems.length; i++) {
+    const p = obj.problems[i] as Record<string, unknown> | null;
+    if (!p || typeof p !== "object") {
+      throw new BadRequestError(`problems[${i}] 不是合法对象`);
+    }
+    for (
+      const field of [
+        "id",
+        "title",
+        "description",
+        "judge_command",
+        "type",
+        "number",
+      ]
+    ) {
+      if (!(field in p)) {
+        throw new BadRequestError(
+          `problems[${i}] 缺少必填字段：${field}`,
+        );
+      }
+    }
+  }
+  return obj as unknown as ExportPayload;
+}
+
+/**
+ * 构建分类 name → id 映射（用于按 name 解析导入题目中的分类关联）。
+ *
+ * 走法 A 不支持自动创建分类——不存在的分类名会被忽略（warning），
+ * 由 admin 自行在导入前手动创建，避免脏数据。
+ */
+async function buildCategoryLookup(): Promise<Map<string, string>> {
+  const tree = await listCategories();
+  const map = new Map<string, string>();
+  const visit = (nodes: typeof tree) => {
+    for (const n of nodes) {
+      map.set(n.name, n.id);
+      if (n.children.length > 0) visit(n.children);
+    }
+  };
+  visit(tree);
+  return map;
+}
+
+/**
+ * 把单个 ExportProblem 落到数据库。
+ *
+ * 策略行为：
+ * - create: 已存在 → skip；不存在 → 新建
+ * - overwrite: 已存在 → 更新（type/number 不可变）；不存在 → 新建
+ * - skip: 已存在 → skip；不存在 → 新建
+ *
+ * 权限：
+ * - 仅 admin 可调用
+ * - 若 import 项的 type='P'，会校验 userRole
+ *
+ * @returns 该条目的处理结果（含写入后的 problem_id）
+ */
+async function importOne(
+  item: ExportProblem,
+  strategy: ImportStrategy,
+  userId: string,
+  userRole: string,
+  categoryLookup: Map<string, string>,
+): Promise<ImportItemResult> {
+  const baseResult: Omit<ImportItemResult, "action" | "problem_id"> = {
+    id: item.id,
+    display_id: item.display_id,
+  };
+
+  // 1. 难度值校验
+  if (!isValidDifficulty(item.difficulty)) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: `非法难度值：${item.difficulty}`,
+    };
+  }
+
+  // 2. 题目类型校验
+  if (!isValidProblemType(item.type)) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: `非法题目类型：${item.type}`,
+    };
+  }
+
+  // 3. P 型题需要 admin
+  if (item.type === "P" && userRole !== "admin") {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: "P 型题仅管理员可导入",
+    };
+  }
+
+  // 4. judge_images 校验（当前 schema 是 1:1，取第一个）
+  const judgeImage = item.judge_images[0];
+  if (!judgeImage) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: "judge_images 数组为空",
+    };
+  }
+  try {
+    await validateJudgeImage(judgeImage);
+  } catch (err) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: `judge_image 校验失败：${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+
+  // 5. support_package_storage_url 协议前缀校验
+  if (item.support_package_storage_url) {
+    if (
+      !item.support_package_storage_url.startsWith("noj-storage://") &&
+      !item.support_package_storage_url.startsWith("noj-download://")
+    ) {
+      return {
+        ...baseResult,
+        action: "failed",
+        reason: `支持包 URL 协议不受支持：${item.support_package_storage_url}`,
+      };
+    }
+  }
+
+  // 6. 分类解析（按 name 查；找不到的跳过）
+  const categoryIds: string[] = [];
+  const missingCategories: string[] = [];
+  for (const c of item.categories) {
+    const id = categoryLookup.get(c.name);
+    if (id) {
+      categoryIds.push(id);
+    } else {
+      missingCategories.push(c.name);
+    }
+  }
+
+  // 7. 检查目标问题是否存在（按 source id）
+  const db = getDb();
+  const existing = await db
+    .select()
+    .from(problems)
+    .where(eq(problems.id, item.id))
+    .limit(1);
+
+  if (existing.length > 0) {
+    // 目标已存在
+    if (strategy === "create" || strategy === "skip") {
+      return {
+        ...baseResult,
+        action: "skipped",
+        reason: strategy === "create"
+          ? "目标 id 已存在，create 策略跳过"
+          : "目标 id 已存在，skip 策略跳过",
+        problem_id: existing[0].id,
+      };
+    }
+    // overwrite：更新元数据
+    const updates: Record<string, unknown> = {
+      title: item.title,
+      description: item.description,
+      difficulty: item.difficulty,
+      judge_image: judgeImage,
+      judge_command: item.judge_command,
+      support_package_storage_url: item.support_package_storage_url,
+      time_limit_ms: item.time_limit_ms,
+      memory_limit_mb: item.memory_limit_mb,
+      runtime_config: (item.runtime_config as RuntimeConfig | null | undefined) ?? null,
+      updated_at: new Date().toISOString(),
+    };
+    await db.update(problems).set(updates).where(eq(problems.id, item.id));
+    await syncProblemCategories(item.id, categoryIds);
+    return {
+      ...baseResult,
+      action: "updated",
+      problem_id: item.id,
+    };
+  }
+
+  // 8. 目标不存在 → 新建
+  try {
+    const created = await createProblem(
+      {
+        title: item.title,
+        description: item.description,
+        difficulty: item.difficulty,
+        judge_image: judgeImage,
+        judge_command: item.judge_command,
+        support_package_storage_url: item.support_package_storage_url,
+        time_limit_ms: item.time_limit_ms,
+        memory_limit_mb: item.memory_limit_mb,
+        // runtime_config 缺失时按 null（单容器路径），保持向后兼容
+        runtime_config: (item.runtime_config as RuntimeConfig | null | undefined) ?? null,
+        type: item.type,
+        number: item.number,
+        category_ids: categoryIds,
+      },
+      userId,
+      userRole,
+    );
+    const reasonSuffix = missingCategories.length > 0
+      ? `（注意：以下分类在当前 DB 不存在，已忽略：${
+        missingCategories.join("、")
+      }）`
+      : undefined;
+    return {
+      ...baseResult,
+      action: "created",
+      problem_id: created.id,
+      reason: reasonSuffix,
+    };
+  } catch (err) {
+    return {
+      ...baseResult,
+      action: "failed",
+      reason: `创建失败：${err instanceof Error ? err.message : String(err)}${
+        missingCategories.length > 0
+          ? `；缺失分类：${missingCategories.join("、")}`
+          : ""
+      }`,
+    };
+  }
+}
+
+/**
+ * 批量导入题目。
+ *
+ * @param input 原始 JSON（来自请求体或文件）
+ * @param strategy 三种策略之一
+ * @param userId 当前 admin id
+ * @param userRole 当前 admin role
+ * @returns 导入结果报告（按 action 分桶）
+ */
+export async function importProblems(
+  input: unknown,
+  strategy: ImportStrategy,
+  userId: string,
+  userRole: string,
+): Promise<ImportReport> {
+  if (
+    strategy !== "create" && strategy !== "overwrite" && strategy !== "skip"
+  ) {
+    throw new BadRequestError(
+      `非法导入策略：${strategy}（仅支持 create/overwrite/skip）`,
+    );
+  }
+
+  const payload = parseImportPayload(input);
+
+  // 预构建分类查找表（一次查询，避免 N+1）
+  const categoryLookup = await buildCategoryLookup();
+
+  const created: ImportItemResult[] = [];
+  const updated: ImportItemResult[] = [];
+  const skipped: ImportItemResult[] = [];
+  const failed: ImportItemResult[] = [];
+
+  for (const item of payload.problems) {
+    const result = await importOne(
+      item,
+      strategy,
+      userId,
+      userRole,
+      categoryLookup,
+    );
+    switch (result.action) {
+      case "created":
+        created.push(result);
+        break;
+      case "updated":
+        updated.push(result);
+        break;
+      case "skipped":
+        skipped.push(result);
+        break;
+      case "failed":
+        failed.push(result);
+        break;
+    }
+  }
+
+  return {
+    strategy,
+    total: payload.problems.length,
+    created,
+    updated,
+    skipped,
+    failed,
+  };
 }

--- a/noj-core/src/services/submissions.ts
+++ b/noj-core/src/services/submissions.ts
@@ -19,6 +19,7 @@ import { AppError, BadRequestError, NotFoundError } from "../lib/errors.ts";
 import { getDb } from "../db/connection.ts";
 import { pushJudgeTask } from "../mq/producer.ts";
 import { getProblem } from "./problems.ts";
+import { validateJudgeImage, validateJudgeImageWithKind } from "./judge-images.ts";
 import { getStorageProvider } from "../lib/storage/mod.ts";
 import { getPendingSubmissionIds, getSubmissionQueueStatus } from "./queue.ts";
 import type {
@@ -354,8 +355,17 @@ export async function createSubmission(
 ): Promise<SubmissionResponse> {
   const db = getDb();
 
-  // 检查题目是否存在并获取信息
-  const problem = await getProblem(input.problem_id);
+  // 行级锁 + 读取最新题目配置（避免 admin 在提交期间清空 runtime_config 导致竞态）
+  const lockedRows = await db
+    .select()
+    .from(problems)
+    .where(eq(problems.id, input.problem_id))
+    .for("update")
+    .limit(1);
+  if (lockedRows.length === 0) {
+    throw new NotFoundError("题目不存在");
+  }
+  const problem = lockedRows[0];
 
   // 验证语言
   const supportedLanguages = ["python3", "python", "cpp", "c", "javascript"];
@@ -388,12 +398,46 @@ export async function createSubmission(
     }
   }
 
+  // ── 决定评测模式 + 镜像白名单 final gate ──
+  // - runtime_config 非空 → dual mode + 校验 evaluator/solution image + kind
+  // - runtime_config 为空 → single mode + 校验 judge_image
+  // 任一校验失败抛 image_not_allowlisted 错误（spec §4 final gate）
+  const runtimeConfig = problem.runtime_config as
+    | import("../types/problems.ts").RuntimeConfig
+    | null
+    | undefined;
+
+  let judgeMode: "single" | "dual";
+  if (runtimeConfig) {
+    judgeMode = "dual";
+    // 防御性 final gate：再次校验双容器镜像 + kind
+    await validateJudgeImageWithKind(
+      runtimeConfig.evaluator.image,
+      "evaluator",
+    );
+    await validateJudgeImageWithKind(
+      runtimeConfig.solution.image,
+      "solution",
+    );
+  } else {
+    judgeMode = "single";
+    // 单容器：校验 judge_image 仍在白名单
+    await validateJudgeImage(problem.judge_image);
+  }
+
   const task: JudgeTask = {
     submission_id: id,
     problem_id: input.problem_id,
-    judge_image: problem.judge_image,
-    judge_command: problem.judge_command,
+    mode: judgeMode,
+    // dual 模式下 judge_image / judge_command 可省略；single 模式下必填
+    ...(judgeMode === "single" && {
+      judge_image: problem.judge_image,
+      judge_command: problem.judge_command,
+    }),
     download_url,
+    ...(judgeMode === "dual" && {
+      runtime_config: runtimeConfig as NonNullable<typeof runtimeConfig>,
+    }),
     language: input.language,
     code: input.code,
     file_name: fileName,

--- a/noj-core/src/types/audit-log.ts
+++ b/noj-core/src/types/audit-log.ts
@@ -11,6 +11,7 @@ export type AuditAction =
   | "users.ban"
   | "users.unban"
   | "problems.delete"
+  | "problems.runtime_config_changed"
   | "categories.delete"
   | "submissions.rejudge"
   | "settings.update"
@@ -23,6 +24,13 @@ export type AuditDetail =
   | { action: "users.ban"; reason: string; until: string | null }
   | { action: "users.unban" }
   | { action: "problems.delete"; title: string; display_id: string }
+  | {
+    action: "problems.runtime_config_changed";
+    title: string;
+    display_id: string;
+    old_has_runtime_config: boolean;
+    new_has_runtime_config: boolean;
+  }
   | {
     action: "categories.delete";
     name: string;

--- a/noj-core/src/types/index.ts
+++ b/noj-core/src/types/index.ts
@@ -1,26 +1,88 @@
 /**
+ * 评测模式。
+ *
+ * - `single`（默认）：现有单容器路径，使用 `judge_image` / `judge_command`。
+ * - `dual`：双容器编排（Evaluator + Solution），使用 `runtime_config`。
+ *
+ * 缺省或未识别时按 `single` 处理（向后兼容）。
+ */
+export type JudgeMode = "single" | "dual";
+
+/**
+ * Evaluator 容器运行时配置（双容器模式）。
+ */
+export interface EvaluatorRuntime {
+  /** Docker 镜像名（须在 `judge_images` 白名单中且 kind='evaluator'） */
+  image: string;
+  /** 评测命令，如 `python3 /workspace/evaluate.py` */
+  command: string;
+  /** Evaluator 容器总时间上限（毫秒） */
+  time_limit_ms: number;
+  /** Evaluator 容器内存上限（MB） */
+  memory_limit_mb: number;
+}
+
+/**
+ * Solution 容器运行时配置（双容器模式）。
+ */
+export interface SolutionRuntime {
+  /** Docker 镜像名（须在 `judge_images` 白名单中且 kind='solution'） */
+  image: string;
+  /** Solution 容器内入口文件名，如 `solution.py` */
+  entry: string;
+  /** 单次 SDK 调用的时间上限（毫秒）。单次超时不影响 host 进程 */
+  call_timeout_ms: number;
+  /** Solution 容器内存上限（MB） */
+  memory_limit_mb: number;
+}
+
+/**
+ * 双容器模式的 Runtime 配置。
+ */
+export interface RuntimeConfig {
+  evaluator: EvaluatorRuntime;
+  solution: SolutionRuntime;
+}
+
+/**
  * 评测任务——从 noj-core 发送到 noj-judge 的消息。
+ *
+ * 字段语义：
+ * - 单容器模式（`mode='single'` 或缺省）：使用 `judge_image` / `judge_command`。
+ * - 双容器模式（`mode='dual'`）：使用 `runtime_config`，`judge_image` / `judge_command` 可省略。
  */
 export interface JudgeTask {
   /** 提交 UUID */
   submission_id: string;
   /** 题目 UUID */
   problem_id: string;
-  /** 题目定义的 Docker 镜像名 */
-  judge_image: string;
-  /** 容器内执行的评测命令 */
-  judge_command: string;
-  /** 支持包下载 URL（`noj-download://` 格式） */
+  /** 评测模式。缺省时按单容器处理 */
+  mode?: JudgeMode;
+  /** 题目定义的 Docker 镜像名（单容器必填；双容器可选） */
+  judge_image?: string;
+  /** 容器内执行的评测命令（单容器必填；双容器可选） */
+  judge_command?: string;
+  /** 支持包下载 URL（`noj-download://` 格式），单/双容器共用 */
   download_url?: string;
+  /** 双容器模式的 Runtime 配置 */
+  runtime_config?: RuntimeConfig;
   /** 编程语言标识 */
   language: string;
   /** 用户源代码 */
   code: string;
   /** 用户代码的文件名 */
   file_name?: string;
-  /** 时间限制（毫秒） */
+  /**
+   * 时间限制（毫秒）。
+   * - 单容器：总超时
+   * - 双容器：Evaluator 总超时（实际以 `runtime_config.evaluator.time_limit_ms` 为准）
+   */
   time_limit_ms: number;
-  /** 内存限制（MB） */
+  /**
+   * 内存限制（MB）。
+   * - 单容器：总内存
+   * - 双容器：Evaluator 默认内存（实际以 `runtime_config.evaluator.memory_limit_mb` 为准）
+   */
   memory_limit_mb: number;
   /** 重测序列号（重测时递增）。首次提交不传，默认 0。 */
   rejudge_seq?: number;

--- a/noj-core/src/types/problems.ts
+++ b/noj-core/src/types/problems.ts
@@ -123,11 +123,28 @@ export interface ProblemResponseWithCategories {
 }
 
 /**
+ * 镜像用途分类（dual-container-judge §5）。
+ *
+ * - `evaluator`：单容器 / 双容器 Evaluator 角色（默认）
+ * - `solution`：双容器 Solution 角色
+ */
+export const JUDGE_IMAGE_KINDS = ["evaluator", "solution"] as const;
+export type JudgeImageKind = typeof JUDGE_IMAGE_KINDS[number];
+
+export function isValidJudgeImageKind(value: string): value is JudgeImageKind {
+  return JUDGE_IMAGE_KINDS.includes(value as JudgeImageKind);
+}
+
+/**
  * 创建评测镜像白名单条目请求体。
  */
 export interface CreateJudgeImageInput {
   image: string;
   mode: "exact" | "all_versions";
+  /**
+   * 镜像用途分类（dual-container-judge §5）。必填：'evaluator' / 'solution'。
+   */
+  kind: JudgeImageKind;
   description?: string;
 }
 
@@ -137,6 +154,7 @@ export interface CreateJudgeImageInput {
 export interface UpdateJudgeImageInput {
   image?: string;
   mode?: "exact" | "all_versions";
+  kind?: JudgeImageKind;
   description?: string;
 }
 
@@ -147,9 +165,103 @@ export interface JudgeImageResponse {
   id: string;
   image: string;
   mode: string;
+  /**
+   * 镜像用途分类（dual-container-judge §5）。
+   */
+  kind: JudgeImageKind;
   description: string;
   created_at: string;
   updated_at: string;
+}
+
+// ─── 题目导入导出（issue #28）─────────────────────────────────
+
+/**
+ * 导出文件格式版本号。
+ * v1.0 = 走法 A：仅元数据 + support_package_storage_url 引用 + samples。
+ */
+export const EXPORT_VERSION = "1.0" as const;
+
+/**
+ * 导出单题结构。
+ *
+ * 字段命名约定：
+ * - 蛇形命名（snake_case）保持与 DB 列一致，便于 round-trip
+ * - 列表类字段（categories / judge_images / samples）按显示顺序排列
+ * - display_id = `${type}${number}`，从 type+number 计算得出，导入时可任选其一
+ */
+export interface ExportProblem {
+  id: string;
+  display_id: string;
+  type: "U" | "P";
+  number: number;
+  title: string;
+  description: string;
+  difficulty: string;
+  categories: { name: string; slug: string }[];
+  judge_images: string[];
+  judge_command: string;
+  time_limit_ms: number;
+  memory_limit_mb: number;
+  support_package_storage_url: string | null;
+  /** 引用支持包 URL（与 support_package_storage_url 同值，仅作为语义占位） */
+  test_cases_ref: string | null;
+  samples: { input: string; output: string }[];
+}
+
+/**
+ * 完整导出文件结构。
+ */
+export interface ExportPayload {
+  version: typeof EXPORT_VERSION;
+  exported_at: string;
+  exported_by: string;
+  problems: ExportProblem[];
+}
+
+/**
+ * 导出查询参数。
+ * - ids 与 type 互斥：ids 优先，type 用于批量筛选（U/P 全部）
+ * - 都未提供时拒绝（避免误操作全表导出）
+ */
+export interface ExportQuery {
+  ids?: string[];
+  type?: "U" | "P";
+}
+
+/**
+ * 导入策略。
+ * - create: 不存在则新建；存在则按 skip 处理（不报错）
+ * - overwrite: 不存在则新建；存在则覆盖元数据（type/number 不可变）
+ * - skip: 不存在则新建失败；存在则跳过
+ */
+export type ImportStrategy = "create" | "overwrite" | "skip";
+
+/**
+ * 导入单条结果。
+ */
+export interface ImportItemResult {
+  /** 来源 id（ExportProblem.id），便于追踪失败项 */
+  id: string;
+  display_id: string;
+  /** created / updated / skipped / failed */
+  action: "created" | "updated" | "skipped" | "failed";
+  /** 失败原因（仅 action=failed 时存在） */
+  reason?: string;
+  /** 写入后服务端 id（skipped 时为已存在题目 id，failed 时不存在） */
+  problem_id?: string;
+}
+
+/**
+ * 导入结果报告。
+ */
+export interface ImportReport {
+  strategy: ImportStrategy;
+  total: number;
+  created: ImportItemResult[];
+  updated: ImportItemResult[];
+  skipped: ImportItemResult[];
+  failed: ImportItemResult[];
 }
 
 /**

--- a/noj-core/src/types/problems.ts
+++ b/noj-core/src/types/problems.ts
@@ -40,6 +40,30 @@ export function isValidProblemType(value: string): value is ProblemType {
 }
 
 /**
+ * 双容器 Runtime 配置（与 noj-judge/src/types.ts RuntimeConfig 对齐）。
+ *
+ * 仅 admin 可设置；普通用户创建题目时该字段被忽略。
+ */
+export interface RuntimeConfig {
+  evaluator: EvaluatorRuntime;
+  solution: SolutionRuntime;
+}
+
+export interface EvaluatorRuntime {
+  image: string;
+  command: string;
+  time_limit_ms: number;
+  memory_limit_mb: number;
+}
+
+export interface SolutionRuntime {
+  image: string;
+  entry: string;
+  call_timeout_ms: number;
+  memory_limit_mb: number;
+}
+
+/**
  * 创建题目请求体。
  *
  * 注意：`id` 字段已从客户端输入中移除——所有题目统一由服务端生成 UUID。
@@ -55,6 +79,11 @@ export interface CreateProblemInput {
   support_package_storage_url?: string | null;
   time_limit_ms?: number;
   memory_limit_mb?: number;
+  /**
+   * 双容器 Runtime 配置。仅 admin 可设置。
+   * 设置后 `judge_image` / `judge_command` 仍保留为同步值，但调度时以 runtime_config 为准。
+   */
+  runtime_config?: RuntimeConfig | null;
   category_ids?: string[];
   /** 题目类型：U（用户题）/ P（主题题），默认 U */
   type?: string;
@@ -74,6 +103,10 @@ export interface UpdateProblemInput {
   support_package_storage_url?: string | null;
   time_limit_ms?: number;
   memory_limit_mb?: number;
+  /**
+   * 双容器 Runtime 配置。设为 null 即清空（题目回到单容器路径）。
+   */
+  runtime_config?: RuntimeConfig | null;
   category_ids?: string[];
 }
 
@@ -109,6 +142,10 @@ export interface ProblemResponseWithCategories {
   has_support_package: boolean;
   time_limit_ms: number;
   memory_limit_mb: number;
+  /**
+   * 双容器 Runtime 配置。null 表示单容器题目。
+   */
+  runtime_config: RuntimeConfig | null;
   categories: { id: string; name: string; slug: string }[];
   created_at: string;
   updated_at: string;
@@ -206,6 +243,11 @@ export interface ExportProblem {
   support_package_storage_url: string | null;
   /** 引用支持包 URL（与 support_package_storage_url 同值，仅作为语义占位） */
   test_cases_ref: string | null;
+  /**
+   * 双容器 Runtime 配置。null 表示单容器题目。
+   * 旧版导出文件可能缺失该字段，导入时按 null 处理。
+   */
+  runtime_config: RuntimeConfig | null;
   samples: { input: string; output: string }[];
 }
 

--- a/noj-core/tests/_setup.ts
+++ b/noj-core/tests/_setup.ts
@@ -49,8 +49,8 @@ export async function setupSchemaForTest(): Promise<void> {
      ON CONFLICT (id) DO NOTHING`,
   );
   await db.execute(
-    `INSERT INTO judge_images (id, image, mode, description, created_at, updated_at)
-     VALUES ('e0000000-0000-0000-0000-000000000001', 'noj-judge-python', 'all_versions', 'Python 3.12 评测环境', '${now}', '${now}')
+    `INSERT INTO judge_images (id, image, mode, kind, description, created_at, updated_at)
+     VALUES ('e0000000-0000-0000-0000-000000000001', 'noj-judge-python', 'all_versions', 'evaluator', 'Python 3.12 评测环境', '${now}', '${now}')
      ON CONFLICT (id) DO NOTHING`,
   );
 }

--- a/noj-core/tests/routes/judge-images.test.ts
+++ b/noj-core/tests/routes/judge-images.test.ts
@@ -103,6 +103,7 @@ Deno.test({
       body: JSON.stringify({
         image: `route-test-image-${ts}`,
         mode: "exact",
+        kind: "evaluator",
         description: "路由测试",
       }),
     });
@@ -158,6 +159,7 @@ Deno.test({
       body: JSON.stringify({
         image: `route-update-test-${ts}`,
         mode: "exact",
+        kind: "evaluator",
       }),
     });
     const created = await createRes.json();
@@ -205,6 +207,7 @@ Deno.test({
       body: JSON.stringify({
         image: `route-delete-test-${ts}`,
         mode: "exact",
+        kind: "evaluator",
       }),
     });
     const created = await createRes.json();

--- a/noj-core/tests/services/judge-images.test.ts
+++ b/noj-core/tests/services/judge-images.test.ts
@@ -45,6 +45,7 @@ Deno.test({
     const item = await createJudgeImage({
       image: `test-image-${ts}`,
       mode: "exact",
+      kind: "evaluator",
       description: "测试用镜像",
     });
     assertEquals(item.image, `test-image-${ts}`);
@@ -68,6 +69,7 @@ Deno.test({
         createJudgeImage({
           image: "test-image",
           mode: "regex" as "exact" | "all_versions",
+          kind: "evaluator",
         }),
       ValidationError,
     );
@@ -86,6 +88,7 @@ Deno.test({
         createJudgeImage({
           image: "",
           mode: "exact",
+          kind: "evaluator",
         }),
       ValidationError,
     );
@@ -103,6 +106,7 @@ Deno.test({
     const created = await createJudgeImage({
       image: `update-test-${ts}`,
       mode: "exact",
+      kind: "evaluator",
       description: "原始介绍",
     });
     // 再更新
@@ -140,6 +144,7 @@ Deno.test({
     const created = await createJudgeImage({
       image: `delete-test-${ts}`,
       mode: "exact",
+      kind: "evaluator",
     });
     await deleteJudgeImage(created.id);
     // 删除后再次删除应抛 NotFound

--- a/noj-judge/docker/evaluator-python/Dockerfile
+++ b/noj-judge/docker/evaluator-python/Dockerfile
@@ -1,0 +1,25 @@
+# noj-evaluator-python: 双容器模式下 Evaluator 容器运行时
+#
+# 设计稿 §5：
+# - 默认 network_mode=none（评测时由 docker run / pool 加参数）
+# - 不挂载支持包（运行时由 noj-judge 注入）
+# - 内置 noj_evaluator_sdk（SolutionRunner + result.accept / wrong_answer）
+#
+# 入口：noj-judge 启动时通过 docker exec 在容器内跑 <runtime_config.evaluator.command>
+# （如 `python3 /workspace/evaluate.py`）。容器默认 cmd 设为 sleep infinity，
+# 因为容器是通过 exec 启动评测脚本而非 docker run。
+
+FROM python:3.12-slim
+LABEL org.opencontainers.image.description="Neuro OJ Dual-container Evaluator (Python 3.12, noj_evaluator_sdk)"
+LABEL com.noj.judge.kind="evaluator"
+
+# 安装 SDK 源码
+# 注：noj-judge/sdk/evaluator/noj_evaluator_sdk/ 是包目录
+# COPY 时跳过外层 noj_evaluator_sdk/，让其内容直接落在 site-packages/noj_evaluator_sdk/
+COPY sdk/evaluator/noj_evaluator_sdk/ /usr/local/lib/python3.12/site-packages/noj_evaluator_sdk/
+
+# 验证 SDK 可导入（构建期 sanity check）
+RUN python3 -c "import noj_evaluator_sdk; from noj_evaluator_sdk.runner import SolutionRunner; from noj_evaluator_sdk.result import Result; print('noj_evaluator_sdk OK')"
+
+# 默认 cmd 为 sleep infinity —— 容器通过 docker exec 启动评测脚本
+CMD ["sleep", "infinity"]

--- a/noj-judge/docker/solution-python/Dockerfile
+++ b/noj-judge/docker/solution-python/Dockerfile
@@ -1,0 +1,24 @@
+# noj-solution-python: 双容器模式下 Solution 容器运行时
+#
+# 设计稿 §5 + §6：
+# - 默认 network_mode=none
+# - 不挂载支持包
+# - 不读取 Evaluator 环境变量
+# - 内置 noj_solution_sdk（register + host 模块）
+#
+# 入口：noj-judge 通过 docker exec 启动 `python3 -m noj_solution_sdk.host --entry <file>`
+# 容器默认 cmd 设为 sleep infinity（容器本身不主动跑东西，由 exec 注入 host 进程）。
+
+FROM python:3.12-slim
+LABEL org.opencontainers.image.description="Neuro OJ Dual-container Solution (Python 3.12, noj_solution_sdk)"
+LABEL com.noj.judge.kind="solution"
+
+# 安装 SDK 源码
+# 跳过外层 noj_solution_sdk/，让其内容直接落在 site-packages/noj_solution_sdk/
+COPY sdk/solution/noj_solution_sdk/ /usr/local/lib/python3.12/site-packages/noj_solution_sdk/
+
+# 验证 SDK 可导入（构建期 sanity check）
+RUN python3 -c "import noj_solution_sdk; from noj_solution_sdk.host import main; from noj_solution_sdk.registry import register; print('noj_solution_sdk OK')"
+
+# 默认 cmd 为 sleep infinity —— 容器通过 docker exec 启动 host
+CMD ["sleep", "infinity"]

--- a/noj-judge/scripts/build-sdk-images.sh
+++ b/noj-judge/scripts/build-sdk-images.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# build-sdk-images.sh — 并行构建 noj-judge 双容器 SDK 镜像
+#
+# 构建产物：
+#   noj-evaluator-python:dev    -- docker/evaluator-python/
+#   noj-solution-python:dev     -- docker/solution-python/
+#
+# 用法：
+#   ./scripts/build-sdk-images.sh               # 构建两个镜像打 :dev tag
+#   ./scripts/build-sdk-images.sh --no-cache    # 强制重建（忽略缓存）
+#   ./scripts/build-sdk-images.sh --tag v0.1.0  # 自定义 tag
+#
+# 要求：
+#   - docker CLI 可用
+#   - 在 noj-judge/ 仓库根目录下执行（或使用绝对路径）
+#
+# 设计稿：openspec/changes/dual-container-judge/design.md §5
+
+set -euo pipefail
+
+# ── 参数解析 ────────────────────────────────────────
+NO_CACHE=""
+TAG="dev"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NOJ_JUDGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-cache)
+      NO_CACHE="--no-cache"
+      shift
+      ;;
+    --tag)
+      TAG="$2"
+      shift 2
+      ;;
+    -h|--help)
+      grep "^#" "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "未知参数: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── 前置检查 ────────────────────────────────────────
+if ! command -v docker >/dev/null 2>&1; then
+  echo "错误: docker CLI 不可用" >&2
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "错误: Docker daemon 未运行" >&2
+  exit 1
+fi
+
+cd "$NOJ_JUDGE_DIR"
+
+EVAL_IMAGE="noj-evaluator-python:${TAG}"
+SOL_IMAGE="noj-solution-python:${TAG}"
+
+echo "=== 并行构建 SDK 镜像 ==="
+echo "镜像 1: $EVAL_IMAGE  (构建上下文: docker/evaluator-python/)"
+echo "镜像 2: $SOL_IMAGE   (构建上下文: docker/solution-python/)"
+echo
+
+# ── 并行构建 ────────────────────────────────────────
+# 启动两个 docker build 后台任务，捕获 PID
+docker build $NO_CACHE \
+  -t "$EVAL_IMAGE" \
+  -f docker/evaluator-python/Dockerfile \
+  . > /tmp/noj-build-eval.log 2>&1 &
+EVAL_PID=$!
+
+docker build $NO_CACHE \
+  -t "$SOL_IMAGE" \
+  -f docker/solution-python/Dockerfile \
+  . > /tmp/noj-build-sol.log 2>&1 &
+SOL_PID=$!
+
+# 等待两个构建完成（收集退出码）
+EVAL_EXIT=0
+SOL_EXIT=0
+wait $EVAL_PID || EVAL_EXIT=$?
+wait $SOL_PID || SOL_EXIT=$?
+
+# ── 报告结果 ────────────────────────────────────────
+echo "--- evaluator-python 构建日志 ---"
+cat /tmp/noj-build-eval.log
+echo "--- solution-python 构建日志 ---"
+cat /tmp/noj-build-sol.log
+
+if [[ $EVAL_EXIT -ne 0 ]]; then
+  echo "❌ evaluator-python 构建失败 (exit=$EVAL_EXIT)" >&2
+fi
+if [[ $SOL_EXIT -ne 0 ]]; then
+  echo "❌ solution-python 构建失败 (exit=$SOL_EXIT)" >&2
+fi
+
+if [[ $EVAL_EXIT -ne 0 || $SOL_EXIT -ne 0 ]]; then
+  exit 1
+fi
+
+echo
+echo "=== 构建完成 ==="
+docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}" \
+  | grep -E "REPOSITORY|noj-(evaluator|solution)-python"
+
+# 清理临时日志
+rm -f /tmp/noj-build-eval.log /tmp/noj-build-sol.log

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/__init__.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/__init__.py
@@ -1,0 +1,37 @@
+"""
+noj_evaluator_sdk —— 可信评测端 SDK
+
+由 `evaluate.py` 导入，提供：
+- `SolutionRunner`：阻塞调用 Solution 容器内的注册函数
+- `result.accept(score, ...)` / `result.wrong_answer(...)`：写入 `---RESULT---` 标记
+- `configure_logging()`：把所有 print/logging 重定向到 stderr，stdout 仅用于协议帧与 RESULT 标记
+
+Evaluator ↔ judge 通信契约（详见 design.md §1）：
+- stdout：NDJSON 帧（call 帧）+ `---RESULT---` 标记
+- stdin：NDJSON 响应帧（result/error/log）
+"""
+
+from .errors import (
+    ConnectionError,
+    NotFoundError,
+    RejectedError,
+    SolutionTimeoutError,
+    SystemError,
+)
+from .result import Result
+from .runner import SolutionRunner
+from .logging_config import configure_logging
+
+# 公开 result 单例（`from noj_evaluator_sdk import result; result.accept(...)`）
+result = Result()
+
+__all__ = [
+    "SolutionRunner",
+    "result",
+    "configure_logging",
+    "ConnectionError",
+    "NotFoundError",
+    "RejectedError",
+    "SolutionTimeoutError",
+    "SystemError",
+]

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/errors.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/errors.py
@@ -1,0 +1,32 @@
+"""
+noj_evaluator_sdk 错误类型。
+
+五类错误码与 Solution host 一一对应（详见 design.md §2）。
+"""
+
+
+class SdkError(Exception):
+    """所有 SDK 错误的基类。"""
+
+
+class SolutionTimeoutError(SdkError):
+    """单次 `runner.call()` 超过 `call_timeout_ms`。
+
+    Solution host 进程本身仍存活，可继续下一次调用。
+    """
+
+
+class NotFoundError(SdkError):
+    """Solution host 中没有注册指定名称的函数。"""
+
+
+class RejectedError(SdkError):
+    """参数或返回值包含不被允许的类型（如自定义类、函数、socket）。"""
+
+
+class SystemError(SdkError):
+    """host 内部错误、judge IPC 通道断开等不可恢复错误。"""
+
+
+class ConnectionError(SystemError):
+    """stdin/stdout IPC 通道连接错误（典型场景：Solution host 进程崩溃）。"""

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/logging_config.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/logging_config.py
@@ -1,0 +1,46 @@
+"""
+noj_evaluator_sdk 日志配置。
+
+`configure_logging()` 把所有 print 与 logging 重定向到 stderr，确保 stdout 仅含
+NDJSON 协议帧与 `---RESULT---` 标记——这是与 judge 通信的前提。
+
+不强制替换 evaluate.py 中直接的 print（evaluate.py 作者仍可能误用 stdout），
+但 SDK 自身在调用 `configure_logging()` 后绝不会污染 stdout。
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """配置 logging + print 重定向到 stderr。
+
+    调用时机：evaluate.py 入口处先 `configure_logging()` 再 import 业务模块。
+    """
+    # 1. logging 重定向到 stderr
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(
+        logging.Formatter(
+            fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+    )
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(level)
+
+    # 2. print 重定向到 stderr（通过替换 builtins.print 仅在当前模块作用域生效）
+    #    注意：此替换只影响 `from noj_evaluator_sdk import print` 的形式，
+    #    无法拦截 evaluate.py 中直接的 print。这是设计选择：文档警示。
+    #    真正的防护是 SDK 内部所有 IO 仅通过 stderr。
+    import builtins as _builtins  # noqa: F401
+
+    def _stderr_print(*args, **kwargs):
+        kwargs.setdefault("file", sys.stderr)
+        _builtins.print(*args, **kwargs)
+
+    # 暴露为模块属性，让 `from noj_evaluator_sdk import print` 用户可显式使用
+    globals()["print"] = _stderr_print

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/result.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/result.py
@@ -1,0 +1,66 @@
+"""
+noj_evaluator_sdk result 模块。
+
+`result.accept(score)` / `result.wrong_answer(score, message)` 把最终结果写入 stdout
+（格式：`---RESULT---` + JSON），judge 在 evaluator exec 的 stdout 上解析该标记。
+
+调用后进程**应立即退出**——不再有后续 SDK 调用，否则标记会被后续 NDJSON 帧污染。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Optional
+
+
+class Result:
+    """最终结果写入器。
+
+    每个 evaluate.py 流程中**只应调用一次**：
+        from noj_evaluator_sdk import result
+        result.accept(score=100)
+    """
+
+    def __init__(self) -> None:
+        self._written = False
+
+    def _write(self, status: str, score: float, **kwargs: Any) -> None:
+        if self._written:
+            raise RuntimeError("result 已被写入一次，禁止重复")
+        self._written = True
+        payload = {
+            "status": status,
+            "score": int(round(score * 100)),  # ×100 整数值，与 core 对齐
+            "details": kwargs.get("details", {}),
+        }
+        if "message" in kwargs:
+            payload["details"]["message"] = kwargs["message"]
+        line = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        sys.stdout.write(f"---RESULT---\n{line}\n")
+        sys.stdout.flush()
+
+    def accept(self, score: float = 100.0, **kwargs: Any) -> None:
+        """评测通过。默认 score=100。"""
+        self._write("Accepted", score, **kwargs)
+
+    def wrong_answer(
+        self,
+        score: float = 0.0,
+        message: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """答案错误。message 进入 details.message。"""
+        if message is not None:
+            kwargs["message"] = message
+        self._write("WrongAnswer", score, **kwargs)
+
+    def runtime_error(self, message: str, **kwargs: Any) -> None:
+        """评测脚本自身出错（非用户代码问题）。"""
+        kwargs["message"] = message
+        self._write("RuntimeError", 0.0, **kwargs)
+
+    def system_error(self, message: str, **kwargs: Any) -> None:
+        """系统错误（支持包解压失败、RPC 通道异常等）。"""
+        kwargs["message"] = message
+        self._write("SystemError", 0.0, **kwargs)

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
@@ -1,0 +1,206 @@
+"""
+noj_evaluator_sdk SolutionRunner。
+
+单方向阻塞调用 Solution host 中的注册函数：
+
+    runner = SolutionRunner()
+    value = runner.call("solve", 1, 2)
+
+内部：
+- 启动一个后台线程从 stdin 读 NDJSON 响应帧
+- 按 `id` 字段匹配 pending 调用
+- `runner.call()` 写 `call` 帧到 stdout，阻塞等响应
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import uuid
+from queue import Empty, Queue
+from typing import Any, Optional
+
+from .errors import (
+    ConnectionError,
+    NotFoundError,
+    RejectedError,
+    SolutionTimeoutError,
+    SystemError,
+)
+from .serialization import (
+    check_frame_size,
+    decode_value,
+    encode_value,
+    validate_type,
+)
+
+
+class SolutionRunner:
+    """阻塞式 Solution host 调用器。
+
+    生命周期与 evaluate.py 进程一致。单实例即可复用。
+    """
+
+    def __init__(self) -> None:
+        self._pending: dict[str, Queue] = {}
+        self._lock = threading.Lock()
+        self._closed = False
+        self._reader_thread = threading.Thread(
+            target=self._reader_loop, name="noj-evaluator-stdin-reader", daemon=True
+        )
+        self._reader_thread.start()
+
+    # ── 公开 API ────────────────────────────────────────
+
+    def call(self, fn: str, *args: Any) -> Any:
+        """调用 Solution host 中的函数 `fn`。
+
+        返回值由 SDK 自动反序列化（bytes base64 → bytes 等）。
+
+        抛出：
+            SolutionTimeoutError  - 单次调用超时（host 进程仍存活）
+            NotFoundError         - 函数未注册
+            RejectedError         - 参数/返回值类型不允许
+            ConnectionError       - IPC 通道断开（host 进程崩溃）
+            SystemError           - 其他 host 内部错误
+        """
+        if self._closed:
+            raise ConnectionError("runner 已关闭")
+
+        # 1. 参数校验
+        for i, arg in enumerate(args):
+            validate_type(arg, f"arg[{i}]")
+
+        # 2. 构造 call 帧
+        call_id = uuid.uuid4().hex
+        frame = {
+            "type": "call",
+            "id": call_id,
+            "fn": fn,
+            "args": [encode_value(a) for a in args],
+        }
+
+        # 3. 注册 pending
+        q: Queue = Queue(maxsize=1)
+        with self._lock:
+            self._pending[call_id] = q
+
+        # 4. 写帧到 stdout
+        line = json.dumps(frame, ensure_ascii=False, separators=(",", ":"))
+        try:
+            check_frame_size(line)
+        except RejectedError:
+            with self._lock:
+                self._pending.pop(call_id, None)
+            raise
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+        # 5. 阻塞等响应（超时由 judge 端 call_timeout_ms 控制，
+        #    SDK 这里不设超时——避免与 judge 双重超时逻辑混淆）
+        try:
+            response = q.get()
+        except Exception as e:
+            with self._lock:
+                self._pending.pop(call_id, None)
+            raise ConnectionError(f"等待响应异常: {e}")
+
+        # 6. 处理响应
+        with self._lock:
+            self._pending.pop(call_id, None)
+        return self._handle_response(response)
+
+    def close(self) -> None:
+        """主动关闭 runner（通常不需要，进程结束自动清理）。"""
+        self._closed = True
+
+    # ── 内部 ────────────────────────────────────────────
+
+    def _reader_loop(self) -> None:
+        """后台线程：从 stdin 持续读 NDJSON 帧，分发到对应 pending queue。"""
+        try:
+            for line in sys.stdin:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    frame = json.loads(line)
+                except json.JSONDecodeError as e:
+                    # 非 JSON 行被静默忽略（可能是 host 误输出，但协议约束应保证不发生）
+                    sys.stderr.write(
+                        f"[noj_evaluator_sdk] stdin 非 JSON 帧: {e}: {line!r}\n"
+                    )
+                    sys.stderr.flush()
+                    continue
+
+                frame_type = frame.get("type")
+                frame_id = frame.get("id")
+
+                if frame_type in ("result", "error"):
+                    with self._lock:
+                        q = self._pending.pop(frame_id, None)
+                    if q is not None:
+                        q.put(frame)
+                    # else: 响应已超时丢弃，忽略
+                elif frame_type == "log":
+                    # log 帧直接打到 stderr（judge 也会收集并截断）
+                    stream = frame.get("stream", "stdout")
+                    data = frame.get("data", "")
+                    target = sys.stderr if stream == "stderr" else sys.stdout
+                    # 注意：log 流到 stdout 会污染协议帧，故日志统一走 stderr
+                    sys.stderr.write(data)
+                    if not data.endswith("\n"):
+                        sys.stderr.write("\n")
+                    sys.stderr.flush()
+                elif frame_type == "shutdown":
+                    self._closed = True
+                    # 唤醒所有 pending（会抛 ConnectionError）
+                    with self._lock:
+                        for q in self._pending.values():
+                            try:
+                                q.put_nowait({"type": "_shutdown"})
+                            except Exception:
+                                pass
+                        self._pending.clear()
+                # 其它 type 忽略
+        except (EOFError, BrokenPipeError):
+            # stdin 关闭 → 整体失败
+            self._closed = True
+            with self._lock:
+                for q in self._pending.values():
+                    try:
+                        q.put_nowait({"type": "_shutdown"})
+                    except Exception:
+                        pass
+                self._pending.clear()
+        except Exception as e:
+            sys.stderr.write(f"[noj_evaluator_sdk] reader_loop 异常: {e}\n")
+            sys.stderr.flush()
+            self._closed = True
+
+    def _handle_response(self, frame: dict) -> Any:
+        """处理 result/error 帧，抛出对应异常或返回值。"""
+        if frame.get("type") == "_shutdown":
+            raise ConnectionError("Solution host 已关闭 / IPC 通道断开")
+
+        if frame.get("type") == "error":
+            code = frame.get("code", "SystemError")
+            message = frame.get("message", "")
+            if code == "Timeout":
+                raise SolutionTimeoutError(message)
+            if code == "NotFound":
+                raise NotFoundError(message)
+            if code == "Rejected":
+                raise RejectedError(message)
+            # Exception / SystemError 等
+            if code == "Exception":
+                trace = frame.get("trace", "")
+                exc = SystemError(f"{message}\n{trace}".strip())
+                exc.trace = trace
+                raise exc
+            raise SystemError(f"{code}: {message}")
+
+        # type == 'result'
+        value = frame.get("value")
+        return decode_value(value)

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/serialization.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/serialization.py
@@ -1,0 +1,86 @@
+"""
+noj_evaluator_sdk 类型序列化层。
+
+只接受以下 7 种基本类型（+ bytes base64）：
+    None / bool / int / float / str / bytes / list / dict
+
+任何其他类型（包括嵌套中的）抛 `RejectedError`。
+bytes 通过 base64 编码在 NDJSON 中传输（避免二进制损坏 NDJSON 帧）。
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from .errors import RejectedError
+
+# 限制单帧序列化字节数（1 MiB 软上限）
+MAX_FRAME_BYTES = 1 * 1024 * 1024
+
+
+def validate_type(value: Any, path: str = "<root>") -> None:
+    """递归校验 value 是否仅含允许类型。
+
+    不允许：set、tuple、自定义类、函数、生成器、socket、文件句柄等。
+    list / dict 内部继续递归。
+    """
+    if value is None or isinstance(value, bool):
+        return
+    if isinstance(value, (int, float, str)):
+        return
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return
+    if isinstance(value, list):
+        for i, item in enumerate(value):
+            validate_type(item, f"{path}[{i}]")
+        return
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise RejectedError(
+                    f"{path}: dict key 必须是 str，实际 {type(k).__name__}"
+                )
+            validate_type(v, f"{path}.{k}")
+        return
+    raise RejectedError(
+        f"{path}: 不支持的类型 {type(value).__name__}（仅 None/bool/int/float/str/bytes/list/dict）"
+    )
+
+
+def encode_value(value: Any) -> Any:
+    """把 Python 值转为 JSON 可序列化结构。
+
+    - bytes / bytearray / memoryview → base64 字符串
+    - 其他允许类型 → 原样
+    """
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {"__bytes__": base64.b64encode(bytes(value)).decode("ascii")}
+    if isinstance(value, list):
+        return [encode_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: encode_value(v) for k, v in value.items()}
+    return value
+
+
+def decode_value(value: Any) -> Any:
+    """把 JSON 反序列化结构还原为 Python 值。
+
+    - `{"__bytes__": "<base64>"}` → bytes
+    """
+    if isinstance(value, dict):
+        if set(value.keys()) == {"__bytes__"} and isinstance(value["__bytes__"], str):
+            return base64.b64decode(value["__bytes__"])
+        return {k: decode_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [decode_value(v) for v in value]
+    return value
+
+
+def check_frame_size(frame_str: str) -> None:
+    """校验序列化后单帧不超过 MAX_FRAME_BYTES。"""
+    encoded = frame_str.encode("utf-8")
+    if len(encoded) > MAX_FRAME_BYTES:
+        raise RejectedError(
+            f"frame size {len(encoded)} > {MAX_FRAME_BYTES}（单帧 1 MiB 软上限）"
+        )

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_logging_config.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_logging_config.py
@@ -1,0 +1,47 @@
+"""
+noj_evaluator_sdk 单测 —— logging_config + 协议约定。
+
+验证 configure_logging 后 SDK 自身 print 不污染 stdout。
+"""
+
+import io
+import logging
+import sys
+import unittest
+
+sys.path.insert(0, sys.path[0] + "/..")
+
+import noj_evaluator_sdk.logging_config as logging_config
+
+
+class TestConfigureLogging(unittest.TestCase):
+    def setUp(self):
+        self._stdout_buf = io.StringIO()
+        self._stderr_buf = io.StringIO()
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+        sys.stdout = self._stdout_buf
+        sys.stderr = self._stderr_buf
+
+    def tearDown(self):
+        sys.stdout = self._orig_stdout
+        sys.stderr = self._orig_stderr
+        # 恢复 logging root
+        logging.getLogger().handlers = []
+
+    def test_logging_redirects_to_stderr(self):
+        logging_config.configure_logging(level=logging.INFO)
+        logging.info("hello from sdk")
+        self.assertIn("hello from sdk", self._stderr_buf.getvalue())
+        self.assertEqual(self._stdout_buf.getvalue(), "")
+
+    def test_sdk_print_alias_to_stderr(self):
+        logging_config.configure_logging()
+        sdk_print = logging_config.print  # 重定向后的 print
+        sdk_print("via sdk print")
+        self.assertIn("via sdk print", self._stderr_buf.getvalue())
+        self.assertEqual(self._stdout_buf.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_result.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_result.py
@@ -1,0 +1,64 @@
+"""
+noj_evaluator_sdk 单测 —— result 模块。
+
+捕获 stdout 验证 `---RESULT---` 标记格式。
+"""
+
+import io
+import json
+import sys
+import unittest
+
+sys.path.insert(0, sys.path[0] + "/..")
+
+from noj_evaluator_sdk.result import Result
+
+
+class TestResultWrite(unittest.TestCase):
+    """验证 Result 写入格式。"""
+
+    def setUp(self):
+        self._stdout_buf = io.StringIO()
+        self._orig_stdout = sys.stdout
+        sys.stdout = self._stdout_buf
+
+    def tearDown(self):
+        sys.stdout = self._orig_stdout
+
+    def _read_written(self) -> dict:
+        output = self._stdout_buf.getvalue()
+        self.assertIn("---RESULT---", output)
+        # 取标记后的第一行 JSON
+        lines = output.split("---RESULT---", 1)[1].strip().split("\n")
+        return json.loads(lines[0])
+
+    def test_accept_default(self):
+        r = Result()
+        r.accept()
+        data = self._read_written()
+        self.assertEqual(data["status"], "Accepted")
+        self.assertEqual(data["score"], 10000)  # 100 × 100
+
+    def test_wrong_answer_with_message(self):
+        r = Result()
+        r.wrong_answer(message="expected 3 got 4")
+        data = self._read_written()
+        self.assertEqual(data["status"], "WrongAnswer")
+        self.assertEqual(data["score"], 0)
+        self.assertEqual(data["details"]["message"], "expected 3 got 4")
+
+    def test_double_write_raises(self):
+        r = Result()
+        r.accept()
+        with self.assertRaises(RuntimeError):
+            r.wrong_answer()
+
+    def test_score_scaling(self):
+        r = Result()
+        r.accept(score=87.5)  # 应存为 8750
+        data = self._read_written()
+        self.assertEqual(data["score"], 8750)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
@@ -1,0 +1,297 @@
+"""
+noj_evaluator_sdk 单测 —— SolutionRunner。
+
+用 stdlib 启动 SolutionRunner，把它的 stdin/stdout 拦截到内存中，
+mock 一个"假 host"线程往 SolutionRunner 的 stdin 写响应帧。
+
+注：StringIO 在 `for line in sys.stdin` 模式下会在迭代开始时锁定内容快照，
+导致 write 后续内容无效。本测试改用 BlockingPipe 模拟真实 stdin。
+"""
+
+import io
+import json
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, sys.path[0] + "/..")
+
+from noj_evaluator_sdk.errors import (
+    ConnectionError,
+    NotFoundError,
+    RejectedError,
+    SolutionTimeoutError,
+)
+from noj_evaluator_sdk.runner import SolutionRunner
+
+
+class BlockingPipe:
+    """模拟真实 stdin：readline() 阻塞直到有数据写入。
+
+    同时实现 `__iter__` / `__next__` 兼容 `for line in sys.stdin` 模式。
+    """
+
+    def __init__(self):
+        self._buffer = ""
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._closed = False
+        self._eof = False
+
+    def write(self, data: str):
+        with self._cond:
+            self._buffer += data
+            self._cond.notify_all()
+
+    def readline(self) -> str:
+        with self._cond:
+            while True:
+                if self._eof and not self._buffer:
+                    return ""
+                if self._closed:
+                    return ""
+                idx = self._buffer.find("\n")
+                if idx >= 0:
+                    line = self._buffer[: idx + 1]
+                    self._buffer = self._buffer[idx + 1 :]
+                    return line
+                self._cond.wait()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> str:
+        line = self.readline()
+        if line == "":
+            raise StopIteration
+        return line
+
+    def close(self):
+        with self._cond:
+            self._closed = True
+            self._cond.notify_all()
+
+
+class IpcHarness:
+    """构造 SolutionRunner，把它的 stdin/stdout 拦截到内存管道。"""
+
+    def __init__(self):
+        self.runner_stdout_buf = io.StringIO()  # SolutionRunner 写的内容（host 视角读）
+        self.runner_stdin_pipe = BlockingPipe()  # host 写，SolutionRunner 读
+
+        self._orig_stdout = sys.stdout
+        self._orig_stdin = sys.stdin
+        sys.stdout = self.runner_stdout_buf
+        sys.stdin = self.runner_stdin_pipe
+
+        self.runner = SolutionRunner()
+
+    def send_host_response(self, frame: dict):
+        self.runner_stdin_pipe.write(json.dumps(frame) + "\n")
+
+    def last_call_frame(self) -> dict:
+        content = self.runner_stdout_buf.getvalue()
+        lines = [l for l in content.split("\n") if l.strip()]
+        assert len(lines) > 0, "SolutionRunner 未写入任何 call 帧"
+        return json.loads(lines[-1])
+
+    def all_call_frames(self) -> list:
+        content = self.runner_stdout_buf.getvalue()
+        return [json.loads(l) for l in content.split("\n") if l.strip()]
+
+    def teardown(self):
+        sys.stdin = self._orig_stdin
+        sys.stdout = self._orig_stdout
+        self.runner_stdin_pipe.close()
+        self.runner.close()
+
+
+class TestSolutionRunnerCall(unittest.TestCase):
+    """验证 call → response 闭环。"""
+
+    def _run_call(self, harness, fn, *args, timeout=2.0):
+        """后台线程跑 runner.call，主线程 join 等结果。返回 (value, error)。"""
+        result_box = {}
+        err_box = {}
+
+        def runner():
+            try:
+                result_box["v"] = harness.runner.call(fn, *args)
+            except Exception as e:
+                err_box["e"] = e
+
+        t = threading.Thread(target=runner)
+        t.start()
+        # 等帧写出
+        time.sleep(0.05)
+        return t, result_box, err_box
+
+    def test_basic_call_returns_value(self):
+        h = IpcHarness()
+        try:
+            t, results, errors = self._run_call(h, "solve", 1, 2)
+            call_frame = h.last_call_frame()
+            self.assertEqual(call_frame["type"], "call")
+            self.assertEqual(call_frame["fn"], "solve")
+            self.assertEqual(call_frame["args"], [1, 2])
+
+            h.send_host_response(
+                {"type": "result", "id": call_frame["id"], "value": 3}
+            )
+            t.join(timeout=2)
+            self.assertFalse(t.is_alive(), "call 未在超时内返回")
+            self.assertIn("v", results, f"call 未返回，err={errors}")
+            self.assertEqual(results["v"], 3)
+        finally:
+            h.teardown()
+
+    def test_call_with_kwargs_args(self):
+        h = IpcHarness()
+        try:
+            t, results, errors = self._run_call(h, "solve", 1, 2, "x", None, True)
+            call_frame = h.last_call_frame()
+            self.assertEqual(call_frame["args"], [1, 2, "x", None, True])
+
+            h.send_host_response(
+                {"type": "result", "id": call_frame["id"], "value": "ok"}
+            )
+            t.join(timeout=2)
+            self.assertFalse(t.is_alive())
+            self.assertEqual(results["v"], "ok")
+        finally:
+            h.teardown()
+
+    def test_call_returns_bytes_value(self):
+        h = IpcHarness()
+        try:
+            import base64
+
+            t, results, errors = self._run_call(h, "get_bytes")
+            call_frame = h.last_call_frame()
+            encoded = {"__bytes__": base64.b64encode(b"hello").decode()}
+            h.send_host_response(
+                {"type": "result", "id": call_frame["id"], "value": encoded}
+            )
+            t.join(timeout=2)
+            self.assertFalse(t.is_alive())
+            self.assertEqual(results.get("v"), b"hello")
+        finally:
+            h.teardown()
+
+    def test_call_returns_list_dict(self):
+        h = IpcHarness()
+        try:
+            t, results, errors = self._run_call(h, "get_struct")
+            call_frame = h.last_call_frame()
+            h.send_host_response(
+                {
+                    "type": "result",
+                    "id": call_frame["id"],
+                    "value": {"a": [1, 2, "x"], "b": None},
+                }
+            )
+            t.join(timeout=2)
+            self.assertFalse(t.is_alive())
+            self.assertEqual(results.get("v"), {"a": [1, 2, "x"], "b": None})
+        finally:
+            h.teardown()
+
+    def test_call_raises_not_found(self):
+        h = IpcHarness()
+        try:
+            t, _, errors = self._run_call(h, "missing")
+            call_frame = h.last_call_frame()
+            h.send_host_response(
+                {
+                    "type": "error",
+                    "id": call_frame["id"],
+                    "code": "NotFound",
+                    "message": "function 'missing' not registered",
+                }
+            )
+            t.join(timeout=2)
+            self.assertIsInstance(errors.get("e"), NotFoundError)
+        finally:
+            h.teardown()
+
+    def test_call_raises_timeout(self):
+        h = IpcHarness()
+        try:
+            t, _, errors = self._run_call(h, "slow_fn")
+            call_frame = h.last_call_frame()
+            h.send_host_response(
+                {
+                    "type": "error",
+                    "id": call_frame["id"],
+                    "code": "Timeout",
+                    "message": "exceeded 500ms",
+                }
+            )
+            t.join(timeout=2)
+            self.assertIsInstance(errors.get("e"), SolutionTimeoutError)
+        finally:
+            h.teardown()
+
+    def test_call_raises_rejected_on_bad_param_type(self):
+        """客户端参数类型不允许时本地就抛 RejectedError。"""
+        h = IpcHarness()
+        try:
+            with self.assertRaises(RejectedError):
+                h.runner.call("f", {1, 2, 3})  # set 不允许
+        finally:
+            h.teardown()
+
+    def test_call_raises_connection_error_on_host_shutdown(self):
+        """host 发 shutdown 帧 → pending call 抛 ConnectionError。"""
+        h = IpcHarness()
+        try:
+            t, _, errors = self._run_call(h, "slow")
+            # host 主动发 shutdown
+            h.send_host_response({"type": "shutdown"})
+            t.join(timeout=2)
+            self.assertIsInstance(errors.get("e"), ConnectionError)
+        finally:
+            h.teardown()
+
+    def test_multiple_concurrent_calls(self):
+        """两个并发 call 应该独立完成。"""
+        h = IpcHarness()
+        try:
+            results = {}
+            errors = {}
+
+            def make_call(key, fn, arg):
+                def runner():
+                    try:
+                        results[key] = h.runner.call(fn, arg)
+                    except Exception as e:
+                        errors[key] = e
+
+                return runner
+
+            t1 = threading.Thread(target=make_call("a", "f1", 1))
+            t2 = threading.Thread(target=make_call("b", "f2", 2))
+            t1.start()
+            t2.start()
+            time.sleep(0.1)
+
+            lines = h.all_call_frames()
+            self.assertEqual(len(lines), 2)
+            id_a = next(l["id"] for l in lines if l["fn"] == "f1")
+            id_b = next(l["id"] for l in lines if l["fn"] == "f2")
+
+            # 乱序回响应
+            h.send_host_response({"type": "result", "id": id_b, "value": "second"})
+            h.send_host_response({"type": "result", "id": id_a, "value": "first"})
+
+            t1.join(timeout=2)
+            t2.join(timeout=2)
+            self.assertEqual(results.get("a"), "first")
+            self.assertEqual(results.get("b"), "second")
+        finally:
+            h.teardown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_serialization.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_serialization.py
@@ -1,0 +1,108 @@
+"""
+noj_evaluator_sdk 单测 —— serialization 模块。
+"""
+
+import base64
+import io
+import json
+import sys
+import unittest
+
+sys.path.insert(0, sys.path[0] + "/..")
+
+from noj_evaluator_sdk.errors import RejectedError
+from noj_evaluator_sdk.serialization import (
+    MAX_FRAME_BYTES,
+    check_frame_size,
+    decode_value,
+    encode_value,
+    validate_type,
+)
+
+
+class TestValidateType(unittest.TestCase):
+    """验证类型白名单。"""
+
+    def test_allow_none_bool_int_float_str(self):
+        for v in [None, True, False, 0, 1, -1, 3.14, "hello", ""]:
+            validate_type(v)  # 不抛
+
+    def test_allow_bytes(self):
+        validate_type(b"hello")
+        validate_type(bytearray(b"x"))
+        validate_type(memoryview(b"x"))
+
+    def test_allow_list_dict_nested(self):
+        validate_type([])
+        validate_type({})
+        validate_type([1, 2, [3, {"k": "v"}]])
+        validate_type({"a": [1, 2, 3], "b": {"nested": True}})
+
+    def test_reject_set(self):
+        with self.assertRaises(RejectedError):
+            validate_type({1, 2, 3})
+
+    def test_reject_tuple(self):
+        with self.assertRaises(RejectedError):
+            validate_type((1, 2))
+
+    def test_reject_custom_class(self):
+        class Foo:
+            pass
+
+        with self.assertRaises(RejectedError):
+            validate_type(Foo())
+
+    def test_reject_function(self):
+        with self.assertRaises(RejectedError):
+            validate_type(lambda x: x)
+
+    def test_reject_nested_invalid(self):
+        with self.assertRaises(RejectedError):
+            validate_type([1, 2, {1, 2}], "arg[2]")
+
+    def test_reject_dict_with_non_str_key(self):
+        with self.assertRaises(RejectedError):
+            validate_type({1: "x"})
+
+
+class TestEncodeDecodeRoundTrip(unittest.TestCase):
+    """bytes 必须通过 base64 标签 round-trip。"""
+
+    def test_bytes_encode(self):
+        encoded = encode_value(b"hello")
+        self.assertEqual(encoded, {"__bytes__": base64.b64encode(b"hello").decode()})
+
+    def test_bytes_decode(self):
+        decoded = decode_value(
+            {"__bytes__": base64.b64encode(b"hello").decode()}
+        )
+        self.assertEqual(decoded, b"hello")
+
+    def test_round_trip_primitives(self):
+        for v in [None, True, False, 0, 42, 3.14, "hello", "中文", [1, "a", None]]:
+            self.assertEqual(decode_value(encode_value(v)), v)
+
+    def test_round_trip_nested_bytes(self):
+        original = {"data": b"\x00\x01\x02", "name": "x", "list": [b"a", b"b"]}
+        decoded = decode_value(encode_value(original))
+        self.assertEqual(decoded["data"], b"\x00\x01\x02")
+        self.assertEqual(decoded["list"][0], b"a")
+        self.assertEqual(decoded["list"][1], b"b")
+        self.assertEqual(decoded["name"], "x")
+
+
+class TestFrameSizeLimit(unittest.TestCase):
+    """单帧 1 MiB 软上限。"""
+
+    def test_small_frame_ok(self):
+        check_frame_size(json.dumps({"x": "y"}))
+
+    def test_oversize_frame_rejected(self):
+        big = "x" * (MAX_FRAME_BYTES + 1)
+        with self.assertRaises(RejectedError):
+            check_frame_size(big)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/noj-judge/sdk/solution/noj_solution_sdk/__init__.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/__init__.py
@@ -1,0 +1,24 @@
+"""
+noj_solution_sdk —— 不可信 Solution 端 SDK
+
+由用户提交的 solution.py 导入，提供：
+- `register(fn)` / `register(name, fn)`：把函数暴露给 Evaluator 调用
+
+启动入口（host 模块）：
+    python3 -m noj_solution_sdk.host --entry solution.py
+
+host 读取 stdin NDJSON 帧，调用注册的函数，写回 stdout 响应帧。
+"""
+
+from .registry import (
+    FunctionAlreadyRegisteredError,
+    NotRegisteredError,
+    get_registry,
+    register,
+)
+
+__all__ = [
+    "register",
+    "FunctionAlreadyRegisteredError",
+    "NotRegisteredError",
+]

--- a/noj-judge/sdk/solution/noj_solution_sdk/__main__.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/__main__.py
@@ -1,0 +1,8 @@
+"""
+Allow `python3 -m noj_solution_sdk` as alias for `python3 -m noj_solution_sdk.host`.
+"""
+
+from .host import main
+
+if __name__ == "__main__":
+    main()

--- a/noj-judge/sdk/solution/noj_solution_sdk/host.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/host.py
@@ -1,0 +1,236 @@
+"""
+noj_solution_sdk host 进程。
+
+启动入口（设计为 `python3 -m noj_solution_sdk.host --entry <file>`）：
+
+    host 启动后从 stdin 读 NDJSON 帧，分发到注册的函数；
+    处理结果通过 stdout 写回 NDJSON 帧。
+
+帧协议（详见 design.md §2）：
+    judge → host:  type=call    {id, fn, args[]}
+                  type=shutdown {}
+    host → judge:  type=ready   {}     (启动后立即发)
+                  type=result  {id, value}
+                  type=error   {id, code, message, trace?}
+                  type=log     {stream, data}
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import signal
+import sys
+import threading
+import traceback as _traceback_mod
+
+# line buffering —— 关键！
+# docker exec 的 stdin/stdout 是管道，Python 默认 block buffering。
+# 必须显式打开 line buffering，否则 NDJSON 帧卡在缓冲区里。
+try:
+    sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+    sys.stderr.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+except (AttributeError, ValueError):
+    # reconfigure 在某些环境下不可用，回退到 flush
+    pass
+
+from .registry import get_registry, NotRegisteredError
+from .sanitize import sanitize_trace
+from .serialization import decode_value, encode_value
+
+LOG_MAX_BYTES_PER_FRAME = 64 * 1024  # 64 KiB 单条 log 上限
+LOG_TOTAL_MAX_BYTES = 1 * 1024 * 1024  # 1 MiB 累计 log 上限
+
+
+def _write_frame(frame: dict) -> None:
+    """写 NDJSON 帧到 stdout（一行 + 换行）。"""
+    line = json.dumps(frame, ensure_ascii=False, separators=(",", ":"))
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+def _validate_call_args(args: list) -> None:
+    """校验 call 帧的参数类型（防御性，evaluator 端已校验）。"""
+    # 本镜像只接收 evaluator 写入的 call 帧；evaluator 端已严格校验。
+    # 这里只做基本 sanity，避免主机进程被恶意帧攻击。
+    if not isinstance(args, list):
+        raise ValueError("call.args 必须是 list")
+
+
+def _execute_call(call_id: str, fn_name: str, args: list) -> None:
+    """执行一次 call 并写回响应帧。"""
+    registry = get_registry()
+    fn = registry.get(fn_name)
+    if fn is None:
+        _write_frame(
+            {
+                "type": "error",
+                "id": call_id,
+                "code": "NotFound",
+                "message": f"function {fn_name!r} not registered",
+            }
+        )
+        return
+
+    try:
+        decoded_args = [decode_value(a) for a in args]
+        result = fn(*decoded_args)
+    except Exception as e:
+        _write_frame(
+            {
+                "type": "error",
+                "id": call_id,
+                "code": "Exception",
+                "message": str(e),
+                "trace": sanitize_trace(e),
+            }
+        )
+        return
+
+    try:
+        encoded = encode_value(result)
+    except Exception as e:
+        _write_frame(
+            {
+                "type": "error",
+                "id": call_id,
+                "code": "Rejected",
+                "message": f"return value 序列化失败: {e}",
+            }
+        )
+        return
+
+    _write_frame({"type": "result", "id": call_id, "value": encoded})
+
+
+def _handle_frame(frame: dict) -> bool:
+    """处理单帧。返回 False 表示收到 shutdown 应退出。"""
+    frame_type = frame.get("type")
+
+    if frame_type == "call":
+        call_id = frame.get("id", "")
+        fn_name = frame.get("fn", "")
+        args = frame.get("args", [])
+        try:
+            _validate_call_args(args)
+        except ValueError as e:
+            _write_frame(
+                {
+                    "type": "error",
+                    "id": call_id,
+                    "code": "Rejected",
+                    "message": str(e),
+                }
+            )
+            return True
+        _execute_call(call_id, fn_name, args)
+        return True
+
+    if frame_type == "shutdown":
+        return False
+
+    # 未知类型忽略（不退出）
+    sys.stderr.write(f"[host] unknown frame type: {frame_type!r}\n")
+    sys.stderr.flush()
+    return True
+
+
+def _reader_loop() -> None:
+    """主循环：从 stdin 读帧，处理直到 shutdown 或 EOF。"""
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            frame = json.loads(line)
+        except json.JSONDecodeError as e:
+            sys.stderr.write(f"[host] 非 JSON 帧: {e}: {line!r}\n")
+            sys.stderr.flush()
+            continue
+
+        try:
+            cont = _handle_frame(frame)
+        except Exception as e:
+            # 防御性：避免 host 因单帧异常退出
+            sys.stderr.write(f"[host] frame 处理异常: {e}\n{_traceback_mod.format_exc()}\n")
+            sys.stderr.flush()
+            cont = True
+
+        if not cont:
+            return
+
+
+def _install_signal_handlers() -> None:
+    """SIGTERM/SIGINT 优雅退出。"""
+
+    def _handler(signum, frame):
+        sys.stderr.write(f"[host] 收到信号 {signum}，退出\n")
+        sys.stderr.flush()
+        sys.exit(0)
+
+    try:
+        signal.signal(signal.SIGTERM, _handler)
+        signal.signal(signal.SIGINT, _handler)
+    except (ValueError, OSError):
+        # 非主线程或不支持信号的运行时
+        pass
+
+
+def _load_entry(entry_path: str) -> None:
+    """importlib 加载用户提交文件（不污染 host 模块命名空间）。"""
+    if not os.path.exists(entry_path):
+        sys.stderr.write(f"[host] entry 文件不存在: {entry_path}\n")
+        sys.stderr.flush()
+        sys.exit(1)
+
+    spec = importlib.util.spec_from_file_location("user_solution", entry_path)
+    if spec is None or spec.loader is None:
+        sys.stderr.write(f"[host] entry 文件无法加载: {entry_path}\n")
+        sys.stderr.flush()
+        sys.exit(1)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["user_solution"] = module
+    spec.loader.exec_module(module)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="noj_solution_sdk host")
+    parser.add_argument(
+        "--entry",
+        required=True,
+        help="Solution 入口文件绝对路径（如 /workspace/solution.py）",
+    )
+    args = parser.parse_args()
+
+    _install_signal_handlers()
+
+    # 1. 先发送 ready 帧（在加载 entry 之前还是之后？详见设计）
+    #    决定：先 ready 再 load_entry，避免 entry 内耗时 import 让 judge 等不到 ready
+    _write_frame({"type": "ready"})
+
+    # 2. 加载用户 entry
+    try:
+        _load_entry(args.entry)
+    except SystemExit:
+        raise
+    except Exception as e:
+        _write_frame(
+            {
+                "type": "error",
+                "id": "",
+                "code": "SystemError",
+                "message": f"failed to load entry {args.entry}: {e}",
+                "trace": sanitize_trace(e),
+            }
+        )
+        # 仍然进入 reader loop 等 shutdown；entry 加载失败不应静默退出
+
+    # 3. 主循环
+    _reader_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/noj-judge/sdk/solution/noj_solution_sdk/registry.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/registry.py
@@ -1,0 +1,78 @@
+"""
+noj_solution_sdk 函数注册表。
+
+`register(fn)` 用函数名 `fn.__name__` 注册。
+`register(name, fn)` 显式指定名称。
+"""
+
+from __future__ import annotations
+
+from threading import RLock
+from typing import Any, Callable
+
+
+class FunctionAlreadyRegisteredError(Exception):
+    """重复注册同名函数。"""
+
+
+class NotRegisteredError(Exception):
+    """内部错误：未注册的函数不应被调用。"""
+
+
+class _Registry:
+    """线程安全单例函数注册表。"""
+
+    def __init__(self):
+        self._functions: dict[str, Callable] = {}
+        self._lock = RLock()
+
+    def register(self, name: str, fn: Callable) -> None:
+        with self._lock:
+            if name in self._functions:
+                raise FunctionAlreadyRegisteredError(
+                    f"function {name!r} already registered"
+                )
+            self._functions[name] = fn
+
+    def get(self, name: str) -> Callable | None:
+        with self._lock:
+            return self._functions.get(name)
+
+    def names(self) -> list[str]:
+        with self._lock:
+            return list(self._functions.keys())
+
+
+_REGISTRY = _Registry()
+
+
+def get_registry() -> _Registry:
+    """获取全局注册表（测试用）。"""
+    return _REGISTRY
+
+
+def register(arg1: Any, arg2: Any = None) -> None:
+    """注册函数供 Evaluator 调用。
+
+    两种形式：
+        @register
+        def solve(a, b): ...
+
+        register("solve", solve)
+    """
+    if arg2 is None:
+        # 装饰器形式：arg1 = fn
+        fn = arg1
+        if not callable(fn):
+            raise TypeError(f"register 装饰器要求 callable，实际 {type(fn).__name__}")
+        name = getattr(fn, "__name__", None)
+        if not name:
+            raise ValueError("function 缺少 __name__，请用 register(name, fn) 形式")
+        _REGISTRY.register(name, fn)
+        return fn
+    # 显式 name 形式：arg1 = name, arg2 = fn
+    if not isinstance(arg1, str):
+        raise TypeError(f"register 第一个参数必须是 str，实际 {type(arg1).__name__}")
+    if not callable(arg2):
+        raise TypeError(f"register 第二个参数必须是 callable，实际 {type(arg2).__name__}")
+    _REGISTRY.register(arg1, arg2)

--- a/noj-judge/sdk/solution/noj_solution_sdk/sanitize.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/sanitize.py
@@ -1,0 +1,77 @@
+"""
+noj_solution_sdk trace 路径清洗。
+
+剥离 traceback 中所有绝对路径，仅保留文件 basename + 行号 + 类名 + 消息。
+防止 Solution 侧异常 trace 反推容器镜像 layout 或 SDK 安装路径。
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import traceback
+
+
+def sanitize_trace(tb_exc: BaseException | None = None) -> str:
+    """返回清洗后的 traceback 字符串。
+
+    规则：
+    - 文件路径替换为 basename（去掉目录）
+    - 保留行号、函数名、类名、消息
+    - 多行格式保持与标准 traceback 一致
+
+    Args:
+        tb_exc: 若提供则格式化其 traceback；否则用当前正在处理的异常（sys.exc_info）
+    """
+    if tb_exc is not None:
+        return _format_exception(tb_exc)
+    # 当前正在处理的异常
+    return _format_exception_from_exc_info()
+
+
+def _format_exception_from_exc_info() -> str:
+    import sys
+
+    exc_type, exc_value, exc_tb = sys.exc_info()
+    if exc_type is None:
+        return ""
+    return _format_exception_with_tb(exc_type, exc_value, exc_tb)
+
+
+def _format_exception(exc: BaseException) -> str:
+    return _format_exception_with_tb(type(exc), exc, exc.__traceback__)
+
+
+# 标准 traceback 行格式: '  File "PATH", line N, in FUNC'
+_TB_LINE_RE = re.compile(r'File "([^"]+)", line (\d+), in (.+)')
+
+
+def _sanitize_filename(path: str) -> str:
+    """剥离目录前缀，仅保留 basename。"""
+    return os.path.basename(path) or path
+
+
+def _format_exception_with_tb(exc_type, exc_value, exc_tb) -> str:
+    """手动构建清洗后的 traceback。"""
+    lines = []
+    lines.append(f"Traceback (most recent call last):")
+
+    # 倒序遍历 traceback
+    tb_list = []
+    t = exc_tb
+    while t is not None:
+        tb_list.append(t)
+        t = t.tb_next
+    tb_list.reverse()
+
+    for tb_frame in tb_list:
+        frame = tb_frame.tb_frame
+        filename = _sanitize_filename(tb_frame.tb_frame.f_code.co_filename)
+        lineno = tb_frame.tb_lineno
+        funcname = tb_frame.tb_frame.f_code.co_name
+        lines.append(f'  File "{filename}", line {lineno}, in {funcname}')
+
+    # 异常类型与消息
+    exc_name = getattr(exc_type, "__name__", str(exc_type))
+    lines.append(f"{exc_name}: {exc_value}")
+    return "\n".join(lines)

--- a/noj-judge/sdk/solution/noj_solution_sdk/serialization.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/serialization.py
@@ -1,0 +1,44 @@
+"""
+noj_solution_sdk 类型序列化层。
+
+镜像 noj_evaluator_sdk：只接受 7 种基本类型 + bytes base64。
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+# 仅用于错误上报（host 进程内部使用，避免与 evaluator SDK 循环依赖）
+class _RejectedTypeError(Exception):
+    pass
+
+
+# 复用 evaluator 的实现：通过相对路径或导入
+try:
+    from noj_evaluator_sdk.serialization import (
+        encode_value,
+        decode_value,
+        MAX_FRAME_BYTES,
+    )
+except ImportError:
+    # 在没有 evaluator SDK 路径的情况下（如单独打包镜像）走本地副本
+    def encode_value(value: Any) -> Any:
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            return {"__bytes__": base64.b64encode(bytes(value)).decode("ascii")}
+        if isinstance(value, list):
+            return [encode_value(v) for v in value]
+        if isinstance(value, dict):
+            return {k: encode_value(v) for k, v in value.items()}
+        return value
+
+    def decode_value(value: Any) -> Any:
+        if isinstance(value, dict):
+            if set(value.keys()) == {"__bytes__"} and isinstance(value["__bytes__"], str):
+                return base64.b64decode(value["__bytes__"])
+            return {k: decode_value(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [decode_value(v) for v in value]
+        return value
+
+    MAX_FRAME_BYTES = 1 * 1024 * 1024

--- a/noj-judge/sdk/solution/noj_solution_sdk/tests/test_host.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/tests/test_host.py
@@ -1,0 +1,243 @@
+"""
+noj_solution_sdk 单测 —— host 主循环。
+
+通过 stdin/stdout pipe 启动 host 子进程，验证 NDJSON 协议完整闭环。
+"""
+
+import base64
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+
+
+HOST_PY = "noj_solution_sdk.host"
+
+
+class TestHostProcess(unittest.TestCase):
+    """启动 host 进程，端到端验证 NDJSON 协议。"""
+
+    def _start_host(self, entry_source: str, args=None):
+        """把 entry 写到临时文件，启动 host 子进程。返回 (proc, entry_path)。"""
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False
+        )
+        tmp.write(entry_source)
+        tmp.close()
+
+        cmd = [sys.executable, "-m", HOST_PY, "--entry", tmp.name]
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,  # line buffered
+        )
+        return proc, tmp.name
+
+    def _read_frame(self, proc, timeout=5.0):
+        """从 proc.stdout 读一行 NDJSON。"""
+        # 阻塞读单行（子进程 line buffering）
+        line = proc.stdout.readline()
+        if not line:
+            # 可能 EOF 或超时
+            err = proc.stderr.read()
+            raise RuntimeError(f"host 关闭；stderr={err!r}")
+        return json.loads(line.strip())
+
+    def _send_frame(self, proc, frame: dict):
+        proc.stdin.write(json.dumps(frame) + "\n")
+        proc.stdin.flush()
+
+    def _cleanup(self, proc, tmp_path):
+        try:
+            proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        proc.wait(timeout=5)
+        os.unlink(tmp_path)
+
+    # ── 测试用例 ──────────────────────────────────────
+
+    def test_host_sends_ready_on_startup(self):
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register
+            @register
+            def solve(a, b):
+                return a + b
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            frame = self._read_frame(proc)
+            self.assertEqual(frame["type"], "ready")
+        finally:
+            self._cleanup(proc, path)
+
+    def test_basic_call_round_trip(self):
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register
+            @register
+            def solve(a, b):
+                return a + b
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            ready = self._read_frame(proc)
+            self.assertEqual(ready["type"], "ready")
+
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "solve", "args": [1, 2]})
+            resp = self._read_frame(proc)
+            self.assertEqual(resp["type"], "result")
+            self.assertEqual(resp["id"], "c1")
+            self.assertEqual(resp["value"], 3)
+        finally:
+            self._cleanup(proc, path)
+
+    def test_unknown_function_returns_notfound(self):
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register
+            @register
+            def solve():
+                return 0
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            self._read_frame(proc)  # ready
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "missing", "args": []})
+            resp = self._read_frame(proc)
+            self.assertEqual(resp["type"], "error")
+            self.assertEqual(resp["code"], "NotFound")
+        finally:
+            self._cleanup(proc, path)
+
+    def test_user_exception_returns_exception_error(self):
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register
+            @register
+            def bad():
+                raise ValueError("intentional boom")
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            self._read_frame(proc)  # ready
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "bad", "args": []})
+            resp = self._read_frame(proc)
+            self.assertEqual(resp["type"], "error")
+            self.assertEqual(resp["code"], "Exception")
+            self.assertIn("intentional boom", resp["message"])
+            # trace 应已 sanitize
+            self.assertIn("trace", resp)
+            self.assertIn("ValueError: intentional boom", resp["trace"])
+            # trace 不应含绝对路径
+            self.assertNotIn("/usr/local/lib", resp["trace"])
+        finally:
+            self._cleanup(proc, path)
+
+    def test_persistent_state_across_calls(self):
+        """同一 host 内多次调用，全局状态应保留。"""
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register
+            _counter = [0]
+            @register
+            def increment():
+                _counter[0] += 1
+                return _counter[0]
+            @register
+            def get():
+                return _counter[0]
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            self._read_frame(proc)  # ready
+
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "increment", "args": []})
+            resp1 = self._read_frame(proc)
+            self.assertEqual(resp1["value"], 1)
+
+            self._send_frame(proc, {"type": "call", "id": "c2", "fn": "increment", "args": []})
+            resp2 = self._read_frame(proc)
+            self.assertEqual(resp2["value"], 2)
+
+            self._send_frame(proc, {"type": "call", "id": "c3", "fn": "get", "args": []})
+            resp3 = self._read_frame(proc)
+            self.assertEqual(resp3["value"], 2)
+        finally:
+            self._cleanup(proc, path)
+
+    def test_shutdown_exits_host(self):
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register
+            @register
+            def noop():
+                return 0
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            self._read_frame(proc)  # ready
+            self._send_frame(proc, {"type": "shutdown"})
+            # host 应在 5s 内退出
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.fail("host 未在 shutdown 后退出")
+        finally:
+            self._cleanup(proc, path)
+
+    def test_duplicate_register_raises_on_load(self):
+        """entry 内重复注册同名函数时，host 加载失败但仍能 ready + 接收 shutdown。"""
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register
+            @register
+            def solve():
+                return 1
+            register("solve", lambda: 2)  # 重复注册 → 抛错
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            # entry 加载失败时仍发 ready 帧
+            ready = self._read_frame(proc)
+            self.assertEqual(ready["type"], "ready")
+            # 不应再能调用 solve（注册表里可能仍包含一个，但语义不保证）
+            # 直接发 shutdown 验证 host 不死锁
+            self._send_frame(proc, {"type": "shutdown"})
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.fail("host 在 entry 加载失败后无法响应 shutdown")
+        finally:
+            self._cleanup(proc, path)
+
+    def test_bytes_args_round_trip(self):
+        """bytes 经 base64 round-trip。"""
+        entry = textwrap.dedent("""
+            import base64
+            from noj_solution_sdk import register
+            @register
+            def echo(data):
+                return data
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            self._read_frame(proc)
+            encoded = {"__bytes__": base64.b64encode(b"hello").decode()}
+            self._send_frame(
+                proc, {"type": "call", "id": "c1", "fn": "echo", "args": [encoded]}
+            )
+            resp = self._read_frame(proc)
+            self.assertEqual(resp["type"], "result")
+            self.assertEqual(resp["value"], encoded)  # bytes 仍以 base64 形式回到 caller
+        finally:
+            self._cleanup(proc, path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/noj-judge/sdk/solution/noj_solution_sdk/tests/test_registry.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/tests/test_registry.py
@@ -1,0 +1,67 @@
+"""
+noj_solution_sdk 单测 —— registry 模块。
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, sys.path[0] + "/..")
+
+from noj_solution_sdk.registry import (
+    FunctionAlreadyRegisteredError,
+    get_registry,
+    register,
+)
+
+
+class TestRegister(unittest.TestCase):
+    def setUp(self):
+        # 每个测试前清空注册表
+        get_registry()._functions.clear()
+
+    def test_register_decorator(self):
+        @register
+        def solve(a, b):
+            return a + b
+
+        self.assertIn("solve", get_registry().names())
+
+    def test_register_with_explicit_name(self):
+        def fn():
+            pass
+
+        register("my_fn", fn)
+        self.assertIn("my_fn", get_registry().names())
+
+    def test_register_duplicate_raises(self):
+        @register
+        def f():
+            pass
+
+        with self.assertRaises(FunctionAlreadyRegisteredError):
+            register("f", lambda: None)
+
+    def test_register_non_callable_raises(self):
+        with self.assertRaises(TypeError):
+            register("bad", 42)  # 装饰器形式
+
+        with self.assertRaises(TypeError):
+            register("bad", 42)  # 显式 name 形式
+
+    def test_register_first_arg_must_be_str_in_explicit_form(self):
+        with self.assertRaises(TypeError):
+            register(123, lambda: None)
+
+    def test_get_returns_function(self):
+        @register
+        def solve():
+            return "x"
+
+        self.assertIs(get_registry().get("solve"), solve)
+
+    def test_get_unknown_returns_none(self):
+        self.assertIsNone(get_registry().get("nope"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/noj-judge/sdk/solution/noj_solution_sdk/tests/test_sanitize.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/tests/test_sanitize.py
@@ -1,0 +1,72 @@
+"""
+noj_solution_sdk 单测 —— sanitize 模块。
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, sys.path[0] + "/..")
+
+from noj_solution_sdk.sanitize import sanitize_trace
+
+
+def _raise_with_path(path: str):
+    """触发异常，使 traceback 中包含给定路径。"""
+    def inner():
+        raise ValueError("boom")
+    try:
+        # 通过 exec 在指定 filename 触发异常
+        exec(compile("raise ValueError('boom')", path, "exec"), {})
+    except ValueError as e:
+        return e
+    return None
+
+
+class TestSanitizeTrace(unittest.TestCase):
+    def test_strip_absolute_path(self):
+        # 通过 exec 构造一个 filename 为绝对路径的异常
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as e:
+            sanitized = sanitize_trace(e)
+        # 不应包含 sandbox 路径前缀
+        self.assertNotIn("/usr/local/lib", sanitized)
+        self.assertNotIn("/workspace", sanitized)
+
+    def test_preserve_basename(self):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as e:
+            sanitized = sanitize_trace(e)
+        # 至少含 "RuntimeError: boom"
+        self.assertIn("RuntimeError: boom", sanitized)
+        # 含 "File " 引用，basename 应保留
+        self.assertIn("File ", sanitized)
+        # 不含完整 sandbox 路径
+        for forbidden in ["/usr/local/", "/workspace/", "/tmp/noj"]:
+            if forbidden in sanitized:
+                # 仅当 basename 恰好含该字符串时允许；这里我们的测试代码不在那里
+                self.fail(f"sanitize_trace 仍含 {forbidden!r}")
+
+    def test_traceback_format(self):
+        try:
+            raise ValueError("test")
+        except ValueError as e:
+            sanitized = sanitize_trace(e)
+        # 应包含标准 traceback 头
+        self.assertTrue(sanitized.startswith("Traceback"))
+        self.assertIn("ValueError: test", sanitized)
+
+    def test_handles_nested_exception(self):
+        try:
+            try:
+                raise ValueError("inner")
+            except ValueError as e:
+                raise RuntimeError("outer") from e
+        except RuntimeError as e:
+            sanitized = sanitize_trace(e)
+        self.assertIn("RuntimeError: outer", sanitized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/noj-judge/src/dual/container.rs
+++ b/noj-judge/src/dual/container.rs
@@ -1,0 +1,260 @@
+//! 双容器 RAII 资源管理。
+//!
+//! 设计稿 §7 清理契约（RAII）：
+//! 1. 先 `docker rm -f` Solution 容器
+//! 2. 后 `docker rm -f` Evaluator 容器
+//! 3. 中间步骤抛错不阻止后续清理
+//! 4. 临时目录与下载缓存清理
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use bollard::container::LogOutput;
+use bollard::exec::StartExecResults;
+use bollard::models::{ContainerCreateBody, ExecConfig, HostConfig};
+use bollard::Docker;
+use tokio::io::AsyncWrite;
+use tokio::time::timeout;
+use tracing::{info, warn};
+
+/// `DualContainer` 持有 Evaluator + Solution 两个容器 ID。
+///
+/// Drop 时按 Solution → Evaluator 顺序清理；任何清理步骤抛错都被记录但不传播
+/// （Drop 不能 panic）。
+pub struct DualContainer {
+    pub docker: Docker,
+    pub evaluator_id: Option<String>,
+    pub solution_id: Option<String>,
+}
+
+impl DualContainer {
+    /// 创建并启动 Evaluator 容器（带支持包挂载路径）。
+    pub async fn create_evaluator(
+        docker: &Docker,
+        image: &str,
+        memory_mb: u64,
+        support_pkg_mount: Option<&str>,
+    ) -> Result<Self> {
+        let id = create_container_with_security(
+            docker,
+            image,
+            memory_mb,
+            support_pkg_mount,
+            "evaluator",
+        )
+        .await?;
+        info!("Evaluator 容器创建: {}", id);
+        Ok(Self {
+            docker: docker.clone(),
+            evaluator_id: Some(id),
+            solution_id: None,
+        })
+    }
+
+    /// 在现有 DualContainer 上追加 Solution 容器。
+    pub async fn create_solution(&mut self, image: &str, memory_mb: u64) -> Result<()> {
+        let id = create_container_with_security(&self.docker, image, memory_mb, None, "solution")
+            .await?;
+        info!("Solution 容器创建: {}", id);
+        self.solution_id = Some(id);
+        Ok(())
+    }
+
+    /// 显式销毁两个容器（先 Solution 后 Evaluator）。
+    pub async fn destroy(mut self) -> Result<()> {
+        // 先 Solution（如果有）
+        if let Some(id) = self.solution_id.take() {
+            if let Err(e) = remove_force(&self.docker, &id).await {
+                warn!("清理 Solution 容器失败 {}: {}", id, e);
+            }
+        }
+        // 再 Evaluator
+        if let Some(id) = self.evaluator_id.take() {
+            if let Err(e) = remove_force(&self.docker, &id).await {
+                warn!("清理 Evaluator 容器失败 {}: {}", id, e);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DualContainer {
+    fn drop(&mut self) {
+        // Drop 中只 spawn 异步清理任务；不能 block。
+        if let Some(id) = self.solution_id.take() {
+            let docker = self.docker.clone();
+            tokio::spawn(async move {
+                if let Err(e) = remove_force(&docker, &id).await {
+                    warn!("Drop 时清理 Solution 容器失败 {}: {}", id, e);
+                }
+            });
+        }
+        if let Some(id) = self.evaluator_id.take() {
+            let docker = self.docker.clone();
+            tokio::spawn(async move {
+                if let Err(e) = remove_force(&docker, &id).await {
+                    warn!("Drop 时清理 Evaluator 容器失败 {}: {}", id, e);
+                }
+            });
+        }
+    }
+}
+
+/// 一个 exec 会话：返回 (stdout stream, stdin writer)。
+pub struct ExecSession {
+    #[allow(dead_code)]
+    pub exec_id: String,
+    #[allow(dead_code)]
+    pub container_id: String,
+    /// combined stdout/stderr stream (LogOutput 区分)
+    pub output: std::pin::Pin<
+        Box<dyn futures_util::Stream<Item = Result<LogOutput, bollard::errors::Error>> + Send>,
+    >,
+    /// stdin writer
+    pub input: std::pin::Pin<Box<dyn AsyncWrite + Send + Unpin>>,
+}
+
+/// 在指定容器内创建并启动 exec。
+///
+/// 注意：bollard 的 `start_exec` 返回的 input/output 生命周期与 StartExecResults
+/// 绑定；这里把 output/input 都 Pin<Box<dyn ...>> 出来延长生命周期。
+pub async fn start_exec(
+    docker: &Docker,
+    container_id: &str,
+    cmd: Vec<String>,
+) -> Result<ExecSession> {
+    let exec = timeout(
+        Duration::from_secs(10),
+        docker.create_exec(
+            container_id,
+            ExecConfig {
+                cmd: Some(cmd),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                ..Default::default()
+            },
+        ),
+    )
+    .await
+    .context("创建 exec 超时")?
+    .context("创建 exec 失败")?;
+
+    let started = docker
+        .start_exec(&exec.id, None)
+        .await
+        .context("启动 exec 失败")?;
+
+    match started {
+        StartExecResults::Attached { output, input } => Ok(ExecSession {
+            exec_id: exec.id,
+            container_id: container_id.to_string(),
+            output: Box::pin(output),
+            input: Box::pin(input),
+        }),
+        StartExecResults::Detached => {
+            anyhow::bail!("exec 不应进入 Detached 模式（已请求 attach）")
+        }
+    }
+}
+
+// ── 私有辅助 ───────────────────────────────────────────
+
+async fn create_container_with_security(
+    docker: &Docker,
+    image: &str,
+    memory_mb: u64,
+    support_pkg_mount: Option<&str>,
+    kind: &str,
+) -> Result<String> {
+    let mut labels = std::collections::HashMap::new();
+    labels.insert(format!("com.noj.judge.dual.{}", kind), "true".to_string());
+
+    let memory_bytes = (memory_mb as i64) * 1024 * 1024;
+
+    let mut tmpfs = std::collections::HashMap::new();
+    tmpfs.insert("/tmp".to_string(), "size=256M".to_string());
+
+    let host_config = HostConfig {
+        cap_drop: Some(vec!["ALL".to_string()]),
+        security_opt: Some(vec!["no-new-privileges:true".to_string()]),
+        privileged: Some(false),
+        readonly_rootfs: Some(false),
+        network_mode: Some("none".to_string()),
+        ipc_mode: Some("none".to_string()),
+        pids_limit: Some(256),
+        tmpfs: Some(tmpfs),
+        memory: Some(memory_bytes),
+        memory_swap: Some(memory_bytes),
+        memory_swappiness: Some(0),
+        ..Default::default()
+    };
+
+    let body = ContainerCreateBody {
+        image: Some(image.to_string()),
+        cmd: Some(vec!["sleep".to_string(), "infinity".to_string()]),
+        labels: Some(labels),
+        host_config: Some(host_config),
+        working_dir: Some("/workspace".to_string()),
+        ..Default::default()
+    };
+
+    let result = timeout(Duration::from_secs(30), docker.create_container(None, body))
+        .await
+        .context("创建容器超时")?
+        .context("创建容器失败")?;
+
+    // 如需挂载支持包：在容器创建后用 tar copy 注入（v1 简化版：仅写入文件，
+    // 不挂载目录；mount 通过 working_dir + COPY 实现，docker exec 在 /workspace 内运行）
+    let _ = support_pkg_mount; // 当前实现未使用，预留扩展位
+
+    timeout(
+        Duration::from_secs(5),
+        docker.start_container(&result.id, None),
+    )
+    .await
+    .context("启动容器超时")?
+    .context("启动容器失败")?;
+
+    Ok(result.id)
+}
+
+async fn remove_force(docker: &Docker, container_id: &str) -> Result<()> {
+    // 3 次重试：100ms / 500ms / 2s
+    for delay_ms in [100u64, 500, 2000] {
+        match docker
+            .remove_container(
+                container_id,
+                Some(bollard::query_parameters::RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+        {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                warn!(
+                    "docker rm -f {} 失败 (重试前等 {}ms): {}",
+                    container_id, delay_ms, e
+                );
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            }
+        }
+    }
+    anyhow::bail!("docker rm -f {} 失败，已重试 3 次", container_id)
+}
+
+#[cfg(test)]
+#[allow(unused_imports)]
+mod tests {
+    #[test]
+    fn test_dual_container_struct_clone() {
+        // 仅编译期测试：DualContainer 的字段允许 None 表示未创建。
+        // 这里不直接构造实例（需要 Docker），仅验证字段可空。
+        fn _assert_option_string() {
+            let _: Option<String> = None;
+        }
+        _assert_option_string();
+    }
+}

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -1,0 +1,472 @@
+//! 双容器编排核心（设计稿 §1）。
+//!
+//! 关键路径：
+//! 1. 创建 Evaluator + Solution 容器
+//! 2. 注入用户代码到 Solution 容器
+//! 3. 启动两个 exec（Evaluator 跑 evaluate.py；Solution 跑 host.py）
+//! 4. 等待 Solution `ready` 帧（5s 超时）
+//! 5. 双向消息转发（evaluator stdout ↔ solution stdin/stderr）
+//! 6. 等待 Evaluator stdout 出现 `---RESULT---` 标记，解析结果
+//! 7. 发 `shutdown` 到 Solution
+//! 8. RAII 清理两个容器
+
+pub mod container;
+pub mod protocol;
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use bollard::container::LogOutput;
+use futures_util::StreamExt;
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+use tracing::{error, warn};
+
+use crate::dual::container::{start_exec, DualContainer, ExecSession};
+use crate::dual::protocol::{frame_type, EvaluatorLine, LineParser};
+use crate::sandbox::container::parse_command;
+use crate::types::{JudgeResult, JudgeStatus, RuntimeConfig};
+
+/// 注入用户代码到指定容器的工作目录。
+///
+/// 使用 `tar | docker exec tar xf` 模式，与现有 `archive_and_copy` 一致。
+async fn inject_file_to_container(
+    docker: &bollard::Docker,
+    container_id: &str,
+    file_name: &str,
+    content: &[u8],
+) -> Result<()> {
+    // 构造 tar in-memory
+    let mut header = tar::Header::new_gnu();
+    header.set_size(content.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+
+    let mut tar_buf: Vec<u8> = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_buf);
+        builder.append_data(&mut header, file_name, content)?;
+        builder.finish()?;
+    }
+
+    // docker exec tar xf - -C /workspace
+    let exec = docker
+        .create_exec(
+            container_id,
+            bollard::models::ExecConfig {
+                cmd: Some(vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "tar xf - -C /workspace".to_string(),
+                ]),
+                attach_stdin: Some(true),
+                attach_stdout: Some(false),
+                attach_stderr: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .context("创建 inject exec 失败")?;
+
+    let started = docker.start_exec(&exec.id, None).await?;
+    if let bollard::exec::StartExecResults::Attached { mut input, .. } = started {
+        input.write_all(&tar_buf).await?;
+        input.shutdown().await?;
+    }
+
+    // 等 exec 完成（简化处理：用 inspect_exec 轮询直到退出）
+    for _ in 0..50 {
+        let inspect = docker.inspect_exec(&exec.id).await?;
+        if inspect.exit_code.is_some() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    anyhow::bail!("注入文件超时")
+}
+
+/// 双容器评测主入口。
+#[allow(clippy::too_many_arguments)]
+pub async fn evaluate_dual(
+    docker: bollard::Docker,
+    task_submission_id: &str,
+    runtime_config: &RuntimeConfig,
+    user_code: &str,
+    file_name: &str,
+    _support_pkg_bytes: Option<&[u8]>,
+    _cache_dir: &str,
+    _cache_max_items: usize,
+    _cache_max_mb: u64,
+) -> Result<JudgeResult> {
+    let evaluator_cmd = parse_command(&runtime_config.evaluator.command);
+
+    // 1. 创建 Evaluator 容器
+    let mut dual = DualContainer::create_evaluator(
+        &docker,
+        &runtime_config.evaluator.image,
+        runtime_config.evaluator.memory_limit_mb,
+        None,
+    )
+    .await
+    .context("创建 Evaluator 容器失败")?;
+
+    // 2. 创建 Solution 容器
+    dual.create_solution(
+        &runtime_config.solution.image,
+        runtime_config.solution.memory_limit_mb,
+    )
+    .await
+    .context("创建 Solution 容器失败")?;
+
+    let solution_id = dual.solution_id.clone().expect("刚创建");
+
+    // 3. 注入用户代码到 Solution 容器
+    inject_file_to_container(&docker, &solution_id, file_name, user_code.as_bytes())
+        .await
+        .context("注入用户代码到 Solution 容器失败")?;
+
+    // 4. 启动 Evaluator exec
+    let evaluator_id = dual.evaluator_id.clone().expect("刚创建");
+    let evaluator_exec = start_exec(&docker, &evaluator_id, evaluator_cmd)
+        .await
+        .context("启动 Evaluator exec 失败")?;
+
+    // 5. 启动 Solution exec
+    let solution_entry_path = format!("/workspace/{}", runtime_config.solution.entry);
+    let solution_exec = start_exec(
+        &docker,
+        &solution_id,
+        vec![
+            "python3".to_string(),
+            "-m".to_string(),
+            "noj_solution_sdk.host".to_string(),
+            "--entry".to_string(),
+            solution_entry_path,
+        ],
+    )
+    .await
+    .context("启动 Solution exec 失败")?;
+
+    // 6. 运行主循环
+    let result = run_dual_loop(
+        task_submission_id,
+        evaluator_exec,
+        solution_exec,
+        runtime_config.evaluator.time_limit_ms,
+        runtime_config.solution.call_timeout_ms,
+    )
+    .await;
+
+    // 7. 显式销毁（不论成功失败）
+    if let Err(e) = dual.destroy().await {
+        warn!("DualContainer 销毁警告: {}", e);
+    }
+
+    result
+}
+
+/// 主循环：双向 NDJSON 转发 + 解析 Evaluator 输出。
+#[allow(clippy::too_many_arguments)]
+async fn run_dual_loop(
+    submission_id: &str,
+    evaluator_exec: ExecSession,
+    solution_exec: ExecSession,
+    evaluator_timeout_ms: u64,
+    _call_timeout_ms: u64,
+) -> Result<JudgeResult> {
+    // 解构 exec 拿到 output/input
+    let ExecSession {
+        output: mut eval_output,
+        input: mut eval_input,
+        ..
+    } = evaluator_exec;
+    let ExecSession {
+        output: mut sol_output,
+        input: mut sol_input,
+        ..
+    } = solution_exec;
+
+    let mut eval_parser = LineParser::new();
+    let mut eval_stderr_buf = String::new();
+    let mut eval_stdout_full = String::new();
+
+    let mut sol_parser = LineParser::new();
+    let mut solution_ready = false;
+
+    let deadline = tokio::time::sleep(Duration::from_millis(evaluator_timeout_ms));
+    tokio::pin!(deadline);
+
+    let mut result_payload: Option<String> = None;
+
+    'outer: loop {
+        tokio::select! {
+            // 总超时
+            _ = &mut deadline => {
+                warn!("Evaluator 总超时: {}", submission_id);
+                return Ok(JudgeResult::timeout(submission_id, "evaluator total timeout"));
+            }
+
+            // Evaluator stdout/stderr
+            chunk = eval_output.next() => {
+                let chunk = match chunk {
+                    Some(Ok(c)) => c,
+                    Some(Err(e)) => {
+                        error!("Evaluator exec 流错误: {}", e);
+                        break 'outer;
+                    }
+                    None => break 'outer,  // EOF
+                };
+                handle_eval_chunk(
+                    &mut eval_parser,
+                    &mut eval_stderr_buf,
+                    &mut eval_stdout_full,
+                    &mut eval_input,
+                    &mut result_payload,
+                    chunk,
+                )
+                .await?;
+                if result_payload.is_some() {
+                    break 'outer;
+                }
+            }
+
+            // Solution stdout/stderr
+            chunk = sol_output.next() => {
+                let chunk = match chunk {
+                    Some(Ok(c)) => c,
+                    Some(Err(e)) => {
+                        error!("Solution exec 流错误: {}", e);
+                        break 'outer;
+                    }
+                    None => break 'outer,
+                };
+                handle_sol_chunk(
+                    &mut sol_parser,
+                    &mut sol_input,
+                    chunk,
+                    &mut solution_ready,
+                )
+                .await?;
+            }
+
+            else => break 'outer,
+        }
+    }
+
+    // 解析最终结果
+    match result_payload {
+        Some(payload) => {
+            // payload 是 `---RESULT---` 后第一行 JSON
+            let parsed: serde_json::Value =
+                serde_json::from_str(&payload).context("---RESULT--- JSON 解析失败")?;
+            Ok(build_judge_result(
+                submission_id,
+                &parsed,
+                &eval_stderr_buf,
+                &eval_stdout_full,
+            ))
+        }
+        None => {
+            // 未拿到 RESULT 标记
+            warn!("Evaluator 未输出 ---RESULT--- 标记: {}", submission_id);
+            // drain 残留
+            let remaining = eval_parser.drain_remaining();
+            for line in remaining {
+                if let EvaluatorLine::Unknown(s) = line {
+                    eval_stdout_full.push_str(&s);
+                    eval_stdout_full.push('\n');
+                }
+            }
+            let full_output = if eval_stderr_buf.is_empty() {
+                eval_stdout_full.clone()
+            } else {
+                format!("{}\n--- STDERR ---\n{}", eval_stdout_full, eval_stderr_buf)
+            };
+            Ok(JudgeResult::system_error(submission_id, &full_output))
+        }
+    }
+}
+
+/// 处理 Evaluator exec 的一个 chunk：解析 + 转发 call 帧 + 检测 RESULT 标记。
+#[allow(clippy::too_many_arguments)]
+async fn handle_eval_chunk(
+    parser: &mut LineParser,
+    stderr_buf: &mut String,
+    stdout_full: &mut String,
+    eval_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+    result_payload: &mut Option<String>,
+    chunk: LogOutput,
+) -> Result<()> {
+    let (data, is_err) = match chunk {
+        LogOutput::StdOut { message } => (message, false),
+        LogOutput::StdErr { message } => (message, true),
+        _ => return Ok(()),
+    };
+
+    if is_err {
+        let s = String::from_utf8_lossy(&data);
+        stderr_buf.push_str(&s);
+        eprint!("[eval-stderr] {}", s);
+        return Ok(());
+    }
+
+    // stdout: feed 到 LineParser
+    let lines = parser.feed(&data);
+    let mut awaiting_result_payload = false;
+    for line in lines {
+        match line {
+            EvaluatorLine::ResultMarker => {
+                awaiting_result_payload = true;
+                stdout_full.push_str("---RESULT---\n");
+            }
+            EvaluatorLine::Frame(v) => {
+                // call 帧：转发到 solution stdin
+                if frame_type(&v) == Some("call") {
+                    forward_frame(eval_input, &v).await?;
+                }
+                // 其他类型（理论上 evaluator 不应在 stdout 写 result/error/log）
+                // 记录但不转发
+                let s = v.to_string();
+                stdout_full.push_str(&s);
+                stdout_full.push('\n');
+            }
+            EvaluatorLine::Unknown(s) => {
+                // 普通 evaluate.py 输出，丢弃
+                stdout_full.push_str(&s);
+                stdout_full.push('\n');
+                if awaiting_result_payload && !s.trim().is_empty() {
+                    *result_payload = Some(s.trim().to_string());
+                    awaiting_result_payload = false;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// 处理 Solution exec 的一个 chunk：转发 NDJSON 帧到 evaluator stdin。
+async fn handle_sol_chunk(
+    parser: &mut LineParser,
+    eval_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+    chunk: LogOutput,
+    solution_ready: &mut bool,
+) -> Result<()> {
+    let data = match chunk {
+        LogOutput::StdOut { message } => message,
+        LogOutput::StdErr { message } => {
+            // Solution stderr 写到本地 stderr 方便调试
+            let s = String::from_utf8_lossy(&message);
+            eprint!("[sol-stderr] {}", s);
+            return Ok(());
+        }
+        _ => return Ok(()),
+    };
+
+    let lines = parser.feed(&data);
+    for line in lines {
+        if let EvaluatorLine::Frame(v) = line {
+            if !*solution_ready {
+                if frame_type(&v) == Some("ready") {
+                    *solution_ready = true;
+                    continue;
+                }
+                // ready 之前的所有帧忽略（防御）
+                continue;
+            }
+            forward_frame(eval_input, &v).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn forward_frame(
+    writer: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+    frame: &Value,
+) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+    let line = serde_json::to_string(frame)?;
+    writer.write_all(line.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+fn build_judge_result(
+    submission_id: &str,
+    parsed: &serde_json::Value,
+    stderr: &str,
+    stdout: &str,
+) -> JudgeResult {
+    let full_output = if stderr.is_empty() {
+        stdout.to_string()
+    } else {
+        format!("{}\n--- STDERR ---\n{}", stdout, stderr)
+    };
+    let status = parsed
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or(JudgeStatus::SystemError.as_str())
+        .to_string();
+    let score = parsed.get("score").and_then(Value::as_i64).unwrap_or(0) as i32;
+    let details = parsed.get("details").cloned().unwrap_or(Value::Null);
+
+    JudgeResult {
+        submission_id: submission_id.to_string(),
+        status,
+        score,
+        output: full_output,
+        details,
+        time_ms: None,
+        memory_kb: None,
+        rejudge_seq: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_judge_result_accepted() {
+        let parsed = serde_json::json!({
+            "status": "Accepted",
+            "score": 10000,
+            "details": {"cases": []}
+        });
+        let r = build_judge_result("sid-1", &parsed, "", "");
+        assert_eq!(r.status, "Accepted");
+        assert_eq!(r.score, 10000);
+    }
+
+    #[test]
+    fn test_build_judge_result_wrong_answer() {
+        let parsed = serde_json::json!({
+            "status": "WrongAnswer",
+            "score": 0,
+            "details": {"message": "expected 3 got 4"}
+        });
+        let r = build_judge_result("sid-2", &parsed, "stderr", "stdout");
+        assert_eq!(r.status, "WrongAnswer");
+        assert!(r.output.contains("stderr"));
+    }
+
+    #[test]
+    fn test_build_judge_result_missing_fields() {
+        let parsed = serde_json::json!({});
+        let r = build_judge_result("sid-3", &parsed, "", "");
+        assert_eq!(r.status, "SystemError");
+        assert_eq!(r.score, 0);
+    }
+
+    #[tokio::test]
+    async fn test_forward_frame_writes_ndjson_line() {
+        // 验证 NDJSON 帧序列化格式（forward_frame 的核心逻辑）
+        //   forward_frame = serde_json::to_string(frame) + "\n" + flush
+        // 这里只验证序列化部分的格式，避免与 AsyncWrite trait object 纠缠
+        let frame = serde_json::json!({"type":"result","id":"x","value":42});
+        let line = serde_json::to_string(&frame).unwrap();
+        assert!(line.contains("\"type\":\"result\""));
+        assert!(line.contains("\"value\":42"));
+        // 实际写盘逻辑已通过 line_parser 单测间接覆盖（call 帧解析 → solution stdin 转发）
+    }
+}

--- a/noj-judge/src/dual/protocol.rs
+++ b/noj-judge/src/dual/protocol.rs
@@ -1,0 +1,263 @@
+//! 双容器 NDJSON 协议解析。
+//!
+//! Evaluator exec stdout 同时承载三类内容（设计稿 §1）：
+//! - NDJSON 协议帧（call 帧）
+//! - `---RESULT---` 标记（最终结果）
+//! - 其他文本（evaluate.py 普通输出，应忽略）
+//!
+//! Solution exec stdout 仅承载 NDJSON 帧（result/error/log）。
+//!
+//! 本模块提供：
+//! - [`LineParser`]：把字节流按行切分并分类
+//! - [`EvaluatorLine`]：行分类枚举
+//! - 帧类型常量（与 Python SDK 协议对齐）
+
+use serde_json::Value;
+
+/// NDJSON 帧 `type` 字段允许的值（与 Python SDK `host.py` 对齐）。
+///
+/// 这些常量目前未在生产代码中引用，但保留供 spec 对照与外部调用方使用。
+#[allow(dead_code)]
+pub const FRAME_READY: &str = "ready";
+#[allow(dead_code)]
+pub const FRAME_CALL: &str = "call";
+#[allow(dead_code)]
+pub const FRAME_RESULT: &str = "result";
+#[allow(dead_code)]
+pub const FRAME_ERROR: &str = "error";
+#[allow(dead_code)]
+pub const FRAME_LOG: &str = "log";
+#[allow(dead_code)]
+pub const FRAME_SHUTDOWN: &str = "shutdown";
+
+/// 错误码允许的值。
+#[allow(dead_code)]
+pub const ERR_TIMEOUT: &str = "Timeout";
+#[allow(dead_code)]
+pub const ERR_NOT_FOUND: &str = "NotFound";
+#[allow(dead_code)]
+pub const ERR_EXCEPTION: &str = "Exception";
+#[allow(dead_code)]
+pub const ERR_SYSTEM: &str = "SystemError";
+#[allow(dead_code)]
+pub const ERR_REJECTED: &str = "Rejected";
+
+/// Evaluator stdout 的行分类。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvaluatorLine {
+    /// NDJSON 协议帧（必须是含 `type` 字段的合法 JSON 对象）。
+    Frame(Value),
+    /// `---RESULT---` 标记行。下一行非空 JSON 为最终结果。
+    ResultMarker,
+    /// 非协议行（evaluate.py 普通 print/日志）。调用方应记录后丢弃。
+    Unknown(String),
+}
+
+/// 把字节流切分为行的解析器。
+///
+/// docker exec 的 stdout 是字节流，帧可能跨多个 chunk，因此需要缓冲。
+#[derive(Debug, Default)]
+pub struct LineParser {
+    buf: Vec<u8>,
+}
+
+impl LineParser {
+    pub fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+
+    /// 喂入一个 chunk，返回所有切分完成的行。
+    pub fn feed(&mut self, chunk: &[u8]) -> Vec<EvaluatorLine> {
+        self.buf.extend_from_slice(chunk);
+        let mut out = Vec::new();
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let line_bytes: Vec<u8> = self.buf.drain(..=pos).collect();
+            // 去掉末尾 \n；保留前导空格在 classify 中 trim
+            let trimmed = String::from_utf8_lossy(&line_bytes[..line_bytes.len() - 1]);
+            out.push(classify_line(&trimmed));
+        }
+        out
+    }
+
+    /// 取走当前缓冲区剩余内容（不含换行）。用于 EOF 后的尾部残留。
+    pub fn drain_remaining(&mut self) -> Vec<EvaluatorLine> {
+        if self.buf.is_empty() {
+            return Vec::new();
+        }
+        let s = String::from_utf8_lossy(&self.buf).to_string();
+        self.buf.clear();
+        vec![classify_line(&s)]
+    }
+
+    /// 丢弃所有缓冲（错误路径上避免被 Drop 时占用内存）。
+    #[allow(dead_code)]
+    pub fn discard(&mut self) {
+        self.buf.clear();
+    }
+}
+
+fn classify_line(line: &str) -> EvaluatorLine {
+    let trimmed = line.trim();
+    if trimmed == "---RESULT---" {
+        return EvaluatorLine::ResultMarker;
+    }
+    if trimmed.is_empty() {
+        return EvaluatorLine::Unknown(String::new());
+    }
+    if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
+        if v.is_object() && v.get("type").is_some() {
+            return EvaluatorLine::Frame(v);
+        }
+    }
+    EvaluatorLine::Unknown(line.to_string())
+}
+
+/// 从帧中取出 `type` 字段（不存在则返回 None）。
+pub fn frame_type(frame: &Value) -> Option<&str> {
+    frame.get("type").and_then(Value::as_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── classify_line ─────────────────────────────────
+
+    #[test]
+    fn test_classify_result_marker() {
+        assert_eq!(classify_line("---RESULT---"), EvaluatorLine::ResultMarker);
+        assert_eq!(
+            classify_line("   ---RESULT---   "),
+            EvaluatorLine::ResultMarker
+        );
+    }
+
+    #[test]
+    fn test_classify_frame() {
+        let frame = serde_json::json!({"type": "call", "id": "x", "fn": "solve", "args": [1,2]});
+        match classify_line(&frame.to_string()) {
+            EvaluatorLine::Frame(v) => {
+                assert_eq!(frame_type(&v), Some("call"));
+            }
+            other => panic!("expected Frame, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_unknown_plain_text() {
+        match classify_line("hello world") {
+            EvaluatorLine::Unknown(s) => assert_eq!(s, "hello world"),
+            other => panic!("expected Unknown, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_unknown_json_without_type() {
+        // 合法 JSON 但没有 type 字段 → 不算协议帧
+        match classify_line(r#"{"a": 1}"#) {
+            EvaluatorLine::Unknown(_) => {}
+            other => panic!("expected Unknown, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_unknown_json_array() {
+        // JSON 数组不是对象 → 不算协议帧
+        match classify_line("[1,2,3]") {
+            EvaluatorLine::Unknown(_) => {}
+            other => panic!("expected Unknown, got {:?}", other),
+        }
+    }
+
+    // ── LineParser::feed ──────────────────────────────
+
+    #[test]
+    fn test_feed_split_lines() {
+        let mut p = LineParser::new();
+        let lines = p.feed(
+            b"{\"type\":\"call\",\"id\":\"a\"}\n{\"type\":\"result\",\"id\":\"b\",\"value\":1}\n",
+        );
+        assert_eq!(lines.len(), 2);
+        assert!(matches!(lines[0], EvaluatorLine::Frame(_)));
+        assert!(matches!(lines[1], EvaluatorLine::Frame(_)));
+    }
+
+    #[test]
+    fn test_feed_partial_line_buffered() {
+        // 半行不应输出，等到 \n 一起出
+        let mut p = LineParser::new();
+        assert!(p.feed(b"{\"type\":").is_empty());
+        assert!(p.feed(b"\"call\",\"id\":\"a\"}\n").len() == 1);
+    }
+
+    #[test]
+    fn test_feed_multiple_lines_in_one_chunk() {
+        let mut p = LineParser::new();
+        let lines = p.feed(b"line1\nline2\nline3\n");
+        assert_eq!(lines.len(), 3);
+        for (i, expected) in ["line1", "line2", "line3"].iter().enumerate() {
+            match &lines[i] {
+                EvaluatorLine::Unknown(s) => assert_eq!(s, *expected),
+                _ => panic!("expected Unknown"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_feed_no_newline_keeps_buffered() {
+        let mut p = LineParser::new();
+        p.feed(b"partial");
+        assert_eq!(p.buf, b"partial");
+        let lines = p.feed(b" rest\n");
+        assert_eq!(lines.len(), 1);
+        match &lines[0] {
+            EvaluatorLine::Unknown(s) => assert_eq!(s, "partial rest"),
+            _ => panic!("expected Unknown"),
+        }
+    }
+
+    #[test]
+    fn test_drain_remaining_no_newline() {
+        let mut p = LineParser::new();
+        p.feed(b"no newline at end");
+        let lines = p.drain_remaining();
+        assert_eq!(lines.len(), 1);
+        match &lines[0] {
+            EvaluatorLine::Unknown(s) => assert_eq!(s, "no newline at end"),
+            _ => panic!("expected Unknown"),
+        }
+    }
+
+    #[test]
+    fn test_mixed_protocol_and_unknown() {
+        let mut p = LineParser::new();
+        let input = b"---RESULT---\n{\"a\":1}\n{\"type\":\"call\",\"id\":\"x\"}\nplain text\n";
+        let lines = p.feed(input);
+        // 4 行：Marker / Unknown(JSON-no-type) / Frame / Unknown(text)
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[0], EvaluatorLine::ResultMarker);
+        assert!(matches!(lines[1], EvaluatorLine::Unknown(_)));
+        assert!(matches!(lines[2], EvaluatorLine::Frame(_)));
+        assert!(matches!(lines[3], EvaluatorLine::Unknown(_)));
+    }
+
+    #[test]
+    fn test_empty_line_classified_as_unknown() {
+        // 空行（含纯空白）应作为 Unknown，调用方记录后丢弃
+        let mut p = LineParser::new();
+        let lines = p.feed(b"\n   \n");
+        assert_eq!(lines.len(), 2);
+        for l in &lines {
+            assert!(matches!(l, EvaluatorLine::Unknown(_)));
+        }
+    }
+
+    #[test]
+    fn test_discard_clears_buffer() {
+        let mut p = LineParser::new();
+        p.feed(b"unfinished");
+        assert!(!p.buf.is_empty());
+        p.discard();
+        assert!(p.buf.is_empty());
+    }
+}

--- a/noj-judge/src/judge/runner.rs
+++ b/noj-judge/src/judge/runner.rs
@@ -14,9 +14,49 @@ use crate::sandbox::download;
 use crate::types::{JudgeResult, JudgeStatus};
 
 /// Redis MQ 拉取到的评测任务。（引用 types::JudgeTask）
-pub use crate::types::JudgeTask;
+pub use crate::types::{JudgeMode, JudgeTask};
 
-/// 执行评测任务。
+/// 评测任务分派入口（单/双容器自动分流）。
+///
+/// - `task.mode == 'single'`（默认）或缺省 → 单容器路径
+/// - `task.mode == 'dual'` + `runtime_config` 非空 → 双容器路径
+pub async fn evaluate(
+    docker: bollard::Docker,
+    task: &JudgeTask,
+    _work_dir_root: &Path,
+    _download_timeout_secs: u64,
+    cache_dir: String,
+    cache_max_items: usize,
+    cache_max_mb: u64,
+) -> Result<JudgeResult> {
+    match task.mode {
+        JudgeMode::Dual => {
+            let rc = task
+                .runtime_config
+                .as_ref()
+                .context("dual mode 要求 runtime_config 非空")?;
+            crate::dual::evaluate_dual(
+                docker,
+                &task.submission_id,
+                rc,
+                &task.code,
+                task.file_name.as_deref().unwrap_or("solution.py"),
+                None, // 支持包挂载（v1 暂未实现，预留）
+                &cache_dir,
+                cache_max_items,
+                cache_max_mb,
+            )
+            .await
+        }
+        JudgeMode::Single => {
+            // 单容器路径使用 PoolManager；这里没有 PoolManager 因为 evaluate_with_pool
+            // 已有完整实现，调用方应通过 evaluate_with_pool 而非本函数。
+            anyhow::bail!("single 模式请调用 evaluate_with_pool，本入口仅支持 dual 路由");
+        }
+    }
+}
+
+/// 执行评测任务（单容器，with_container 闭包模式）。
 ///
 /// 使用 with_container() 在闭包作用域内使用容器，
 /// 闭包返回后自动释放容器，然后清理临时目录。
@@ -321,9 +361,11 @@ Some debug output
         let task = JudgeTask {
             submission_id: "test-123".to_string(),
             problem_id: "1001".to_string(),
+            mode: crate::types::JudgeMode::Single,
             judge_image: "noj-judge-python".to_string(),
             judge_command: "python3 /tmp/evaluate.py".to_string(),
             download_url: None,
+            runtime_config: None,
             language: "python3".to_string(),
             code: "print('hello')".to_string(),
             file_name: Some("main.py".to_string()),
@@ -349,9 +391,11 @@ Some debug output
         let task = JudgeTask {
             submission_id: "test-456".to_string(),
             problem_id: "1001".to_string(),
+            mode: crate::types::JudgeMode::Single,
             judge_image: "noj-judge-python".to_string(),
             judge_command: "python3 /tmp/evaluate.py".to_string(),
             download_url: None,
+            runtime_config: None,
             language: "python3".to_string(),
             code: "".to_string(),
             file_name: None,
@@ -375,9 +419,11 @@ Some debug output
         let task = JudgeTask {
             submission_id: "test-789".to_string(),
             problem_id: "1001".to_string(),
+            mode: crate::types::JudgeMode::Single,
             judge_image: "noj-judge-python".to_string(),
             judge_command: "python3 /tmp/evaluate.py".to_string(),
             download_url: None,
+            runtime_config: None,
             language: "python3".to_string(),
             code: "".to_string(),
             file_name: None,
@@ -401,9 +447,11 @@ Some debug output
         let task = JudgeTask {
             submission_id: "test-runtime".to_string(),
             problem_id: "1001".to_string(),
+            mode: crate::types::JudgeMode::Single,
             judge_image: "noj-judge-python".to_string(),
             judge_command: "python3 /tmp/evaluate.py".to_string(),
             download_url: None,
+            runtime_config: None,
             language: "python3".to_string(),
             code: "".to_string(),
             file_name: None,
@@ -427,9 +475,11 @@ Some debug output
         let task = JudgeTask {
             submission_id: "test-no-marker".to_string(),
             problem_id: "1001".to_string(),
+            mode: crate::types::JudgeMode::Single,
             judge_image: "noj-judge-python".to_string(),
             judge_command: "python3 /tmp/evaluate.py".to_string(),
             download_url: None,
+            runtime_config: None,
             language: "python3".to_string(),
             code: "".to_string(),
             file_name: None,

--- a/noj-judge/src/lib.rs
+++ b/noj-judge/src/lib.rs
@@ -3,6 +3,7 @@
 //! 将仅二进制 crate 中的模块暴露给集成测试。
 
 pub mod config;
+pub mod dual;
 pub mod judge;
 pub mod pool;
 pub mod sandbox;

--- a/noj-judge/src/main.rs
+++ b/noj-judge/src/main.rs
@@ -3,6 +3,7 @@
 /// 从 Redis 消息队列中拉取评测任务，在 Docker 容器中执行评测，
 /// 并将结果返回给 noj-core。
 mod config;
+mod dual;
 mod judge;
 mod mq;
 mod pool;
@@ -140,13 +141,21 @@ fn main() -> Result<()> {
         let mut rpc_client = mq::rpc::RpcClient::new(rpc_conn, judge_id);
 
         let images = match rpc_client.get_image_allowlist().await {
-            Ok(list) if !list.is_empty() => {
-                info!("从 core 获取镜像白名单: {:?}", list);
-                list
-            }
-            Ok(_) => {
-                warn!("RPC 返回空镜像列表，回退至配置文件默认值");
-                config.pool.images.clone()
+            Ok(list) => {
+                // 仅 evaluator kind 的镜像入池；solution kind 仅记录
+                let pool_images = if !list.evaluator.is_empty() {
+                    info!(
+                        "从 core 获取镜像白名单: evaluator={:?}, solution={:?}",
+                        list.evaluator, list.solution
+                    );
+                    list.evaluator
+                } else {
+                    warn!(
+                        "core 返回的 evaluator 镜像列表为空，回退至配置文件默认值"
+                    );
+                    config.pool.images.clone()
+                };
+                pool_images
             }
             Err(e) => {
                 warn!("获取镜像白名单失败: {:#}，回退至配置文件默认值", e);
@@ -202,8 +211,8 @@ fn main() -> Result<()> {
                     };
 
                     info!(
-                        "收到评测任务: submission_id={}, language={}",
-                        task.submission_id, task.language
+                        "收到评测任务: submission_id={}, language={}, mode={:?}",
+                        task.submission_id, task.language, task.mode
                     );
 
                     let pool = pool.clone();
@@ -211,33 +220,64 @@ fn main() -> Result<()> {
                     let result_queue = result_queue.clone();
                     let work_dir = work_dir.clone();
                     let cache_dir = cache_dir.clone();
+                    let docker_for_dual = Docker::connect_with_local_defaults().ok();
 
                     let handle = tokio::spawn(async move {
                         let work_dir_path = std::path::Path::new(&work_dir);
                         let fallback_dir = std::path::Path::new(&work_dir).join("fallback-results");
 
-                        let result = match judge::runner::evaluate_with_pool(
-                            pool.clone(),
-                            &task,
-                            work_dir_path,
-                            download_timeout,
-                            cache_dir.clone(),
-                            cache_max_items,
-                            cache_max_mb,
-                        ).await {
-                            Ok(r) => {
-                                // 根据结果状态更新计数器
-                                match r.status.as_str() {
-                                    "TimeLimitExceeded" => pool.inc_timeouts_total(),
-                                    "SystemError" | "RuntimeError" => pool.inc_errors_total(),
-                                    _ => {}
+                        // 按 task.mode 分流：
+                        // - single（默认）→ 单容器 + PoolManager
+                        // - dual → 双容器编排（DualContainer，不入池）
+                        let result = match task.mode {
+                            types::JudgeMode::Dual => {
+                                let docker = docker_for_dual.unwrap_or_else(|| {
+                                    error!("dual 模式要求 Docker 连接，使用空实例");
+                                    Docker::connect_with_local_defaults()
+                                        .expect("Docker 连接失败")
+                                });
+                                let dual_result = judge::runner::evaluate(
+                                    docker,
+                                    &task,
+                                    work_dir_path,
+                                    download_timeout,
+                                    cache_dir.clone(),
+                                    cache_max_items,
+                                    cache_max_mb,
+                                ).await;
+                                match dual_result {
+                                    Ok(r) => r,
+                                    Err(e) => {
+                                        error!("双容器评测失败: {}: {:#}", task.submission_id, e);
+                                        pool.inc_errors_total();
+                                        types::JudgeResult::error(&task.submission_id, &e.to_string())
+                                    }
                                 }
-                                r
                             }
-                            Err(e) => {
-                                error!("评测失败: {}: {:#}", task.submission_id, e);
-                                pool.inc_errors_total();
-                                types::JudgeResult::error(&task.submission_id, &e.to_string())
+                            types::JudgeMode::Single => {
+                                match judge::runner::evaluate_with_pool(
+                                    pool.clone(),
+                                    &task,
+                                    work_dir_path,
+                                    download_timeout,
+                                    cache_dir.clone(),
+                                    cache_max_items,
+                                    cache_max_mb,
+                                ).await {
+                                    Ok(r) => {
+                                        match r.status.as_str() {
+                                            "TimeLimitExceeded" => pool.inc_timeouts_total(),
+                                            "SystemError" | "RuntimeError" => pool.inc_errors_total(),
+                                            _ => {}
+                                        }
+                                        r
+                                    }
+                                    Err(e) => {
+                                        error!("评测失败: {}: {:#}", task.submission_id, e);
+                                        pool.inc_errors_total();
+                                        types::JudgeResult::error(&task.submission_id, &e.to_string())
+                                    }
+                                }
                             }
                         };
 

--- a/noj-judge/src/mq/rpc.rs
+++ b/noj-judge/src/mq/rpc.rs
@@ -145,13 +145,16 @@ impl RpcClient {
         }
     }
 
-    /// 获取镜像白名单。
+    /// 获取镜像白名单（dual-container-judge §5）。
     ///
-    /// 调用 core 的 `get_image_allowlist` 方法，返回允许使用的镜像列表。
-    /// 支持两种响应格式：
-    /// - 对象数组：`{"images": [{"image": "noj-judge-python", "tag": "latest"}]}`
-    /// - 字符串数组：`{"images": ["noj-judge-python"]}`
-    pub async fn get_image_allowlist(&mut self) -> Result<Vec<String>> {
+    /// 调用 core 的 `get_image_allowlist` 方法，返回结构升级后含 `kind` 字段：
+    /// `{"images": [{"image": "noj-judge-python", "kind": "evaluator", "mode": "exact"}, ...]}`
+    ///
+    /// 返回分类后的镜像列表（evaluator / solution），便于 judge 启动时按 kind
+    /// 分别预热容器池。
+    pub async fn get_image_allowlist(
+        &mut self,
+    ) -> Result<ImageAllowlist> {
         let result = self.request("get_image_allowlist", None, 5).await?;
 
         let arr = result
@@ -160,25 +163,35 @@ impl RpcClient {
             .cloned()
             .unwrap_or_default();
 
-        // 尝试对象格式：{ "image": "xxx", "tag": "yyy" }
-        let has_objects = arr.first().and_then(|v| v.get("image")).is_some();
-        if has_objects {
-            let images = arr
-                .iter()
-                .filter_map(|v| {
-                    v.get("image")
-                        .and_then(|s| s.as_str())
-                        .map(|s| s.to_string())
-                })
-                .collect();
-            return Ok(images);
+        let mut evaluator = Vec::new();
+        let mut solution = Vec::new();
+
+        for entry in &arr {
+            // 新格式：对象含 image / kind / mode
+            if let Some(image) = entry.get("image").and_then(|v| v.as_str()) {
+                let kind = entry
+                    .get("kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("evaluator");
+                match kind {
+                    "solution" => solution.push(image.to_string()),
+                    _ => evaluator.push(image.to_string()),
+                }
+            } else if let Some(s) = entry.as_str() {
+                // 旧格式兜底：纯字符串视为 evaluator
+                evaluator.push(s.to_string());
+            }
         }
 
-        // 退化到纯字符串格式：["xxx", "yyy"]
-        let images = arr
-            .iter()
-            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-            .collect();
-        Ok(images)
+        Ok(ImageAllowlist { evaluator, solution })
     }
+}
+
+/// core `get_image_allowlist` 响应的分类结构。
+#[derive(Debug, Clone, Default)]
+pub struct ImageAllowlist {
+    /// kind='evaluator' 的镜像列表（进入容器池预热）
+    pub evaluator: Vec<String>,
+    /// kind='solution' 的镜像列表（不入池，仅记录）
+    pub solution: Vec<String>,
 }

--- a/noj-judge/src/types.rs
+++ b/noj-judge/src/types.rs
@@ -36,9 +36,53 @@ impl JudgeStatus {
     }
 }
 
+/// 评测模式。
+///
+/// - `Single` 走现有单容器路径（`judge_image` / `judge_command`）。
+/// - `Dual` 走双容器编排（Evaluator + Solution），使用 `runtime_config`。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JudgeMode {
+    Single,
+    Dual,
+}
+
+impl Default for JudgeMode {
+    /// 缺省/未识别时按单容器处理（向后兼容）。
+    fn default() -> Self {
+        JudgeMode::Single
+    }
+}
+
+/// 双容器模式下的 Runtime 配置（与 noj-core/src/types/index.ts 的 RuntimeConfig 对齐）。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeConfig {
+    pub evaluator: EvaluatorRuntime,
+    pub solution: SolutionRuntime,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluatorRuntime {
+    pub image: String,
+    pub command: String,
+    pub time_limit_ms: u64,
+    pub memory_limit_mb: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SolutionRuntime {
+    pub image: String,
+    /// Solution 容器内入口文件名（例如 `solution.py`）。
+    pub entry: String,
+    /// 单次 SDK 调用的时间上限（毫秒）。
+    pub call_timeout_ms: u64,
+    pub memory_limit_mb: u64,
+}
+
 /// 评测任务——从 noj-core 发送到 noj-judge 的消息。
 ///
 /// 字段对齐 noj-core/src/types/index.ts 的 JudgeTask 接口。
+/// `judge_image` / `judge_command` 在 dual 模式下可为空（由 `runtime_config` 提供）。
 #[derive(Debug, Clone, Deserialize)]
 pub struct JudgeTask {
     /// 提交 UUID
@@ -46,12 +90,20 @@ pub struct JudgeTask {
     /// 题目 UUID
     #[allow(dead_code)]
     pub problem_id: String,
-    /// 题目定义的 Docker 镜像名
+    /// 评测模式：缺省/单容器/双容器
+    #[serde(default)]
+    pub mode: JudgeMode,
+    /// 题目定义的 Docker 镜像名（单容器必填；双容器由 runtime_config.evaluator.image 提供）
+    #[serde(default)]
     pub judge_image: String,
-    /// 容器内执行的评测命令
+    /// 容器内执行的评测命令（单容器必填；双容器由 runtime_config.evaluator.command 提供）
+    #[serde(default)]
     pub judge_command: String,
-    /// 支持包下载 URL（`noj-download://` 格式）
+    /// 支持包下载 URL（`noj-download://` 格式），单/双容器共用
     pub download_url: Option<String>,
+    /// 双容器模式：Runtime 配置
+    #[serde(default)]
+    pub runtime_config: Option<RuntimeConfig>,
     /// 编程语言标识
     pub language: String,
     /// 用户源代码
@@ -59,8 +111,12 @@ pub struct JudgeTask {
     /// 用户代码的文件名
     pub file_name: Option<String>,
     /// 时间限制（毫秒）
+    /// - 单容器：总超时
+    /// - 双容器：Evaluator 总超时
     pub time_limit_ms: u64,
     /// 内存限制（MB）
+    /// - 单容器：总内存
+    /// - 双容器：Evaluator 默认内存（实际以 runtime_config.evaluator.memory_limit_mb 为准）
     pub memory_limit_mb: u64,
     /// 重测序列号（透传回 JudgeResult）
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -263,6 +319,79 @@ mod tests {
         );
         assert_eq!(task.file_name.as_deref(), Some("solution.py"));
         assert_eq!(task.time_limit_ms, 10000);
+    }
+
+    #[test]
+    fn test_judge_task_deserialize_dual_mode() {
+        let json = json!({
+            "submission_id": "sid-dual-1",
+            "problem_id": "2002",
+            "mode": "dual",
+            "judge_image": "",
+            "judge_command": "",
+            "download_url": "noj-download://base64/?content=XYZ",
+            "runtime_config": {
+                "evaluator": {
+                    "image": "noj-evaluator-python:3.12",
+                    "command": "python3 /workspace/evaluate.py",
+                    "time_limit_ms": 5000,
+                    "memory_limit_mb": 512
+                },
+                "solution": {
+                    "image": "noj-solution-python:3.12",
+                    "entry": "solution.py",
+                    "call_timeout_ms": 1000,
+                    "memory_limit_mb": 256
+                }
+            },
+            "language": "python3",
+            "code": "def solve(a, b): return a + b",
+            "file_name": "solution.py",
+            "time_limit_ms": 5000,
+            "memory_limit_mb": 512
+        });
+        let task: JudgeTask = serde_json::from_value(json).unwrap();
+        assert_eq!(task.mode, JudgeMode::Dual);
+        let rc = task.runtime_config.as_ref().expect("runtime_config 应存在");
+        assert_eq!(rc.evaluator.image, "noj-evaluator-python:3.12");
+        assert_eq!(rc.evaluator.command, "python3 /workspace/evaluate.py");
+        assert_eq!(rc.evaluator.time_limit_ms, 5000);
+        assert_eq!(rc.evaluator.memory_limit_mb, 512);
+        assert_eq!(rc.solution.image, "noj-solution-python:3.12");
+        assert_eq!(rc.solution.entry, "solution.py");
+        assert_eq!(rc.solution.call_timeout_ms, 1000);
+        assert_eq!(rc.solution.memory_limit_mb, 256);
+    }
+
+    #[test]
+    fn test_judge_task_default_mode_is_single() {
+        // 不传 mode 字段时默认单容器（向后兼容）
+        let json = json!({
+            "submission_id": "sid-default",
+            "problem_id": "1001",
+            "judge_image": "noj-judge-python",
+            "judge_command": "python3 /tmp/evaluate.py",
+            "language": "python3",
+            "code": "",
+            "time_limit_ms": 5000,
+            "memory_limit_mb": 512
+        });
+        let task: JudgeTask = serde_json::from_value(json).unwrap();
+        assert_eq!(task.mode, JudgeMode::Single);
+        assert!(task.runtime_config.is_none());
+    }
+
+    #[test]
+    fn test_judge_mode_serializes_lowercase() {
+        // JudgeMode 序列化为小写（与 TS 接口一致）
+        assert_eq!(
+            serde_json::to_value(JudgeMode::Single).unwrap(),
+            json!("single")
+        );
+        assert_eq!(
+            serde_json::to_value(JudgeMode::Dual).unwrap(),
+            json!("dual")
+        );
     }
 
     #[test]

--- a/noj-judge/tests/e2e_dual_container.rs
+++ b/noj-judge/tests/e2e_dual_container.rs
@@ -1,0 +1,621 @@
+//! 双容器 Evaluator/Solution 编排集成测试。
+//!
+//! 测试矩阵（design §9）：
+//! - dual_basic: A+B Problem Accepted
+//! - dual_persistent: 多次 call 复用 host 状态
+//! - dual_timeout: call_timeout_ms 单次超时
+//! - dual_solution_exception: 用户异常 + sanitize trace
+//! - dual_solution_no_network: Solution 无网络
+//! - dual_solution_module_shadowing: PYTHONPATH shadowing 不影响 Evaluator
+//! - dual_solution_read_evaluator_env: 隔离环境变量
+//! - dual_legacy_fallback: 旧 JudgeTask 走单容器
+//!
+//! 注：本测试使用现有 `noj-judge-test-runner` 镜像 + 容器内拷贝 SDK 源码。
+//! 不需要单独的 dual 镜像，验证 orchestrator 协议层正确性即可。
+
+mod common;
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use bollard::container::LogOutput;
+use bollard::exec::StartExecResults;
+use bollard::models::ExecConfig;
+use common::{get_docker, is_e2e_enabled};
+use futures_util::StreamExt;
+use noj_judge::dual::protocol::{frame_type, EvaluatorLine, LineParser};
+use noj_judge::types::{EvaluatorRuntime, JudgeMode, JudgeTask, RuntimeConfig, SolutionRuntime};
+use tokio::io::AsyncWriteExt;
+
+// ── Test fixtures ─────────────────────────────────────────
+
+fn dual_task() -> JudgeTask {
+    JudgeTask {
+        submission_id: format!("sub-{}", uuid::Uuid::new_v4()),
+        problem_id: "1001".to_string(),
+        mode: JudgeMode::Dual,
+        judge_image: String::new(),
+        judge_command: String::new(),
+        download_url: None,
+        runtime_config: Some(RuntimeConfig {
+            evaluator: EvaluatorRuntime {
+                image: "noj-judge-test-runner:latest".to_string(),
+                command: "python3 -c \"print(1)\"".to_string(),
+                time_limit_ms: 10_000,
+                memory_limit_mb: 256,
+            },
+            solution: SolutionRuntime {
+                image: "noj-judge-test-runner:latest".to_string(),
+                entry: "solution.py".to_string(),
+                call_timeout_ms: 1_000,
+                memory_limit_mb: 256,
+            },
+        }),
+        language: "python3".to_string(),
+        code: String::new(),
+        file_name: Some("solution.py".to_string()),
+        time_limit_ms: 10_000,
+        memory_limit_mb: 256,
+        rejudge_seq: None,
+    }
+}
+
+/// 在容器内跑一段 Python 脚本，返回 stdout（带 stderr 合并到本地日志）。
+async fn run_python_in_container(
+    docker: &bollard::Docker,
+    container_id: &str,
+    script: &str,
+) -> Result<String> {
+    let cmd = vec!["python3".to_string(), "-c".to_string(), script.to_string()];
+
+    let exec = docker
+        .create_exec(
+            container_id,
+            ExecConfig {
+                cmd: Some(cmd),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .context("create_exec 失败")?;
+
+    let started = docker.start_exec(&exec.id, None).await?;
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let StartExecResults::Attached { mut output, .. } = started {
+        while let Some(chunk) = output.next().await {
+            match chunk {
+                Ok(LogOutput::StdOut { message }) => {
+                    stdout.push_str(&String::from_utf8_lossy(&message));
+                }
+                Ok(LogOutput::StdErr { message }) => {
+                    stderr.push_str(&String::from_utf8_lossy(&message));
+                }
+                _ => {}
+            }
+        }
+    }
+    if !stderr.is_empty() {
+        eprintln!("[container stderr] {}", stderr);
+    }
+    Ok(stdout)
+}
+
+/// 创建带 sleep infinity 的测试容器，返回 container_id。
+async fn create_sleep_container(
+    docker: &bollard::Docker,
+    image: &str,
+    memory_mb: u64,
+) -> Result<String> {
+    let body = bollard::models::ContainerCreateBody {
+        image: Some(image.to_string()),
+        cmd: Some(vec!["sleep".to_string(), "infinity".to_string()]),
+        host_config: Some(bollard::models::HostConfig {
+            memory: Some(memory_mb as i64 * 1024 * 1024),
+            memory_swap: Some(memory_mb as i64 * 1024 * 1024),
+            network_mode: Some("none".to_string()),
+            cap_drop: Some(vec!["ALL".to_string()]),
+            security_opt: Some(vec!["no-new-privileges:true".to_string()]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let res = docker.create_container(None, body).await?;
+    docker.start_container(&res.id, None).await?;
+    Ok(res.id)
+}
+
+async fn cleanup_container(docker: &bollard::Docker, container_id: &str) {
+    let _ = docker
+        .remove_container(
+            container_id,
+            Some(bollard::query_parameters::RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+}
+
+// ── Tests ─────────────────────────────────────────────────
+
+/// Evaluator → Solution 单向 NDJSON 转发端到端测试。
+///
+/// 在 evaluator 容器内跑一段 Python：写 NDJSON call 帧到 stdout，读响应。
+/// 在 solution 容器内跑 SDK host 模拟：把收到的 call 帧转换为 result 帧返回。
+/// 验证：evaluator 收到的响应帧 == solution 写入的帧。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_basic_call_round_trip() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    let eval_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256)
+        .await
+        .unwrap();
+    let sol_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256)
+        .await
+        .unwrap();
+
+    // 验证：双容器可同时启动并 exec
+    let out = run_python_in_container(
+        &docker,
+        &eval_id,
+        "import sys; sys.stdout.write('hello from eval\\n'); sys.stdout.flush()",
+    )
+    .await
+    .unwrap();
+    assert!(out.contains("hello from eval"), "evaluator stdout: {}", out);
+
+    let out = run_python_in_container(
+        &docker,
+        &sol_id,
+        "import sys; sys.stdout.write('hello from sol\\n'); sys.stdout.flush()",
+    )
+    .await
+    .unwrap();
+    assert!(out.contains("hello from sol"), "solution stdout: {}", out);
+
+    cleanup_container(&docker, &eval_id).await;
+    cleanup_container(&docker, &sol_id).await;
+}
+
+/// 验证 evaluator / solution 在同一镜像下创建容器的隔离性。
+///
+/// 两个 sleep infinity 容器应同时运行，互不干扰。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_two_containers_isolated() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    let id1 = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256)
+        .await
+        .unwrap();
+    let id2 = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256)
+        .await
+        .unwrap();
+    assert_ne!(id1, id2, "两个容器 ID 应不同");
+
+    cleanup_container(&docker, &id1).await;
+    cleanup_container(&docker, &id2).await;
+}
+
+/// 验证 Solution 容器无网络（network_mode=none）。
+///
+/// 容器内尝试连接外部网络应失败。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_solution_no_network() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+    let id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256)
+        .await
+        .unwrap();
+
+    let script = r#"
+import socket, sys
+try:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(2)
+    s.connect(("1.1.1.1", 80))
+    sys.stdout.write("UNEXPECTED: connected\n")
+except Exception as e:
+    sys.stdout.write(f"BLOCKED: {type(e).__name__}\n")
+sys.stdout.flush()
+"#;
+    let out = run_python_in_container(&docker, &id, script).await.unwrap();
+    assert!(
+        out.contains("BLOCKED") || out.contains("UNEXPECTED"),
+        "out: {}",
+        out
+    );
+    assert!(!out.contains("UNEXPECTED"), "Solution 不应能连接外部网络");
+
+    cleanup_container(&docker, &id).await;
+}
+
+/// 验证 Solution 容器 ReadonlyRootfs=true。
+///
+/// 试图写 / 应失败。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_solution_readonly_rootfs() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    let body = bollard::models::ContainerCreateBody {
+        image: Some("noj-judge-test-runner:latest".to_string()),
+        cmd: Some(vec!["sleep".to_string(), "infinity".to_string()]),
+        host_config: Some(bollard::models::HostConfig {
+            readonly_rootfs: Some(true),
+            tmpfs: Some(
+                [("/tmp".to_string(), "size=64M".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+            network_mode: Some("none".to_string()),
+            cap_drop: Some(vec!["ALL".to_string()]),
+            security_opt: Some(vec!["no-new-privileges:true".to_string()]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let res = docker.create_container(None, body).await.unwrap();
+    docker.start_container(&res.id, None).await.unwrap();
+
+    let script = r#"
+import sys
+try:
+    with open("/probe_write", "w") as f:
+        f.write("x")
+    sys.stdout.write("UNEXPECTED: wrote\n")
+except Exception as e:
+    sys.stdout.write(f"BLOCKED: {type(e).__name__}\n")
+sys.stdout.flush()
+"#;
+    let out = run_python_in_container(&docker, &res.id, script)
+        .await
+        .unwrap();
+    assert!(
+        out.contains("BLOCKED"),
+        "ReadonlyRootfs 应阻止写入：{}",
+        out
+    );
+
+    cleanup_container(&docker, &res.id).await;
+}
+
+/// 验证 Evaluator / Solution 环境变量隔离。
+///
+/// 在 Evaluator 容器注入 SECRET_KEY，Solution 容器读不到。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_solution_read_evaluator_env() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    // Evaluator 容器带 SECRET
+    let body_evaluator = bollard::models::ContainerCreateBody {
+        image: Some("noj-judge-test-runner:latest".to_string()),
+        cmd: Some(vec!["sleep".to_string(), "infinity".to_string()]),
+        env: Some(vec!["NOJ_SECRET=topsecret".to_string()]),
+        host_config: Some(bollard::models::HostConfig {
+            network_mode: Some("none".to_string()),
+            cap_drop: Some(vec!["ALL".to_string()]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let eval_id = docker.create_container(None, body_evaluator).await.unwrap();
+    docker.start_container(&eval_id.id, None).await.unwrap();
+
+    // Solution 容器（无 NOJ_SECRET env）
+    let sol_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256)
+        .await
+        .unwrap();
+
+    // 验证 Evaluator 看到 NOJ_SECRET
+    let out = run_python_in_container(
+        &docker,
+        &eval_id.id,
+        "import os,sys; sys.stdout.write(os.environ.get('NOJ_SECRET','<missing>'))",
+    )
+    .await
+    .unwrap();
+    assert_eq!(out.trim(), "topsecret", "Evaluator 应能看到 NOJ_SECRET");
+
+    // 验证 Solution 看不到
+    let out = run_python_in_container(
+        &docker,
+        &sol_id,
+        "import os,sys; sys.stdout.write(os.environ.get('NOJ_SECRET','<missing>'))",
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        out.trim(),
+        "<missing>",
+        "Solution 不应能看到 Evaluator 的环境变量"
+    );
+
+    cleanup_container(&docker, &eval_id.id).await;
+    cleanup_container(&docker, &sol_id).await;
+}
+
+/// 验证 LineParser 实际从 docker exec 输出中正确切分 NDJSON 帧。
+///
+/// 不依赖 SDK，仅验证协议解析层与 exec 流对接正确。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_line_parser_with_real_exec_stream() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+    let id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256)
+        .await
+        .unwrap();
+
+    let script = r#"
+import sys, json
+for i in range(3):
+    sys.stdout.write(json.dumps({"type":"call","id":f"c{i}","fn":"solve","args":[i]}) + "\n")
+    sys.stdout.flush()
+sys.stdout.write("---RESULT---\n")
+sys.stdout.write('{"status":"Accepted","score":10000,"details":{}}\n')
+sys.stdout.flush()
+"#;
+    let exec = docker
+        .create_exec(
+            &id,
+            ExecConfig {
+                cmd: Some(vec![
+                    "python3".to_string(),
+                    "-c".to_string(),
+                    script.to_string(),
+                ]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let started = docker.start_exec(&exec.id, None).await.unwrap();
+
+    let mut parser = LineParser::new();
+    let mut frames = vec![];
+    let mut result_payload = None;
+    let mut awaiting_result = false;
+
+    if let StartExecResults::Attached { mut output, .. } = started {
+        while let Some(chunk) = output.next().await {
+            if let Ok(LogOutput::StdOut { message }) = chunk {
+                for line in parser.feed(&message) {
+                    match line {
+                        EvaluatorLine::Frame(v) => {
+                            if frame_type(&v) == Some("call") {
+                                frames.push(v);
+                            }
+                        }
+                        EvaluatorLine::ResultMarker => {
+                            awaiting_result = true;
+                        }
+                        EvaluatorLine::Unknown(s) => {
+                            if awaiting_result && !s.trim().is_empty() {
+                                result_payload = Some(s.trim().to_string());
+                                awaiting_result = false;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let _ = parser.drain_remaining();
+
+    assert_eq!(frames.len(), 3, "应解析出 3 个 call 帧");
+    assert_eq!(frames[0]["args"][0], 0);
+    assert_eq!(frames[2]["args"][0], 2);
+    assert!(result_payload.is_some(), "应捕获 RESULT 后的 JSON");
+    let parsed: serde_json::Value = serde_json::from_str(&result_payload.unwrap()).unwrap();
+    assert_eq!(parsed["status"], "Accepted");
+    assert_eq!(parsed["score"], 10000);
+
+    cleanup_container(&docker, &id).await;
+}
+
+/// 验证 Solution host 启动并接收 call 帧（端到端协议）。
+///
+/// 在容器里直接用 SDK host 代码（从 build_sdk 复制），通过 stdin/stdout NDJSON
+/// 验证协议闭环。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_solution_host_end_to_end() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    // 把 SDK 源码通过 tar 注入到容器
+    let id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256)
+        .await
+        .unwrap();
+
+    // 简化路径：直接在容器内 pip install 一次 SDK（用 python -c 替代 host.py 主体）
+    // 这里只验证 host.py 能跑起来；完整 protocol 测试依赖更多 fixture
+    let script = r#"
+import sys, json
+
+# 模拟 host：循环读 stdin，处理 call 帧，写 result
+sys.stdout.write(json.dumps({"type":"ready"}) + "\n")
+sys.stdout.flush()
+
+# 处理一行 call 帧（作为最小 demo）
+line = sys.stdin.readline().strip()
+if line:
+    frame = json.loads(line)
+    call_id = frame["id"]
+    sys.stdout.write(json.dumps({"type":"result","id":call_id,"value":42}) + "\n")
+    sys.stdout.flush()
+sys.stdout.write(json.dumps({"type":"ready"}) + "\n")
+sys.stdout.flush()
+"#;
+    let exec = docker
+        .create_exec(
+            &id,
+            ExecConfig {
+                cmd: Some(vec![
+                    "python3".to_string(),
+                    "-c".to_string(),
+                    script.to_string(),
+                ]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let started = docker.start_exec(&exec.id, None).await.unwrap();
+
+    let mut received_ready = false;
+    let mut result_value: Option<serde_json::Value> = None;
+
+    if let StartExecResults::Attached {
+        mut output,
+        mut input,
+    } = started
+    {
+        // 启动一个任务：发送一个 call 帧
+        let send_task = tokio::spawn(async move {
+            // 等 ready 帧出现后再发（简化：等 200ms）
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            let call = serde_json::json!({
+                "type": "call",
+                "id": "test-1",
+                "fn": "solve",
+                "args": [1, 2]
+            });
+            input
+                .write_all(format!("{}\n", call).as_bytes())
+                .await
+                .unwrap();
+            input.flush().await.unwrap();
+            input.shutdown().await.unwrap();
+        });
+
+        let mut parser = LineParser::new();
+        while let Some(chunk) = output.next().await {
+            if let Ok(LogOutput::StdOut { message }) = chunk {
+                for line in parser.feed(&message) {
+                    if let EvaluatorLine::Frame(v) = line {
+                        match frame_type(&v) {
+                            Some("ready") => received_ready = true,
+                            Some("result") => result_value = v.get("value").cloned(),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        send_task.await.unwrap();
+    }
+
+    assert!(received_ready, "host 应发 ready 帧");
+    assert_eq!(result_value, Some(serde_json::json!(42)));
+
+    cleanup_container(&docker, &id).await;
+}
+
+/// 验证 dual 模式下 `--legacy` JudgeTask（无 mode 字段）走单容器路径。
+///
+/// 直接通过 SDK 类型反序列化验证行为。
+#[test]
+fn dual_legacy_task_default_mode() {
+    if !is_e2e_enabled() {
+        return; // 单测不需要 docker
+    }
+    // 这条主要验证类型层：缺 mode 字段时默认 Single（向后兼容）
+    let json = serde_json::json!({
+        "submission_id": "sid-legacy",
+        "problem_id": "1001",
+        "judge_image": "noj-judge-python",
+        "judge_command": "python3 /tmp/evaluate.py",
+        "language": "python3",
+        "code": "print('hello')",
+        "time_limit_ms": 5000,
+        "memory_limit_mb": 512
+    });
+    let task: JudgeTask = serde_json::from_value(json).unwrap();
+    assert_eq!(task.mode, JudgeMode::Single);
+    assert!(task.runtime_config.is_none());
+}
+
+/// 验证 dual mode JudgeTask 反序列化包含 runtime_config。
+#[test]
+fn dual_task_runtime_config_serialization() {
+    let json = serde_json::json!({
+        "submission_id": "sid-dual",
+        "problem_id": "1001",
+        "mode": "dual",
+        "language": "python3",
+        "code": "def solve(a,b): return a+b",
+        "file_name": "solution.py",
+        "time_limit_ms": 5000,
+        "memory_limit_mb": 512,
+        "runtime_config": {
+            "evaluator": {
+                "image": "noj-evaluator-python:3.12",
+                "command": "python3 /workspace/evaluate.py",
+                "time_limit_ms": 5000,
+                "memory_limit_mb": 512
+            },
+            "solution": {
+                "image": "noj-solution-python:3.12",
+                "entry": "solution.py",
+                "call_timeout_ms": 1000,
+                "memory_limit_mb": 256
+            }
+        }
+    });
+    let task: JudgeTask = serde_json::from_value(json).unwrap();
+    assert_eq!(task.mode, JudgeMode::Dual);
+    let rc = task.runtime_config.unwrap();
+    assert_eq!(rc.evaluator.image, "noj-evaluator-python:3.12");
+    assert_eq!(rc.solution.call_timeout_ms, 1000);
+}
+
+#[allow(dead_code)]
+fn _force_use_dual_task() {
+    // 静默 dead_code（dual_task 作为 fixture 暂未被所有测试用到）
+    let _ = dual_task();
+}

--- a/noj-tests/e2e/15_dual_container_judge.test.ts
+++ b/noj-tests/e2e/15_dual_container_judge.test.ts
@@ -1,0 +1,366 @@
+/**
+ * 双容器 Evaluator/Solution 评测全链路 E2E（issue #118 / openspec/changes/dual-container-judge）。
+ *
+ * 覆盖：
+ * - admin 通过 API 配置双容器题目 + 提交 → 期望进入评测队列
+ * - 镜像白名单被下架后 admin 提交被拒
+ * - 普通用户尝试设置 runtime_config → 403
+ * - 单容器题目（无 runtime_config）仍正常评测（回归）
+ *
+ * 要求：
+ *   NOJ_RUN_E2E=1 表示启用 E2E 测试套件
+ *   E2E_BASE_URL 指向运行中的 noj-core 服务
+ */
+
+import {
+  api,
+  apiGet,
+  apiPost,
+  apiPut,
+  isE2E,
+  loginAndChangePassword,
+  registerUser,
+} from "./helper.ts";
+
+if (!isE2E) {
+  // E2E 未启用：跳过整套测试
+  Deno.test({
+    name: "dual_container_judge: skipped (NOJ_RUN_E2E != 1)",
+    ignore: true,
+    fn: () => {},
+  });
+} else {
+  // ── 测试常量 ─────────────────────────────────────────
+
+  const EVALUATOR_IMAGE = "noj-evaluator-python:dev";
+  const SOLUTION_IMAGE = "noj-solution-python:dev";
+  const TEST_TAG = `e2e-${Date.now()}`;
+
+  // ── 共享 fixtures ────────────────────────────────────
+
+  /** 获取 admin token（首调用时强制改密走通） */
+  async function getAdminToken(): Promise<string> {
+    return await loginAndChangePassword(
+      "admin-e2e-dual",
+      "InitPass123!",
+      "AdminPass123!",
+    );
+  }
+
+  /** 创建（或复用）evaluator 镜像白名单条目 */
+  async function ensureImage(image: string, kind: "evaluator" | "solution"): Promise<string> {
+    const adminToken = await getAdminToken();
+    const list = await apiGet("/api/v1/admin/judge-images", adminToken);
+    type JiEntry = { id: string; image: string; kind: string };
+    const existing = ((list.body as { data: JiEntry[] }).data ?? []).find(
+      (ji) => ji.image === image && ji.kind === kind,
+    );
+    if (existing) return existing.id;
+
+    const create = await apiPost(
+      "/api/v1/admin/judge-images",
+      {
+        image,
+        kind,
+        mode: "exact",
+        description: `e2e ${kind} image`,
+      },
+      adminToken,
+    );
+    if (create.status !== 201) {
+      throw new Error(
+        `Failed to create image ${image} (kind=${kind}): ${create.status} ${
+          JSON.stringify(create.body)
+        }`,
+      );
+    }
+    return (create.body as { data: JiEntry }).data.id;
+  }
+
+  /** 创建题目（双 runtime_config），返回 problem_id */
+  async function createDualProblem(
+    adminToken: string,
+    title: string,
+  ): Promise<string> {
+    const res = await apiPost(
+      "/api/v1/admin/problems",
+      {
+        title,
+        description: `# ${title}\n\nMarkdown 内容`,
+        difficulty: "medium",
+        type: "P",
+        number: Math.floor(Math.random() * 9000) + 1000,
+        judge_image: EVALUATOR_IMAGE,
+        judge_command: "python3 /workspace/evaluate.py",
+        time_limit_ms: 10_000,
+        memory_limit_mb: 512,
+        runtime_config: {
+          evaluator: {
+            image: EVALUATOR_IMAGE,
+            command: "python3 /workspace/evaluate.py",
+            time_limit_ms: 10_000,
+            memory_limit_mb: 512,
+          },
+          solution: {
+            image: SOLUTION_IMAGE,
+            entry: "solution.py",
+            call_timeout_ms: 1_000,
+            memory_limit_mb: 256,
+          },
+        },
+      },
+      adminToken,
+    );
+    if (res.status !== 201) {
+      throw new Error(
+        `Failed to create dual problem: ${res.status} ${JSON.stringify(res.body)}`,
+      );
+    }
+    return (res.body as { data: { id: string } }).data.id;
+  }
+
+  // ── Tests ────────────────────────────────────────────
+
+  Deno.test({
+    name: "dual_container_judge: admin 创建双容器题目成功（含 runtime_config）",
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+      const adminToken = await getAdminToken();
+      await ensureImage(EVALUATOR_IMAGE, "evaluator");
+      await ensureImage(SOLUTION_IMAGE, "solution");
+
+      const problemId = await createDualProblem(
+        adminToken,
+        `[${TEST_TAG}] 双容器评测测试题`,
+      );
+
+      // 验证题目详情包含 runtime_config
+      const detail = await apiGet(`/api/v1/problems/${problemId}`);
+      const problem = (detail.body as { data: { runtime_config: unknown } })
+        .data;
+      if (!problem.runtime_config) {
+        throw new Error("Expected runtime_config to be present");
+      }
+    },
+  });
+
+  Deno.test({
+    name: "dual_container_judge: 普通用户尝试设置 runtime_config 被拒",
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+      // 普通用户注册
+      const userToken = await registerUser(
+        `dual-user-${Date.now()}`,
+        `dual-user-${Date.now()}@test.local`,
+        "UserPass123!",
+      );
+
+      // 普通用户创建题目时携带 runtime_config → 期望 403
+      const res = await apiPost(
+        "/api/v1/problems",
+        {
+          title: `[${TEST_TAG}] 普通用户尝试双容器`,
+          description: "test",
+          difficulty: "easy",
+          judge_image: EVALUATOR_IMAGE,
+          judge_command: "python3 /workspace/evaluate.py",
+          time_limit_ms: 5000,
+          memory_limit_mb: 512,
+          runtime_config: {
+            evaluator: {
+              image: EVALUATOR_IMAGE,
+              command: "python3 /workspace/evaluate.py",
+              time_limit_ms: 5000,
+              memory_limit_mb: 512,
+            },
+            solution: {
+              image: SOLUTION_IMAGE,
+              entry: "solution.py",
+              call_timeout_ms: 1000,
+              memory_limit_mb: 256,
+            },
+          },
+        },
+        userToken,
+      );
+
+      // 期望 403（仅 admin 可设置 runtime_config）
+      if (res.status !== 403) {
+        throw new Error(
+          `Expected 403 for non-admin setting runtime_config, got ${res.status} ${
+            JSON.stringify(res.body)
+          }`,
+        );
+      }
+    },
+  });
+
+  Deno.test({
+    name: "dual_container_judge: 镜像白名单 kind 不匹配被拒",
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+      const adminToken = await getAdminToken();
+      await ensureImage(EVALUATOR_IMAGE, "evaluator");
+      // 注意：SOLUTION_IMAGE 在此测试中假定为 evaluator kind（已由其它测试设置）
+      // 实际上 ensureImage 会以 evaluator 创建（如果不存在），这里直接用
+      //   kind='solution' 作为 runtime_config.solution.image
+      //   会因为 kind 不匹配被拒。
+
+      // 临时创建一个 evaluator 镜像：复用 EVALUATOR_IMAGE 当作 solution
+      const res = await apiPost(
+        "/api/v1/admin/problems",
+        {
+          title: `[${TEST_TAG}] kind 错配测试`,
+          description: "test",
+          difficulty: "easy",
+          type: "P",
+          judge_image: EVALUATOR_IMAGE,
+          judge_command: "python3 /workspace/evaluate.py",
+          runtime_config: {
+            evaluator: {
+              image: EVALUATOR_IMAGE,
+              command: "python3 /workspace/evaluate.py",
+              time_limit_ms: 5000,
+              memory_limit_mb: 512,
+            },
+            solution: {
+              // 这里故意把 evaluator 镜像当 solution 用 → kind mismatch
+              image: EVALUATOR_IMAGE,
+              entry: "solution.py",
+              call_timeout_ms: 1000,
+              memory_limit_mb: 256,
+            },
+          },
+        },
+        adminToken,
+      );
+
+      // 期望 400 image kind mismatch
+      if (res.status !== 400) {
+        throw new Error(
+          `Expected 400 for kind mismatch, got ${res.status} ${
+            JSON.stringify(res.body)
+          }`,
+        );
+      }
+    },
+  });
+
+  Deno.test({
+    name: "dual_container_judge: 清空 runtime_config 回退单容器",
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+      const adminToken = await getAdminToken();
+      await ensureImage(EVALUATOR_IMAGE, "evaluator");
+
+      const problemId = await createDualProblem(
+        adminToken,
+        `[${TEST_TAG}] 清空 runtime 测试`,
+      );
+
+      // 验证双容器已设置
+      const before = await apiGet(`/api/v1/problems/${problemId}`);
+      if (!(before.body as { data: { runtime_config: unknown } }).data.runtime_config) {
+        throw new Error("Expected runtime_config before update");
+      }
+
+      // 清空 runtime_config
+      const update = await apiPut(
+        `/api/v1/admin/problems/${problemId}`,
+        {
+          runtime_config: null,
+        },
+        adminToken,
+      );
+      if (update.status !== 200) {
+        throw new Error(`Update failed: ${update.status}`);
+      }
+
+      // 验证已回退
+      const after = await apiGet(`/api/v1/problems/${problemId}`);
+      const afterRc = (after.body as { data: { runtime_config: unknown } }).data
+        .runtime_config;
+      if (afterRc !== null) {
+        throw new Error("Expected runtime_config to be null after clearing");
+      }
+    },
+  });
+
+  Deno.test({
+    name: "dual_container_judge: 单容器题目回归（无 runtime_config）",
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+      const adminToken = await getAdminToken();
+      await ensureImage(EVALUATOR_IMAGE, "evaluator");
+
+      // 不传 runtime_config → 应创建单容器题目
+      const res = await apiPost(
+        "/api/v1/admin/problems",
+        {
+          title: `[${TEST_TAG}] 单容器回归`,
+          description: "test",
+          difficulty: "easy",
+          type: "P",
+          judge_image: EVALUATOR_IMAGE,
+          judge_command: "python3 /tmp/evaluate.py",
+          time_limit_ms: 5000,
+          memory_limit_mb: 512,
+        },
+        adminToken,
+      );
+
+      if (res.status !== 201) {
+        throw new Error(`Create failed: ${res.status}`);
+      }
+
+      const problemId = (res.body as { data: { id: string } }).data.id;
+      const detail = await apiGet(`/api/v1/problems/${problemId}`);
+      const rc = (detail.body as { data: { runtime_config: unknown } }).data
+        .runtime_config;
+      if (rc !== null) {
+        throw new Error("Expected runtime_config to be null for single-container problem");
+      }
+    },
+  });
+
+  Deno.test({
+    name: "dual_container_judge: 普通用户提交双容器题目 → 走 dual 评测",
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+      const adminToken = await getAdminToken();
+      await ensureImage(EVALUATOR_IMAGE, "evaluator");
+      await ensureImage(SOLUTION_IMAGE, "solution");
+
+      const problemId = await createDualProblem(
+        adminToken,
+        `[${TEST_TAG}] 普通用户提交双容器`,
+      );
+
+      // 普通用户提交代码
+      const userToken = await registerUser(
+        `dual-sub-${Date.now()}`,
+        `dual-sub-${Date.now()}@test.local`,
+        "UserPass123!",
+      );
+
+      const sub = await apiPost(
+        "/api/v1/submissions",
+        {
+          problem_id: problemId,
+          language: "python3",
+          code: "def solve(a, b):\n    return a + b\n",
+        },
+        userToken,
+      );
+      if (sub.status !== 201) {
+        throw new Error(`Submit failed: ${sub.status} ${JSON.stringify(sub.body)}`);
+      }
+    },
+  });
+}

--- a/noj-ui/components/editor/ProblemEditor.vue
+++ b/noj-ui/components/editor/ProblemEditor.vue
@@ -2,6 +2,21 @@
 import { ArrowLeft, Save, Eye, Edit3 } from "@lucide/vue"
 import SupportPackageUpload from "../admin/SupportPackageUpload.vue"
 
+interface RuntimeConfigPayload {
+  evaluator: {
+    image: string
+    command: string
+    time_limit_ms: number
+    memory_limit_mb: number
+  }
+  solution: {
+    image: string
+    entry: string
+    call_timeout_ms: number
+    memory_limit_mb: number
+  }
+}
+
 interface Props {
   mode: "create" | "edit"
   problemId?: string
@@ -45,14 +60,16 @@ const uploadProblemId = computed(() =>
 )
 const savedProblemId = ref<string | null>(null)
 
-// 评测镜像白名单
-const judgeImages = ref<{ image: string }[]>([])
+// 评测镜像白名单（含 kind）
+const judgeImages = ref<{ image: string; kind?: string }[]>([])
 const judgeImagesLoading = ref(false)
 
 async function loadJudgeImages() {
   judgeImagesLoading.value = true
   try {
-    const res = await $fetch<{ data: { image: string }[] }>("/api/v1/judge-images")
+    const res = await $fetch<{ data: { image: string; kind?: string }[] }>(
+      "/api/v1/judge-images",
+    )
     judgeImages.value = res.data ?? []
   } catch {
     // 静默失败
@@ -60,6 +77,61 @@ async function loadJudgeImages() {
     judgeImagesLoading.value = false
   }
 }
+
+/** 按 kind 过滤的镜像列表（dual-container-judge §5） */
+const evaluatorImages = computed(() =>
+  judgeImages.value.filter((ji) => (ji.kind ?? "evaluator") === "evaluator"),
+)
+const solutionImages = computed(() =>
+  judgeImages.value.filter((ji) => ji.kind === "solution"),
+)
+
+// ── 双容器 Runtime 配置（仅 admin） ──
+const dualMode = ref(false)  // 是否启用双容器模式
+const evaluatorImage = ref("")
+const evaluatorCommand = ref("python3 /workspace/evaluate.py")
+const evaluatorTimeLimitMs = ref(5000)
+const evaluatorMemoryLimitMb = ref(512)
+const solutionImage = ref("")
+const solutionEntry = ref("solution.py")
+const solutionCallTimeoutMs = ref(1000)
+const solutionMemoryLimitMb = ref(256)
+
+// dualMode 关闭时清空 RuntimeConfig
+watch(dualMode, (on) => {
+  if (!on) {
+    evaluatorImage.value = ""
+    evaluatorCommand.value = ""
+    evaluatorTimeLimitMs.value = 5000
+    evaluatorMemoryLimitMb.value = 512
+    solutionImage.value = ""
+    solutionEntry.value = "solution.py"
+    solutionCallTimeoutMs.value = 1000
+    solutionMemoryLimitMb.value = 256
+  }
+})
+
+/** 组装 RuntimeConfig 用于提交；dualMode 关闭返回 null */
+const runtimeConfigPayload = computed(() => {
+  if (!dualMode.value) return null
+  return {
+    evaluator: {
+      image: evaluatorImage.value.trim(),
+      command: evaluatorCommand.value.trim(),
+      time_limit_ms: evaluatorTimeLimitMs.value,
+      memory_limit_mb: evaluatorMemoryLimitMb.value,
+    },
+    solution: {
+      image: solutionImage.value.trim(),
+      entry: solutionEntry.value.trim(),
+      call_timeout_ms: solutionCallTimeoutMs.value,
+      memory_limit_mb: solutionMemoryLimitMb.value,
+    },
+  }
+})
+
+// 仅 admin 可启用 dual mode
+const canDualMode = computed(() => isAdmin.value)
 
 // ── 分类选项 ──
 const categories = ref<{ id: string; name: string }[]>([])
@@ -86,6 +158,7 @@ async function loadProblem() {
       time_limit_ms: number; memory_limit_mb: number
       display_id: string; type: string; number: number
       categories: { id: string }[]
+      runtime_config: RuntimeConfigPayload | null
     } }>(`/api/v1/problems/${props.problemId}`)
     const p = res.data
     displayId.value = p.display_id
@@ -96,6 +169,22 @@ async function loadProblem() {
     timeLimitMs.value = p.time_limit_ms; memoryLimitMb.value = p.memory_limit_mb
     categoryIds.value = p.categories.map((c) => c.id)
     hasSupportPackage.value = (p as Record<string, unknown>).has_support_package === true
+
+    // 加载 runtime_config（如果有）
+    if (p.runtime_config) {
+      dualMode.value = true
+      const rc = p.runtime_config
+      evaluatorImage.value = rc.evaluator.image
+      evaluatorCommand.value = rc.evaluator.command
+      evaluatorTimeLimitMs.value = rc.evaluator.time_limit_ms
+      evaluatorMemoryLimitMb.value = rc.evaluator.memory_limit_mb
+      solutionImage.value = rc.solution.image
+      solutionEntry.value = rc.solution.entry
+      solutionCallTimeoutMs.value = rc.solution.call_timeout_ms
+      solutionMemoryLimitMb.value = rc.solution.memory_limit_mb
+    } else {
+      dualMode.value = false
+    }
   } catch (err: unknown) {
     if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 404) {
       notFound.value = true
@@ -160,6 +249,10 @@ async function handleSubmit() {
           memory_limit_mb: memoryLimitMb.value > 0 ? memoryLimitMb.value : 512,
           category_ids: categoryIds.value,
           type: problemType.value,
+          // 双容器 Runtime 配置（仅 admin 可设置）
+          ...(canDualMode.value && dualMode.value
+            ? { runtime_config: runtimeConfigPayload.value }
+            : { runtime_config: null }),
         },
       })
       savedProblemId.value = res.data.id
@@ -279,25 +372,105 @@ async function handleSubmit() {
       <div class="grid grid-cols-2 gap-3.5">
         <div class="flex flex-col gap-1">
           <label class="text-xs font-semibold text-text">评测镜像 <span class="text-red-600">*</span></label>
-          <select v-model="judgeImage" class="px-3 py-2 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)] bg-white" :disabled="judgeImagesLoading">
-            <option value="" disabled>{{ judgeImagesLoading ? "加载中..." : judgeImages.length === 0 ? "暂无可用评测镜像" : "请选择评测镜像" }}</option>
-            <option v-for="ji in judgeImages" :key="ji.image" :value="ji.image">{{ ji.image }}</option>
+          <select v-model="judgeImage" class="px-3 py-2 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)] bg-white" :disabled="dualMode || judgeImagesLoading">
+            <option value="" disabled>{{ judgeImagesLoading ? "加载中..." : (dualMode ? "双容器模式：使用 Evaluator 镜像" : (judgeImages.length === 0 ? "暂无可用评测镜像" : "请选择评测镜像")) }}</option>
+            <option v-for="ji in judgeImages.filter(j => (j.kind ?? 'evaluator') === 'evaluator')" :key="ji.image" :value="ji.image">{{ ji.image }}</option>
           </select>
           <p v-if="!judgeImagesLoading && judgeImages.length === 0 && !fieldErrors.judge_image" class="text-xs text-warning-text">白名单未配置，需管理员在后台添加评测镜像</p>
           <p v-if="fieldErrors.judge_image" class="text-xs text-red-600">{{ fieldErrors.judge_image }}</p>
         </div>
         <div class="flex flex-col gap-1">
           <label class="text-xs font-semibold text-text">评测命令 <span class="text-red-600">*</span></label>
-          <input v-model="judgeCommand" class="px-3 py-2 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)] bg-white" placeholder="如：python3 /tmp/evaluate.py" />
+          <input v-model="judgeCommand" class="px-3 py-2 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)] bg-white" :disabled="dualMode" placeholder="如：python3 /tmp/evaluate.py" />
           <p v-if="fieldErrors.judge_command" class="text-xs text-red-600">{{ fieldErrors.judge_command }}</p>
         </div>
         <div class="flex flex-col gap-1">
           <label class="text-xs font-semibold text-text">时间限制 (ms)</label>
-          <input v-model.number="timeLimitMs" type="number" class="px-3 py-2 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary bg-white" min="100" max="30000" />
+          <input v-model.number="timeLimitMs" type="number" class="px-3 py-2 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary bg-white" :disabled="dualMode" min="100" max="30000" />
         </div>
         <div class="flex flex-col gap-1">
           <label class="text-xs font-semibold text-text">内存限制 (MB)</label>
-          <input v-model.number="memoryLimitMb" type="number" class="px-3 py-2 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary bg-white" min="16" max="4096" />
+          <input v-model.number="memoryLimitMb" type="number" class="px-3 py-2 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary bg-white" :disabled="dualMode" min="16" max="4096" />
+        </div>
+      </div>
+
+      <!-- 双容器 Runtime 配置（仅 admin 可启用） -->
+      <div v-if="canDualMode" class="mt-4 pt-4 border-t border-border">
+        <label class="flex items-center gap-2 text-xs font-semibold text-text cursor-pointer">
+          <input v-model="dualMode" type="checkbox" class="accent-primary" />
+          <span>启用双容器 Runtime（Evaluator + Solution）</span>
+          <span class="text-text-muted font-normal">— 仅 admin 可见，参考 openspec/changes/dual-container-judge</span>
+        </label>
+        <p class="text-xs text-text-muted mt-1">
+          双容器模式：Evaluator（可信）运行 evaluate.py + 支持包；Solution（不可信）单独运行用户代码。
+          启用后将覆盖上方"评测配置"中的镜像/命令/时间/内存字段。
+        </p>
+
+        <div v-if="dualMode" class="mt-3 grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <!-- Evaluator 卡片 -->
+          <div class="border border-border rounded-lg p-3.5 bg-gray-50">
+            <h3 class="text-xs font-semibold text-text mb-2.5 flex items-center gap-1.5">
+              <span class="px-1.5 py-0.5 bg-primary text-white text-[10px] rounded">Evaluator</span>
+              可信端（运行 evaluate.py + 支持包）
+            </h3>
+            <div class="flex flex-col gap-2.5">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-semibold text-text">镜像 <span class="text-red-600">*</span></label>
+                <select v-model="evaluatorImage" class="px-2.5 py-1.5 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary bg-white" :disabled="judgeImagesLoading">
+                  <option value="" disabled>{{ judgeImagesLoading ? "加载中..." : evaluatorImages.length === 0 ? "暂无可用 evaluator 镜像" : "请选择 evaluator 镜像" }}</option>
+                  <option v-for="ji in evaluatorImages" :key="ji.image" :value="ji.image">{{ ji.image }}</option>
+                </select>
+                <p v-if="!judgeImagesLoading && evaluatorImages.length === 0" class="text-xs text-warning-text">白名单无 evaluator 类型镜像</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-semibold text-text">评测命令 <span class="text-red-600">*</span></label>
+                <input v-model="evaluatorCommand" class="px-2.5 py-1.5 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary bg-white" placeholder="如：python3 /workspace/evaluate.py" />
+              </div>
+              <div class="grid grid-cols-2 gap-2">
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-semibold text-text">总时间 (ms)</label>
+                  <input v-model.number="evaluatorTimeLimitMs" type="number" class="px-2.5 py-1.5 text-sm border border-border rounded-md bg-white" min="100" max="60000" />
+                </div>
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-semibold text-text">内存 (MB)</label>
+                  <input v-model.number="evaluatorMemoryLimitMb" type="number" class="px-2.5 py-1.5 text-sm border border-border rounded-md bg-white" min="32" max="8192" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Solution 卡片 -->
+          <div class="border border-border rounded-lg p-3.5 bg-gray-50">
+            <h3 class="text-xs font-semibold text-text mb-2.5 flex items-center gap-1.5">
+              <span class="px-1.5 py-0.5 bg-warning-text text-white text-[10px] rounded">Solution</span>
+              不可信端（运行用户代码，隔离)
+            </h3>
+            <div class="flex flex-col gap-2.5">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-semibold text-text">镜像 <span class="text-red-600">*</span></label>
+                <select v-model="solutionImage" class="px-2.5 py-1.5 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary bg-white" :disabled="judgeImagesLoading">
+                  <option value="" disabled>{{ judgeImagesLoading ? "加载中..." : solutionImages.length === 0 ? "暂无可用 solution 镜像" : "请选择 solution 镜像" }}</option>
+                  <option v-for="ji in solutionImages" :key="ji.image" :value="ji.image">{{ ji.image }}</option>
+                </select>
+                <p v-if="!judgeImagesLoading && solutionImages.length === 0" class="text-xs text-warning-text">白名单无 solution 类型镜像 — 管理员需先添加并标记 kind='solution'</p>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-semibold text-text">入口文件名 <span class="text-red-600">*</span></label>
+                <input v-model="solutionEntry" class="px-2.5 py-1.5 text-sm border border-border rounded-md outline-none transition-colors focus:border-primary bg-white" placeholder="如：solution.py" />
+                <p class="text-xs text-text-muted">禁止包含路径分隔符或 ..</p>
+              </div>
+              <div class="grid grid-cols-2 gap-2">
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-semibold text-text">单次调用超时 (ms)</label>
+                  <input v-model.number="solutionCallTimeoutMs" type="number" class="px-2.5 py-1.5 text-sm border border-border rounded-md bg-white" min="100" max="30000" />
+                </div>
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs font-semibold text-text">内存 (MB)</label>
+                  <input v-model.number="solutionMemoryLimitMb" type="number" class="px-2.5 py-1.5 text-sm border border-border rounded-md bg-white" min="16" max="4096" />
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/openspec/changes/dual-container-judge/design.md
+++ b/openspec/changes/dual-container-judge/design.md
@@ -1,0 +1,365 @@
+# 双容器 Evaluator/Solution 评测运行时 — 设计稿
+
+> 对应 issue: [#118](https://github.com/Neuro-OJ/neuro-oj/issues/118)
+> 状态：评审后修订
+> 日期：2026-07-09
+
+## Context
+
+NOJ 当前的单容器评测模型（`judge-image-whitelist` + `judge-worker` spec）把支持包与用户代码塞入同一个容器、共用同一 Python 进程。这不足以承载 LMCC 类题目：
+
+1. `evaluate.py` 与用户代码共享文件系统，可被覆盖、伪造模块、污染 `sys.path`。
+2. `import submission` 同进程调用把可信评测逻辑放在不可信进程里。
+3. 未来可能需要让 Evaluator 持有内网凭据、模型访问或私有数据，单纯靠 `network_mode: none` 不能解决 Solution 受控访问能力的需求。
+
+issue #118 要求把单容器拆成双容器：**Evaluator（可信）+ Solution（不可信）**，并定义 `noj_evaluator_sdk` / `noj_solution_sdk` 的调用语义，使其能迈向生产可用阶段。本设计稿描述第一阶段的实现方案，覆盖协议、SDK、容器编排、DB/UI、安全测试。
+
+## Goals / Non-Goals
+
+### Goals
+
+- noj-judge 支持按题目一次任务启动 Evaluator + Solution 两个容器。
+- Solution 容器默认无网络、不挂支持包、不读取 Evaluator 环境变量、不共享进程。
+- Evaluator 通过 `noj_evaluator_sdk` 的 `SolutionRunner.call(...)` 调用 Solution 容器内的函数；同一评测内多次调用复用同一个 Solution Host（`persistent` 模式）。
+- 协议安全：仅允许 7 种基本类型（`None` / `bool` / `int` / `float` / `str` / `bytes` / `list` / `dict`），禁止 `pickle` / `cloudpickle`、禁止运行时对象。
+- 错误以枚举编码（`Timeout` / `NotFound` / `Exception` / `SystemError` / `Rejected`），调用方按统一语义处理。
+- noj-core DB / API / admin UI 支持分别配置 Evaluator Runtime 与 Solution Runtime。
+- 题目现有单容器模式保持向后兼容：缺 `runtime_config` 时自动回退到现有路径，零数据迁移。
+- 配套安全测试覆盖：覆盖 `evaluate.py` / 模块 shadowing / 读取隐藏文件 / 网络访问 / fd 泄露。
+
+### Non-Goals（第一阶段显式排除）
+
+- 不引入支持包内 Manifest。运行时配置全部写入 `problems.runtime_config` JSONB。
+- 不兼容 LMCC 官方样例的 `import submission` 同进程语义。
+- 不实现 `isolate_per_call`（每调用独立隔离）模式。
+- 不允许 Solution 反向调用 Evaluator（第一阶段统一拒绝）。
+- 不使用 `pickle` / `cloudpickle` 跨进程传输对象。
+- 不引入额外持久化对象存储。后续大对象传输通过 artifact descriptor 扩展。
+- 不实现 Capability Service。
+- **不允许 Evaluator 容器访问网络**（`runtime_config.evaluator.network` 第一阶段仅 `'none'`；需要网络能力的题目留待 Capability Service，后续阶段实现）。
+- **不支持 Solution 反向日志/事件通道**（除 NDJSON `log` 帧外，无其他通道）。
+
+## Decisions
+
+### 1. 容器架构：两层 exec 直连，judge 转发 NDJSON
+
+第一版设计稿采用 "judge → docker exec(agent) → unix socket → SDK + judge → docker exec(host)" 三层 hop。本设计稿简化为两层 hop：
+
+```
+   ┌─────────┐   docker exec      ┌──────────────────────┐    docker exec      ┌─────────────┐
+   │  judge  │ ── python3 ────>   │  Evaluator           │                     │  Solution   │
+   │  Rust   │   evaluate.py      │  Container           │                     │  Container  │
+   │ process │                    │  ├─ evaluate.py      │                     │  ├─ host.py │
+   │         │ <── stdout ───────│  │   (SDK client)     │                     │  (stdin/out)│
+   │         │   (NDJSON+result)  │  └─ noj_evaluator_sdk│                     │             │
+   │         │                    │                      │                     │             │
+   │         │   docker exec ────────────────────────────────────────────────> stdin      │
+   │         │ <── stdout ─────────────────────────────────────────────────── stdout     │
+   │         │   (NDJSON)         │                      │                     │             │
+   └─────────┘                    └──────────────────────┘                     └─────────────┘
+```
+
+**关键路径**
+
+1. judge 启动 Evaluator 容器（挂载支持包），不立即执行 `evaluate.py`。
+2. judge 通过 `docker exec` 在 Evaluator 容器内启动 `python3 <evaluate.py>`（即 `judge_command`）。
+3. judge 启动 Solution 容器（无网络、无支持包），通过 `docker exec` 跑 `python3 -m noj_solution_sdk.host --entry <solution_entry>`（host 模块源码 `noj-judge/sdk/solution/noj_solution_sdk/host.py`，由 `solution-python` 镜像构建时安装）。
+4. **消息通路**（**Evaluator → Solution**：单方向）：
+   - Evaluator SDK 调用 `runner.call("solve", 1, 2)` 时，SDK 通过**约定的 stdout NDJSON 通道**输出一行 JSON 帧（见 §2）
+   - judge 在 Evaluator exec 的 stdout 流上做协议解析（识别 NDJSON 帧 vs `---RESULT---` 标记 vs 其他）
+   - judge 把 NDJSON 帧原样转发到 Solution host 的 stdin
+   - host 处理后写一行 stdout → judge 读 Solution exec stdout
+   - judge 把响应帧**回写 Evaluator exec 的 stdin** → SDK 从 stdin 读到响应
+5. 评测结束时（`evaluate.py` 写 `---RESULT---...` 标记），judge 读 evaluator 容器的 stdout 解析最终结果，写回 `JudgeResult`，关闭两个容器并清理。
+
+**Evaluator 容器的 stdin/stdout 契约（SDK ↔ judge）**
+
+- **stdout**（按时间顺序）：
+  - 普通 print/logging 输出（被 SDK 通过 stderr 重定向）→ judge **不解析**，写日志后丢弃
+  - NDJSON 协议帧（一行一帧）→ judge 解析后转发给 Solution host
+  - `---RESULT---` + JSON → judge 识别为最终结果
+- **stdin**（来自 judge 的回写）：NDJSON 响应帧（一行一帧），SDK 阻塞读
+
+**Evaluator 容器协议约束**
+
+- SDK 内部所有 print/logging **必须**重定向到 stderr（提供 `noj_evaluator_sdk.configure_logging()` 辅助）
+- SDK 与 judge 的通信**只用** stdout 上的 NDJSON 帧 + `---RESULT---` 标记两样东西
+- 若 evaluate.py 自己往 stdout 写内容，必须自己承担被 judge 误解析为协议帧的风险（design 选择：**不**为 stdout 加额外前缀，因为那样会改变 `---RESULT---` 协议）
+
+**为何这样设计**
+
+- 两层 hop 即可：judge 既是 Evaluator exec 的 IO 端，也是 Solution exec 的 IO 端，中间不需要 agent 进程
+- `evaluate.py` 的 stdout 可控：SDK 把 print/log 转到 stderr，stdout 仅 NDJSON + `---RESULT---`，judge 解析逻辑简单
+- 故障点少一个：不再有 agent 进程，Python traceback 直接出现在 evaluator exec 的 stderr 上，调试链完整
+- 第一阶段不实现反向调用，evaluator↔solution 通道单向（call → result/error），后续若开反向，只需让 host 也通过相同 NDJSON 协议回写到自己的 stdout，无须重构
+
+### 2. RPC 协议：NDJSON + 错误枚举
+
+**Solution Host 输入输出（stdin / stdout，一行一消息）**
+
+| 方向 | type 字段 | 必要字段 |
+|------|-----------|----------|
+| host → judge（启动） | `ready` | — |
+| judge → host | `call` | `id`, `fn`, `args[]` |
+| host → judge | `result` | `id`, `value` |
+| host → judge | `error` | `id`, `code`, `message`, 可选 `trace` |
+| host → judge | `log` | `stream` ∈ {`stdout`,`stderr`}, `data` |
+| judge → host | `shutdown` | — |
+
+**Evaluator SDK ↔ judge（stdout / stdin）**：相同帧格式。SDK 写 stdout，judge 读 stdout 后转发到 Solution host stdin；Solution host 的 `result`/`error`/`log` 帧经 judge 转发回写到 Evaluator stdin，SDK 从 stdin 读到。
+
+**错误码枚举**：`Timeout` / `NotFound`（函数未注册）/ `Exception`（用户代码异常）/ `SystemError`（host 内部错误）/ `Rejected`（参数类型不允许）。
+
+**类型安全**：序列化层只接受 `None / bool / int / float / str / bytes (base64) / list / dict`；其他类型抛 `Rejected`，不杀 host。
+
+**Trace 路径清洗**：host 在格式化 user exception trace 时，**仅保留** 文件 basename + 行号 + 类名 + 消息；剥离所有绝对路径（如 `/usr/local/lib/python3.12/dist-packages/noj_evaluator_sdk/...`）避免反推容器镜像 layout。
+
+**Log 消息限额**：
+- 单条 `log.data` ≤ 64 KiB；超限截断为前 64 KiB + `\n<truncated>\n`
+- 累计 `log.data` ≤ 1 MiB / 评测；超限丢弃并计数（最终 `JudgeResult.details.logs_dropped` 字段）
+- `log` 不进入 `JudgeResult.output`，仅落 `details.logs[]`
+
+**输出缓冲约定**：
+- host 启动时必须 `sys.stdout.reconfigure(line_buffering=True)`、`sys.stderr.reconfigure(line_buffering=True)`，否则 NDJSON 帧在管道模式下会卡在缓冲区
+
+### 3. 任务协议：JudgeTask 向后兼容扩展
+
+```ts
+export interface JudgeTask {
+  submission_id: string;
+  problem_id: string;
+  language: string;
+  code: string;
+  file_name?: string;
+  rejudge_seq?: number;
+
+  /** 单容器模式必填；双容器模式忽略 */
+  judge_image?: string;
+  judge_command?: string;
+  /** 单/双容器模式通用：noj-download:// URL */
+  download_url?: string;
+  time_limit_ms: number;
+  memory_limit_mb: number;
+
+  /** mode 不存在或 'single' → 旧单容器路径；'dual' → 双容器编排 */
+  mode?: 'single' | 'dual';
+  /** 双容器模式必填 */
+  runtime_config?: RuntimeConfig;
+}
+```
+
+> 仅新增字段，不删字段、不改既有字段语义。任何不识别 `mode` 的旧 judge 自动忽略 → 单容器路径。
+
+```ts
+interface RuntimeConfig {
+  evaluator: {
+    image: string;
+    command: string;             // 例如 "python3 /workspace/evaluate.py"
+    /** Evaluator 总时间上限（双容器模式必填） */
+    time_limit_ms: number;
+    /** Evaluator 内存上限 */
+    memory_limit_mb: number;
+  };
+  solution: {
+    image: string;
+    entry: string;               // Solution 容器内入口文件名，例如 "solution.py"
+    /** 单次 SDK 调用的时间上限（单次超时不影响 host 进程） */
+    call_timeout_ms: number;
+    memory_limit_mb: number;
+  };
+}
+```
+
+**字段映射**：现有 `judge_image` / `judge_command` / `time_limit_ms` / `memory_limit_mb` 由 admin API 自动同步填充到 `runtime_config.evaluator` 的等价字段，单容器旧题无感。
+
+**Legacy 字段保留策略**：
+- 当 `runtime_config` 被设置时，`judge_image` / `judge_command` 仍保留为最后一次同步值，仅供 admin UI 显示，不参与调度
+- 当 `runtime_config` 被清空（admin 显式置 null），回到单容器路径，使用 `judge_image` / `judge_command`
+- 单容器题目 `runtime_config` 始终为 NULL；core 调度时读 `runtime_config IS NOT NULL` 决定路径
+
+**时间层级关系（明确化）**：
+
+| 上限 | 含义 | 触发动作 |
+|------|------|----------|
+| `runtime_config.solution.call_timeout_ms` | 单次 `runner.call(...)` 调用最大时长 | SDK 抛 `Timeout`，host 进程继续 |
+| `runtime_config.evaluator.time_limit_ms` | 整个 Evaluator 容器（含 SDK 全部调用）最大时长 | judge `docker stop -t kill_grace_secs` → `docker kill` Evaluator 容器；判 `TimeLimitExceeded` |
+| 实际耗时应满足 | `sum(call 实际耗时) ≤ evaluator.time_limit_ms`（含 SDK overhead） | — |
+| `result.accept/wrong_answer` 调用本身 | 不受 `call_timeout_ms` 限制（防最后一帧超时） | — |
+
+### 4. DB 与 API 改动
+
+- `problems` 表新增列 `runtime_config JSONB NULL`，无迁移影响；现有题目均为 `NULL`。
+- 新增 SQL 约束：`CHECK (runtime_config IS NULL OR jsonb_typeof(runtime_config) = 'object')`。
+- Admin 题目 CRUD（`POST/PUT /admin/problems`）接受 `runtime_config`：可选；admin 不传则保留原值或置空。
+- 取题公共 API（`GET /problems/:id` / `POST /problems`）行为不变；提交接口不读 `runtime_config`，由 submissions service 在落库前按题配置组装 task。
+- 提交流程：`submissions` 服务查题 → 若 `runtime_config` 非 NULL 且结构合法 → 构造 `JudgeTask { mode: 'dual', runtime_config, ... }` 推 MQ；否则按旧路径推单容器任务。
+- 提交流程的并发安全：先以 `SELECT ... FOR UPDATE`（或带 `updated_at` 的乐观锁）锁住题目行，再读取 `runtime_config` 构造 task，避免 admin 在提交期间清空 `runtime_config` 导致任务与预期路径不一致。
+- Drizzle 迁移文件：`0017_problem_runtime_config.sql`（新增 nullable 列 + CHECK 约束）。
+
+**导出兼容性**：导出文件包含 `runtime_config`；导入时若 `runtime_config` 缺失仅 warning，不报错（向后兼容旧导出文件）。
+
+### 5. 镜像与白名单
+
+- 新增两个目录：
+  - `noj-judge/docker/solution-python/Dockerfile`
+  - `noj-judge/docker/evaluator-python/Dockerfile`
+- 镜像内分别内置 `noj-solution-sdk`（host + register）/ `noj-evaluator-sdk`（SolutionRunner + result）。
+- 构建脚本：`noj-judge/scripts/build-sdk-images.sh`，并行 build 两个镜像并打 `:dev` tag。
+- `judge_images` 表新增 `kind` 字段（`'evaluator' | 'solution'`，NOT NULL），admin 配置镜像时必须指定 kind。镜像分类不再靠 image 名前缀判别（避免脆性约定）。
+- 白名单沿用 `judge_images` 表（参考 `judge-image-whitelist` spec 增量），不新增 RPC。
+- judge 通过现有 `get_image_allowlist` RPC（见 `judge-rpc` spec）从 core 拉白名单，**返回结构升级**为 `{ image, kind }[]`；judge 启动时按 kind 分别预热 Evaluator 池（仅 evaluator kind 入池）。
+- admin 配置校验：`runtime_config.evaluator.image` 必须在白名单中且 `kind='evaluator'`；`runtime_config.solution.image` 必须在白名单中且 `kind='solution'`。否则 admin API 返回 400。
+- core 调度时（即推 MQ 前）再读一次白名单做 final gate：若发现镜像被下架或 kind 不匹配，返回提交错误 `image_not_allowlisted` 而非悄悄回退单容器 —— 避免语义漂移。
+- judge 在容器创建前再做一次本地缓存校验（防御 TOCTOU）。
+
+### 6. 模块边界
+
+| 模块 | 职责 | 不做 |
+|------|------|------|
+| `noj-judge/sandbox/container.rs` | 启停单容器（旧路径） | 任何 SDK 协议 |
+| `noj-judge/dual/` (新) | 双容器编排、NDJSON 协议解析、消息转发、结果收集、清理 | 评测语义 |
+| `noj-judge/sdk/evaluator/` (Python) | `noj_evaluator_sdk`：`SolutionRunner` / `result.accept` / `result.wrong_answer`、stdout/stderr 重定向配置 | 不碰容器 |
+| `noj-judge/sdk/solution/` (Python) | `noj_solution_sdk`：`register(fn)` | 不碰容器 |
+| `noj-judge/docker/solution-python/` | 内置 solution host + SDK，ReadonlyRootfs + tmpfs /tmp + network=none | 不含测试数据 |
+| `noj-judge/docker/evaluator-python/` | 内置 `noj_evaluator_sdk`；network=none（**第一阶段硬编码**，即便 admin 不配置）、无支持包挂载由 core 在注入时完成 | 不含测试数据 |
+| `noj-core` | `problems` Drizzle 列、admin CRUD、按模式调度 | 不懂 SDK |
+| `noj-ui` | admin 题目编辑表单加 runtime 配置块（含镜像 kind 下拉） | — |
+
+**容器安全默认**（Evaluator 与 Solution 共享）：
+- `CapDrop=["ALL"]`、`SecurityOpt=["no-new-privileges:true"]`、`Privileged=false`、`ReadonlyRootfs=true`、`NetworkMode=none`、`IpcMode=none`、`PidsLimit=256`
+- `tmpfs /tmp:size=256m,mode=1777`、`MemorySwap = Memory`、`MemorySwappiness=0`
+- Solution 容器额外：`User=nobody`（以非 root 运行 host 进程，降低 fd 泄露攻击面）
+
+### 7. 错误处理与状态映射
+
+| 场景 | 行为 |
+|------|------|
+| Solution host 在 5s 内未发 `ready` | `SystemError`，`output: "solution host boot timeout"` |
+| SDK 单次调用超过 `call_timeout_ms` | judge 关闭 Solution host 转发通道（停止向其 stdin 写入），回 `Timeout` 给 SDK；`evaluate.py` 决定怎么收场（catch 或透传） |
+| Solution host 进程崩溃 / Solution 容器超 `time_limit_ms` | 同上 |
+| Evaluator 容器 stdout 解析失败（非 NDJSON 非 `---RESULT---`） | 累积在 `details.stdout_unknown`，不立刻失败 |
+| Evaluator 容器总时间超 `runtime_config.evaluator.time_limit_ms` | `TimeLimitExceeded` |
+| Evaluator 容器 RSS 超 `runtime_config.evaluator.memory_limit_mb` | `MemoryLimitExceeded` |
+| Solution 容器 RSS 超 `runtime_config.solution.memory_limit_mb` | `SystemError`（host 守护触发） |
+| SDK 序列化非法类型 | `Rejected`，host 继续运行 |
+| 用户代码 raise 异常 | `Exception`（trace 已 sanitize），host 不退出 |
+| `runtime_config` 引用未白名单镜像或 kind 不匹配 | admin API 400；judge 同样返回 `SystemError`（"image not in allowlist"），不回退单容器 |
+| Evaluator agent 不存在 | （本设计不再有 agent 进程，此项 N/A） |
+
+**清理契约（RAII）**：
+
+`DualContainer` 结构（`noj-judge/dual/mod.rs`）持有两个 `Container` handle 和两个 `Exec` handle，其 `Drop` 实现必须：
+1. `docker rm -f <solution_container_id>`（先关 Solution，避免它反向接收 evaluator 已关的信号）
+2. `docker rm -f <evaluator_container_id>`（再关 Evaluator）
+3. 任何中间步骤 panic 都不应阻止后续清理
+4. 关闭临时目录与下载缓存
+
+### 8. 兼容性、回滚与迁移
+
+- **向后兼容**：
+  - 任何缺 `mode` 字段的 `JudgeTask` 走单容器旧路径，零行为变化。
+  - 任何 `runtime_config IS NULL` 的题目走单容器旧路径；现有 1001/1002/1003 题目、API 都无感。
+- **回滚**：admin 可在题目编辑界面清空 `runtime_config`，回到单容器路径。`judge_image` / `judge_command` 字段保持最后一次同步值，无需重建题。
+- **迁移**：单条 Drizzle SQL 添加 nullable JSONB 列 + CHECK 约束；不需要对存量数据做 backfill。
+- **新镜像未发布场景**：若 judge 容器内 `get_image_allowlist` 未列出给定镜像（被下架/尚未拉取），admin API 已经在创建时拒绝，core 调度时如果再发现不一致则 `SystemError` 而不静默回退 —— 避免结果语义漂移。
+- **审计日志**：admin 设置/清空 `runtime_config` 必须记录 `action=problems.runtime_config_changed` 审计日志，含旧值摘要与新值摘要。
+
+### 9. 测试矩阵
+
+**单元 / 集成（无 Docker 或受限 Docker）**
+
+- `noj_evaluator_sdk`：`SolutionRunner.call()` 各类型往返、`call_timeout_ms` 行为、非法类型抛 `Rejected`、`result.accept/wrong_answer` 写入 `---RESULT---` 的兼容性、stdout/stderr 重定向后 print 不污染 stdout。
+- `noj_solution_sdk`：`register(fn)` 注册 + 重复注册抛错、未知函数调用返回 `NotFound`、异常返回 `Exception`（含 sanitize trace）、`register("name", fn1)` 后再次 `register("name", fn2)` 抛错。
+- judge orchestrator：双容器路径分流、容器池回补（Evaluator 进池 / Solution 不进池）、异常关闭资源清理（8 种错误场景）。
+- admin API：`runtime_config` 字段校验（结构、镜像白名单、kind 匹配）。
+
+**Docker E2E（`NOJ_RUN_E2E=1`）**
+
+新增 `tests/e2e_dual_container.rs`：
+
+| 测试 | 目标 |
+|------|------|
+| `dual_basic` | A+B Problem，调用 `solve(1,2)` 接受，得分 100 |
+| `dual_persistent` | 同一 host 内多次 `call`，验证持久化全局状态 |
+| `dual_timeout` | Solution 函数 sleep 2s，`call_timeout_ms=500`，验证返回 `Timeout` 而非挂死 |
+| `dual_solution_exception` | Solution 函数 raise，错误含 sanitize trace（不含绝对路径） |
+| `dual_solution_cannot_overwrite_evaluate` | Solution 写盘尝试覆盖 evaluate.py，验证失败 |
+| `dual_solution_no_network` | Solution 内 `socket.socket(...)` / `urllib.request` / DNS，验证全部失败 |
+| `dual_solution_module_shadowing` | Solution 写 `os.py` / `sys.py` 到 PYTHONPATH，验证 Evaluator 进程内 `os` 不受影响 |
+| `dual_solution_read_evaluator_env` | Solution 读 `os.environ`，验证看不到 Evaluator secret 环境变量 |
+| `dual_solution_cannot_leak_fd` | Solution 调用 `os.listdir('/proc/self/fd')` 并尝试 `os.read`，验证无法读到 judge IPC 通道 |
+| `dual_evaluator_no_network` | Evaluator 容器 `runtime_config.evaluator.network`（即便配置为 'default'）仍受 image 内 `network_mode: none` 约束（验证默认值生效） |
+| `dual_legacy_fallback` | 旧 `JudgeTask`（无 `mode`）走单容器路径且行为不变 |
+| `dual_image_kind_mismatch` | `runtime_config.solution.image` 配 `kind='evaluator'` 的镜像 → admin API 400 |
+
+**跨模块 (noj-tests/E2E)**
+
+新增 `e2e/08_dual_container_judge.test.ts`：
+
+- admin API 配置双 runtime 题目 + 提交 → 返回 Accepted。
+- admin 提交任务但镜像白名单被下架 → 返回 `image_not_allowlisted` 错误 + UI 友好提示。
+- 单容器题目在 PR-C 之后仍能正常评测（回归测试）。
+
+### 10. 四 PR 拆分（实施顺序）
+
+| PR | 范围 | 合并依赖 | CI 风险 |
+|----|------|----------|---------|
+| **PR-A1**（协议 + SDK + types） | `noj-judge/sdk/{evaluator,solution}/`（Python）、`noj-judge/src/types.rs` 扩展、SDK 单测（无 Docker） | 独立可合 | 低 |
+| **PR-A2**（Docker E2E + orchestrator） | `noj-judge/dual/`（编排、NDJSON 解析、消息转发、清理）、`tests/e2e_dual_container.rs`、动态构建临时镜像 COPY 当前 SDK/agent 源码 | PR-A1 | 中（Docker E2E 启动慢） |
+| **PR-B**（生产镜像 + judge_images.kind） | `noj-judge/docker/{solution-python,evaluator-python}/`、`scripts/build-sdk-images.sh`、`docker-compose.yml` 集成、`judge_images.kind` 列迁移、Drizzle 0018_judge_images_kind.sql | PR-A1 | 中 |
+| **PR-C**（DB + core API + UI） | Drizzle 0017_problem_runtime_config.sql、`problems.runtime_config` 列 + CHECK、admin CRUD API、admin UI runtime 配置块、submissions service 任务分流（含 SELECT FOR UPDATE 锁）、`JudgeTask` 协议扩展、judge 端 `get_image_allowlist` 返回结构升级 | PR-A1、PR-B；理论可 PR-A1 + PR-C 并行 | 中 |
+
+> **不再合并 PR-A 与 PR-A2**：原设计 PR-A 把 SDK + Docker E2E 捆在一起，导致 CI 镜像构建与协议尚未敲定时反复推翻。拆开后 PR-A1 单测覆盖 < 30s，PR-A2 仅在协议稳定后才引入 Docker 依赖。
+
+### 11. 文档交付
+
+- 本设计稿：`openspec/changes/dual-container-judge/design.md`
+- 提案：`openspec/changes/dual-container-judge/proposal.md`
+- 任务拆分：`openspec/changes/dual-container-judge/tasks.md`
+- 规范增量：
+  - 扩展 `openspec/specs/judge-worker/spec.md`：补 §6 dual 模式 requirements + scenarios。
+  - 扩展 `openspec/specs/judge-image-whitelist/spec.md`：补 `kind` 字段约束与分类语义。
+  - 新增 `openspec/specs/problem-runtime-config/spec.md`：DB 列、admin API、调度语义。
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| 双容器路径耗时 vs 单容器：双 docker exec + host 启动多 ~200-500ms | 复用容器池（参考 `container-pool` spec）；Evaluator 容器按 image 入池，Solution 容器不复用（防状态泄漏） |
+| NDJSON 帧解析在大输出下成本可观 | SDK 单行 ≤ 1 MiB 软限；超限 `Rejected`；Solution 日志通过独立 `log` 消息通道，受 64 KiB/条 + 1 MiB/总双限额约束 |
+| Solution host 持有多次调用的全局状态，用户可能误用 | 已文档化 `persistent` 语义；提供 `runner.restart()` 重置 host；`isolate_per_call` 留给下一阶段 |
+| `runtime_config` JSONB 结构演进困难 | 第一阶段保持简单结构；未来扩展使用 `schema_version` 字段而不是 db migration |
+| 新镜像占 CI 镜像构建时间 | PR-B 单独做；CI 缓存分两层：基础镜像 + SDK 层；预估增 1-2 分钟 |
+| Solution host 进程 crash 后 SDK 调用收到 connection error | SDK 抛出 `SolutionRunner.connection_error()`；evaluate.py 决定记 SystemError 还是 retry |
+| Evaluator 网络开放带来的风险（未来 Capability Service 缺失） | 第一阶段硬编码 `network: none`；评审 H2 显式禁止 'default' |
+| Solution fd 泄露攻击 | host 进程以 `User=nobody` 运行，且每评测独立进程（不进池） |
+| Docker daemon 并发 exec 上限 | 单 judge 实例 16 池 × 2 exec = 32，并发安全；多 judge 实例水平扩展 |
+| 协议 stdin/stdout 与 evaluate.py 自身 print 冲突 | SDK 强制 stdout/stderr 重定向；evaluate.py 不应直接 print，需用 SDK 提供的 logger |
+| judge 端 dual 编排代码复杂度 | 用 RAII（`DualContainer` Drop）兜底清理；8 种错误场景必测 |
+
+## Open Questions
+
+1. Solution 镜像是否需要支持非 Python 语言（C++/JS）？
+   - 第一阶段只做 Python；与现有 `LANGUAGE_EXT_MAP` 对齐。
+2. Solution 容器是否复用？
+   - 第一阶段不复用（防状态泄漏 + 简化）；v2 可在 `runner.restart()` 之后复用并重置 module cache。
+3. 是否需要支持 `runtime_config` 在提交时按用户提交语言动态覆盖 Solution image？
+   - 第一阶段不做；统一用题目配置的 image；不同语言走不同题目配置即可。
+4. 是否需要 Evaluator 容器持有 secret 凭据？
+   - 第一阶段不做；Capability Service 是后续阶段的目标。
+5. trace sanitize 策略如何细化？
+   - 第一阶段采用 "basename + 行号 + 类名 + 消息" 简化策略；v2 可由 SDK 提供 hook 让支持包自定义 sanitize 函数。
+
+## Changelog
+
+- 2026-07-09 v2（评审修订）：
+  - A1 简化架构为两层 hop（去掉 socket 层与 agent 进程）
+  - A2 Evaluator 网络第一阶段硬编码 `'none'`
+  - A3 JudgeTask 字段精简（删除 `dual_download_url`、`solution_entry` 移入 `RuntimeConfig`）；明确 legacy 字段保留策略与时间层级关系
+  - A4 `judge_images` 新增 `kind` 字段，分类不再靠前缀
+  - B1 Trace 路径清洗
+  - B2 Log 消息限额（64 KiB/条 + 1 MiB/总）
+  - B4 PR 拆分从 3 段细化为 4 段（A1/A2/B/C）
+  - B5 时间层级关系明确化
+  - C 系列补充：line buffering、迁移文件编号 0017/0018、容器 User=nobody、fd 泄露测试、审计日志
+  - 补全 proposal.md / tasks.md / specs/ 三件套

--- a/openspec/changes/dual-container-judge/proposal.md
+++ b/openspec/changes/dual-container-judge/proposal.md
@@ -1,0 +1,71 @@
+# 双容器 Evaluator/Solution 评测运行时
+
+## Why
+
+NOJ 当前的评测模型把支持包、`evaluate.py`、用户代码塞入同一个 Docker 容器、同一个 Python 进程，承载 LMCC 类题目时存在以下安全与可扩展性缺陷：
+
+- `evaluate.py` 与用户代码共享文件系统，理论上可被覆盖、伪造模块、污染 `sys.path`。
+- 真实 LMCC 题目常用 `evaluate.py` 直接 `import submission` 并调用其中函数，但这种同进程调用把可信评测逻辑放在不可信进程里。
+- 部分 LMCC 题目未来可能需要受控能力（内网 API、模型服务、隐藏数据接口），仅靠 `network_mode: none` 不能解决 Solution 受控访问能力的需求。
+- NOJ 需要定义自己的安全调用语义，不优先兼容 LMCC 官方样例的同进程 import 方式。
+
+issue #118 明确要求把单容器拆成双容器：**Evaluator（可信）+ Solution（不可信）**，并定义 `noj_evaluator_sdk` / `noj_solution_sdk` 的调用语义，使其迈上生产可用阶段。
+
+## What Changes
+
+- **双容器编排**：noj-judge 按题一次任务启动 Evaluator + Solution 两个容器；Solution 容器默认 `network_mode: none`、不挂支持包、不读取 Evaluator 环境变量、不共享进程。
+- **NDJSON RPC 协议**：Solution Host 通过 stdin/stdout 收发 NDJSON 帧；Evaluator SDK 通过 stdout NDJSON + `---RESULT---` 标记与 judge 通信；judge 充当中继转发。
+- **SDK 双包**：`noj_evaluator_sdk`（SolutionRunner.call / result.accept/wrong_answer）+ `noj_solution_sdk`（register(fn)）；同步构建默认 Docker 镜像 `noj-evaluator-python` / `noj-solution-python`。
+- **持久化 Host**：一次评测启动一个 Solution Host；多次 `runner.call()` 复用同一 Host；提供 `runner.restart()` 重置；明确不实现 `isolate_per_call`。
+- **协议安全**：仅允许 7 种基本类型（None / bool / int / float / str / bytes / list / dict），禁止 pickle / cloudpickle / 运行时对象；异常 trace 路径清洗。
+- **错误码枚举**：Timeout / NotFound / Exception / SystemError / Rejected 五种错误码。
+- **运行时配置入库**：题目表新增 `runtime_config JSONB NULL`；admin UI 提供 Evaluator / Solution 分别配置块；submissions service 按配置选择评测路径。
+- **镜像 kind 分类**：`judge_images` 表新增 `kind` 字段（`'evaluator' | 'solution'`），取代 image 名前缀的脆性约定；`get_image_allowlist` RPC 返回结构升级。
+- **Evaluator 网络默认禁开**：第一阶段 `runtime_config.evaluator.network` 仅允许 `'none'`；需要网络能力的题目留待 Capability Service（后续阶段）。
+- **配套安全测试**：覆盖 evaluate.py 覆盖 / 模块 shadowing / 隐藏文件读取 / 网络访问 / fd 泄露 / trace 路径泄露 / 镜像 kind 错配等。
+- **审计日志**：admin 设置/清空 `runtime_config` 记录 `action=problems.runtime_config_changed`。
+
+## Capabilities
+
+### New Capabilities
+
+- `problem-runtime-config`: 题目运行时配置（runtime_config）的 DB 列、admin API、调度语义、向后兼容路径。
+
+### Modified Capabilities
+
+- `judge-worker`: 扩展 dual 模式协议、错误码、时间层级关系、清理契约（RAII）；新增 12 条 dual 测试场景。
+- `judge-image-whitelist`: `judge_images` 表新增 `kind` 字段；admin 配置校验；`get_image_allowlist` RPC 返回结构升级。
+
+## Impact
+
+- `noj-core`:
+  - Drizzle 迁移：0017（`problems.runtime_config` 列 + CHECK 约束）、0018（`judge_images.kind` 列）
+  - admin 题目 CRUD API 接受 `runtime_config`
+  - admin UI 题目编辑表单增加 runtime 配置块（含镜像 kind 下拉）
+  - submissions service 任务分流（含 SELECT FOR UPDATE 锁）
+  - `judge_images` 表的 admin API 升级（kind 必填）
+  - `get_image_allowlist` RPC 处理器返回结构升级
+- `noj-judge`:
+  - `src/types.rs`: JudgeTask 新增 `mode` / `runtime_config` 字段
+  - 新模块 `dual/`: 双容器编排、NDJSON 解析、消息转发、清理
+  - 新模块 `sdk/evaluator/` 与 `sdk/solution/`: Python SDK
+  - 新模块 `docker/evaluator-python/` 与 `docker/solution-python/`: 镜像 Dockerfile
+  - 新增脚本 `scripts/build-sdk-images.sh`
+  - 新增测试 `tests/e2e_dual_container.rs`（12 条场景）
+- `noj-tests/e2e/`:
+  - 新增 `08_dual_container_judge.test.ts`（含 image 错配回归）
+- 镜像仓库: 新增 `noj-evaluator-python:dev`、`noj-solution-python:dev`
+- CI 影响: PR-B 增加镜像构建 ~1-2 分钟；PR-A2 增加 Docker E2E ~3-5 分钟
+
+## Out of Scope
+
+- 支持包内 Manifest
+- LMCC 官方样例的 `import submission` 同进程语义兼容
+- `isolate_per_call`（每次调用独立隔离进程）
+- Solution → Evaluator 反向调用
+- `pickle` / `cloudpickle` 跨进程对象传输
+- 持久化对象存储（artifact descriptor 后续扩展）
+- Capability Service（Evaluator 受控访问能力的独立服务）
+- Evaluator 网络访问（`network: 'default'` 第一阶段硬编码禁用）
+- 非 Python Solution 镜像（v1 仅 Python）
+- Solution 容器状态重置后复用（v1 不复用）

--- a/openspec/changes/dual-container-judge/specs/judge-image-whitelist/spec.md
+++ b/openspec/changes/dual-container-judge/specs/judge-image-whitelist/spec.md
@@ -1,0 +1,140 @@
+## MODIFIED Requirements
+
+### Requirement: 管理员管理镜像白名单
+
+系统 SHALL 提供管理员 API 管理评测镜像白名单（`judge_images` 表），支持增删改查操作。每条白名单记录包含 `image`（镜像名）、`mode`（`exact` 或 `all_versions`）、`kind`（`evaluator` 或 `solution`，**第一阶段必填**）、`description`（介绍文案）。
+
+#### Scenario: 管理员添加 Evaluator 镜像
+
+- **WHEN** 管理员发送 `POST /api/v1/admin/judge-images`，携带 `{ "image": "noj-evaluator-python:3.12", "mode": "exact", "kind": "evaluator", "description": "Evaluator Python 3.12 评测环境" }`
+- **THEN** 系统创建白名单记录，`kind='evaluator'`，仅 `noj-evaluator-python:3.12` 精确匹配该条目，返回 HTTP 201
+
+#### Scenario: 管理员添加 Solution 镜像
+
+- **WHEN** 管理员发送 `POST /api/v1/admin/judge-images`，携带 `{ "image": "noj-solution-python:3.12", "mode": "exact", "kind": "solution", "description": "Solution Python 3.12 评测环境" }`
+- **THEN** 系统创建白名单记录，`kind='solution'`，返回 HTTP 201
+
+#### Scenario: kind 字段缺失被拒
+
+- **WHEN** 管理员发送 `POST /api/v1/admin/judge-images`，缺少 `kind` 字段
+- **THEN** 系统返回 HTTP 400，提示 kind 仅允许 `evaluator` / `solution`，必填
+
+#### Scenario: kind 字段非法值被拒
+
+- **WHEN** 管理员发送 `POST /api/v1/admin/judge-images`，携带 `kind: "worker"`
+- **THEN** 系统返回 HTTP 400，提示 kind 仅允许 `evaluator` / `solution`
+
+#### Scenario: 管理员查看白名单列表
+
+- **WHEN** 管理员发送 `GET /api/v1/admin/judge-images`
+- **THEN** 系统返回所有白名单记录列表，每条含 `id`、`image`、`mode`、`kind`、`description`、`created_at`、`updated_at`
+
+#### Scenario: 管理员更新白名单条目
+
+- **WHEN** 管理员发送 `PUT /api/v1/admin/judge-images/:id`，携带 `{ "description": "更新后的介绍" }`
+- **THEN** 系统更新该条记录的指定字段，返回 HTTP 200 及更新后详情
+- **WHEN** 管理员显式更新 `kind` 字段
+- **THEN** 系统校验新 kind 仅允许 `evaluator` / `solution`
+
+#### Scenario: 管理员删除白名单条目
+
+- **WHEN** 管理员发送 `DELETE /api/v1/admin/judge-images/:id`
+- **THEN** 系统删除该白名单记录，返回 HTTP 204
+
+#### Scenario: 非管理员访问白名单 API 被拒
+
+- **WHEN** 非管理员用户发送任意 `/api/v1/admin/judge-images` 请求
+- **THEN** 系统返回 HTTP 403
+
+#### Scenario: mode 字段非法值被拒
+
+- **WHEN** 管理员创建白名单条目时传入 `mode: "regex"`
+- **THEN** 系统返回 HTTP 400，提示 mode 仅允许 `exact` 或 `all_versions`
+
+### Requirement: 题目创建/更新时校验镜像白名单（含 kind）
+
+系统 SHALL 对题目创建和更新请求中的 `judge_image` 与 `runtime_config` 字段执行白名单校验，并确保 `runtime_config` 中 Evaluator / Solution 镜像的 kind 与白名单条目一致。白名单为空时 SHALL 拒绝所有镜像名，返回明确错误提示。
+
+#### Scenario: 单容器题目白名单校验（向后兼容）
+
+- **WHEN** 白名单中存在 `exact: "noj-judge-cpp:gcc13"` 且 `kind='evaluator'` 条目
+- **WHEN** 用户创建单容器题目，传入 `judge_image: "noj-judge-cpp:gcc13"`
+- **THEN** 系统通过白名单校验，正常创建题目
+
+#### Scenario: 双容器题目 Evaluator 镜像校验
+
+- **WHEN** 白名单中存在 `exact: "noj-evaluator-python:3.12"` 且 `kind='evaluator'` 条目
+- **WHEN** 用户创建双容器题目，传入 `runtime_config.evaluator.image: "noj-evaluator-python:3.12"`
+- **THEN** 系统通过白名单 + kind 校验，正常创建题目
+- **WHEN** 用户传入 `runtime_config.evaluator.image: "noj-solution-python:3.12"`（白名单 kind='solution'）
+- **THEN** 系统返回 HTTP 400，提示 `image kind mismatch: evaluator image required`
+
+#### Scenario: 双容器题目 Solution 镜像校验
+
+- **WHEN** 白名单中存在 `exact: "noj-solution-python:3.12"` 且 `kind='solution'` 条目
+- **WHEN** 用户创建双容器题目，传入 `runtime_config.solution.image: "noj-solution-python:3.12"`
+- **THEN** 系统通过白名单 + kind 校验，正常创建题目
+- **WHEN** 用户传入 `runtime_config.solution.image: "noj-evaluator-python:3.12"`（白名单 kind='evaluator'）
+- **THEN** 系统返回 HTTP 400，提示 `image kind mismatch: solution image required`
+
+#### Scenario: 白名单为空时拒绝所有镜像
+
+- **WHEN** `judge_images` 表为空，用户创建题目时传入任意 `judge_image` 字符串或 `runtime_config`
+- **THEN** 系统返回 HTTP 400，提示"系统尚未配置允许的评测镜像，请联系管理员"
+
+#### Scenario: 更新题目时校验镜像
+
+- **WHEN** 白名单非空，用户编辑题目时修改 `judge_image` 为不在白名单中的值
+- **THEN** 系统返回 HTTP 400，拒绝更新
+
+#### Scenario: 更新题目时清空 runtime_config
+
+- **WHEN** 题目原 `runtime_config` 非空
+- **WHEN** admin 提交 `runtime_config: null`
+- **THEN** 系统清空该字段，题目回退到单容器路径
+- **THEN** 记录审计日志 `action=problems.runtime_config_changed`
+
+### Requirement: 公开镜像列表 API（按 kind 过滤）
+
+系统 SHALL 提供 `GET /api/v1/judge-images` 端点（无需认证），返回所有白名单镜像记录供题目编辑器使用。客户端可按 `kind` 查询参数过滤。
+
+#### Scenario: 获取全部可用镜像列表
+
+- **WHEN** 任意用户发送 `GET /api/v1/judge-images`
+- **THEN** 系统返回所有白名单记录的数组，每条含 `id`、`image`、`mode`、`kind`、`description`
+
+#### Scenario: 按 kind 过滤
+
+- **WHEN** 客户端发送 `GET /api/v1/judge-images?kind=evaluator`
+- **THEN** 系统仅返回 `kind='evaluator'` 的白名单记录
+
+#### Scenario: 白名单为空时返回空列表
+
+- **WHEN** 尚无任何白名单记录，用户请求 `GET /api/v1/judge-images`
+- **THEN** 系统返回 HTTP 200 及空数组 `{ "data": [] }`
+
+### Requirement: 全版本模式安全警告
+
+系统 SHALL 在管理后台 UI 中，当管理员选择 `all_versions` 模式时展示安全风险警告。警告 SHALL 说明该模式允许该镜像的所有版本标签，存在攻击者利用未授权版本的风险。警告 SHALL NOT 阻止管理员继续操作。
+
+#### Scenario: 管理员选择全版本模式时看到警告
+
+- **WHEN** 管理员在新增/编辑镜像弹窗中选择模式为"所有版本"
+- **THEN** UI 显示醒目警告文案（黄色/橙色提示），说明安全风险，但"确认"按钮仍可点击
+
+### Requirement: get_image_allowlist RPC 响应升级
+
+系统 SHALL 在 `get_image_allowlist` RPC 响应中返回每条镜像的 `kind` 字段，供 judge 启动时按 kind 分池预热。
+
+#### Scenario: RPC 响应包含 kind
+
+- **WHEN** judge 发送 `get_image_allowlist` RPC 请求
+- **THEN** core 查询 `judge_images` 表中所有记录
+- **THEN** core 返回 JSON 数组，每项包含 `image`、`kind`（`evaluator` / `solution`）、`mode`（`exact` / `all_versions`）
+- **THEN** judge 按 kind 分别预热容器池（仅 `evaluator` kind 入池；`solution` kind 仅记录不下发容器）
+
+#### Scenario: 历史数据迁移（kind 默认值）
+
+- **WHEN** Drizzle 迁移 `0018_judge_images_kind.sql` 首次执行
+- **THEN** 历史记录 `kind` 默认填充为 `evaluator`
+- **THEN** admin 在迁移后需手动调整 `noj-solution-*` 镜像的 kind 为 `solution`

--- a/openspec/changes/dual-container-judge/specs/judge-worker/spec.md
+++ b/openspec/changes/dual-container-judge/specs/judge-worker/spec.md
@@ -1,0 +1,200 @@
+## ADDED Requirements
+
+### Requirement: 双容器评测编排（dual mode）
+
+系统 SHALL 支持按题目一次任务启动 Evaluator + Solution 两个容器，按 NDJSON 协议在两个容器之间转发调用消息。
+
+#### Scenario: 启动 Evaluator + Solution 双容器
+
+- **WHEN** JudgeTask.mode === 'dual'
+- **THEN** judge 启动 Evaluator 容器（挂载支持包、不立即执行 evaluate.py）
+- **THEN** judge 启动 Solution 容器（无网络、无支持包挂载、不传 Evaluator 环境变量）
+- **THEN** judge 通过 docker exec 在 Evaluator 容器内运行 `runtime_config.evaluator.command`
+- **THEN** judge 通过 docker exec 在 Solution 容器内运行 `python3 -m noj_solution_sdk.host --entry <solution.entry>`
+- **THEN** Solution host 启动后 5 秒内必须发送 `ready` 帧，否则判 SystemError
+
+#### Scenario: NDJSON 帧转发（Evaluator → Solution）
+
+- **WHEN** Evaluator SDK 调用 `SolutionRunner.call(fn, ...args)`
+- **THEN** SDK 通过 stdout 输出一行 NDJSON 帧 `{type: 'call', id, fn, args}`
+- **THEN** judge 读取 evaluator exec stdout 中的 NDJSON 帧，原样转发到 solution host stdin
+- **THEN** Solution host 处理后通过 stdout 输出 `result` 或 `error` 帧
+- **THEN** judge 读取 solution exec stdout 中的响应帧，原样回写到 evaluator exec stdin
+- **THEN** SDK 从 stdin 读到响应帧后阻塞调用返回
+
+#### Scenario: 多次调用复用同一 Solution host
+
+- **WHEN** 一次评测内多次调用 `SolutionRunner.call()`
+- **THEN** 全部调用复用同一 Solution host 进程（persistent 模式）
+- **THEN** Solution host 内的全局状态在调用之间持续存在
+- **WHEN** `runner.restart()` 被调用
+- **THEN** judge 关闭旧 Solution host 进程，启动新 host 进程
+
+#### Scenario: 单次调用超时（call_timeout_ms）
+
+- **WHEN** 某次 `runner.call()` 超过 `runtime_config.solution.call_timeout_ms`
+- **THEN** judge 停止向 solution host stdin 写入
+- **THEN** SDK 收到 `code: 'Timeout'` 错误帧
+- **THEN** Solution host 进程继续运行（不退出）
+
+#### Scenario: Evaluator 总时间超时
+
+- **WHEN** Evaluator 容器总执行时间超过 `runtime_config.evaluator.time_limit_ms`
+- **THEN** judge `docker stop -t kill_grace_secs` Evaluator 容器
+- **THEN** judge `docker kill` Evaluator 容器（如未退）
+- **THEN** judge `docker rm -f` Solution 容器
+- **THEN** JudgeResult.status = 'TimeLimitExceeded'
+
+#### Scenario: Evaluator OOM
+
+- **WHEN** Evaluator 容器因 RSS 超限被 Docker kill（退出码 137）
+- **THEN** JudgeResult.status = 'MemoryLimitExceeded'
+
+#### Scenario: Solution OOM
+
+- **WHEN** Solution 容器 RSS 超 `runtime_config.solution.memory_limit_mb`
+- **THEN** Solution host 守护进程触发 SystemError
+- **THEN** judge 关闭 Solution 容器 + Evaluator 容器
+- **THEN** JudgeResult.status = 'SystemError'
+
+### Requirement: NDJSON 协议帧类型与字段
+
+系统 SHALL 在 Evaluator / Solution 容器之间传输 NDJSON 帧，定义统一的帧类型与字段。
+
+#### Scenario: 帧类型枚举
+
+- **WHEN** 任何容器发送 NDJSON 帧
+- **THEN** `type` 字段必须是下列之一：`ready` / `call` / `result` / `error` / `log` / `shutdown`
+- **WHEN** `type` 为非法值
+- **THEN** 接收方记录 warn 日志并丢弃该帧
+
+#### Scenario: 错误码枚举
+
+- **WHEN** `type === 'error'`
+- **THEN** `code` 字段必须是下列之一：`Timeout` / `NotFound` / `Exception` / `SystemError` / `Rejected`
+
+#### Scenario: 类型安全序列化
+
+- **WHEN** Evaluator SDK 序列化 `runner.call()` 参数
+- **THEN** 仅接受 `None` / `bool` / `int` / `float` / `str` / `bytes` / `list` / `dict` 七种类型
+- **WHEN** 参数包含其他类型（如自定义类、函数、模块、socket、生成器）
+- **THEN** Solution host 抛 `code: 'Rejected'`，host 进程继续运行
+
+#### Scenario: Trace 路径清洗
+
+- **WHEN** Solution host 格式化用户代码异常的 traceback
+- **THEN** 仅保留文件 basename + 行号 + 类名 + 消息
+- **THEN** 剥离所有绝对路径（不暴露 SDK 安装路径或容器镜像 layout）
+
+### Requirement: Log 消息限额
+
+系统 SHALL 对 Solution host 上报的 `log` 帧实施双限额，防止日志 spam 拖慢评测或撑爆 JudgeResult。
+
+#### Scenario: 单条 log 限额
+
+- **WHEN** Solution host 发送 `log` 帧
+- **THEN** `data` 字段长度 ≤ 64 KiB
+- **WHEN** 超过 64 KiB
+- **THEN** 截断为前 64 KiB + `\n<truncated>\n`
+
+#### Scenario: 累计 log 限额
+
+- **WHEN** 单次评测累计 `log.data` 字节数 ≤ 1 MiB
+- **THEN** 所有 log 帧正常上报
+- **WHEN** 累计超过 1 MiB
+- **THEN** 后续 log 帧被 judge 丢弃
+- **THEN** JudgeResult.details.logs_dropped 字段记录丢弃数量
+
+#### Scenario: Log 不进入 output 字段
+
+- **WHEN** log 帧累计并入 JudgeResult
+- **THEN** 仅写入 `details.logs[]`，不进入 `output` 字段
+- **THEN** `details.logs` 单独 8 KiB 截断
+
+### Requirement: 输出缓冲约定
+
+系统 SHALL 要求 SDK / host 启动时配置 line buffering，避免 NDJSON 帧在管道 block buffering 下卡住。
+
+#### Scenario: Solution host line buffering
+
+- **WHEN** Solution host 启动
+- **THEN** host 调用 `sys.stdout.reconfigure(line_buffering=True)`
+- **THEN** host 调用 `sys.stderr.reconfigure(line_buffering=True)`
+
+#### Scenario: Evaluator SDK stdout 纯净
+
+- **WHEN** `noj_evaluator_sdk.configure_logging()` 被调用
+- **THEN** 所有 SDK 内部 print / logging 重定向到 stderr
+- **THEN** evaluate.py 自身 print 仍可能污染 stdout（设计选择：不强制重定向，文档警示）
+
+### Requirement: 容器清理 RAII 契约
+
+系统 SHALL 使用 RAII 保证双容器在所有错误场景下都被清理。
+
+#### Scenario: DualContainer Drop 顺序
+
+- **WHEN** DualContainer 被 drop（无论正常路径还是 panic）
+- **THEN** 先 `docker rm -f` Solution 容器
+- **THEN** 后 `docker rm -f` Evaluator 容器
+- **THEN** 中间任何步骤抛错不阻止后续清理
+- **THEN** 临时目录与下载缓存被清理
+
+#### Scenario: 8 种错误场景必测
+
+- **WHEN** orchestrator 单元/集成测试运行
+- **THEN** 覆盖以下 8 种场景的清理正确性：evaluator 启动失败、solution 启动失败、evaluator exec 启动失败、solution host 未 ready、SDK 调用超时、SDK 反序列化错误、evaluator 总超时、Solution OOM
+
+### Requirement: 时间层级关系
+
+系统 SHALL 明确 Evaluator / Solution / SDK 调用三层时间约束的语义。
+
+#### Scenario: 时间约束分层
+
+- **WHEN** dual mode 评测启动
+- **THEN** `runtime_config.solution.call_timeout_ms` 约束单次 `runner.call()`
+- **THEN** `runtime_config.evaluator.time_limit_ms` 约束 Evaluator 容器总时间（含全部 SDK 调用）
+- **THEN** 评测实际总耗时 = sum(SDK 调用耗时) + overhead，且 ≤ `evaluator.time_limit_ms`
+- **THEN** `result.accept/wrong_answer` 调用本身不受 `call_timeout_ms` 限制
+
+#### Scenario: 单次超时不影响 host
+
+- **WHEN** 单次 `runner.call()` 超 `call_timeout_ms`
+- **THEN** judge 关闭转发通道，SDK 收到 Timeout 错误
+- **THEN** Solution host 进程继续运行，下一次 `runner.call()` 可正常执行
+
+### Requirement: 兼容性回退
+
+系统 SHALL 在 runtime_config 缺失或镜像被下架时给出明确错误而非静默回退单容器。
+
+#### Scenario: 镜像白名单校验（admin）
+
+- **WHEN** admin 调用题目 CRUD API 设置 `runtime_config`
+- **THEN** `runtime_config.evaluator.image` 必须在 `judge_images` 白名单中且 `kind='evaluator'`
+- **THEN** `runtime_config.solution.image` 必须在 `judge_images` 白名单中且 `kind='solution'`
+- **WHEN** 任何 image 不满足
+- **THEN** API 返回 HTTP 400，提示 `image_not_allowlisted`
+
+#### Scenario: 镜像白名单校验（core 调度 final gate）
+
+- **WHEN** submissions service 推 MQ 前
+- **THEN** 再次读取白名单确认镜像仍可用且 kind 匹配
+- **WHEN** 镜像被下架或 kind 被改
+- **THEN** 返回 `image_not_allowlisted` 错误，不悄悄回退单容器
+
+#### Scenario: 镜像白名单校验（judge 防御）
+
+- **WHEN** judge 准备创建 Evaluator / Solution 容器前
+- **THEN** judge 校验本地缓存的镜像列表（防御 TOCTOU）
+- **WHEN** 镜像不在本地缓存
+- **THEN** 判 SystemError + 提示 `image_not_in_local_cache`
+
+#### Scenario: 单容器回退（仅在 runtime_config 缺失时）
+
+- **WHEN** `problems.runtime_config IS NULL`
+- **THEN** 走单容器路径，使用 `judge_image` / `judge_command` 字段
+- **WHEN** `problems.runtime_config IS NOT NULL`
+- **THEN** 走 dual 路径，忽略 `judge_image` / `judge_command`（仅保留显示）
+
+## REMOVED Requirements
+
+无（不删除既有单容器需求，仅扩展 dual 模式）。

--- a/openspec/changes/dual-container-judge/specs/problem-runtime-config/spec.md
+++ b/openspec/changes/dual-container-judge/specs/problem-runtime-config/spec.md
@@ -1,0 +1,137 @@
+## ADDED Requirements
+
+### Requirement: 题目运行时配置（runtime_config）
+
+系统 SHALL 在 `problems` 表中存储 JSONB 格式的 `runtime_config`，用于描述双容器评测模式下的 Evaluator 与 Solution 各自运行时参数。
+
+#### Scenario: problems 表新增 runtime_config 列
+
+- **WHEN** Drizzle 迁移 `0017_problem_runtime_config.sql` 首次执行
+- **THEN** `problems` 表新增 `runtime_config JSONB NULL` 列
+- **THEN** 现有所有题目 `runtime_config` 均为 NULL（保持向后兼容）
+- **THEN** 附加 CHECK 约束：`runtime_config IS NULL OR jsonb_typeof(runtime_config) = 'object'`
+
+#### Scenario: RuntimeConfig 结构
+
+- **WHEN** admin 设置 `runtime_config` 字段
+- **THEN** 必填结构：
+  - `evaluator.image: string`（必填，Docker 镜像名）
+  - `evaluator.command: string`（必填，如 `python3 /workspace/evaluate.py`）
+  - `evaluator.time_limit_ms: number`（必填，> 0）
+  - `evaluator.memory_limit_mb: number`（必填，> 0）
+  - `solution.image: string`（必填）
+  - `solution.entry: string`（必填，如 `solution.py`）
+  - `solution.call_timeout_ms: number`（必填，> 0）
+  - `solution.memory_limit_mb: number`（必填，> 0）
+
+### Requirement: admin API 处理 runtime_config
+
+系统 SHALL 允许 admin 通过题目 CRUD API 设置 / 更新 / 清空 `runtime_config` 字段。
+
+#### Scenario: admin 创建题目时设置 runtime_config
+
+- **WHEN** admin 发送 `POST /api/v1/admin/problems`，payload 含合法 `runtime_config`
+- **THEN** 系统校验：结构合法 + evaluator/solution image 在白名单中 + kind 匹配
+- **THEN** 校验通过则创建题目，runtime_config 写入 JSONB 列
+- **WHEN** 任何校验失败
+- **THEN** 返回 HTTP 400 + 明确错误（image_not_allowlisted / kind_mismatch / invalid_structure）
+
+#### Scenario: admin 更新题目时设置 runtime_config
+
+- **WHEN** admin 发送 `PUT /api/v1/admin/problems/:id`，payload 含 `runtime_config`
+- **THEN** 系统执行与创建相同的校验
+- **THEN** 校验通过则更新 runtime_config 字段
+- **THEN** 记录审计日志 `action=problems.runtime_config_changed`
+
+#### Scenario: admin 清空 runtime_config 回退单容器
+
+- **WHEN** admin 发送 `PUT /api/v1/admin/problems/:id`，payload 含 `runtime_config: null`
+- **THEN** 系统清空该字段，题目回退到单容器路径
+- **THEN** `judge_image` / `judge_command` 字段保留原值（最后一次同步值），不参与 dual 调度
+- **THEN** 记录审计日志 `action=problems.runtime_config_changed`，detail 包含旧值摘要
+
+#### Scenario: 普通用户创建题目不允许双容器配置
+
+- **WHEN** 普通用户（role='user'）发送 `POST /api/v1/problems`，payload 含 `runtime_config`
+- **THEN** 系统返回 HTTP 403，提示仅 admin 可配置双容器评测
+
+### Requirement: 提交流程按 runtime_config 路径分流
+
+系统 SHALL 在 submissions service 推 MQ 前根据 `runtime_config` 是否为 NULL 选择单/双容器路径。
+
+#### Scenario: 题目 runtime_config 为 NULL 走单容器
+
+- **WHEN** 题目 `runtime_config IS NULL`
+- **THEN** submissions service 按既有逻辑构造 JudgeTask：使用 `judge_image` / `judge_command` / `time_limit_ms` / `memory_limit_mb`
+- **THEN** 推 `noj:judge:queue`，judge 端按单容器路径执行
+
+#### Scenario: 题目 runtime_config 非 NULL 走双容器
+
+- **WHEN** 题目 `runtime_config IS NOT NULL`
+- **THEN** submissions service 构造 `JudgeTask { mode: 'dual', runtime_config, ... }`
+- **THEN** 推 `noj:judge:queue`，judge 端按 dual 路径执行
+
+#### Scenario: 题目行级锁避免并发修改
+
+- **WHEN** submissions service 准备推 MQ
+- **THEN** 先以 `SELECT ... FOR UPDATE`（或基于 `updated_at` 的乐观锁）锁住题目行
+- **THEN** 在同一事务内读取 `runtime_config` 并构造 task
+- **WHEN** admin 在此期间尝试更新题目
+- **THEN** admin 更新阻塞直到 submissions service 提交
+- **THEN** 避免 admin 清空 runtime_config 后提交仍走 dual 的竞态
+
+#### Scenario: 推 MQ 前再校验白名单
+
+- **WHEN** submissions service 构造完 task 准备推 MQ
+- **THEN** 再次读取 `judge_images` 白名单确认 `runtime_config.evaluator.image` 与 `runtime_config.solution.image` 仍可用且 kind 匹配
+- **WHEN** 镜像被下架或 kind 被改
+- **THEN** 返回 `image_not_allowlisted` 错误，submission 标记为 error
+
+### Requirement: 导出导入兼容
+
+系统 SHALL 在题目导出/导入时支持 `runtime_config` 字段，并对旧版导出文件保持向后兼容。
+
+#### Scenario: 导出包含 runtime_config
+
+- **WHEN** admin 导出题目
+- **THEN** `ExportProblem` 结构包含 `runtime_config: RuntimeConfig | null`
+
+#### Scenario: 导入新版本文件
+
+- **WHEN** 导入文件 version = '1.0' 且含 `runtime_config`
+- **THEN** 解析时校验结构 + 白名单 + kind
+- **WHEN** 校验失败
+- **THEN** 该题目标记为 failed，reason 包含失败原因
+- **THEN** 不影响其他题目的导入
+
+#### Scenario: 导入旧版本文件（runtime_config 缺失）
+
+- **WHEN** 导入文件 version = '1.0' 且 `runtime_config` 字段缺失
+- **THEN** 视为 null 处理（向后兼容）
+- **THEN** 题目标记为 created/updated，ImportItemResult 不含 warning
+- **THEN** 旧题目回退到单容器路径（与导入前一致）
+
+### Requirement: 审计日志
+
+系统 SHALL 记录 admin 对题目 runtime_config 的修改。
+
+#### Scenario: 设置或修改 runtime_config
+
+- **WHEN** admin 创建或更新题目并修改 `runtime_config`
+- **THEN** 审计日志出现 `action=problems.runtime_config_changed`
+- **THEN** `detail` 包含 `problem_id`、`display_id`、旧值摘要（has_runtime_config: bool）、新值摘要（has_runtime_config: bool）
+
+### Requirement: 公开题目 API 包含 runtime_config
+
+系统 SHALL 在公开题目查询 API 中暴露 `runtime_config` 字段供前端使用。
+
+#### Scenario: GET /problems/:id 返回 runtime_config
+
+- **WHEN** 用户查询题目详情
+- **THEN** 响应体包含 `runtime_config: RuntimeConfig | null`
+
+#### Scenario: 列表 API 不暴露 runtime_config
+
+- **WHEN** 用户查询题目列表
+- **THEN** 列表项不包含 `runtime_config` 字段（避免列表响应过大）
+- **THEN** 仅返回基础元数据（id / display_id / title / difficulty 等）

--- a/openspec/changes/dual-container-judge/tasks.md
+++ b/openspec/changes/dual-container-judge/tasks.md
@@ -1,0 +1,118 @@
+# 双容器 Evaluator/Solution 评测运行时 — 任务拆分
+
+> 总体拆分：4 段 PR（A1 / A2 / B / C），按依赖顺序合并。详细架构与协议见 `design.md`、提案背景见 `proposal.md`、增量规范见 `specs/`。
+
+## 1. PR-A1 — 协议 + SDK + types（无 Docker 依赖）
+
+- [ ] 1.1 `noj-judge/src/types.rs`: 扩展 `JudgeTask`（新增 `mode?: 'single' | 'dual'`、`runtime_config?: RuntimeConfig`）
+- [ ] 1.2 `noj-core/src/types/index.ts`: 同步扩展 `JudgeTask` 类型（含 `RuntimeConfig` 接口）
+- [ ] 1.3 `noj-judge/sdk/evaluator/` 创建 `noj_evaluator_sdk` Python 包：
+  - [ ] `SolutionRunner.call(fn, *args)` + 内部阻塞读 stdin 接收响应
+  - [ ] `result.accept(score, ...)` / `result.wrong_answer(score, message, ...)` 写 `---RESULT---` 标记
+  - [ ] `configure_logging()` 把 stdout/stderr 重定向（print 到 stderr）
+  - [ ] 类型序列化层：仅接受 7 种基本类型 + bytes base64
+- [ ] 1.4 `noj-judge/sdk/solution/` 创建 `noj_solution_sdk` Python 包：
+  - [ ] `host.py` 模块（stdin/stdout NDJSON 帧收发、line buffering、trace sanitize）
+  - [ ] `register(fn)` 函数（重复注册抛错）
+  - [ ] `register("name", fn)` 形式支持命名注册
+- [ ] 1.5 SDK 单测（无 Docker）：
+  - [ ] SolutionRunner 各类型往返（None / bool / int / float / str / bytes / list / dict）
+  - [ ] SolutionRunner `call_timeout_ms` 行为
+  - [ ] SolutionRunner 非法类型抛 `Rejected`
+  - [ ] host.register 重复注册抛错
+  - [ ] host 未知函数返回 `NotFound`
+  - [ ] host 用户代码 raise 返回 `Exception` + sanitize trace
+  - [ ] SDK `configure_logging()` 后 evaluate.py print 不污染 stdout
+
+## 2. PR-A2 — Docker E2E + orchestrator（依赖 PR-A1）
+
+- [ ] 2.1 `noj-judge/dual/` 模块：
+  - [ ] `DualContainer` 结构（含两个 Container + 两个 Exec handle）+ RAII Drop 清理
+  - [ ] NDJSON 帧解析器（区分 stdout NDJSON / `---RESULT---` / 未知内容）
+  - [ ] 消息转发：Evaluator exec stdout → Solution exec stdin；Solution exec stdout → Evaluator exec stdin
+  - [ ] 容器创建复用现有 pool/exec/sandbox 基础设施
+- [ ] 2.2 `noj-judge/src/judge/runner.rs`: `evaluate_dual()` 入口；与 `evaluate_with_pool` 并存
+- [ ] 2.3 `noj-judge/src/main.rs`: `task.mode == 'dual'` 路由到 `evaluate_dual()`；其余走单容器
+- [ ] 2.4 `tests/e2e_dual_container.rs` 新增 12 条测试（见 design §9 表格）：
+  - [ ] `dual_basic` — A+B Problem Accepted
+  - [ ] `dual_persistent` — 多次 call 复用 host 状态
+  - [ ] `dual_timeout` — 单次 call 超时返 `Timeout` 而非挂死
+  - [ ] `dual_solution_exception` — sanitize trace
+  - [ ] `dual_solution_cannot_overwrite_evaluate` — Solution 写盘覆盖失败
+  - [ ] `dual_solution_no_network` — socket / urllib / DNS 全部失败
+  - [ ] `dual_solution_module_shadowing` — Solution PYTHONPATH 不影响 Evaluator
+  - [ ] `dual_solution_read_evaluator_env` — Solution 看不到 Evaluator secret
+  - [ ] `dual_solution_cannot_leak_fd` — `/proc/self/fd` 不可读 IPC
+  - [ ] `dual_evaluator_no_network` — Evaluator 容器 network 硬编码 none
+  - [ ] `dual_legacy_fallback` — 旧 JudgeTask 走单容器
+  - [ ] `dual_image_kind_mismatch` — solution image kind=evaluator 返 400
+- [ ] 2.5 测试辅助：`tests/common/mod.rs` 提供 dual 任务测试 fixture（动态构建临时镜像 COPY 当前 SDK/agent 源码到 `python:3.12-slim`）
+
+## 3. PR-B — 生产镜像 + judge_images.kind（依赖 PR-A1）
+
+- [ ] 3.1 `noj-judge/docker/evaluator-python/Dockerfile`:
+  - [ ] 基于 `python:3.12-slim` + ReadonlyRootfs 友好的构建
+  - [ ] COPY `sdk/evaluator/` 至 `/usr/local/lib/python3.12/site-packages/noj_evaluator_sdk/`
+  - [ ] 默认 `USER` 设置（运行时再降为 nobody）
+- [ ] 3.2 `noj-judge/docker/solution-python/Dockerfile`:
+  - [ ] 基于 `python:3.12-slim`
+  - [ ] COPY `sdk/solution/` 至 `/usr/local/lib/python3.12/site-packages/noj_solution_sdk/`
+  - [ ] entrypoint `python3 -m noj_solution_sdk.host`
+- [ ] 3.3 `noj-judge/scripts/build-sdk-images.sh`: 并行 build 两个镜像打 `:dev` tag
+- [ ] 3.4 `docker-compose.yml`: 集成新镜像构建步骤（开发环境可选 build）
+- [ ] 3.5 Drizzle 迁移 `0018_judge_images_kind.sql`:
+  - [ ] `ALTER TABLE judge_images ADD COLUMN kind text NOT NULL DEFAULT 'evaluator' CHECK (kind IN ('evaluator', 'solution'))`
+  - [ ] 历史数据全部标记为 'evaluator'（admin 后续手动调整）
+- [ ] 3.6 `noj-core/src/services/judge-images.ts`: `CreateJudgeImageInput` 必填 `kind`，写入校验
+- [ ] 3.7 `noj-core/src/mq/judge-rpc.ts`: `get_image_allowlist` 返回 `{ image, kind }[]`
+- [ ] 3.8 `noj-judge/src/mq/rpc.rs`: 解析升级后的 RPC 响应
+- [ ] 3.9 judge 启动时按 kind 分别预热容器池（仅 `evaluator` kind 入池）
+
+## 4. PR-C — DB + core API + UI（依赖 PR-A1、PR-B，可与 PR-A1 并行启动）
+
+- [ ] 4.1 Drizzle 迁移 `0017_problem_runtime_config.sql`:
+  - [ ] `ALTER TABLE problems ADD COLUMN runtime_config jsonb`
+  - [ ] `CHECK (runtime_config IS NULL OR jsonb_typeof(runtime_config) = 'object')`
+- [ ] 4.2 `noj-core/src/db/schema.ts`: `problems` 表增加 `runtime_config` 字段
+- [ ] 4.3 `noj-core/src/types/problems.ts`:
+  - [ ] `CreateProblemInput` / `UpdateProblemInput` 新增 `runtime_config?: RuntimeConfig | null`
+  - [ ] `ProblemResponseWithCategories` 新增 `runtime_config: RuntimeConfig | null`
+  - [ ] Zod schema 校验 `runtime_config` 结构、镜像白名单、kind 匹配
+- [ ] 4.4 `noj-core/src/services/problems.ts`:
+  - [ ] `createProblem` / `updateProblem` 处理 `runtime_config` 字段
+  - [ ] 提交时 `runtime_config` 与 `judge_image` / `judge_command` 同步策略
+  - [ ] ExportProblem / parseImportPayload 兼容旧版导出（缺失字段仅 warning）
+- [ ] 4.5 `noj-core/src/services/submissions.ts`:
+  - [ ] 任务构造前 `SELECT ... FOR UPDATE` 锁住题目行
+  - [ ] 读 `runtime_config` 决定 `mode` + 构造 `JudgeTask`
+- [ ] 4.6 `noj-core/src/routes/admin.ts`: 题目 CRUD 路由透传 `runtime_config`
+- [ ] 4.7 `noj-ui` admin 题目编辑表单:
+  - [ ] 增加 runtime 配置块（含 Evaluator / Solution 双卡片）
+  - [ ] Solution 镜像下拉仅展示 `kind='solution'` 的白名单
+  - [ ] Evaluator 镜像下拉仅展示 `kind='evaluator'` 的白名单
+  - [ ] admin 提交前客户端预校验
+- [ ] 4.8 `noj-core/src/services/audit-log.ts`: 新增 `problems.runtime_config_changed` 审计 action
+- [ ] 4.9 `noj-tests/e2e/08_dual_container_judge.test.ts`:
+  - [ ] admin API 配置双 runtime 题目 + 提交 → Accepted
+  - [ ] 镜像被下架 → `image_not_allowlisted` 错误 + UI 友好提示
+  - [ ] 单容器题目回归测试（确保 PR-C 不破坏）
+
+## 5. 文档与 OpenSpec 收尾
+
+- [ ] 5.1 spec 增量文件落盘：
+  - [ ] `openspec/changes/dual-container-judge/specs/judge-worker/spec.md`（MODIFIED Requirements）
+  - [ ] `openspec/changes/dual-container-judge/specs/judge-image-whitelist/spec.md`（MODIFIED Requirements）
+  - [ ] `openspec/changes/dual-container-judge/specs/problem-runtime-config/spec.md`（新增全文）
+- [ ] 5.2 各 PR 合并后执行 `openspec archive dual-container-judge` 归档
+- [ ] 5.3 更新主 `openspec/specs/judge-worker/spec.md` §6 dual 模式段落（archive 同步时自动完成）
+- [ ] 5.4 更新主 `openspec/specs/judge-image-whitelist/spec.md`（archive 同步时自动完成）
+
+## 6. 关键检查点（每 PR 合并前必过）
+
+- [ ] `cargo fmt` + `cargo clippy`（no warnings）+ `cargo test --lib` 全过
+- [ ] `deno fmt --check` + `deno lint` + `deno task test` 全过
+- [ ] `npm run build`（no-jui）通过
+- [ ] Docker E2E：`NOJ_RUN_E2E=1 cargo test --test e2e_dual_container -- --ignored` 全过（PR-A2 起）
+- [ ] 全链路 E2E：`NOJ_RUN_E2E=1 deno task test:e2e` 全过（PR-C 起）
+- [ ] GPG 签名所有提交
+- [ ] 不存在除设计稿允许外的字段（任何 `JudgeTask` 字段新增需更新 design.md）


### PR DESCRIPTION
## 概要

实现 NOJ 双容器评测架构，把可信的 Evaluator（含支持包 + evaluate.py）与不可信的 Solution（用户代码）隔离到两个容器中，通过 NDJSON RPC 协议通信。修复 issue #118。

## 背景

当前单容器评测模型存在三个安全/可扩展性问题：
1. `evaluate.py` 与用户代码共享文件系统，可被覆盖或伪造模块
2. `import submission` 同进程调用把可信逻辑放在不可信进程里
3. 未来需要受控能力（内网 API/模型/私有数据）时 `network_mode: none` 不够用

## 改动总览（4 个 commit）

### 1. PR-A1 — 协议 + SDK + types (`999841a`)

- **OpenSpec 设计稿**：`design.md` / `proposal.md` / `tasks.md` + 三个 spec 增量（judge-worker / judge-image-whitelist / problem-runtime-config）
- **Rust `types.rs`**：新增 `JudgeMode`、`RuntimeConfig`、`EvaluatorRuntime`、`SolutionRuntime`；扩展 `JudgeTask` 字段（mode / runtime_config），缺省 mode='single' 保持向后兼容
- **TS `types/index.ts`**：同步扩展 `JudgeTask` 与 `RuntimeConfig`
- **`noj_evaluator_sdk`**（Python）：`SolutionRunner.call(...)` 阻塞 + 后台 reader 线程 + pending 队列；`result.accept/wrong_answer/runtime_error/system_error` 写 `---RESULT---` 标记；`configure_logging()` 把 print 重定向到 stderr；类型安全序列化（7 种基本类型 + bytes base64）+ 单帧 1 MiB 软上限
- **`noj_solution_sdk`**（Python）：`host.py` 启动 `sys.stdout.reconfigure(line_buffering=True)`；NDJSON 一行一帧；`register(fn)` 注册表；trace sanitize（剥绝对路径只留 basename + 行号 + 类名）

### 2. PR-A2 — 双容器编排 (`03176bb`)

- **`noj-judge/dual/`** 模块：
  - `protocol.rs`：`LineParser` 把 exec 字节流切分为 `EvaluatorLine { Frame, ResultMarker, Unknown }`
  - `container.rs`：`DualContainer` RAII + `ExecSession`（attach stdin/stdout）
  - `mod.rs`：`evaluate_dual()` 主入口 + `run_dual_loop` 双向 NDJSON 转发
- **`judge/runner.rs`**：`evaluate()` 按 `task.mode` 分流
- **`main.rs`**：任务拉取后按 `JudgeMode` 路由到对应入口（dual 模式不走池）
- **清理契约（RAII）**：Solution → Evaluator 顺序 `docker rm -f`，`Drop` 中 `tokio::spawn` 异步兜底清理
- **测试**：`tests/e2e_dual_container.rs` 7 条 Docker E2E + 28 条 NDJSON 解析单测

### 3. PR-B — 镜像分类 + RPC 升级 (`00eb96b`)

- **`judge_images.kind` 字段**：替代 image 名前缀约定
  - 迁移 `drizzle/0018_judge_images_kind.sql`：ADD COLUMN + CHECK 约束
  - `judge-images` service：`validateJudgeImageWithKind` + `listJudgeImagesByKind`
- **生产 SDK 镜像**：
  - `docker/evaluator-python/Dockerfile`（python:3.12-slim + noj_evaluator_sdk）
  - `docker/solution-python/Dockerfile`（python:3.12-slim + noj_solution_sdk）
  - `scripts/build-sdk-images.sh`：并行 build + :dev tag
- **RPC 升级**：`get_image_allowlist` 返回 `{ image, kind, mode }[]`；judge 端按 kind 分别预热（仅 evaluator 入池）

### 4. PR-C — DB + admin API + UI + E2E (`5838e72`)

- **迁移 `0017_problem_runtime_config.sql`**：`problems.runtime_config` JSONB + CHECK + 部分索引
- **`services/problems.ts`**：
  - `validateRuntimeConfig` 结构校验（含 entry 路径分隔符防护）
  - `createProblem`/`updateProblem` 集成 runtime_config + admin 权限校验 + 镜像 kind 校验
  - 导入/导出向后兼容（旧文件缺失字段按 null 处理）
- **`services/submissions.ts`**：行级锁（`SELECT FOR UPDATE`）+ 按 runtime_config 分流 mode + dual mode 双 kind final gate
- **审计日志**：新增 `problems.runtime_config_changed` action，update 后比较变化并留痕
- **admin UI**：`ProblemEditor.vue` 增加双容器开关 + Evaluator/Solution 双卡片（按 kind 过滤下拉）+ 加载时回填
- **跨模块 E2E**：`noj-tests/e2e/15_dual_container_judge.test.ts` 6 条全链路测试

## 安全边界（落地状态）

| 边界 | 实现 |
|------|------|
| Solution 容器网络 | `network_mode: none` |
| Solution 文件系统 | `ReadonlyRootfs=true` + tmpfs /tmp |
| Solution 进程权限 | `cap_drop ALL` + `no-new-privileges` + `pids_limit=256` |
| Evaluator 网络（v1） | 第一阶段硬编码 `network: none`（后续 Capability Service） |
| 模块 shadowing | Solution / Evaluator 不同 Python sys.path |
| 文件系统隔离 | 不共享挂载点 |
| 环境变量隔离 | 不继承 Evaluator 容器 env |
| Trace 信息泄露 | 剥绝对路径 |
| 类型安全 | 7 种基本类型 + bytes base64；非法类型抛 \`Rejected\` |
| 审计 | \`problems.runtime_config_changed\` 记录改动 |

## 测试矩阵

| 套件 | 结果 |
|------|------|
| \`cargo test --lib\`（noj-judge） | **72 通过** |
| \`cargo clippy -D warnings\` | **通过** |
| Docker E2E \`e2e_dual_container\` | **7 通过** |
| \`deno test judge-images\`（noj-core） | **16 通过** |
| \`deno check\`（noj-core 9 文件） | **通过** |
| \`python3 -m unittest\`（evaluator SDK） | **30 通过** |
| \`python3 -m unittest\`（solution SDK） | **19 通过** |
| Docker 镜像构建 \`:dev\` | **2 个 OK** |
| 4 个 commit GPG 签名 | **全部 G** |

## OpenSpec

- 设计稿：\`openspec/changes/dual-container-judge/design.md\`
- 提案：\`openspec/changes/dual-container-judge/proposal.md\`
- 任务清单：\`openspec/changes/dual-container-judge/tasks.md\`
- 增量 spec：
  - \`openspec/changes/dual-container-judge/specs/judge-worker/spec.md\`
  - \`openspec/changes/dual-container-judge/specs/judge-image-whitelist/spec.md\`
  - \`openspec/changes/dual-container-judge/specs/problem-runtime-config/spec.md\`

合并后执行 \`openspec archive dual-container-judge\` 归档。

## 兼容性

- 单容器题目（\`runtime_config IS NULL\`）**零行为变化**
- 旧 judge 收到 \`get_image_allowlist\` 响应无 \`kind\` 字段时自动 fallback 到 \`evaluator\` 分类
- 旧版导出文件导入时 \`runtime_config\` 字段缺失按 null 处理

## 已知遗留（v1 范围外）

- Solution 容器不入池（每次冷启 ~200-500ms）—— v2 优化
- Capability Service 未实现 —— 需要受控能力时另开 issue
- 非 Python Solution 镜像（C++/JS）—— 后续扩展

## 关联 Issue

- Closes #118