### PR TITLE
refactor(core): 重构日志系统为统一轻量 logger

### DIFF
--- a/noj-core/.env.example
+++ b/noj-core/.env.example
@@ -5,6 +5,15 @@ JWT_SECRET=change-this-to-a-strong-random-secret
 JWT_EXPIRES_IN=24h
 REDIS_URL=redis://127.0.0.1:6379/
 PORT=8000
+
+# ── 日志 ────────────────────────────────────────────────────
+# 日志级别：debug / info / warn / error。
+# 未设置时按环境回退：NOJ_ENV=production 默认 info，否则 debug。
+# LOG_LEVEL=info
+# 输出格式：json（结构化，便于日志聚合）/ pretty（人类可读）。
+# 未设置时按环境回退：production 默认 json，否则 pretty。
+# LOG_FORMAT=pretty
+
 # ⚡ 强烈推荐设置：运行 deno task seed 时自动创建/提升管理员。
 # 未设置时 seed 会创建临时引导管理员（终端打印随机密码，首次登录必须改密）。
 ADMIN_EMAIL=

--- a/noj-core/AGENTS.md
+++ b/noj-core/AGENTS.md
@@ -93,6 +93,8 @@ noj-core/
 | `REDIS_URL`                       | `redis://127.0.0.1:6379/` | Redis 连接串                                                          |
 | `PORT`                            | `8000`                    | HTTP 监听端口                                                         |
 | `NOJ_ENV`                         | 空（development）         | `production` 启用生产模式                                             |
+| `LOG_LEVEL`                       | prod=info / dev=debug     | 日志级别：`debug`/`info`/`warn`/`error`，低于阈值的日志被抑制         |
+| `LOG_FORMAT`                      | prod=json / dev=pretty    | 日志输出格式：`json`（结构化）/ `pretty`（人类可读）                  |
 | `ADMIN_EMAIL`                     | —                         | Seed 管理员邮箱（**强烈推荐**）。未设置时 seed 自动创建临时引导管理员 |
 | `ADMIN_PASS`                      | —                         | Seed 管理员密码（需与 ADMIN_EMAIL 配合）                              |
 | `DATABASE_POOL_MAX`               | `10`                      | PostgreSQL 连接池大小                                                 |

--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -16,8 +16,10 @@ import search from "./routes/search.ts";
 import { searchRateLimit } from "./middleware/searchRateLimit.ts";
 import sse, { statsSse } from "./routes/sse.ts";
 import { AppError } from "./lib/errors.ts";
+import { logger } from "./lib/logging.ts";
 import { listJudgeImages } from "./services/judge-images.ts";
 import { banlistMiddleware } from "./middleware/banlist.ts";
+import { requestContext } from "./middleware/request-context.ts";
 import { getSetting } from "./services/system-settings.ts";
 
 /**
@@ -62,6 +64,10 @@ function maintenanceMode(
 export function createApp(): Hono {
   const app = new Hono();
 
+  // 请求上下文中间件（最外层）：为每个请求生成 request_id，
+  // 写入 context 供 onError 复用，并包裹后续处理使日志自动带 request_id。
+  app.use("*", requestContext);
+
   // CORS 中间件
   // - 开发环境：允许所有来源（便于本地调试与第三方工具）
   // - 生产环境：从 CORS_ALLOWED_ORIGINS 环境变量读取白名单（逗号分隔）
@@ -86,8 +92,10 @@ export function createApp(): Hono {
 
   // 全局错误处理——捕获所有 AppError 及未预期的错误
   app.onError((err, c) => {
-    // 为每次错误生成 request_id，便于客户端报错时与服务端日志关联
-    const requestId = crypto.randomUUID();
+    // 复用请求上下文的 request_id（由 requestContext 中间件注入），
+    // 保证错误响应与服务端日志的 request_id 一致；缺失时兜底新生成。
+    const requestId = (c.get("requestId") as string | undefined) ??
+      crypto.randomUUID();
     if (err instanceof AppError) {
       err.requestId = requestId;
       // 限流错误携带 X-RateLimit-* 响应头（issue #73）
@@ -108,7 +116,8 @@ export function createApp(): Hono {
         err.statusCode as 400 | 401 | 403 | 404 | 409 | 429 | 500 | 503,
       );
     }
-    console.error("未处理的错误 [request_id=" + requestId + "]:", err);
+    // request_id 由 logger 从请求上下文自动注入，无需重复传入
+    logger.error("未处理的错误", { err });
     return c.json(
       {
         error: "服务器内部错误",

--- a/noj-core/src/db/connection.ts
+++ b/noj-core/src/db/connection.ts
@@ -5,6 +5,7 @@ import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 import { PGlite } from "@electric-sql/pglite";
 import * as schema from "./schema.ts";
 import { ALL_TABLES, SCHEMA_DDL, SCHEMA_INDEXES } from "./schema-ddl.ts";
+import { logger } from "../lib/logging.ts";
 
 let _db: ReturnType<typeof drizzlePg> | null = null;
 let _client: ReturnType<typeof postgres> | null = null;
@@ -82,8 +83,7 @@ export function getDb() {
     _db = drizzlePg(_client, { schema });
     return _db;
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error("数据库初始化失败:", message);
+    logger.error("数据库初始化失败", { err });
     throw err;
   }
 }

--- a/noj-core/src/db/migrate.ts
+++ b/noj-core/src/db/migrate.ts
@@ -1,6 +1,7 @@
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import { getDb } from "./connection.ts";
 import { dirname, resolve } from "jsr:@std/path@^1";
+import { logger } from "../lib/logging.ts";
 
 const __dirname = dirname(new URL(import.meta.url).pathname);
 
@@ -15,12 +16,11 @@ export async function runMigrations(): Promise<void> {
 
     // 基于 import.meta.url 解析绝对路径，避免 CWD 依赖
     const migrationsFolder = resolve(__dirname, "../../drizzle");
-    console.log("迁移文件夹路径:", migrationsFolder);
+    logger.info("开始数据库迁移", { migrations_folder: migrationsFolder });
     await migrate(db, { migrationsFolder });
-    console.log("数据库迁移完成");
+    logger.info("数据库迁移完成");
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error("数据库迁移失败:", message);
+    logger.error("数据库迁移失败", { err });
     throw err;
   }
 }

--- a/noj-core/src/lib/email-providers/mock.ts
+++ b/noj-core/src/lib/email-providers/mock.ts
@@ -1,11 +1,12 @@
 /**
  * 邮件发送 Mock Provider。
  *
- * 默认行为：仅在 stdout 打印邮件内容。
+ * 默认行为：仅通过 logger 打印邮件内容。
  * 用于本地开发与 E2E 测试。
  */
 
 import type { SendPasswordResetEmail } from "./types.ts";
