### PR TITLE
fix(ci): Round1 提速 — e2e.yml paths-ignore（文档 PR 跳过 Full Pipeline）+ cache-to mode=min

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,15 @@ on:
   push:
     branches: [main]
   pull_request:
+    # 纯文档 / 规范 / lint 配置类改动无需跑完整评测栈（节省 10-15 min / PR）。
+    # push to main 仍全量跑；workflow_dispatch 仍可手动强跑。
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'openspec/**'
+      - '.opencode/**'
+      - '.github/dependabot.yml'
+      - '.github/actionlint.yaml'
   workflow_dispatch:
 
 concurrency:
@@ -106,7 +115,7 @@ jobs:
           tags: noj-judge-python
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: 构建 Docker Compose 镜像 (noj-core, 带 GHA 缓存)
         uses: docker/build-push-action@v6
@@ -116,7 +125,7 @@ jobs:
           tags: noj-e2e-core
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: 构建 Docker Compose 镜像 (noj-judge, 带 GHA 缓存)
         uses: docker/build-push-action@v6
@@ -126,7 +135,7 @@ jobs:
           tags: noj-e2e-judge
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
       - name: 初始化 MinIO bucket
         run: |


### PR DESCRIPTION
## 背景

CI 单 PR 平均 12-18 min，主要时间消耗在 `e2e.yml` 的 Full Pipeline（10-15 min）。其中大量时间用于"明知不该跑也跑了"。本 PR 是 **Round 1 提速**——纯 workflow 优化，**不动应用代码**，目标：>50% 的 PR 节省 10-15 min。

## 改动（1 文件，20+/3-）

### 路径 A · `e2e.yml` 加 `paths-ignore`

```yaml
on:
  push:
    branches: [main]
  pull_request:
    paths-ignore:
      - 'docs/**'
      - '**/*.md'
      - 'openspec/**'
      - '.opencode/**'
      - '.github/dependabot.yml'
      - '.github/actionlint.yaml'
  workflow_dispatch:
```

**机制**：`paths-ignore` 只在"命中 excluded 列表"时跳过 workflow。`push to main` 仍然全量跑（每次 main commit 都要验证 e2e）；`workflow_dispatch` 仍然手动可强跑。

**预期效果**：
- 改 README.md / 改 docs/ / 改 openspec/ 提案 → 不再跑 Full Pipeline（节省 10-15 min / PR）
- 改代码、配置、Dockerfile → 仍正常触发（无测试覆盖损失）
- 改 `.github/dependabot.yml`（Dependabot 自动 PR）→ 不跑 Full Pipeline（Dependabot PR 是依赖 bump，本来就该单独验证）

**风险**：极小。`paths-ignore` 是 GitHub 官方支持的精确筛选，原生语义清晰。

### 路径 D · `cache-to: type=gha,mode=min`

3 处 docker build 步骤（noj-judge-python / noj-e2e-core / noj-e2e-judge）的 `cache-to` 从 `mode=max` 改为 `mode=min`：

```diff
- cache-to: type=gha,mode=max
+ cache-to: type=gha,mode=min
```

**机制**：
- `mode=max`：导出所有 buildkit 中间层，包括 RUN 步骤 cache、临时文件等。体积往往是最终 image 的 5-10×
- `mode=min`：只导出最终镜像大小的层 cache，体积小得多

**预期效果**：
- GHA cache storage 节省（OSS 公开仓库 $0.25/GB-mo）
- `cache-from: type=gha` 仍能从缩小但完整的 cache 拉取，构建时间几乎无变化

**风险**：极小。`mode=min` 是 GHA cache 标准选项。

---

## 不触动

- `core-test / ui-check / judge-clippy / judge-test / judge-e2e` 等 ci.yml job 逻辑不变
- 应用代码（noj-core / noj-judge / noj-ui / noj-tests）不动
- `docker-compose.e2e.yml` 不动
- 任何 open PR（PR-122 / PR-123 / PR-126）的内容不动

## 验证方式

1. 在本 PR 上跑一次 CI：
   - 应该有 1 个 run 触发 ci.yml + e2e.yml（因为改了 e2e.yml 文件）
   - 预期 e2e.yml 时间比 10-15 min 短（~7-8 min），主要因为 mode=min 缓存更精确
2. 在 main 上开一个仅改 README.md 的 PR：
   - ci.yml 应该跑（因为 README 不在 ci.yml 的 paths-ignore）
   - e2e.yml 应该 **跳过**

## GPG

本 commit 已 GPG 签名。
