### PR TITLE
fix(ci): P2-1 — 加每 job timeout-minutes、cache key 收紧（deno.json / lockfile）、JWT_SECRET 长度校验

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     name: Core Smoke
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    timeout-minutes: 5
 
     steps:
       - name: 检出代码
@@ -50,6 +51,7 @@ jobs:
   core-fmt:
     name: Core Fmt
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: 检出代码
@@ -70,6 +72,7 @@ jobs:
   core-lint:
     name: Core Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: 检出代码
@@ -90,6 +93,7 @@ jobs:
   core-test:
     name: Core Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     services:
       postgres:
@@ -130,11 +134,26 @@ jobs:
         with:
           deno-version: v2.x
 
+      # 校验 JWT_SECRET 长度 ≥32（修复 finding S7）。
+      # noj-core main.ts 启动时硬校验，但 CI 在测试环节会先 launch main.ts；
+      # 把校验提前到 step 层，错误信息更精准。
+      - name: Validate secrets
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+        run: |
+          if [ "${#JWT_SECRET}" -lt 32 ]; then
+            echo "::error::JWT_SECRET must be ≥32 chars (got ${#JWT_SECRET})"
+            exit 1
+          fi
+
       - name: 缓存 Deno 依赖
         uses: actions/cache@v4
         with:
+          # cache key 同时 hash deno.lock 和 deno.json（修复 finding P7）。
+          # 原单 hashFiles('deno.lock') 在 imports map 变更时不刷新缓存，
+          # 会用到旧的下载模块。
           path: ${{ github.workspace }}/noj-core/.deno_cache
-          key: deno-${{ hashFiles('noj-core/deno.lock') }}
+          key: deno-${{ hashFiles('noj-core/deno.lock', 'noj-core/deno.json') }}
           restore-keys: |
             deno-
 
@@ -150,6 +169,7 @@ jobs:
   ui-check:
     name: UI (Nuxt)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: 检出代码
@@ -163,8 +183,11 @@ jobs:
       - name: 缓存 node_modules
         uses: actions/cache@v4
         with:
+          # cache key 同时 hash package.json 和 lockfile（修复 finding P8）。
+          # 原单 hashFiles('package.json') 在 lockfile 隐式更新时不刷缓存，
+          # 会出现非确定性依赖版本。
           path: noj-ui/node_modules
-          key: npm-${{ hashFiles('noj-ui/package.json') }}
+          key: npm-${{ hashFiles('noj-ui/package.json', 'noj-ui/package-lock.json', 'noj-ui/pnpm-lock.yaml') }}
           restore-keys: |
             npm-
 
@@ -182,6 +205,7 @@ jobs:
   judge-fmt:
     name: Judge Fmt
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: 检出代码
@@ -202,6 +226,7 @@ jobs:
   judge-clippy:
     name: Judge Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: 检出代码
@@ -233,6 +258,7 @@ jobs:
   judge-test:
     name: Judge Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: 检出代码
@@ -263,6 +289,7 @@ jobs:
     name: Judge E2E (Docker)
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 30
     env:
       NOJ_RUN_E2E: "1"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,8 +68,11 @@ jobs:
       - name: 缓存 Deno 依赖
         uses: actions/cache@v4
         with:
+          # cache key 同时 hash deno.lock 和 deno.json（修复 finding P7）：
+          # 单 hashFiles('deno.lock') 在 imports map 变更时不刷缓存，
+          # 会用到旧的下载模块。
           path: ${{ github.workspace }}/noj-core/.deno_cache
-          key: deno-${{ hashFiles('noj-core/deno.lock') }}
+          key: deno-${{ hashFiles('noj-core/deno.lock', 'noj-core/deno.json') }}
           restore-keys: |
             deno-
 


### PR DESCRIPTION
## 背景

延续 PR-122 / PR-123 的 CI 修复。本 PR 是 **P2 批-1**：聚焦 CI **可靠性 + 可重复性**——timeout / cache key / 密钥长度校验。这些项目前"可用但脆弱"，不改 P0/P1 已经修的范围内不会回归。

---

## 改动（2 文件，33+/3-）

### 1. 每 job 显式 `timeout-minutes`

