### PR TITLE
fix: 一系列小问题修复

### DIFF
--- a/noj-core/data/problems-src/1003/submission.py
+++ b/noj-core/data/problems-src/1003/submission.py
@@ -6,7 +6,10 @@ T0-LMCC：A+B Problem — 参考实现（双容器版）
 输出：它们的和
 """
 
+from noj_solution_sdk import register
 
+
+@register
 def solve(input_str: str) -> str:
     """入口函数：由 noj_solution_sdk.host 调用"""
     line = input_str.strip()

--- a/noj-core/data/problems-src/1003/submission.py
+++ b/noj-core/data/problems-src/1003/submission.py
@@ -6,10 +6,6 @@ T0-LMCC：A+B Problem — 参考实现（双容器版）
 输出：它们的和
 """
 
-from noj_solution_sdk import register
-
-
-@register
 def solve(input_str: str) -> str:
     """入口函数：由 noj_solution_sdk.host 调用"""
     line = input_str.strip()

--- a/noj-core/src/services/judge-images.ts
+++ b/noj-core/src/services/judge-images.ts
@@ -236,7 +236,8 @@ export async function validateJudgeImageWithKind(
   // 防止 all_versions 模式下，tagged 版本（如 noj-solution-python:3.12）
   // 被错误地匹配到无 tag 的引用（如 noj-solution-python）
   const exactMatch = rows.find((r) => r.image === image);
-  const matched = exactMatch ?? rows.find((r) => isImageInWhitelist(image, [r]));
+  const matched = exactMatch ??
+    rows.find((r) => isImageInWhitelist(image, [r]));
   if (!matched) {
     throw new ValidationError(
       `评测镜像 '${image}' 未匹配任何白名单条目`,

--- a/noj-judge/sdk/solution/noj_solution_sdk/host.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/host.py
@@ -36,7 +36,7 @@ except (AttributeError, ValueError):
     # reconfigure 在某些环境下不可用，回退到 flush
     pass
 
-from .registry import get_registry, NotRegisteredError
+from .registry import _REGISTRY, get_registry, NotRegisteredError
 from .sanitize import sanitize_trace
 from .serialization import decode_value, encode_value
 
@@ -179,7 +179,7 @@ def _install_signal_handlers() -> None:
 
 
 def _load_entry(entry_path: str) -> None:
-    """importlib 加载用户提交文件（不污染 host 模块命名空间）。"""
+    """importlib 加载用户提交文件，自动注册顶层函数。"""
     if not os.path.exists(entry_path):
         sys.stderr.write(f"[host] entry 文件不存在: {entry_path}\n")
         sys.stderr.flush()
@@ -194,6 +194,14 @@ def _load_entry(entry_path: str) -> None:
     module = importlib.util.module_from_spec(spec)
     sys.modules["user_solution"] = module
     spec.loader.exec_module(module)
+
+    # 自动注册模块中所有顶层函数，用户无需显式 @register
+    import inspect
+    for name, obj in inspect.getmembers(module, inspect.isfunction):
+        if obj.__module__ == module.__name__:
+            _REGISTRY.register(name, obj)
+            sys.stderr.write(f"[host] 已自动注册函数: {name}\n")
+    sys.stderr.flush()
 
 
 def main() -> None:

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -13,6 +13,7 @@
 pub mod container;
 pub mod protocol;
 
+use std::io::Read;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -20,7 +21,7 @@ use bollard::container::LogOutput;
 use futures_util::StreamExt;
 use serde_json::Value;
 use tokio::io::AsyncWriteExt;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 use crate::dual::container::{start_exec, DualContainer, ExecSession};
 use crate::dual::protocol::{frame_type, EvaluatorLine, LineParser};
@@ -29,7 +30,74 @@ use crate::types::{JudgeResult, JudgeStatus, RuntimeConfig};
 
 /// 注入用户代码到指定容器的工作目录。
 ///
-/// 使用 `tar | docker exec tar xf` 模式，与现有 `archive_and_copy` 一致。
+/// 注入支持包（zip）到 Evaluator 容器的 /workspace 目录。
+///
+/// 先同步提取 zip 中所有文件到内存，再逐个异步注入到容器。
+async fn inject_support_package_to_evaluator(
+    docker: &bollard::Docker,
+    container_id: &str,
+    zip_bytes: &[u8],
+) -> Result<()> {
+    // 同步提取 zip 内容到内存（ZipFile 不是 Send，不能在 tokio::spawn 中跨 await 持有）
+    let entries = tokio::task::spawn_blocking({
+        let data = zip_bytes.to_vec();
+        move || -> Result<Vec<(String, Vec<u8>)>> {
+            let cursor = std::io::Cursor::new(data);
+            let mut archive = zip::ZipArchive::new(cursor).context("打开支持包 zip 文件失败")?;
+
+            if archive.len() > 1000 {
+                anyhow::bail!("zip 条目数 {} 超过上限 1000", archive.len());
+            }
+
+            let mut entries = Vec::new();
+            let mut total_size: u64 = 0;
+
+            for i in 0..archive.len() {
+                let mut file = archive.by_index(i).context("读取 zip 条目失败")?;
+                let file_name = file.name().to_string();
+
+                // 跳过目录项
+                if file_name.ends_with('/') || file_name.ends_with('\\') {
+                    continue;
+                }
+
+                // 路径穿越防护
+                if file_name.split(['/', '\\']).any(|part| part == "..") || file_name.starts_with('/') {
+                    anyhow::bail!("zip 包含非法路径条目: {}", file_name);
+                }
+
+                let mut content = Vec::new();
+                file.read_to_end(&mut content).context("读取 zip 条目内容失败")?;
+                total_size = total_size.saturating_add(content.len() as u64);
+
+                if total_size > 512 * 1024 * 1024 {
+                    anyhow::bail!("zip 总解压大小超过上限 512MB");
+                }
+
+                entries.push((file_name, content));
+            }
+
+            info!("支持包提取完成 ({} 个文件)", entries.len());
+            Ok(entries)
+        }
+    })
+    .await
+    .context("spawn_blocking 提取 zip 失败")??;
+
+    // 异步逐个注入到容器
+    for (file_name, content) in &entries {
+        // 只传文件名（相对路径），因为 docker exec 的 tar 已 -C /workspace
+        inject_file_to_container(docker, container_id, file_name, content)
+            .await
+            .context(format!("注入支持包文件 {} 失败", file_name))?;
+        info!("  已注入支持包文件: {}", file_name);
+    }
+
+    info!("支持包注入完成 (共 {} 个文件)", entries.len());
+    Ok(())
+}
+
+/// 使用 `tar | docker exec tar xf` 模式，注入文件到容器。
 async fn inject_file_to_container(
     docker: &bollard::Docker,
     container_id: &str,
@@ -92,8 +160,8 @@ pub async fn evaluate_dual(
     task_submission_id: &str,
     runtime_config: &RuntimeConfig,
     user_code: &str,
-    _file_name: &str,
-    _support_pkg_bytes: Option<&[u8]>,
+    _file_name_from_submission: &str,
+    support_pkg_bytes: Option<&[u8]>,
     _cache_dir: &str,
     _cache_max_items: usize,
     _cache_max_mb: u64,
@@ -119,9 +187,20 @@ pub async fn evaluate_dual(
     .await
     .context("创建 Solution 容器失败")?;
 
+    let evaluator_id = dual.evaluator_id.clone().expect("刚创建");
     let solution_id = dual.solution_id.clone().expect("刚创建");
 
-    // 3. 注入用户代码到 Solution 容器（使用 runtime_config.solution.entry 作为文件名）
+    // 3. 注入支持包到 Evaluator 容器（evaluate.py 等评测脚本）
+    if let Some(pkg_bytes) = support_pkg_bytes {
+        info!("注入支持包到 Evaluator 容器 ({} bytes)", pkg_bytes.len());
+        inject_support_package_to_evaluator(&docker, &evaluator_id, pkg_bytes)
+            .await
+            .context("注入支持包到 Evaluator 容器失败")?;
+    } else {
+        info!("无支持包，跳过注入");
+    }
+
+    // 4. 注入用户代码到 Solution 容器（使用 runtime_config.solution.entry 作为文件名）
     inject_file_to_container(
         &docker,
         &solution_id,
@@ -131,8 +210,7 @@ pub async fn evaluate_dual(
     .await
     .context("注入用户代码到 Solution 容器失败")?;
 
-    // 4. 启动 Evaluator exec
-    let evaluator_id = dual.evaluator_id.clone().expect("刚创建");
+    // 5. 启动 Evaluator exec
     let evaluator_exec = start_exec(&docker, &evaluator_id, evaluator_cmd)
         .await
         .context("启动 Evaluator exec 失败")?;
@@ -228,7 +306,7 @@ async fn run_dual_loop(
                     &mut eval_parser,
                     &mut eval_stderr_buf,
                     &mut eval_stdout_full,
-                    &mut eval_input,
+                    &mut sol_input,
                     &mut result_payload,
                     chunk,
                 )
@@ -250,7 +328,7 @@ async fn run_dual_loop(
                 };
                 handle_sol_chunk(
                     &mut sol_parser,
-                    &mut sol_input,
+                    &mut eval_input,
                     chunk,
                     &mut solution_ready,
                 )

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -62,12 +62,15 @@ async fn inject_support_package_to_evaluator(
                 }
 
                 // 路径穿越防护
-                if file_name.split(['/', '\\']).any(|part| part == "..") || file_name.starts_with('/') {
+                if file_name.split(['/', '\\']).any(|part| part == "..")
+                    || file_name.starts_with('/')
+                {
                     anyhow::bail!("zip 包含非法路径条目: {}", file_name);
                 }
 
                 let mut content = Vec::new();
-                file.read_to_end(&mut content).context("读取 zip 条目内容失败")?;
+                file.read_to_end(&mut content)
+                    .context("读取 zip 条目内容失败")?;
                 total_size = total_size.saturating_add(content.len() as u64);
 
                 if total_size > 512 * 1024 * 1024 {

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -71,6 +71,15 @@ async fn inject_support_package_to_evaluator(
                 let mut content = Vec::new();
                 file.read_to_end(&mut content)
                     .context("读取 zip 条目内容失败")?;
+
+                if content.len() > 64 * 1024 * 1024 {
+                    anyhow::bail!(
+                        "zip 单文件 {} ({} bytes) 超过上限 64MB",
+                        file_name,
+                        content.len()
+                    );
+                }
+
                 total_size = total_size.saturating_add(content.len() as u64);
 
                 if total_size > 512 * 1024 * 1024 {

--- a/noj-judge/src/judge/runner.rs
+++ b/noj-judge/src/judge/runner.rs
@@ -17,18 +17,54 @@ pub async fn evaluate(
     docker: bollard::Docker,
     task: &JudgeTask,
     _work_dir_root: &Path,
-    _download_timeout_secs: u64,
+    download_timeout_secs: u64,
     cache_dir: String,
     cache_max_items: usize,
     cache_max_mb: u64,
 ) -> Result<JudgeResult> {
+    // 下载/获取支持包（含缓存）
+    let support_pkg = if let Some(ref url) = task.download_url {
+        if !url.is_empty() {
+            match fetch_and_cache_support_package(
+                url,
+                download_timeout_secs,
+                &cache_dir,
+                cache_max_items,
+                cache_max_mb,
+            )
+            .await
+            {
+                Ok(bytes) => {
+                    info!(
+                        submission_id = %task.submission_id,
+                        size = bytes.len(),
+                        "支持包已获取"
+                    );
+                    Some(bytes)
+                }
+                Err(e) => {
+                    error!(
+                        submission_id = %task.submission_id,
+                        error = %e,
+                        "支持包获取失败，继续执行（可能缺少评测文件）"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     crate::dual::evaluate_dual(
         docker,
         &task.submission_id,
         &task.runtime_config,
         &task.code,
         task.file_name.as_deref().unwrap_or("solution.py"),
-        None, // 支持包挂载（v1 暂未实现，预留）
+        support_pkg.as_deref(),
         &cache_dir,
         cache_max_items,
         cache_max_mb,
@@ -38,7 +74,6 @@ pub async fn evaluate(
 }
 
 /// 获取支持包：缓存优先 → 按 host 分派下载 → SHA-256 校验 → 写缓存。
-#[allow(dead_code)]
 async fn fetch_and_cache_support_package(
     download_url: &str,
     download_timeout_secs: u64,

--- a/noj-ui/server/api/[...slug].ts
+++ b/noj-ui/server/api/[...slug].ts
@@ -53,15 +53,17 @@ export default defineEventHandler(async (event) => {
   // 改密（issue #75 撤销机制）成功后服务端签发新 token，旧 token 被撤销；
   // 前端不感知，由 Nitro 代理同步替换 Cookie，避免「改密后被踢回登录页」的体验。
   if (shouldInterceptAuth(event)) {
-    const body = event.path.endsWith('/api/v1/auth/login')
-      ? await readBody(event)
-      : undefined;
+    const body = await readBody(event);
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (token) {
+      headers['authorization'] = `Bearer ${token}`;
+    }
 
     try {
       const response = await $fetch.raw(target, {
         method: 'POST',
-        ...(body !== undefined ? { body } : {}),
-        headers: { 'content-type': 'application/json' },
+        body,
+        headers,
       });
 
       const data = response._data as

--- a/openspec/changes/dual-container-judge/design.md
+++ b/openspec/changes/dual-container-judge/design.md
@@ -61,7 +61,7 @@ issue #118 要求把单容器拆成双容器：**Evaluator（可信）+ Solution
 
 **关键路径**
 
-1. judge 启动 Evaluator 容器（挂载支持包），不立即执行 `evaluate.py`。
+1. judge 启动 Evaluator 容器（网络隔离），不立即执行 `evaluate.py`。
 2. judge 通过 `docker exec` 在 Evaluator 容器内启动 `python3 <evaluate.py>`（即 `judge_command`）。
 3. judge 启动 Solution 容器（无网络、无支持包），通过 `docker exec` 跑 `python3 -m noj_solution_sdk.host --entry <solution_entry>`（host 模块源码 `noj-judge/sdk/solution/noj_solution_sdk/host.py`，由 `solution-python` 镜像构建时安装）。
 4. **消息通路**（**Evaluator → Solution**：单方向）：
@@ -221,7 +221,7 @@ interface RuntimeConfig {
 | `noj-judge/sdk/evaluator/` (Python) | `noj_evaluator_sdk`：`SolutionRunner` / `result.accept` / `result.wrong_answer`、stdout/stderr 重定向配置 | 不碰容器 |
 | `noj-judge/sdk/solution/` (Python) | `noj_solution_sdk`：`register(fn)` | 不碰容器 |
 | `noj-judge/docker/solution-python/` | 内置 solution host + SDK，ReadonlyRootfs + tmpfs /tmp + network=none | 不含测试数据 |
-| `noj-judge/docker/evaluator-python/` | 内置 `noj_evaluator_sdk`；network=none（**第一阶段硬编码**，即便 admin 不配置）、无支持包挂载由 core 在注入时完成 | 不含测试数据 |
+| `noj-judge/docker/evaluator-python/` | 内置 `noj_evaluator_sdk`；network=none（**第一阶段硬编码**，即便 admin 不配置）、无支持包，由 judge 在运行时 tar 注入 | 不含测试数据 |
 | `noj-core` | `problems` Drizzle 列、admin CRUD、按模式调度 | 不懂 SDK |
 | `noj-ui` | admin 题目编辑表单加 runtime 配置块（含镜像 kind 下拉） | — |
 

--- a/openspec/changes/dual-container-judge/specs/judge-worker/spec.md
+++ b/openspec/changes/dual-container-judge/specs/judge-worker/spec.md
@@ -7,8 +7,9 @@
 #### Scenario: 启动 Evaluator + Solution 双容器
 
 - **WHEN** JudgeTask.mode === 'dual'
-- **THEN** judge 启动 Evaluator 容器（挂载支持包、不立即执行 evaluate.py）
-- **THEN** judge 启动 Solution 容器（无网络、无支持包挂载、不传 Evaluator 环境变量）
+- **THEN** judge 启动 Evaluator 容器（网络隔离、不立即执行 evaluate.py）
+- **THEN** judge 通过 `docker exec tar xf` 注入支持包文件到 Evaluator 容器的 `/workspace` 目录
+- **THEN** judge 启动 Solution 容器（无网络、无支持包、不传 Evaluator 环境变量）
 - **THEN** judge 通过 docker exec 在 Evaluator 容器内运行 `runtime_config.evaluator.command`
 - **THEN** judge 通过 docker exec 在 Solution 容器内运行 `python3 -m noj_solution_sdk.host --entry <solution.entry>`
 - **THEN** Solution host 启动后 5 秒内必须发送 `ready` 帧，否则判 SystemError


### PR DESCRIPTION
修复评测流水线中的多个问题：

- 修复 Nitro 代理层 change-password 的认证令牌传递问题
- 实现 noj-judge 双容器模式的支持包注入（evaluate.py 等评测文件），以 `docker exec tar xf` 运行时注入替代构建时挂载
- 修复双容器 NDJSON 帧转发方向错误（call → solution, result → evaluator）
- 添加 Solution SDK 函数自动注册，用户提交代码无需（也不建议）显式 `@register`
- 更新 noj_solution_sdk.host 模块，支持批量自动注册顶层函数（镜像需重新构建方可生效）