### PR TITLE
fix(ci): paths-ignore 让纯文档 PR 跳过 Full Pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,16 @@ on:
   push:
     branches: [main]
   pull_request:
+    # 纯文档 / 规范 / lint 配置类改动无需跑完整评测栈（节省 10-15 min / PR）。
+    # push to main 仍全量跑；workflow_dispatch 仍可手动强跑。
+    # 修复点：之前的 cache-to mode=min 拆分到独立的 workflow 安全与配置一致性 PR。
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'openspec/**'
+      - '.opencode/**'
+      - '.github/dependabot.yml'
+      - '.github/actionlint.yaml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## 背景

CI 单 PR 平均 12-18 min，Full Pipeline 跑 10-15 min。文档 / openspec / lint 配置类 PR 不需要完整评测栈验证。

## 改动（1 文件，9+/0-）

```yaml
on:
  pull_request:
    paths-ignore:
      - 'docs/**'
      - '**/*.md'
      - 'openspec/**'
      - '.opencode/**'
      - '.github/dependabot.yml'
      - '.github/actionlint.yaml'
```

**机制**：
- `paths-ignore` 命中 excluded 列表时跳过 workflow
- `push to main` 仍全量跑（每次 main commit 都要验证 e2e）
- `workflow_dispatch` 仍可手动强跑
- 代码 / 配置 / Dockerfile 改动 → 仍正常触发（无测试覆盖损失）

## 预期效果

- 改 README.md / docs/ / openspec/ 提案 → 不再跑 Full Pipeline（节省 10-15 min/PR）
- Dependabot 自动 PR（仅改 `.github/dependabot.yml`）→ 不跑 Full Pipeline
- 代码改动 PR → 仍正常触发

## 不包含

- **不包含** `cache-to mode=min`（已拆分到 workflow 安全与配置一致性 PR 的 fork-aware 版本）

## GPG

本 commit 已 GPG 签名。