| Job | 之前 | 之后 |
|-----|------|------|
| core-smoke | (默认 360m) | **5m** |
| core-fmt | (默认 360m) | **5m** |
| core-lint | (默认 360m) | **5m** |
| core-test | (默认 360m) | **15m** |
| ui-check | (默认 360m) | **15m** |
| judge-fmt | (默认 360m) | **5m** |
| judge-clippy | (默认 360m) | **20m** |
| judge-test | (默认 360m) | **20m** |
| judge-e2e | (默认 360m) | **30m** |
| e2e.yml Full Pipeline | 60m | (不变) |

**修复 finding M4**（部分）：显式超时避免"挂死的 deno install 跑 6 小时"。每个 job 的 timeout 是该 job 实际最长跑时的 2-3x 富余量。

### 2. Cache key 收紧（deno + npm）

#### deno cache key

**之前**（ci.yml:147, e2e.yml:72）：
```yaml
key: deno-${{ hashFiles('noj-core/deno.lock') }}
```

**之后**：
```yaml
key: deno-${{ hashFiles('noj-core/deno.lock', 'noj-core/deno.json') }}
```

**修复 finding P7**：原 key 只 hash `deno.lock`，`deno.json` 的 `imports` map 变更时不刷缓存，会用到旧的下载模块，导致测试偶现失败难以追因。

#### npm cache key（ui-check）

**之前**：
```yaml
key: npm-${{ hashFiles('noj-ui/package.json') }}
```

**之后**：
```yaml
key: npm-${{ hashFiles('noj-ui/package.json', 'noj-ui/package-lock.json', 'noj-ui/pnpm-lock.yaml') }}
```

**修复 finding P8**：仓库同时存在 `package-lock.json` 和 `pnpm-lock.yaml`（488K + 263K）。单 hashFiles 不带 lockfile 时，npm/pnpm 隐式更新不会触发缓存刷新，导致依赖版本在不同 CI run 间漂移。

### 3. JWT_SECRET 长度校验 step（ci.yml core-test）

**新增 step**（在 cache step 之前）：
```yaml
- name: Validate secrets
  env:
    JWT_SECRET: ${{ secrets.JWT_SECRET }}
  run: |
    if [ "${#JWT_SECRET}" -lt 32 ]; then
      echo "::error::JWT_SECRET must be ≥32 chars (got ${#JWT_SECRET})"
      exit 1
    fi
```

**修复 finding S7**：原版若有人误把 `<32` 字符的 secret 粘到 repo secrets，CI 会 fail 在 `noj-core/main.ts` 内部 `Deno.exit(1)`（错误信息指向启动失败，定位模糊）。提前到 step 层校验后，错误信息精准指向 secret 不合规。

**只在 ci.yml 添加**——e2e.yml 用 workflow env（硬编码 ≥32），无需 step 校验。

---

## 不与 PR-122 / PR-123 冲突

本 PR 故意避开 PR-122 / PR-123 已触及的代码区（permissions / cancel-in-progress / 不加 `--parallel` / 等）。冲突点的归属：

| 项 | 归属 | 本 PR 是否触碰 |
|---|------|---------------|
| `permissions: contents: read` | PR-123 | ❌ |
| `cancel-in-progress: github.event_name == 'pull_request'` | PR-123 | ❌ |
| 去掉 `deno test --parallel` | PR-122 | ❌ |
| `core-smoke` 不再仅 PR | PR-122 | ❌ |
| `judge-e2e` 不再仅 manual | PR-122 | ❌ |
| noj-core `healthcheck` | PR-123 | ❌ |
| JWT_SECRET 三处统一 | PR-123 | ❌ |

`timeout-minutes` / `cache key` / `JWT validation` 都在此前未触及的位置，新加不冲突。

---

## 不包含（留给后续）

| 项 | 优先级 | 计划 PR |
|-----|--------|--------|
| action SHA 钉 | P2-3 (供应链) | 不急，依赖 Dependabot 设置 |
| 服务镜像 digest 钉 | P2-3 | 同上 |
| composite action 抽取 | P2-3 | 较大重构 |
| `actions/upload-artifact` | P2-2 | 易 |
| `dependabot.yml` + `actionlint`/`zizmor` 工作流 lint | P2-3 | 易 |

## GPG

本 commit 已 GPG 签名。