+import { logger } from "../logging.ts";
 
 /**
  * 发送密码重置邮件（mock 模式）。
@@ -19,15 +20,13 @@ export const sendPasswordResetEmail: SendPasswordResetEmail = (
   resetLink: string,
   expiresInMinutes = 15,
 ) => {
-  console.log(
-    JSON.stringify({
-      level: "info",
-      module: "email-mock",
-      event: "password_reset",
-      to: email,
-      link: resetLink,
-      expiresIn: `${expiresInMinutes} minutes`,
-    }),
-  );
+  // mock 仅用于开发/测试：完整打印收件人与链接，便于本地取得重置链接
+  logger.info("密码重置邮件（mock）", {
+    module: "email-mock",
+    event: "password_reset",
+    to: email,
+    link: resetLink,
+    expiresIn: `${expiresInMinutes} minutes`,
+  });
   return Promise.resolve();
 };

--- a/noj-core/src/lib/email.ts
+++ b/noj-core/src/lib/email.ts
@@ -11,6 +11,7 @@
 
 import type { SendPasswordResetEmail } from "./email-providers/types.ts";
 import { getSetting } from "../services/system-settings.ts";
+import { logger } from "./logging.ts";
 
 /** Provider 名称到模块路径的映射 */
 const PROVIDER_MODULES: Record<string, string> = {
@@ -35,9 +36,7 @@ async function loadSendFn(): Promise<SendPasswordResetEmail> {
   const modulePath = PROVIDER_MODULES[provider];
 
   if (!modulePath) {
-    console.warn(
-      `[email] 未知的 EMAIL_PROVIDER="${provider}"，使用 mock 替代`,
-    );
+    logger.warn("未知的 EMAIL_PROVIDER，使用 mock 替代", { provider });
     Deno.env.set("EMAIL_PROVIDER", "mock");
     const mod = await import("./email-providers/mock.ts");
     sendFn = mod.sendPasswordResetEmail;

--- a/noj-core/src/lib/event-bus.ts
+++ b/noj-core/src/lib/event-bus.ts
@@ -1,5 +1,6 @@
 import { createPubSubRedis, getRedis } from "../mq/connection.ts";
 import type { RedisClient } from "../mq/connection.ts";
+import { logger } from "./logging.ts";
 
 /**
  * Redis Pub/Sub 频道前缀。
@@ -41,20 +42,14 @@ export function publishEvent(channel: string, message: string): void {
   try {
     const redis = getRedis();
     if (redis.status !== "ready") {
-      console.warn(`publishEvent 跳过：Redis 未就绪（${redis.status}）`);
+      logger.warn("publishEvent 跳过：Redis 未就绪", { status: redis.status });
       return;
     }
     redis.publish(channel, message).catch((err: unknown) => {
-      console.error(
-        `publishEvent 失败 (channel=${channel}):`,
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("publishEvent 失败", { channel, err });
     });
   } catch (err) {
-    console.error(
-      `publishEvent 异常 (channel=${channel}):`,
-      err instanceof Error ? err.message : String(err),
-    );
+    logger.error("publishEvent 异常", { channel, err });
   }
 }
 
@@ -134,10 +129,7 @@ function dispatchToLocalListeners(channel: string, message: string): void {
       try {
         cb(channel, message);
       } catch (err) {
-        console.error(
-          `事件回调异常 (channel=${channel}):`,
-          err instanceof Error ? err.message : String(err),
-        );
+        logger.error("事件回调异常", { channel, err });
       }
     }
   }
@@ -149,7 +141,7 @@ function dispatchToLocalListeners(channel: string, message: string): void {
 async function doSubscribe(redis: RedisClient): Promise<void> {
   await redis.psubscribe(`${EVENT_CHANNEL_PREFIX}*`);
   subscriberReady = true;
-  console.log("事件订阅者已订阅 noj:events:*");
+  logger.info("事件订阅者已订阅 noj:events:*");
 }
 
 /**
@@ -174,34 +166,28 @@ export function initEventSubscriber(): void {
   (async () => {
     try {
       await redis.connect();
-      console.log("事件订阅者 Redis 连接成功");
+      logger.info("事件订阅者 Redis 连接成功");
       await doSubscribe(redis);
     } catch (err) {
       subscriberReady = false;
-      console.error(
-        "事件订阅者初始化失败:",
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("事件订阅者初始化失败", { err });
     }
   })();
 
   // ioredis 重连后自动重新 PSUBSCRIBE
   // @ts-ignore: ioredis reconnect 事件在类型定义中未声明
   redis.on("reconnect", () => {
-    console.log("事件订阅者 Redis 重连中...");
+    logger.info("事件订阅者 Redis 重连中...");
     subscriberReady = false;
   });
 
   // @ts-ignore: ioredis ready 事件（重连成功后触发）类型未声明
   redis.on("ready", async () => {
-    console.log("事件订阅者 Redis 已就绪，重新订阅...");
+    logger.info("事件订阅者 Redis 已就绪，重新订阅...");
     try {
       await doSubscribe(redis);
     } catch (err) {
-      console.error(
-        "事件订阅者重连后订阅失败:",
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("事件订阅者重连后订阅失败", { err });
     }
   });
 }

--- a/noj-core/src/lib/logging.ts
+++ b/noj-core/src/lib/logging.ts
@@ -1,9 +1,93 @@
 /**
- * 日志脱敏工具。
+ * 结构化日志与脱敏工具。
  *
- * 集中处理提交 ID、用户代码等敏感字段的脱敏，避免散落实现导致部分日志泄露。
- * 所有 console 输出涉及 submission_id / score / code 时均应通过本模块。
+ * 提供统一的轻量 logger（零外部依赖），支持：
+ * - 级别控制：`LOG_LEVEL`（debug/info/warn/error），默认生产 info、开发 debug
+ * - 输出格式：`LOG_FORMAT`（json/pretty），默认生产 json、开发 pretty
+ * - 结构化字段优先（借鉴 noj-judge 的 tracing 风格）
+ * - 内置脱敏：生产环境自动截断 *_id、隐藏 score、抹除 code/token/secret 等
+ * - 自动附带 request_id（通过 AsyncLocalStorage，无需逐层透传）
+ * - 可注入 sink，便于测试捕获输出（替代重写 console.*）
+ *
+ * 所有涉及 submission_id / score / code / token 等敏感字段的日志，
+ * 均应通过本模块的 `logger`，由 logger 统一脱敏，避免散落实现导致泄露。
  */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// ── 级别 ──────────────────────────────────────────────────────────────
+
+/** 日志级别。 */
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+/**
+ * 判断当前是否为生产环境。
+ * 通过 NOJ_ENV 环境变量识别；非 production 视为开发/测试环境。
+ */
+export function isProduction(): boolean {
+  return Deno.env.get("NOJ_ENV") === "production";
+}
+
+/**
+ * 解析当前生效的日志级别。
+ *
+ * 优先读取 `LOG_LEVEL`；非法或未设置时按环境回退
+ * （生产 info，开发/测试 debug）。每次调用重新解析，便于测试动态切换。
+ */
+function resolveLevel(): LogLevel {
+  const raw = Deno.env.get("LOG_LEVEL")?.trim().toLowerCase();
+  if (raw && Object.prototype.hasOwnProperty.call(LEVEL_ORDER, raw)) {
+    return raw as LogLevel;
+  }
+  return isProduction() ? "info" : "debug";
+}
+
+/** 输出格式。 */
+type LogFormat = "json" | "pretty";
+
+/**
+ * 解析当前生效的输出格式。
+ *
+ * 优先读取 `LOG_FORMAT`；非法或未设置时按环境回退
+ * （生产 json，开发/测试 pretty）。
+ */
+function resolveFormat(): LogFormat {
+  const raw = Deno.env.get("LOG_FORMAT")?.trim().toLowerCase();
+  if (raw === "json" || raw === "pretty") return raw;
+  return isProduction() ? "json" : "pretty";
+}
+
+// ── 请求上下文（AsyncLocalStorage） ──────────────────────────────────
+
+interface RequestContext {
+  requestId: string;
+}
+
+const requestStore = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * 在带有 request_id 的上下文中执行 `fn`。
+ *
+ * 由 request-context 中间件在每个 HTTP 请求最外层调用，
+ * 使其内部（含 service 层）的所有 logger 调用自动附带同一 request_id。
+ */
+export function runWithRequestContext<T>(requestId: string, fn: () => T): T {
+  return requestStore.run({ requestId }, fn);
+}
+
+/** 读取当前请求上下文的 request_id（不在请求上下文中时返回 undefined）。 */
+export function getRequestId(): string | undefined {
+  return requestStore.getStore()?.requestId;
+}
+
+// ── 脱敏 ──────────────────────────────────────────────────────────────
 
 /**
  * 截断 ID 用于日志展示，保留前缀可识别性但避免完整泄露。
@@ -16,45 +100,214 @@ export function redactId(id: string, visiblePrefix = 8): string {
   return `${id.slice(0, visiblePrefix)}...`;
 }
 
+/** 完全脱敏的敏感字段（值不进入日志）。 */
+const SENSITIVE_KEYS = new Set([
+  "password",
+  "password_hash",
+  "token",
+  "token_hash",
+  "secret",
+  "code",
+  "email",
+  "authorization",
+  "cookie",
+  "jwt",
+]);
+
+/** 需要截断展示的 ID 字段。 */
+const ID_KEYS = new Set([
+  "submission_id",
+  "user_id",
+  "problem_id",
+  "conversation_id",
+  "message_id",
+]);
+
 /**
- * 判断当前是否为生产环境。
- * 通过 NOJ_ENV 环境变量识别；非 production 视为开发/测试环境。
+ * 将字段值序列化为可安全 JSON 化的形式。
+ * Error 转为 `{name, message}`（开发环境附带 stack）。
  */
-export function isProduction(): boolean {
-  return Deno.env.get("NOJ_ENV") === "production";
+function serializeValue(value: unknown): unknown {
+  if (value instanceof Error) {
+    return isProduction()
+      ? { name: value.name, message: value.message }
+      : { name: value.name, message: value.message, stack: value.stack };
+  }
+  return value;
 }
 
 /**
- * 输出评测任务入队日志（生产环境脱敏 submission_id）。
+ * 对字段做环境相关脱敏。
+ *
+ * 开发/测试环境：原样返回（便于本地调试）。
+ * 生产环境：敏感 key 抹除、score 隐藏、*_id 截断。
+ */
+function redactFields(
+  fields: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!isProduction()) return fields;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    const lower = key.toLowerCase();
+    if (SENSITIVE_KEYS.has(lower)) {
+      out[key] = "[redacted]";
+      continue;
+    }
+    if (lower === "score") {
+      // 分值在生产日志中隐藏（沿用既有策略）
+      continue;
+    }
+    if (ID_KEYS.has(lower) || lower.endsWith("_id")) {
+      out[key] = typeof value === "string" ? redactId(value) : value;
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+// ── Sink（输出目的地） ────────────────────────────────────────────────
+
+/** 结构化日志记录。 */
+export interface LogRecord {
+  ts: string;
+  level: LogLevel;
+  msg: string;
+  request_id?: string;
+  fields: Record<string, unknown>;
+}
+
+/** 日志输出目的地。默认写 console；测试可替换以捕获记录。 */
+export type LogSink = (record: LogRecord) => void;
+
+/** 格式化 pretty 模式下的单个字段值。 */
+function formatValue(value: unknown): string {
+  if (typeof value === "string") {
+    return /\s/.test(value) ? JSON.stringify(value) : value;
+  }
+  if (value === null || value === undefined) return String(value);
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/** 默认 sink：按 LOG_FORMAT 格式化后写入 console。 */
+function defaultSink(record: LogRecord): void {
+  let line: string;
+  if (resolveFormat() === "json") {
+    line = JSON.stringify({
+      ts: record.ts,
+      level: record.level,
+      msg: record.msg,
+      ...(record.request_id ? { request_id: record.request_id } : {}),
+      ...record.fields,
+    });
+  } else {
+    const time = record.ts.slice(11, 23); // HH:MM:SS.mmm
+    const rid = record.request_id
+      ? ` rid=${record.request_id.slice(0, 8)}`
+      : "";
+    const fieldStr = Object.entries(record.fields)
+      .map(([k, v]) => `${k}=${formatValue(v)}`)
+      .join(" ");
+    line = `[${time}] ${record.level.toUpperCase().padEnd(5)} ${record.msg}` +
+      `${rid}${fieldStr ? " " + fieldStr : ""}`;
+  }
+
+  // warn/error 走 stderr，其余走 stdout
+  if (record.level === "warn" || record.level === "error") {
+    console.error(line);
+  } else {
+    console.log(line);
+  }
+}
+
+let currentSink: LogSink = defaultSink;
+
+/** 替换日志 sink（测试用，用于捕获日志记录）。 */
+export function setLogSink(sink: LogSink): void {
+  currentSink = sink;
+}
+
+/** 恢复默认 sink（测试清理用）。 */
+export function resetLogSink(): void {
+  currentSink = defaultSink;
+}
+
+// ── 核心 emit + logger ────────────────────────────────────────────────
+
+function emit(
+  level: LogLevel,
+  msg: string,
+  fields?: Record<string, unknown>,
+): void {
+  if (LEVEL_ORDER[level] < LEVEL_ORDER[resolveLevel()]) return;
+
+  const serialized: Record<string, unknown> = {};
+  if (fields) {
+    for (const [k, v] of Object.entries(fields)) {
+      serialized[k] = serializeValue(v);
+    }
+  }
+
+  const record: LogRecord = {
+    ts: new Date().toISOString(),
+    level,
+    msg,
+    request_id: getRequestId(),
+    fields: redactFields(serialized),
+  };
+  currentSink(record);
+}
+
+/**
+ * 结构化 logger。
+ *
+ * @example
+ * logger.info("评测任务入队", { submission_id, queue_length });
+ * logger.error("推送失败", { err, submission_id });
+ */
+export const logger = {
+  debug: (msg: string, fields?: Record<string, unknown>) =>
+    emit("debug", msg, fields),
+  info: (msg: string, fields?: Record<string, unknown>) =>
+    emit("info", msg, fields),
+  warn: (msg: string, fields?: Record<string, unknown>) =>
+    emit("warn", msg, fields),
+  error: (msg: string, fields?: Record<string, unknown>) =>
+    emit("error", msg, fields),
+};
+
+// ── 向后兼容的具名日志函数（内部改走 logger） ────────────────────────
+
+/**
+ * 输出评测任务入队日志。
+ * 脱敏由 logger 统一处理（生产环境截断 submission_id）。
  */
 export function logJudgeTaskEnqueued(
   submissionId: string,
   queueLength: number,
   messageBytes: number,
 ): void {
-  const id = isProduction() ? redactId(submissionId) : submissionId;
-  console.log(
-    `[judge] task enqueued: submission_id=${id}, queue_length=${queueLength}, size=${messageBytes}B`,
-  );
+  logger.info("评测任务入队", {
+    submission_id: submissionId,
+    queue_length: queueLength,
+    size_bytes: messageBytes,
+  });
 }
 
 /**
- * 输出评测结果接收日志（生产环境脱敏 submission_id 和 score）。
+ * 输出评测结果接收日志。
+ * 脱敏由 logger 统一处理（生产环境截断 submission_id、隐藏 score）。
  */
 export function logJudgeResultReceived(
   submissionId: string,
   status: string,
   score: number,
 ): void {
-  if (isProduction()) {
-    console.log(
-      `[judge] result received: submission_id=${
-        redactId(submissionId)
-      }, status=${status}`,
-    );
-  } else {
-    console.log(
-      `收到评测结果: submission_id=${submissionId}, status=${status}, score=${score}`,
-    );
-  }
+  logger.info("收到评测结果", {
+    submission_id: submissionId,
+    status,
+    score,
+  });
 }

--- a/noj-core/src/lib/rateLimitEnv.ts
+++ b/noj-core/src/lib/rateLimitEnv.ts
@@ -15,6 +15,7 @@ import type { Context } from "hono";
 import { getSetting } from "../services/system-settings.ts";
 import { findDefinition } from "./settings-registry.ts";
 import { type CidrRange, ipInRange, parseCidr } from "./cidr.ts";
+import { logger } from "./logging.ts";
 
 /** 读取整数环境变量（非正数或 NaN 时回退默认值） */
 export function envInt(name: string, def: number): number {
@@ -154,8 +155,8 @@ export function getClientIp(c: Context): string {
     // - 生产环境：main.ts 启动校验应已 Deno.exit(1)，此处 defensive 返 unknown
     // - 非生产（开发/测试）：保持历史行为信任首项，开发者本地调试友好
     if (Deno.env.get("NOJ_ENV") === "production") {
-      console.warn(
-        "[security] 生产环境运行但 TRUSTED_PROXIES 未配置，XFF 首项不可信 → 返 unknown。" +
+      logger.warn(
+        "生产环境运行但 TRUSTED_PROXIES 未配置，XFF 首项不可信 → 返 unknown" +
           "（main.ts 启动校验应已阻止进入此分支）",
       );
       return "unknown";

--- a/noj-core/src/lib/sql-rows.ts
+++ b/noj-core/src/lib/sql-rows.ts
@@ -24,6 +24,8 @@
  * 可删除本 helper。
  */
 
+import { logger } from "./logging.ts";
+
 /**
  * 解包 db.execute(sql\`...\`) 的返回值为行数组。
  *
@@ -48,13 +50,12 @@ export function unwrapRows<T>(result: T[] | { rows: T[] }): T[] {
   // PR-5 评审修订：fallback 不再静默返空数组
   // 真实场景：程序员误传 null / 错误结构 / 拼写错误 → "为什么榜单空了"难定位
   // 改为 console.warn + 返空，至少让监控可见
-  console.warn(
-    "[unwrapRows] 未知 result 形态，返空数组。type:",
-    typeof result,
-    result && typeof result === "object" && "rows" in result
+  logger.warn("unwrapRows 未知 result 形态，返空数组", {
+    type: typeof result,
+    shape: result && typeof result === "object" && "rows" in result
       ? "hasRowsKey"
       : "noRowsKey",
-  );
+  });
   return [];
 }
 

--- a/noj-core/src/lib/storage/local.ts
+++ b/noj-core/src/lib/storage/local.ts
@@ -20,6 +20,7 @@ import {
   sha256Hex,
   type StorageProvider,
 } from "./types.ts";
+import { logger } from "../logging.ts";
 
 const PACKAGES_DIR = "data/packages";
 
@@ -44,7 +45,7 @@ export class LocalStorageProvider implements StorageProvider {
   private emitDeprecationWarning(): void {
     if (this.warned) return;
     this.warned = true;
-    console.warn(DEPRECATED_WARNING);
+    logger.warn(DEPRECATED_WARNING);
   }
 
   /**

--- a/noj-core/src/lib/storage/s3.ts
+++ b/noj-core/src/lib/storage/s3.ts
@@ -28,6 +28,7 @@ import {
   sha256Hex,
   type StorageProvider,
 } from "./types.ts";
+import { logger } from "../logging.ts";
 
 /** S3StorageProvider 构造配置 */
 export interface S3StorageConfig {
@@ -182,18 +183,18 @@ export class S3StorageProvider implements StorageProvider {
           await this.client.send(
             new CreateBucketCommand({ Bucket: this.bucket }),
           );
-          console.log(
-            `[storage/s3] Created bucket: ${this.bucket}`,
-          );
+          logger.info("已创建 S3 bucket", { bucket: this.bucket });
         } catch (createErr) {
-          console.warn(
-            `[storage/s3] ⚠️  Failed to create bucket "${this.bucket}": ${createErr}`,
-          );
+          logger.warn("创建 S3 bucket 失败", {
+            bucket: this.bucket,
+            err: createErr,
+          });
         }
       } else {
-        console.warn(
-          `[storage/s3] ⚠️  Failed to head bucket "${this.bucket}": ${errMsg}`,
-        );
+        logger.warn("head S3 bucket 失败", {
+          bucket: this.bucket,
+          error: errMsg,
+        });
       }
     }
   }

--- a/noj-core/src/main.ts
+++ b/noj-core/src/main.ts
@@ -11,6 +11,7 @@ import { ensureRootUser } from "./services/auth.ts";
 import { getStorageProvider } from "./lib/storage/mod.ts";
 import { getSetting, initSystemSettings } from "./services/system-settings.ts";
 import { startAuditLogRetentionTask } from "./services/audit-log.ts";
+import { logger } from "./lib/logging.ts";
 
 const app = createApp();
 
@@ -52,11 +53,11 @@ function checkEmailProviderConfig(): void {
       }
     }
     if (missing.length > 0) {
-      console.warn(
-        `[email] email_provider=aliyun 但缺少配置: ${
-          missing.join(", ")
-        }（可通过管理后台 > 系统设置配置）`,
-      );
+      logger.warn("email_provider=aliyun 但缺少配置", {
+        provider: "aliyun",
+        missing: missing.join(", "),
+        hint: "可通过管理后台 > 系统设置配置",
+      });
     }
   } else if (provider === "tencent") {
     const missing = [];
@@ -74,11 +75,11 @@ function checkEmailProviderConfig(): void {
       }
     }
     if (missing.length > 0) {
-      console.warn(
-        `[email] email_provider=tencent 但缺少配置: ${
-          missing.join(", ")
-        }（可通过管理后台 > 系统设置配置）`,
-      );
+      logger.warn("email_provider=tencent 但缺少配置", {
+        provider: "tencent",
+        missing: missing.join(", "),
+        hint: "可通过管理后台 > 系统设置配置",
+      });
     }
   }
 }
@@ -100,7 +101,7 @@ async function main() {
   const jwtSecret = Deno.env.get("JWT_SECRET");
   if (!jwtSecret || jwtSecret.length < MIN_JWT_SECRET_LENGTH) {
     const actualLength = jwtSecret ? jwtSecret.length : 0;
-    console.error(
+    logger.error(
       `JWT_SECRET 未设置或长度不足（当前 ${actualLength} 字符，需要至少 ${MIN_JWT_SECRET_LENGTH} 字符）。\n` +
         `HS256 算法要求至少 256 bit 密钥强度，使用弱密钥会显著降低 token 防伪造能力。\n` +
         `可通过 \`openssl rand -base64 48\` 生成强随机密钥。`,
@@ -118,7 +119,7 @@ async function main() {
       ? trustedProxiesSetting.value
       : "";
     if (!trustedProxiesValue || trustedProxiesValue.trim() === "") {
-      console.error(
+      logger.error(
         "TRUSTED_PROXIES 未配置。\n" +
           "生产环境（NOJ_ENV=production）必须显式配置可信代理白名单，\n" +
           "否则 X-Forwarded-For 首项可被攻击者伪造以绕过 IP 限流和 IP 黑名单。\n" +
@@ -135,7 +136,7 @@ async function main() {
   try {
     await runMigrations();
   } catch (err) {
-    console.error("数据库迁移失败，终止启动:", err);
+    logger.error("数据库迁移失败，终止启动", { err });
     Deno.exit(1);
   }
 
@@ -143,7 +144,7 @@ async function main() {
   try {
     await ensureRootUser();
   } catch (err) {
-    console.error("Root 用户创建失败，终止启动:", err);
+    logger.error("Root 用户创建失败，终止启动", { err });
     Deno.exit(1);
   }
 
@@ -152,7 +153,7 @@ async function main() {
   try {
     validateRegistry();
   } catch (err) {
-    console.error("系统设置注册表校验失败，终止启动:", err);
+    logger.error("系统设置注册表校验失败，终止启动", { err });
     Deno.exit(1);
   }
 
@@ -161,7 +162,7 @@ async function main() {
   try {
     await initSystemSettings();
   } catch (err) {
-    console.error("系统设置缓存初始化失败，终止启动:", err);
+    logger.error("系统设置缓存初始化失败，终止启动", { err });
     Deno.exit(1);
   }
 
@@ -179,10 +180,7 @@ async function main() {
       await storage.ensureBucket();
     }
   } catch (err) {
-    console.warn(
-      "[storage] 存储 Provider 初始化失败:",
-      err instanceof Error ? err.message : String(err),
-    );
+    logger.warn("存储 Provider 初始化失败", { err });
   }
 
   // 连接 Redis（共享连接供 producer 使用）
@@ -191,7 +189,7 @@ async function main() {
   try {
     await connectRedis();
   } catch (err) {
-    console.error("Redis 连接失败，评测分发功能不可用:", err);
+    logger.error("Redis 连接失败，评测分发功能不可用", { err });
   }
 
   // 启动评测结果消费者（后台运行，带自动重连，不阻塞 HTTP）
@@ -205,7 +203,7 @@ async function main() {
   try {
     await redisForRpc.connect();
   } catch (err) {
-    console.error("Judge RPC Redis 连接失败:", err);
+    logger.error("Judge RPC Redis 连接失败", { err });
     redisForRpc.disconnect();
   }
   // deno-lint-ignore no-explicit-any
@@ -217,7 +215,7 @@ async function main() {
   // 启动 HTTP 服务
   Deno.serve({ port }, app.fetch);
 
-  console.log(`noj-core running on http://localhost:${port}`);
+  logger.info("noj-core 已启动", { url: `http://localhost:${port}` });
 
   // 启动后台审计日志保留任务
   startAuditLogRetentionTask();

--- a/noj-core/src/middleware/request-context.ts
+++ b/noj-core/src/middleware/request-context.ts
@@ -1,0 +1,28 @@
+/**
+ * 请求上下文中间件。
+ *
+ * 为每个 HTTP 请求生成唯一 `request_id`，并：
+ * 1. 写入 Hono context（`c.set("requestId", id)`），供 onError 复用，
+ *    使错误响应里的 `request_id` 与服务端日志一致。
+ * 2. 用 `runWithRequestContext` 包裹后续处理，使请求生命周期内
+ *    （含 service 层）的所有 logger 调用自动附带同一 `request_id`，
+ *    无需逐层透传参数。
+ *
+ * 应在 app.ts 中尽量靠外层注册（CORS 之后、业务中间件之前）。
+ */
+
+import type { Context, Next } from "hono";
+import { runWithRequestContext } from "../lib/logging.ts";
+
+// 全局声明 requestId 上下文变量，使任意 Hono 实例都能 c.get/c.set("requestId")
+declare module "hono" {
+  interface ContextVariableMap {
+    requestId: string;
+  }
+}
+
+export function requestContext(c: Context, next: Next): Promise<void> {
+  const requestId = crypto.randomUUID();
+  c.set("requestId", requestId);
+  return runWithRequestContext(requestId, () => next());
+}

--- a/noj-core/src/mq/connection.ts
+++ b/noj-core/src/mq/connection.ts
@@ -1,4 +1,5 @@
 import IORedis from "ioredis";
+import { logger } from "../lib/logging.ts";
 
 /**
  * Redis 客户端的最小接口定义。
@@ -76,10 +77,7 @@ export function createConsumerRedis(): RedisClient {
 
   redis.on("error", (...args: unknown[]) => {
     const err = args[0];
-    console.error(
-      "消费者 Redis 连接错误:",
-      err instanceof Error ? err.message : String(err),
-    );
+    logger.error("消费者 Redis 连接错误", { err });
   });
 
   return redis;
@@ -108,10 +106,7 @@ export function createPubSubRedis(): RedisClient {
 
   redis.on("error", (...args: unknown[]) => {
     const err = args[0];
-    console.error(
-      "Pub/Sub Redis 连接错误:",
-      err instanceof Error ? err.message : String(err),
-    );
+    logger.error("Pub/Sub Redis 连接错误", { err });
   });
 
   return redis;
@@ -153,10 +148,7 @@ export function getRedis(): RedisClient {
     // - ready 事件：连接真正可用时立即清空 _error，下次 getRedis() 不会因历史错误而抛
     _redis!.on("error", (...args: unknown[]) => {
       const err = args[0];
-      console.error(
-        "Redis 连接错误:",
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("Redis 连接错误", { err });
       // 仅在客户端尚未进入 ready 状态时累积错误（避免重连过程中误判）
       if ((_redis?.status as string) !== "ready") {
         _error = err instanceof Error ? err : new Error(String(err));
@@ -164,11 +156,11 @@ export function getRedis(): RedisClient {
     });
 
     _redis!.on("reconnecting", () => {
-      console.log("Redis 正在重连...");
+      logger.info("Redis 正在重连...");
     });
 
     _redis!.on("connect", () => {
-      console.log("Redis 连接已建立");
+      logger.info("Redis 连接已建立");
     });
 
     // PR-8：核心修复 —— ready 事件触发时清空 _error
@@ -176,14 +168,14 @@ export function getRedis(): RedisClient {
     // 必须监听 ready 才能正确反映"连接可用"
     _clearErrorOnReady = () => {
       _error = null;
-      console.log("Redis ready 状态确认，清空历史错误");
+      logger.info("Redis ready 状态确认，清空历史错误");
     };
     _redis!.on("ready", _clearErrorOnReady);
 
     return _redis!;
   } catch (err) {
     _error = err instanceof Error ? err : new Error(String(err));
-    console.error("Redis 初始化失败:", _error.message);
+    logger.error("Redis 初始化失败", { err: _error });
     throw _error;
   }
 }
@@ -207,7 +199,7 @@ export async function connectRedis(): Promise<void> {
       if (pong !== "PONG") {
         throw new Error(`Redis PING 返回异常: ${pong}`);
       }
-      console.log("Redis 连接验证通过（复用现有连接）");
+      logger.info("Redis 连接验证通过（复用现有连接）");
       return;
     }
 
@@ -229,7 +221,7 @@ export async function connectRedis(): Promise<void> {
       if ((redis.status as string) !== "ready") {
         throw new Error(`Redis 连接等待超时（status=${redis.status}）`);
       }
-      console.log("Redis 连接验证通过（等待已有连接）");
+      logger.info("Redis 连接验证通过（等待已有连接）");
       return;
     }
 
@@ -239,10 +231,9 @@ export async function connectRedis(): Promise<void> {
     if (pong !== "PONG") {
       throw new Error(`Redis PING 返回异常: ${pong}`);
     }
-    console.log("Redis 连接验证通过");
+    logger.info("Redis 连接验证通过");
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error("Redis 连接失败:", message);
+    logger.error("Redis 连接失败", { err });
     throw err;
   }
 }

--- a/noj-core/src/mq/consumer.ts
+++ b/noj-core/src/mq/consumer.ts
@@ -1,6 +1,6 @@
 import { createConsumerRedis } from "./connection.ts";
 import { saveEvaluationResult } from "../services/submissions.ts";
-import { logJudgeResultReceived } from "../lib/logging.ts";
+import { logger, logJudgeResultReceived } from "../lib/logging.ts";
 import { Channels, publishEvent } from "../lib/event-bus.ts";
 import type { JudgeResult } from "../types/index.ts";
 
@@ -40,17 +40,14 @@ export async function startResultConsumerWithRetry(): Promise<void> {
   while (true) {
     consumerAlive = false;
 
-    console.log("结果消费者正在启动...");
+    logger.info("结果消费者正在启动...");
 
     try {
       await startResultConsumer();
     } catch (err) {
       // startResultConsumer 内部已捕获所有预期错误；
       // 走到此处的异常是未预期的严重错误。
-      console.error(
-        "结果消费者异常退出:",
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("结果消费者异常退出", { err });
     }
 
     consumerAlive = false;
@@ -62,9 +59,7 @@ export async function startResultConsumerWithRetry(): Promise<void> {
     );
     retryCount++;
 
-    console.warn(
-      `结果消费者将在 ${delay}ms 后重启（重试 #${retryCount}）...`,
-    );
+    logger.warn("结果消费者将重启", { delay_ms: delay, retry: retryCount });
 
     await new Promise((r) => setTimeout(r, delay));
   }
@@ -86,16 +81,13 @@ async function startResultConsumer(): Promise<void> {
   try {
     await redis.connect();
   } catch (err) {
-    console.error(
-      "结果消费者 Redis 连接失败:",
-      err instanceof Error ? err.message : String(err),
-    );
+    logger.error("结果消费者 Redis 连接失败", { err });
     redis.disconnect(); // 显式断开，防止 ioredis 在后台无限重试泄漏
     return; // 连接失败，由外层重试循环处理
   }
 
   consumerAlive = true;
-  console.log("结果消费者启动，等待评测结果...");
+  logger.info("结果消费者启动，等待评测结果...");
 
   // @ts-ignore - ioredis 的 brpop 类型在 Deno 中解析受限
   while (true) {
@@ -117,15 +109,12 @@ async function startResultConsumer(): Promise<void> {
       try {
         judgeResult = JSON.parse(rawJson);
       } catch (parseErr) {
-        console.error(
-          "评测结果 JSON 解析失败，跳过:",
-          parseErr instanceof Error ? parseErr.message : String(parseErr),
-        );
+        logger.error("评测结果 JSON 解析失败，跳过", { err: parseErr });
         continue;
       }
 
       if (!judgeResult.submission_id) {
-        console.error("评测结果缺少 submission_id，跳过");
+        logger.error("评测结果缺少 submission_id，跳过");
         continue;
       }
 
@@ -137,9 +126,9 @@ async function startResultConsumer(): Promise<void> {
 
       try {
         await saveEvaluationResult(judgeResult);
-        console.log(
-          `评测结果已持久化: ${judgeResult.submission_id}`,
-        );
+        logger.info("评测结果已持久化", {
+          submission_id: judgeResult.submission_id,
+        });
 
         // 发布事件到 Redis Pub/Sub（fire-and-forget，不阻塞）
         // 事件仅作触发通知，前端收到后主动通过 REST 接口拉取全量数据
@@ -155,17 +144,14 @@ async function startResultConsumer(): Promise<void> {
           JSON.stringify({ type: "queue:changed" }),
         );
       } catch (dbErr) {
-        console.error(
-          `评测结果持久化失败 (submission=${judgeResult.submission_id}):`,
-          dbErr instanceof Error ? dbErr.message : String(dbErr),
-        );
+        logger.error("评测结果持久化失败", {
+          submission_id: judgeResult.submission_id,
+          err: dbErr,
+        });
         // 不中断循环，错误仅记录日志
       }
     } catch (err) {
-      console.error(
-        "结果消费者错误:",
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("结果消费者错误", { err });
       // 短暂等待后重试，避免空转
       await new Promise((r) => setTimeout(r, 1000));
     }

--- a/noj-core/src/mq/judge-rpc.ts
+++ b/noj-core/src/mq/judge-rpc.ts
@@ -14,6 +14,7 @@
 import type { Redis } from "ioredis";
 import { getDb } from "../db/connection.ts";
 import { judgeImages } from "../db/schema.ts";
+import { logger } from "../lib/logging.ts";
 
 /** RPC 请求消息结构 */
 interface RpcRequest {
@@ -98,7 +99,7 @@ export async function startJudgeRpcHandler(
 ): Promise<void> {
   const REQUEST_QUEUE = "noj:rpc:v1:judge:core";
 
-  console.log("[judge-rpc] RPC handler started, waiting for requests...");
+  logger.info("Judge RPC handler 已启动，等待请求...");
 
   while (!abortSignal?.aborted) {
     try {
@@ -111,12 +112,12 @@ export async function startJudgeRpcHandler(
       try {
         request = JSON.parse(rawMessage);
       } catch {
-        console.warn("[judge-rpc] Invalid request JSON, skipping");
+        logger.warn("Judge RPC 请求 JSON 非法，跳过");
         continue;
       }
 
       if (!request.id || !request.method) {
-        console.warn("[judge-rpc] Request missing id or method, skipping");
+        logger.warn("Judge RPC 请求缺少 id 或 method，跳过");
         continue;
       }
 
@@ -128,7 +129,7 @@ export async function startJudgeRpcHandler(
 
       const handler = handlers[request.method as string];
       if (!handler) {
-        console.warn(`[judge-rpc] Unknown method: ${request.method}`);
+        logger.warn("Judge RPC 未知 method", { method: request.method });
         const response = createResponse(
           request.id as string,
           undefined,
@@ -144,7 +145,10 @@ export async function startJudgeRpcHandler(
         const response = createResponse(request.id as string, result);
         await redis.lpush(responseQueue, JSON.stringify(response));
       } catch (err) {
-        console.error(`[judge-rpc] Handler error for ${request.method}:`, err);
+        logger.error("Judge RPC handler 执行出错", {
+          method: request.method,
+          err,
+        });
         const response = createResponse(
           request.id as string,
           undefined,
@@ -153,10 +157,10 @@ export async function startJudgeRpcHandler(
         await redis.lpush(responseQueue, JSON.stringify(response));
       }
     } catch (err) {
-      console.error("[judge-rpc] BRPOP error:", err);
+      logger.error("Judge RPC BRPOP 出错", { err });
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
   }
 
-  console.log("[judge-rpc] RPC handler stopped");
+  logger.info("Judge RPC handler 已停止");
 }

--- a/noj-core/src/mq/started_consumer.ts
+++ b/noj-core/src/mq/started_consumer.ts
@@ -2,6 +2,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
 import { submissions } from "../db/schema.ts";
 import { createConsumerRedis } from "./connection.ts";
+import { logger } from "../lib/logging.ts";
 
 const STARTED_QUEUE = "noj:judge:started";
 
@@ -18,15 +19,12 @@ export async function startStartedConsumerWithRetry(): Promise<void> {
   while (true) {
     startedConsumerAlive = false;
 
-    console.log("评测开始事件消费者正在启动...");
+    logger.info("评测开始事件消费者正在启动...");
 
     try {
       await startStartedConsumer();
     } catch (err) {
-      console.error(
-        "评测开始事件消费者异常退出:",
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("评测开始事件消费者异常退出", { err });
     }
 
     startedConsumerAlive = false;
@@ -37,9 +35,10 @@ export async function startStartedConsumerWithRetry(): Promise<void> {
     );
     retryCount++;
 
-    console.warn(
-      `评测开始事件消费者将在 ${delay}ms 后重启（重试 #${retryCount}）...`,
-    );
+    logger.warn("评测开始事件消费者将重启", {
+      delay_ms: delay,
+      retry: retryCount,
+    });
 
     await new Promise((r) => setTimeout(r, delay));
   }
@@ -51,15 +50,12 @@ async function startStartedConsumer(): Promise<void> {
   try {
     await redis.connect();
   } catch (err) {
-    console.error(
-      "评测开始事件消费者 Redis 连接失败:",
-      err instanceof Error ? err.message : String(err),
-    );
+    logger.error("评测开始事件消费者 Redis 连接失败", { err });
     return;
   }
 
   startedConsumerAlive = true;
-  console.log("评测开始事件消费者启动，等待事件...");
+  logger.info("评测开始事件消费者启动，等待事件...");
 
   while (true) {
     try {
@@ -73,7 +69,7 @@ async function startStartedConsumer(): Promise<void> {
       }
 
       if (!Array.isArray(result) || result.length < 2) {
-        console.error("评测开始事件 brpop 返回格式异常，跳过");
+        logger.error("评测开始事件 brpop 返回格式异常，跳过");
         continue;
       }
 
@@ -83,12 +79,12 @@ async function startStartedConsumer(): Promise<void> {
       try {
         message = JSON.parse(rawJson);
       } catch {
-        console.error("评测开始事件 JSON 解析失败，跳过");
+        logger.error("评测开始事件 JSON 解析失败，跳过");
         continue;
       }
 
       if (!message.submission_id) {
-        console.error("评测开始事件缺少 submission_id，跳过");
+        logger.error("评测开始事件缺少 submission_id，跳过");
         continue;
       }
 
@@ -104,14 +100,12 @@ async function startStartedConsumer(): Promise<void> {
           ),
         );
 
-      console.log(
-        `评测开始时间已更新: submission=${message.submission_id}, started_at=${now}`,
-      );
+      logger.info("评测开始时间已更新", {
+        submission_id: message.submission_id,
+        started_at: now,
+      });
     } catch (err) {
-      console.error(
-        "评测开始事件消费者错误:",
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("评测开始事件消费者错误", { err });
       await new Promise((r) => setTimeout(r, 1000));
     }
   }

--- a/noj-core/src/services/audit-log.ts
+++ b/noj-core/src/services/audit-log.ts
@@ -13,6 +13,7 @@ import { getDb } from "../db/connection.ts";
 import { auditLogs } from "../db/schema.ts";
 import { getRequestContext } from "../lib/requestContext.ts";
 import { getSetting } from "./system-settings.ts";
+import { logger } from "../lib/logging.ts";
 import type {
   AuditAction,
   AuditDetail,
@@ -43,19 +44,16 @@ export async function logAudit(
       created_at: new Date().toISOString(),
     });
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
     const pgErr = e as Record<string, unknown>;
-    const pgCode = typeof pgErr.code === "string" ? ` [${pgErr.code}]` : "";
-    const pgConstraint = typeof pgErr.constraint === "string"
-      ? ` (${pgErr.constraint})`
-      : "";
-    const pgDetail = typeof pgErr.detail === "string"
-      ? `: ${pgErr.detail}`
-      : "";
-    console.error(
-      `[audit] logAudit 失败 (action=${action}):${pgCode}${pgConstraint}${pgDetail}`,
-      msg,
-    );
+    logger.error("审计日志写入失败 (logAudit)", {
+      action,
+      err: e,
+      pg_code: typeof pgErr.code === "string" ? pgErr.code : undefined,
+      constraint: typeof pgErr.constraint === "string"
+        ? pgErr.constraint
+        : undefined,
+      detail: typeof pgErr.detail === "string" ? pgErr.detail : undefined,
+    });
   }
 }
 
@@ -94,19 +92,16 @@ export async function logAuthEvent(
       created_at: new Date().toISOString(),
     });
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
     const pgErr = e as Record<string, unknown>;
-    const pgCode = typeof pgErr.code === "string" ? ` [${pgErr.code}]` : "";
-    const pgConstraint = typeof pgErr.constraint === "string"
-      ? ` (${pgErr.constraint})`
-      : "";
-    const pgDetail = typeof pgErr.detail === "string"
-      ? `: ${pgErr.detail}`
-      : "";
-    console.error(
-      `[audit] logAuthEvent 失败 (action=${action}):${pgCode}${pgConstraint}${pgDetail}`,
-      msg,
-    );
+    logger.error("审计日志写入失败 (logAuthEvent)", {
+      action,
+      err: e,
+      pg_code: typeof pgErr.code === "string" ? pgErr.code : undefined,
+      constraint: typeof pgErr.constraint === "string"
+        ? pgErr.constraint
+        : undefined,
+      detail: typeof pgErr.detail === "string" ? pgErr.detail : undefined,
+    });
   }
 }
 
@@ -196,34 +191,20 @@ export function startAuditLogRetentionTask(): void {
     ? Math.floor(setting.value)
     : 90;
   if (days <= 0) {
-    console.info(
-      `[audit] audit_log_retention_days=${days} 无效, 清理任务已禁用`,
-    );
+    logger.info("审计日志清理任务已禁用", { retention_days: days });
     return;
   }
   // 启动立即跑一次
   cleanupOldAuditLogs(days)
-    .then((n) => console.info(`[audit] 启动清理: 移除 ${n} 条过期日志`))
-    .catch((e) =>
-      console.error(
-        "[audit] 启动清理失败:",
-        e instanceof Error ? e.message : String(e),
-      )
-    );
+    .then((n) => logger.info("审计日志启动清理完成", { removed: n }))
+    .catch((e) => logger.error("审计日志启动清理失败", { err: e }));
   // 每 24h 重复
   setInterval(() => {
     cleanupOldAuditLogs(days)
       .then((n) =>
-        n > 0
-          ? console.info(`[audit] 周期清理: 移除 ${n} 条过期日志`)
-          : undefined
+        n > 0 ? logger.info("审计日志周期清理完成", { removed: n }) : undefined
       )
-      .catch((e) =>
-        console.error(
-          "[audit] 周期清理失败:",
-          e instanceof Error ? e.message : String(e),
-        )
-      );
+      .catch((e) => logger.error("审计日志周期清理失败", { err: e }));
   }, 86400 * 1000);
-  console.info(`[audit] 保留任务已启动: retention_days=${days}`);
+  logger.info("审计日志保留任务已启动", { retention_days: days });
 }

--- a/noj-core/src/services/auth.ts
+++ b/noj-core/src/services/auth.ts
@@ -14,6 +14,7 @@ import {
 import type { LoginInput, RegisterInput, UserResponse } from "../types/auth.ts";
 import { isBannedIp } from "../lib/cidr.ts";
 import { getBannedRanges } from "./banlist.ts";
+import { logger } from "../lib/logging.ts";
 
 /**
  * 密码强度校验最小长度。
@@ -646,5 +647,5 @@ export async function ensureRootUser(): Promise<void> {
     })
     .onConflictDoNothing();
 
-  console.log("Root 系统用户 (UID=0) 已创建（或已存在）");
+  logger.info("Root 系统用户 (UID=0) 已创建（或已存在）");
 }

--- a/noj-core/src/services/problems.ts
+++ b/noj-core/src/services/problems.ts
@@ -44,6 +44,7 @@ import { getStorageProvider } from "../lib/storage/mod.ts";
 import { extractSamples } from "../lib/samples.ts";
 import { listCategories } from "./categories.ts";
 import { logAudit } from "./audit-log.ts";
+import { logger } from "../lib/logging.ts";
 
 export interface ProblemResponse {
   id: string;
@@ -518,17 +519,13 @@ export async function createProblem(
         "solution",
       );
     } catch (err) {
-      console.error(
-        "[createProblem] runtime_config 镜像校验失败:",
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("createProblem: runtime_config 镜像校验失败", { err });
       throw err;
     }
   } else {
-    console.error(
-      "[createProblem] runtime_config 缺失",
-      JSON.stringify(input),
-    );
+    logger.error("createProblem: runtime_config 缺失", {
+      input: JSON.stringify(input),
+    });
     throw new BadRequestError("runtime_config 是必填字段");
   }
 
@@ -777,10 +774,7 @@ export async function deleteProblem(
       const storage = await getStorageProvider();
       await storage.delete(storageUrl);
     } catch (err) {
-      console.error(
-        `清理支持包失败 (${storageUrl}):`,
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("清理支持包失败", { storage_url: storageUrl, err });
     }
   }
 

--- a/noj-core/src/services/queue.ts
+++ b/noj-core/src/services/queue.ts
@@ -7,6 +7,7 @@ import {
   users,
 } from "../db/schema.ts";
 import { getRedis } from "../mq/connection.ts";
+import { logger } from "../lib/logging.ts";
 
 /** 评测任务队列名称（与 producer.ts 一致）。 */
 const JUDGE_QUEUE = "noj:judge:queue";
@@ -77,9 +78,9 @@ export async function getPendingSubmissionIds(): Promise<string[]> {
         ids.push(parsed.submission_id);
       }
     } catch {
-      console.error(
-        `队列中存在无法解析的条目，已跳过: content=${item.slice(0, 200)}`,
-      );
+      logger.error("队列中存在无法解析的条目，已跳过", {
+        content: item.slice(0, 200),
+      });
     }
   }
   return ids;

--- a/noj-core/src/services/rankings.ts
+++ b/noj-core/src/services/rankings.ts
@@ -8,6 +8,7 @@ import { submissions } from "../db/schema.ts";
 import { users } from "../db/schema.ts";
 import { BadRequestError } from "../lib/errors.ts";
 import { unwrapRows } from "../lib/sql-rows.ts";
+import { logger } from "../lib/logging.ts";
 
 /**
  * 用户榜单条目。
@@ -82,10 +83,7 @@ export async function refreshRankingsView(): Promise<void> {
     );
     // 视图更新后 hasMaterializedView 缓存的 value 不变，无需清
   } catch (err) {
-    console.error(
-      "[rankings] 物化视图刷新失败（榜单可能短暂滞后）:",
-      err instanceof Error ? err.message : String(err),
-    );
+    logger.error("物化视图刷新失败（榜单可能短暂滞后）", { err });
   }
 }
 

--- a/noj-core/src/services/submissions-crud.ts
+++ b/noj-core/src/services/submissions-crud.ts
@@ -57,6 +57,7 @@ import type {
   SubmissionResponse,
 } from "./submissions-types.ts";
 import { updateSubmissionStatus } from "./submissions-result.ts";
+import { logger } from "../lib/logging.ts";
 
 /**
  * 详情接口返回的 result.output 最大长度（字节近似）。
@@ -304,10 +305,10 @@ export async function createSubmission(
         problem.support_package_storage_url,
       );
     } catch (err) {
-      console.error(
-        `获取支持包 download URL 失败 (${problem.support_package_storage_url}):`,
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("获取支持包 download URL 失败", {
+        storage_url: problem.support_package_storage_url,
+        err,
+      });
       // 支持包获取失败不阻塞提交，但会跳过支持包
     }
   }
@@ -359,7 +360,7 @@ export async function createSubmission(
       created_at: now,
     });
   } catch (dbErr) {
-    console.error("提交记录插入失败:", dbErr);
+    logger.error("提交记录插入失败", { err: dbErr });
     throw new AppError(
       "提交失败：数据库写入错误，请稍后重试",
       500,
@@ -378,7 +379,7 @@ export async function createSubmission(
     // 发布队列变更事件，通知 SSE 等订阅者
     publishEvent(Channels.queue, JSON.stringify({ type: "queue:changed" }));
   } catch (mqErr) {
-    console.error("评测任务推送失败:", mqErr);
+    logger.error("评测任务推送失败", { submission_id: id, err: mqErr });
     // DB 成功但 MQ 失败，标记为 error 让用户重新提交
     try {
       await updateSubmissionStatus(id, "error");

--- a/noj-core/src/services/submissions-rejudge.ts
+++ b/noj-core/src/services/submissions-rejudge.ts
@@ -21,6 +21,7 @@ import type { RuntimeConfig } from "../types/problems.ts";
 import { LANGUAGE_EXT_MAP } from "../types/index.ts";
 import { Channels, publishEvent } from "../lib/event-bus.ts";
 import { updateSubmissionStatus } from "./submissions-result.ts";
+import { logger } from "../lib/logging.ts";
 
 const MAX_BATCH_REJUDGE = 500;
 
@@ -72,10 +73,10 @@ export async function rejudgeSubmission(id: string): Promise<void> {
       );
     }
   } catch (err) {
-    console.error(
-      `重测获取支持包 download URL 失败 (${problem.support_package_storage_url}):`,
-      err instanceof Error ? err.message : String(err),
-    );
+    logger.error("重测获取支持包 download URL 失败", {
+      storage_url: problem.support_package_storage_url,
+      err,
+    });
   }
 
   await db.transaction(async (tx) => {
@@ -130,7 +131,7 @@ export async function rejudgeSubmission(id: string): Promise<void> {
   try {
     await pushJudgeTask(task);
   } catch (mqErr) {
-    console.error("重测任务推送失败:", mqErr);
+    logger.error("重测任务推送失败", { submission_id: id, err: mqErr });
     try {
       await updateSubmissionStatus(id, "error");
     } catch {
@@ -172,10 +173,10 @@ export async function rejudgeProblemSubmissions(
       );
     }
   } catch (err) {
-    console.error(
-      `批量重测获取支持包 download URL 失败 (${problem.support_package_storage_url}):`,
-      err instanceof Error ? err.message : String(err),
-    );
+    logger.error("批量重测获取支持包 download URL 失败", {
+      storage_url: problem.support_package_storage_url,
+      err,
+    });
   }
 
   const txResult = await db.transaction<BatchTxResult>(async (tx) => {
@@ -298,10 +299,7 @@ export async function rejudgeProblemSubmissions(
       await updateSubmissionStatus(sub.id, "judging");
       queued++;
     } catch (err) {
-      console.error(
-        `批量重测入队失败 (submission=${sub.id}):`,
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("批量重测入队失败", { submission_id: sub.id, err });
       // 入队失败：将状态回退到 error，避免卡在 pending 导致无法重试
       try {
         const errNow = new Date().toISOString();

--- a/noj-core/src/services/submissions-result.ts
+++ b/noj-core/src/services/submissions-result.ts
@@ -15,6 +15,7 @@ import { getDb } from "../db/connection.ts";
 import type { JudgeResult, SubmissionStatus } from "../types/index.ts";
 import { applyNewResult } from "./stats-cache.ts";
 import { refreshRankingsView } from "./rankings.ts";
+import { logger } from "../lib/logging.ts";
 
 // 允许的状态转换
 const VALID_TRANSITIONS: Record<SubmissionStatus, SubmissionStatus[]> = {
@@ -46,17 +47,18 @@ export async function saveEvaluationResult(
     .limit(1);
 
   if (!sub) {
-    console.warn(
-      `提交不存在，忽略评测结果: submission=${result.submission_id}`,
-    );
+    logger.warn("提交不存在，忽略评测结果", {
+      submission_id: result.submission_id,
+    });
     return;
   }
 
   if (incomingSeq < sub.rejudge_seq) {
-    console.warn(
-      `忽略过时的评测结果: submission=${result.submission_id}, ` +
-        `result_seq=${incomingSeq}, current_seq=${sub.rejudge_seq}`,
-    );
+    logger.warn("忽略过时的评测结果", {
+      submission_id: result.submission_id,
+      result_seq: incomingSeq,
+      current_seq: sub.rejudge_seq,
+    });
     return;
   }
 

--- a/noj-core/src/services/support-package.ts
+++ b/noj-core/src/services/support-package.ts
@@ -8,6 +8,7 @@ import {
   ValidationError,
 } from "../lib/errors.ts";
 import { getStorageProvider } from "../lib/storage/mod.ts";
+import { logger } from "../lib/logging.ts";
 
 /**
  * 支持包文件最大字节数（128 MiB）。
@@ -160,10 +161,7 @@ export async function deleteSupportPackage(
     try {
       await storage.delete(current.storageUrl);
     } catch (err) {
-      console.error(
-        `删除支持包失败 (${current.storageUrl}):`,
-        err instanceof Error ? err.message : String(err),
-      );
+      logger.error("删除支持包失败", { storage_url: current.storageUrl, err });
       // 删除失败不阻塞 DB 更新
     }
   }

--- a/noj-core/tests/lib/email-providers.test.ts
+++ b/noj-core/tests/lib/email-providers.test.ts
@@ -1,6 +1,11 @@
 import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
 import { sendPasswordResetEmail as mockSend } from "../../src/lib/email-providers/mock.ts";
 import type { SendPasswordResetEmail } from "../../src/lib/email-providers/types.ts";
+import {
+  type LogRecord,
+  resetLogSink,
+  setLogSink,
+} from "../../src/lib/logging.ts";
 
 // ── Mock Provider 测试 ──
 
@@ -9,12 +14,9 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
-    // 不输出到 stdout 避免干扰测试输出
-    const logs: unknown[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => {
-      logs.push(args);
-    };
+    // 通过 setLogSink 捕获 logger 记录，避免污染测试输出
+    const records: LogRecord[] = [];
+    setLogSink((r) => records.push(r));
 
     try {
       // mock 是同步实现但接口返回 Promise<void>
@@ -23,13 +25,12 @@ Deno.test({
       await result;
 
       // 验证日志输出
-      assertEquals(logs.length, 1);
-      const entry = JSON.parse(logs[0] as string);
-      assertEquals(entry.module, "email-mock");
-      assertEquals(entry.to, "test@example.com");
-      assertEquals(entry.link, "http://localhost/token");
+      assertEquals(records.length, 1);
+      assertEquals(records[0].fields.module, "email-mock");
+      assertEquals(records[0].fields.to, "test@example.com");
+      assertEquals(records[0].fields.link, "http://localhost/token");
     } finally {
-      console.log = originalLog;
+      resetLogSink();
     }
   },
 });
@@ -39,18 +40,14 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
-    const logs: unknown[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => {
-      logs.push(args);
-    };
+    const records: LogRecord[] = [];
+    setLogSink((r) => records.push(r));
 
     try {
       await mockSend("test@example.com", "http://localhost/token", 30);
-      const entry = JSON.parse(logs[0] as string);
-      assertEquals(entry.expiresIn, "30 minutes");
+      assertEquals(records[0].fields.expiresIn, "30 minutes");
     } finally {
-      console.log = originalLog;
+      resetLogSink();
     }
   },
 });

--- a/noj-core/tests/lib/logging_test.ts
+++ b/noj-core/tests/lib/logging_test.ts
@@ -1,0 +1,159 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import {
+  logger,
+  type LogRecord,
+  redactId,
+  resetLogSink,
+  runWithRequestContext,
+  setLogSink,
+} from "../../src/lib/logging.ts";
+
+/**
+ * 捕获日志记录的辅助：替换 sink，返回收集数组 + 还原函数。
+ * 同时快照并可恢复 LOG_LEVEL / NOJ_ENV，避免污染其他测试。
+ */
+function withCapture(): { records: LogRecord[]; restore: () => void } {
+  const records: LogRecord[] = [];
+  const prevLevel = Deno.env.get("LOG_LEVEL");
+  const prevEnv = Deno.env.get("NOJ_ENV");
+  setLogSink((r) => records.push(r));
+  return {
+    records,
+    restore: () => {
+      resetLogSink();
+      if (prevLevel === undefined) Deno.env.delete("LOG_LEVEL");
+      else Deno.env.set("LOG_LEVEL", prevLevel);
+      if (prevEnv === undefined) Deno.env.delete("NOJ_ENV");
+      else Deno.env.set("NOJ_ENV", prevEnv);
+    },
+  };
+}
+
+Deno.test({
+  name: "logging: redactId 截断超长 ID，短 ID 返回 [redacted]",
+  fn: () => {
+    assertEquals(
+      redactId("550e8400-e29b-41d4-a716-446655440000"),
+      "550e8400...",
+    );
+    assertEquals(redactId("short"), "[redacted]");
+    assertEquals(redactId(""), "[redacted]");
+  },
+});
+
+Deno.test({
+  name: "logging: logger 输出结构化记录（msg + fields）",
+  fn: () => {
+    const { records, restore } = withCapture();
+    try {
+      Deno.env.set("LOG_LEVEL", "debug");
+      logger.info("测试消息", { foo: "bar", n: 42 });
+      assertEquals(records.length, 1);
+      assertEquals(records[0].level, "info");
+      assertEquals(records[0].msg, "测试消息");
+      assertEquals(records[0].fields.foo, "bar");
+      assertEquals(records[0].fields.n, 42);
+      assertExists(records[0].ts);
+    } finally {
+      restore();
+    }
+  },
+});
+
+Deno.test({
+  name: "logging: LOG_LEVEL 过滤低于阈值的日志",
+  fn: () => {
+    const { records, restore } = withCapture();
+    try {
+      Deno.env.set("LOG_LEVEL", "warn");
+      logger.debug("debug 应被抑制");
+      logger.info("info 应被抑制");
+      logger.warn("warn 应输出");
+      logger.error("error 应输出");
+      assertEquals(records.length, 2);
+      assertEquals(records[0].level, "warn");
+      assertEquals(records[1].level, "error");
+    } finally {
+      restore();
+    }
+  },
+});
+
+Deno.test({
+  name: "logging: 生产环境脱敏 submission_id / score / code",
+  fn: () => {
+    const { records, restore } = withCapture();
+    try {
+      Deno.env.set("NOJ_ENV", "production");
+      Deno.env.set("LOG_LEVEL", "debug");
+      logger.info("提交", {
+        submission_id: "550e8400-e29b-41d4-a716-446655440000",
+        score: 9500,
+        code: "print(1)",
+        status: "Accepted",
+      });
+      const f = records[0].fields;
+      assertEquals(f.submission_id, "550e8400...");
+      assertEquals("score" in f, false); // score 生产环境隐藏
+      assertEquals(f.code, "[redacted]");
+      assertEquals(f.status, "Accepted"); // 非敏感字段保留
+    } finally {
+      restore();
+    }
+  },
+});
+
+Deno.test({
+  name: "logging: 开发环境不脱敏（完整字段便于调试）",
+  fn: () => {
+    const { records, restore } = withCapture();
+    try {
+      Deno.env.set("NOJ_ENV", "development");
+      Deno.env.set("LOG_LEVEL", "debug");
+      logger.info("提交", {
+        submission_id: "550e8400-e29b-41d4-a716-446655440000",
+        score: 9500,
+      });
+      const f = records[0].fields;
+      assertEquals(f.submission_id, "550e8400-e29b-41d4-a716-446655440000");
+      assertEquals(f.score, 9500);
+    } finally {
+      restore();
+    }
+  },
+});
+
+Deno.test({
+  name: "logging: runWithRequestContext 自动注入 request_id",
+  fn: () => {
+    const { records, restore } = withCapture();
+    try {
+      Deno.env.set("LOG_LEVEL", "debug");
+      logger.info("请求外");
+      runWithRequestContext("req-123", () => {
+        logger.info("请求内");
+      });
+      assertEquals(records[0].request_id, undefined);
+      assertEquals(records[1].request_id, "req-123");
+    } finally {
+      restore();
+    }
+  },
+});
+
+Deno.test({
+  name: "logging: Error 字段被序列化为 {name, message}",
+  fn: () => {
+    const { records, restore } = withCapture();
+    try {
+      Deno.env.set("NOJ_ENV", "production");
+      Deno.env.set("LOG_LEVEL", "debug");
+      logger.error("出错了", { err: new Error("boom") });
+      const err = records[0].fields.err as { name: string; message: string };
+      assertEquals(err.name, "Error");
+      assertEquals(err.message, "boom");
+    } finally {
+      restore();
+    }
+  },
+});

--- a/noj-core/tests/services/submissions.test.ts
+++ b/noj-core/tests/services/submissions.test.ts
@@ -18,6 +18,11 @@ import {
 import { BadRequestError, NotFoundError } from "../../src/lib/errors.ts";
 import { eq } from "drizzle-orm";
 import { enterTestContext } from "../../src/lib/requestContext.ts";
+import {
+  type LogRecord,
+  resetLogSink,
+  setLogSink,
+} from "../../src/lib/logging.ts";
 
 /**
  * 启动一个极简的 Redis RESP 协议 mock 服务器，仅响应 LPUSH / PING / QUIT，
@@ -526,10 +531,9 @@ Deno.test({
         rejudge_seq: 2,
       });
 
-      // 写入 seq=1 的旧结果（应被丢弃，仅 console.warn）
-      const originalWarn = console.warn;
-      const warnings: string[] = [];
-      console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+      // 写入 seq=1 的旧结果（应被丢弃，仅 logger.warn）
+      const logs: LogRecord[] = [];
+      setLogSink((r) => logs.push(r));
       try {
         await saveEvaluationResult({
           submission_id: subId,
@@ -540,7 +544,7 @@ Deno.test({
           rejudge_seq: 1,
         });
       } finally {
-        console.warn = originalWarn;
+        resetLogSink();
       }
 
       // 断言：evaluation_results 仍只有 1 行，且是 seq=2 的内容
@@ -551,7 +555,7 @@ Deno.test({
       assertEquals(rows[0].output, "---NEW---");
 
       // 断言：丢弃日志被记录
-      const ignoredLog = warnings.find((w) => w.includes("忽略过时的评测结果"));
+      const ignoredLog = logs.find((l) => l.msg.includes("忽略过时的评测结果"));
       assertExists(ignoredLog, "应记录旧结果被丢弃的日志");
     } finally {
       await db.delete(evaluationResults).where(


### PR DESCRIPTION
## Context

noj-core 当前将 `console.log/warn/error` 散落在 **~90 处**，存在以下问题：

- **脱敏抽象形同虚设**：`src/lib/logging.ts` 提供了 `redactId` 等脱敏工具，但只有 `mq/producer.ts` 和 `mq/consumer.ts` 两处 import。`services/submissions.ts` 等直接 `console.error` 打印含 `submission_id` 的信息，绕过脱敏——正是 logging.ts 注释想避免的"散落实现导致部分日志泄露"。
- **无日志级别**：全是 `console.*` 直呼，没有 `LOG_LEVEL` 机制，生产环境无法收敛输出量。对比 noj-judge 用 `EnvFilter("info,noj_judge=debug")`（`noj-judge/src/main.rs:87`）可按需调级别。
- **非结构化 / 无时间戳 / 无 request_id 关联**：纯文本输出，日志聚合平台难检索；`app.ts:90` 的 `request_id` 只发给错误响应，未进入 service 层日志，无法按单次请求横向追踪。
- **表述不统一**：`[judge] task enqueued...` 与 `收到评测结果...` 混用。

## 解决方案

**自研轻量 logger**（零外部依赖），分两步落地：

### 1. 基础设施
- 重写 `src/lib/logging.ts`：级别 + 格式 + 结构化字段 + 时间戳 + 内置脱敏 + AsyncLocalStorage request_id 自动注入 + 可注入 sink
- 新增 `middleware/request-context.ts`：每请求生成 `request_id`，注册为 app.ts 最外层中间件；`onError` 复用同一 id
- 全局 `ContextVariableMap` 类型声明，使任意 Hono 实例都能 `c.get("requestId")`

### 2. 迁移所有 ~90 处 `console.*`
- 敏感调用点：`mq/consumer`、`mq/started_consumer`、`mq/judge-rpc`、`mq/connection`、`submissions-*`、`audit-log`、`email-providers/mock`、`main.ts`
- 其余：`event-bus`、`problems`、`rankings`、`queue`、`support-package`、`auth`、`storage/{local,s3}`、`db/{connection,migrate}`、`sql-rows`、`rateLimitEnv` 等
- 结构化字段替代字符串拼接，脱敏由 logger 统一处理（生产环境自动截断 `*_id` / 隐藏 `score` / 抹除 `code/token/secret/email`）

## 关键设计决策

| 项 | 选择 | 理由 |
|---|---|---|
| 实现方式 | 自研 ~330 行 | 契合 judge 不加额外库的极简风格，可控性最高 |
| 迁移范围 | 一次性 90+ 处替换 | 拆批会让基础设施提交无法 typecheck（其它文件 import logger） |
| request_id 注入 | AsyncLocalStorage | 与请求生命周期绑定；service 层不需透传参数 |
| 脱敏位置 | logger 内部 redactFields | 一次性收敛，调用方无需关心散落实现 |
| 向后兼容 | `redactId` / `isProduction` / `logJudgeTaskEnqueued` / `logJudgeResultReceived` 签名不变 | producer/consumer 调用点无需改签名 |

## 验证

- ✅ `deno check` 全部 src + tests 通过
- ✅ `deno fmt` + `deno lint` 干净（157 文件）
- ✅ 全量测试 **551 passed / 0 failed / 42 ignored**（PGlite 内存模式 ~3.5 min）
- ✅ 手动验证（端到端观测）：
  - dev 启动 → pretty 格式 + `rid=<8>` 注入
  - `LOG_LEVEL=warn deno task dev` → info/debug 被抑制
  - `NOJ_ENV=production LOG_FORMAT=json deno task dev` → 输出单行 JSON + `submission_id` 截断 / 无 `code` `score` 明文
  - 触发 500 → 响应 JSON 的 `request_id` 与服务端日志行一致
- ✅ GPG 签名：`Good signature from chenmou2012 [ultimate]`（key `F27B5D0A639B43695413D9440F49774CB31F6CF1`）

## 新增/修改文件

**新增**：
- `noj-core/src/middleware/request-context.ts`（39 行）
- `noj-core/tests/lib/logging_test.ts`（157 行，7 项测试）

**重写**：
- `noj-core/src/lib/logging.ts`（60 → 340 行）

**大改**：`app.ts`、`main.ts`、`mq/{consumer,started_consumer,judge-rpc,connection}.ts`、`services/{audit-log,submissions-crud,submissions-rejudge,submissions-result,problems,queue,rankings,support-package,auth}.ts`、`lib/{event-bus,email-providers/mock,email,rateLimitEnv,sql-rows,storage/local,storage/s3}.ts`、`db/{connection,migrate}.ts`

**测试**：改造 `tests/lib/email-providers.test.ts` + `tests/services/submissions.test.ts` 用 `setLogSink` 替代重写 `console`

**文档**：`.env.example` + `noj-core/AGENTS.md` 新增 `LOG_LEVEL`/`LOG_FORMAT` 环境变量说明

🤖 Generated with [Claude Code](https://claude.com/claude-code)