### PR TITLE
chore: 扩展 .gitignore 覆盖 Rust profiling 与 Docker buildx 缓存

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,10 @@ noj-core/data/packages/
 *.idea/
 .playwright-mcp/
 aa.txt
+
+# --- Rust profiling ---
+*.profraw
+*.profdata
+
+# --- Docker buildx cache ---
+.buildx/


### PR DESCRIPTION
## 背景

当前 `.gitignore` 已覆盖大部分开发场景，但遗漏了两类本地产物：

- **Rust profiling 产物**：cargo bench/profile 会生成 `*.profraw`、`*.profdata`
- **Docker buildx 缓存**：buildx 会在工作目录下创建 `.buildx/` 缓存目录

## 改动

在 `.gitignore` 末尾追加三段：

```
# --- Rust profiling ---
*.profraw
*.profdata

# --- Docker buildx cache ---
.buildx/
```

## 验证

`git check-ignore` 实测：

| 路径 | 命中规则 |
|------|---------|
| `main.profraw` | `*.profraw` |
| `app.profdata` | `*.profdata` |
| `.buildx/cache` | `.buildx/` |
| `noj-core/.buildx/cache` | `.buildx/`（嵌套也命中）|

## 不忽略的内容

按讨论保留：

- `.opencode/` — OpenSpec 技能配置（项目级）
- `.claude/` — Claude Code 技能配置（项目级）

## 提交

- 分支：`chore/extend-gitignore-profiling-buildx`（基于 `origin/main`）
- 提交：GPG 签名（key `F27B5D0A639B43695413D9440F49774CB31F6CF1`）
- 改动：1 文件，+7 行