### PR TITLE
fix(ci): workflow 安全与配置一致性

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,25 @@
 
 name: CI
 
+# workflow-level 最小权限：所有 job 默认 contents: read；如需写权限再按 job
+# 单独收窄 scope。修复 finding S3：之前 GITHUB_TOKEN 默认是 write-all，
+# 风险敞口包括 gh release create / gh pr comment 等不必要的写操作。
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
   pull_request:
   workflow_dispatch:
 
-# 同一分支/PR 的新推送自动取消旧运行，避免排队浪费
+# 同一分支/PR 的新推送自动取消旧运行，避免排队浪费。
+# 修复 finding M4：之前 `cancel-in-progress: true` 对 main 推送也生效，
+# 一次 force-push 就会丢失 main 分支的 CI coverage。改为仅在 PR 上取消，
+# main 推送必须跑完，保留质量门禁记录。
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,15 +13,20 @@
 
 name: E2E
 
+# workflow-level 最小权限：所有 job 默认 contents: read。修复 finding S3。
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
   pull_request:
   workflow_dispatch:
 
+# 仅 PR 上可取消旧运行（修复 finding M4），main 推送不可被取消。
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   COMPOSE_PROJECT_NAME: noj-e2e
@@ -31,7 +36,11 @@ env:
   E2E_CORE_PORT: 8099
   E2E_DB_URL: postgres://e2e:e2e@localhost:5433/e2e
   E2E_REDIS_URL: redis://localhost:6380/1
-  JWT_SECRET: e2e-ci-secret-01234567890123456789
+  # JWT_SECRET 单一来源（修复 finding S1）。
+  # 全仓库（e2e.yml workflow env、docker-compose.e2e.yml noj-core、env.e2e.template）
+  # 统一使用此值；任何一处修改必须同步另外两处。
+  # 长度 ≥32 满足 noj-core main.ts 的 JWT_SECRET ≥ 32 字符校验。
+  JWT_SECRET: e2e-ci-secret-fixed-value-with-32-chars-min-abc
   NOJ_RUN_E2E: "1"
   BCRYPT_SALT_ROUNDS: 4
   DENO_DIR: ${{ github.workspace }}/noj-core/.deno_cache
@@ -106,7 +115,10 @@ jobs:
           tags: noj-judge-python
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Fork PR 的 GITHUB_TOKEN 是 read-only，cache 写入会失败且
+          # 浪费存储（修复 finding S6 + P7）。原模式 mode=max 还会把缓存
+          # 体积推到 5-10× image size。改用 fork 感知 + 较小 cache。
+          cache-to: ${{ github.event.pull_request.head.repo.fork && 'type=inline' || 'type=gha,mode=min' }}
 
       - name: 构建 Docker Compose 镜像 (noj-core, 带 GHA 缓存)
         uses: docker/build-push-action@v6
@@ -116,7 +128,7 @@ jobs:
           tags: noj-e2e-core
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: ${{ github.event.pull_request.head.repo.fork && 'type=inline' || 'type=gha,mode=min' }}
 
       - name: 构建 Docker Compose 镜像 (noj-judge, 带 GHA 缓存)
         uses: docker/build-push-action@v6
@@ -126,7 +138,7 @@ jobs:
           tags: noj-e2e-judge
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: ${{ github.event.pull_request.head.repo.fork && 'type=inline' || 'type=gha,mode=min' }}
 
       - name: 初始化 MinIO bucket
         run: |

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -40,12 +40,14 @@ services:
 
   minio-init:
     image: minio/mc:latest
+    # 修复 finding C5：原 condition: service_started 在冷启动下过早触发，
+    # mc alias set 连接偶尔被拒绝，entrypoint 里再 sleep 3 补补丁（脆弱）。
+    # 改为 service_healthy 后等 minio 健康检查通过再起，sleep 3 也去掉。
     depends_on:
       minio:
-        condition: service_started
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
-      sleep 3;
       mc alias set local http://minio:9000 minioadmin minioadmin;
       mc mb --ignore-existing local/noj-support-packages;
       "
@@ -60,7 +62,7 @@ services:
     environment:
       DATABASE_URL: postgres://e2e:e2e@postgres:5432/e2e
       REDIS_URL: redis://redis:6379/1
-      JWT_SECRET: e2e-test-secret-01234567890123456
+      JWT_SECRET: e2e-ci-secret-fixed-value-with-32-chars-min-abc
       PORT: "8000"
       NOJ_RUN_E2E: "1"
       STORAGE_PROVIDER: local

--- a/env.e2e.template
+++ b/env.e2e.template
@@ -4,7 +4,10 @@
 # ---------- noj-core ----------
 DATABASE_URL=postgres://e2e:e2e@localhost:5433/e2e
 REDIS_URL=redis://localhost:6380/1
-JWT_SECRET=e2e-test-secret
+# JWT_SECRET 单一来源（修复 finding S1），与 e2e.yml workflow env、
+# docker-compose.e2e.yml noj-core service 完全一致；长度 ≥32 满足 noj-core
+# main.ts 的强校验。原 e2e-test-secret 仅 15 字符，会被 main.ts 拒启动。
+JWT_SECRET=e2e-ci-secret-fixed-value-with-32-chars-min-abc
 NOJ_RUN_E2E=1
 
 # ---------- noj-judge ----------


### PR DESCRIPTION
## 背景

PR 128 原本是 kitchen-sink（9 类改动混在一起），本 PR 是从中拆分出的安全与配置一致性部分。5 项独立修复，每项都可单独 cherry-pick / revert，风险低。

## 改动（4 文件，37+/11-）

### S3: workflow-level 最小权限
- `.github/workflows/ci.yml` + `.github/workflows/e2e.yml`
- 加 `permissions: contents: read`
- 修复：之前 GITHUB_TOKEN 默认 write-all，风险敞口包括 gh release / gh pr comment 等不必要的写操作

### M4: cancel-in-progress 仅 PR 上生效
- `.github/workflows/ci.yml` + `.github/workflows/e2e.yml`
- 改 `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`
- 修复：之前 `true` 对 main 推送也生效，一次 force-push 就会丢失 main 的 CI coverage

### S1: JWT_SECRET 单一来源（三处统一）
- `.github/workflows/e2e.yml` env
- `env.e2e.template`
- `docker-compose.e2e.yml` noj-core service
- 统一为 `e2e-ci-secret-fixed-value-with-32-chars-min-abc`（≥32 字符，满足 main.ts 强校验）
- 修复：原 `e2e-test-secret` 仅 15 字符，会被 main.ts 拒启动

### S6+P7: docker build cache-to fork 感知
- `.github/workflows/e2e.yml` 3 处
- 改 `${{ github.event.pull_request.head.repo.fork && 'type=inline' || 'type=gha,mode=min' }}`
- 修复：fork PR GITHUB_TOKEN read-only，cache 写入失败且浪费存储；mode=max 还会把缓存体积推到 5-10× image size

### C5: minio-init depends_on 改 service_healthy
- `docker-compose.e2e.yml` minio-init
- 改 `condition: service_healthy` + 去掉 entrypoint `sleep 3` 补丁
- 修复：原 `service_started` 在冷启动下过早触发，mc alias set 连接偶尔被拒绝，entrypoint sleep 3 补补丁（脆弱）

## 验证

合并后 CI 应跑通；fork PR 上 cache-to 走 `type=inline` 不写 GHA cache；JWT_SECRET 校验通过。

## 不包含

- 不触动 noj-migrate 拆分、deno compile AOT、bash loop healthcheck（见配套的冷启动根治 PR）

## GPG

本 commit 已 GPG 签名。