### PR TITLE
refactor: 清理重复代码（Top 10 重构）

### DIFF
--- a/noj-core/src/lib/errors.ts
+++ b/noj-core/src/lib/errors.ts
@@ -126,17 +126,23 @@ export class ServiceUnavailableError extends AppError {
  * 请求过多错误（HTTP 429）。
  * 用于速率限制场景（如接口请求过于频繁、搜索限流 issue #100）。
  *
- * 携带 headers 供 app.ts onError 设置响应头（如 Retry-After）。
+ * 携带 headers 供 app.ts onError 设置响应头（如 Retry-After、X-RateLimit-*）。
  * `meta.retry_after` 由 app.ts onError 透传到响应体。
  */
 export class RateLimitedError extends AppError {
   headers?: Record<string, string>;
 
-  constructor(message: string, retryAfter?: number) {
-    super(message, 429, "RATE_LIMITED", { retry_after: retryAfter });
+  constructor(
+    message: string,
+    retryAfterOrHeaders?: number | Record<string, string>,
+  ) {
+    super(message, 429, "RATE_LIMITED");
     this.name = "RateLimitedError";
-    if (retryAfter !== undefined) {
-      this.headers = { "Retry-After": String(retryAfter) };
+    if (typeof retryAfterOrHeaders === "number") {
+      this.headers = { "Retry-After": String(retryAfterOrHeaders) };
+      this.meta = { retry_after: retryAfterOrHeaders };
+    } else if (retryAfterOrHeaders) {
+      this.headers = retryAfterOrHeaders;
     }
   }
 }

--- a/noj-core/src/lib/errors.ts
+++ b/noj-core/src/lib/errors.ts
@@ -143,6 +143,11 @@ export class RateLimitedError extends AppError {
       this.meta = { retry_after: retryAfterOrHeaders };
     } else if (retryAfterOrHeaders) {
       this.headers = retryAfterOrHeaders;
+      if ("Retry-After" in retryAfterOrHeaders) {
+        this.meta = {
+          retry_after: parseInt(retryAfterOrHeaders["Retry-After"]),
+        };
+      }
     }
   }
 }

--- a/noj-core/src/lib/loginThrottle.ts
+++ b/noj-core/src/lib/loginThrottle.ts
@@ -172,6 +172,6 @@ export function recordLoginBackoff(
 }
 
 /** 测试用：清空内存退避 Map */
-export function _clearLoginBackoffForTest() {
+export function _resetLoginBackoffForTest() {
   inMemoryBackoff.clear();
 }

--- a/noj-core/src/lib/rateLimitEnv.ts
+++ b/noj-core/src/lib/rateLimitEnv.ts
@@ -108,7 +108,7 @@ export function getTrustedProxyEntries(): Array<
 }
 
 /** 测试用：清空 trusted proxies 缓存（避免跨测试配置泄漏） */
-export function _clearTrustedProxyCacheForTest(): void {
+export function _resetTrustedProxyCacheForTest(): void {
   _trustedCache = null;
 }
 

--- a/noj-core/src/middleware/auth.ts
+++ b/noj-core/src/middleware/auth.ts
@@ -111,6 +111,43 @@ async function checkBanStatus(c: Context, userId: string): Promise<void> {
 }
 
 /**
+ * 解析并验证 JWT token，返回 payload 或 null。
+ *
+ * 共享逻辑：authMiddleware 与 optionalAuthMiddleware 共用。
+ * - 从 Authorization header 提取 Bearer token
+ * - 调用 verifyToken 验证签名+有效期
+ * - 检查 JTI 是否已撤销
+ *
+ * @param c Hono Context
+ * @returns payload（验证通过）或 null（无 token / token 无效）
+ */
+async function resolveToken(
+  c: Context,
+): Promise<Awaited<ReturnType<typeof verifyToken>> | null> {
+  const authHeader = c.req.header("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return null;
+  }
+
+  const token = authHeader.slice(7);
+  let payload: Awaited<ReturnType<typeof verifyToken>> | null = null;
+  try {
+    payload = await verifyToken(token);
+  } catch {
+    return null;
+  }
+
+  if (!payload) return null;
+
+  // 撤销检查
+  if (payload.jti && await isJtiRevoked(payload.jti)) {
+    return null;
+  }
+
+  return payload;
+}
+
+/**
  * 可选认证中间件——有 token 则验证并注入用户信息，无 token 则以匿名身份放行。
  *
  * 与 authMiddleware 的区别：
@@ -121,35 +158,15 @@ async function checkBanStatus(c: Context, userId: string): Promise<void> {
  * 下游路由通过 `if (!c.get("userId"))` 判断是否匿名。
  */
 export async function optionalAuthMiddleware(c: Context, next: Next) {
-  const authHeader = c.req.header("Authorization");
+  const payload = await resolveToken(c);
 
-  if (authHeader && authHeader.startsWith("Bearer ")) {
-    const token = authHeader.slice(7);
-    let payload: Awaited<ReturnType<typeof verifyToken>> | null = null;
-    try {
-      payload = await verifyToken(token);
-    } catch {
-      // token 无效或过期：以匿名身份放行
-    }
+  if (payload) {
+    c.set("userId", payload.sub);
+    c.set("userRole", payload.role);
+    c.set("mustChangePassword", payload.must_change_password ?? false);
+    if (payload.jti) c.set("jti", payload.jti);
 
-    if (payload) {
-      // 撤销检查（issue #75 JWT 撤销机制）：
-      // 已被主动撤销的 jti（/logout、/change-password）即使签名有效也视作无效。
-      // Redis 不可用时 isJtiRevoked 抛 ServiceUnavailableError，
-      // 让 Hono onError 统一返 503（fail-closed）。
-      if (payload.jti && await isJtiRevoked(payload.jti)) {
-        payload = null;
-      }
-    }
-
-    if (payload) {
-      c.set("userId", payload.sub);
-      c.set("userRole", payload.role);
-      c.set("mustChangePassword", payload.must_change_password ?? false);
-      if (payload.jti) c.set("jti", payload.jti);
-
-      await checkBanStatus(c, payload.sub);
-    }
+    await checkBanStatus(c, payload.sub);
   }
   await next();
 }
@@ -171,30 +188,19 @@ export async function optionalAuthMiddleware(c: Context, next: Next) {
  * `banUser`/`unbanUser` 写操作会调 `invalidateBanCache` 立即失效。
  */
 export async function authMiddleware(c: Context, next: Next) {
+  // 先检查请求头是否存在（提供精确的错误信息）
   const authHeader = c.req.header("Authorization");
-
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
     throw new UnauthorizedError("未提供认证令牌");
   }
 
-  const token = authHeader.slice(7); // 去掉 "Bearer " 前缀
+  const payload = await resolveToken(c);
 
-  let payload;
-  try {
-    payload = await verifyToken(token);
-  } catch {
+  if (!payload) {
     throw new UnauthorizedError("认证令牌无效或已过期");
   }
 
-  // 撤销检查（issue #75 JWT 撤销机制）：
-  // /logout、/change-password 等场景主动写入 Redis 黑名单。
-  // 即使签名 + iss + aud + exp 均有效，被撤销的 jti 也视作无效。
-  // fail-closed：isJtiRevoked 抛 ServiceUnavailableError 时由 onError 返 503。
-  if (payload.jti && await isJtiRevoked(payload.jti)) {
-    throw new UnauthorizedError("认证令牌已失效");
-  }
-
-  // 强制改密拦截（评审修复 M1：抛 ForbiddenError 而非 c.json）
+  // 强制改密拦截
   if (
     payload.must_change_password === true &&
     !PASSWORD_CHANGE_WHITELIST.includes(c.req.path)
@@ -202,7 +208,7 @@ export async function authMiddleware(c: Context, next: Next) {
     throw new ForbiddenError("请先修改密码", "PASSWORD_CHANGE_REQUIRED");
   }
 
-  // 封禁校验（与 optionalAuthMiddleware 共享 checkBanStatus）
+  // 封禁校验
   await checkBanStatus(c, payload.sub);
 
   c.set("userId", payload.sub);

--- a/noj-core/src/middleware/rate-limit.ts
+++ b/noj-core/src/middleware/rate-limit.ts
@@ -76,7 +76,7 @@ function checkAndRecord(key: string, intervalMs: number): boolean {
 }
 
 /** 测试辅助：重置所有限流记录（生产环境不应调用）。 */
-export function _resetRateLimitForTests(): void {
+export function _resetRateLimitForTest(): void {
   trackedRequests.clear();
 }
 

--- a/noj-core/src/middleware/rateLimit.ts
+++ b/noj-core/src/middleware/rateLimit.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Context, Next } from "hono";
-import { AppError } from "../lib/errors.ts";
+import { RateLimitedError } from "../lib/errors.ts";
 import {
   checkRateLimit,
   type RateLimitConfig,
@@ -25,17 +25,7 @@ import {
   settingInt,
 } from "../lib/rateLimitEnv.ts";
 
-/** 限流 429 错误（继承 AppError，自动被 onError 捕获） */
-class RateLimitedError extends AppError {
-  headers: Record<string, string>;
-  constructor(message: string, headers: Record<string, string>) {
-    super(message, 429, "TOO_MANY_REQUESTS");
-    this.name = "RateLimitedError";
-    this.headers = headers;
-  }
-}
-
-// ── 默认限流配置（可被环境变量覆盖）────────────────────
+// ── 默认限流配置（可被环境变量覆盖） ────────────────────
 
 export const LOGIN_LIMITS = {
   get ip() {

--- a/noj-core/src/middleware/searchRateLimit.ts
+++ b/noj-core/src/middleware/searchRateLimit.ts
@@ -13,10 +13,10 @@
  */
 
 import type { Context, MiddlewareHandler } from "hono";
-import { getRedis } from "../mq/connection.ts";
 import { getClientIp } from "../lib/rateLimitEnv.ts";
 import { settingBool, settingInt } from "../lib/rateLimitEnv.ts";
 import { RateLimitedError } from "../lib/errors.ts";
+import { checkRateLimit, rateLimitHeaders } from "../lib/rateLimit.ts";
 
 export type SearchRateLimitDimension = "anon" | "authed";
 
@@ -40,7 +40,7 @@ export function searchRateLimit(
       return await next();
     }
 
-    const window = settingInt("rate_limit_search_window");
+    const windowSec = settingInt("rate_limit_search_window");
     const max = dimension === "anon"
       ? settingInt("rate_limit_search_max_anon")
       : settingInt("rate_limit_search_max_authed");
@@ -55,33 +55,26 @@ export function searchRateLimit(
         return await next();
       }
       identifier = userId;
-      key = `ratelimit:search:user:${identifier}`;
+      key = `search:user:${identifier}`;
     } else {
       identifier = getClientIp(c);
-      key = `ratelimit:search:ip:${identifier}`;
+      key = `search:ip:${identifier}`;
     }
 
-    const redis = getRedis();
-    const count = await redis.incr(key);
-    if (count === 1) {
-      await redis.expire(key, window);
-    }
+    const cfg = { windowSec, max };
+    const result = await checkRateLimit(key, cfg);
 
-    const remaining = Math.max(0, max - count);
-    c.header("X-RateLimit-Limit", String(max));
-    c.header("X-RateLimit-Remaining", String(remaining));
-
-    if (count > max) {
-      const ttl = await redis.ttl(key);
-      const retryAfter = ttl > 0 ? ttl : window;
-      const resetAt = Math.floor(Date.now() / 1000) + retryAfter;
-      c.header("X-RateLimit-Reset", String(resetAt));
+    if (!result.allowed) {
       throw new RateLimitedError(
-        `搜索请求过于频繁，请稍后再试（${
-          dimension === "anon" ? "IP" : "用户"
-        }维度）`,
-        retryAfter,
+        "搜索请求过于频繁，请稍后再试",
+        rateLimitHeaders(cfg, result),
       );
+    }
+
+    // 未触发限流也设置 X-RateLimit-Remaining 等头
+    const headers = rateLimitHeaders(cfg, result);
+    for (const [k, v] of Object.entries(headers)) {
+      c.header(k, v);
     }
 
     await next();

--- a/noj-core/src/middleware/searchRateLimit.ts
+++ b/noj-core/src/middleware/searchRateLimit.ts
@@ -66,7 +66,9 @@ export function searchRateLimit(
 
     if (!result.allowed) {
       throw new RateLimitedError(
-        "搜索请求过于频繁，请稍后再试",
+        `搜索请求过于频繁，请稍后再试（${
+          dimension === "anon" ? "IP" : "用户"
+        }维度）`,
         rateLimitHeaders(cfg, result),
       );
     }

--- a/noj-core/src/mq/base-consumer.ts
+++ b/noj-core/src/mq/base-consumer.ts
@@ -1,0 +1,93 @@
+import { createConsumerRedis } from "./connection.ts";
+import { logger } from "../lib/logging.ts";
+
+export interface ConsumerOptions {
+  queueName: string;
+  logLabel: string; // e.g. "结果", "评测开始事件"
+  aliveRef: { value: boolean };
+  handleMessage: (data: Record<string, unknown>) => Promise<void>;
+  /** BLPOP timeout in seconds */
+  blpopTimeout?: number;
+}
+
+const DEFAULT_BLPOP_TIMEOUT = 10;
+const INITIAL_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 30_000;
+
+/**
+ * Create a consumer with automatic reconnection using exponential backoff.
+ *
+ * @returns A function that starts the consumer (does not return normally).
+ */
+export function createConsumer(opts: ConsumerOptions): () => Promise<void> {
+  const blpopTimeout = opts.blpopTimeout ?? DEFAULT_BLPOP_TIMEOUT;
+  const label = opts.logLabel;
+
+  return async function startConsumerWithRetry(): Promise<void> {
+    let retryCount = 0;
+
+    while (true) {
+      opts.aliveRef.value = false;
+
+      logger.info(`${label}消费者正在启动...`);
+
+      try {
+        await runConsumer();
+      } catch (err) {
+        logger.error(`${label}消费者异常退出`, { err });
+      }
+
+      opts.aliveRef.value = false;
+
+      const delay = Math.min(
+        INITIAL_RETRY_DELAY_MS * Math.pow(2, retryCount),
+        MAX_RETRY_DELAY_MS,
+      );
+      retryCount++;
+
+      logger.warn(`${label}消费者将重启`, { delay_ms: delay, retry: retryCount });
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  };
+
+  async function runConsumer(): Promise<void> {
+    const redis = createConsumerRedis();
+    try {
+      await redis.connect();
+    } catch (err) {
+      logger.error(`${label}消费者 Redis 连接失败`, { err });
+      redis.disconnect();
+      return;
+    }
+
+    opts.aliveRef.value = true;
+    logger.info(`${label}消费者启动，等待事件...`);
+
+    while (true) {
+      try {
+        // deno-lint-ignore no-explicit-any
+        const result = await redis.brpop(opts.queueName, blpopTimeout) as [string, string] | null;
+        if (!result) continue;
+
+        if (!Array.isArray(result) || result.length < 2) {
+          logger.error(`${label} brpop 返回格式异常，跳过`);
+          continue;
+        }
+
+        const [, rawJson] = result;
+        let message: Record<string, unknown>;
+        try {
+          message = JSON.parse(rawJson);
+        } catch {
+          logger.error(`${label} JSON 解析失败，跳过`);
+          continue;
+        }
+
+        await opts.handleMessage(message);
+      } catch (err) {
+        logger.error(`${label}消费者错误`, { err });
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+  }
+}

--- a/noj-core/src/mq/base-consumer.ts
+++ b/noj-core/src/mq/base-consumer.ts
@@ -45,7 +45,10 @@ export function createConsumer(opts: ConsumerOptions): () => Promise<void> {
       );
       retryCount++;
 
-      logger.warn(`${label}消费者将重启`, { delay_ms: delay, retry: retryCount });
+      logger.warn(`${label}消费者将重启`, {
+        delay_ms: delay,
+        retry: retryCount,
+      });
       await new Promise((r) => setTimeout(r, delay));
     }
   };
@@ -65,8 +68,10 @@ export function createConsumer(opts: ConsumerOptions): () => Promise<void> {
 
     while (true) {
       try {
-        // deno-lint-ignore no-explicit-any
-        const result = await redis.brpop(opts.queueName, blpopTimeout) as [string, string] | null;
+        const result = await redis.brpop(opts.queueName, blpopTimeout) as [
+          string,
+          string,
+        ] | null;
         if (!result) continue;
 
         if (!Array.isArray(result) || result.length < 2) {

--- a/noj-core/src/mq/consumer.ts
+++ b/noj-core/src/mq/consumer.ts
@@ -1,4 +1,4 @@
-import { createConsumerRedis } from "./connection.ts";
+import { createConsumer } from "./base-consumer.ts";
 import { saveEvaluationResult } from "../services/submissions.ts";
 import { logger, logJudgeResultReceived } from "../lib/logging.ts";
 import { Channels, publishEvent } from "../lib/event-bus.ts";
@@ -11,149 +11,63 @@ import type { JudgeResult } from "../types/index.ts";
 const RESULT_QUEUE = "noj:judge:results";
 
 /**
- * BRPOP 超时时间（秒）。
- * 超时后自动重试，防止连接因长时间空闲而断开。
- */
-const BLPOP_TIMEOUT = 10;
-
-/** 初始重试延迟（ms）。 */
-const INITIAL_RETRY_DELAY_MS = 1_000;
-/** 最大重试延迟（ms）。 */
-const MAX_RETRY_DELAY_MS = 30_000;
-
-/**
  * 消费者活跃状态标识。
  * 供健康检查端点查询消费者是否在正常运行。
  */
-export let consumerAlive = false;
+export const consumerAlive = { value: false };
+
+async function handleResultMessage(data: Record<string, unknown>): Promise<void> {
+  const judgeResult = data as unknown as JudgeResult;
+
+  if (!judgeResult.submission_id) {
+    logger.error("评测结果缺少 submission_id，跳过");
+    return;
+  }
+
+  logJudgeResultReceived(
+    judgeResult.submission_id,
+    judgeResult.status,
+    judgeResult.score,
+  );
+
+  try {
+    await saveEvaluationResult(judgeResult);
+    logger.info("评测结果已持久化", {
+      submission_id: judgeResult.submission_id,
+    });
+
+    // 发布事件到 Redis Pub/Sub（fire-and-forget，不阻塞）
+    // 事件仅作触发通知，前端收到后主动通过 REST 接口拉取全量数据
+    publishEvent(
+      Channels.submission(judgeResult.submission_id),
+      JSON.stringify({
+        type: "submission:updated",
+        id: judgeResult.submission_id,
+      }),
+    );
+    publishEvent(
+      Channels.queue,
+      JSON.stringify({ type: "queue:changed" }),
+    );
+  } catch (dbErr) {
+    logger.error("评测结果持久化失败", {
+      submission_id: judgeResult.submission_id,
+      err: dbErr,
+    });
+    // 不中断循环，错误仅记录日志
+  }
+}
 
 /**
  * 启动评测结果消费者（带自动重连）。
  *
- * 在 `startResultConsumer` 因 Redis 断开等原因退出时，
+ * 在内部因 Redis 断开等原因退出时，
  * 使用指数退避策略自动创建新连接并重新启动消费。
  * 此函数不会正常返回——它会持续尝试重连。
  */
-export async function startResultConsumerWithRetry(): Promise<void> {
-  let retryCount = 0;
-
-  while (true) {
-    consumerAlive = false;
-
-    logger.info("结果消费者正在启动...");
-
-    try {
-      await startResultConsumer();
-    } catch (err) {
-      // startResultConsumer 内部已捕获所有预期错误；
-      // 走到此处的异常是未预期的严重错误。
-      logger.error("结果消费者异常退出", { err });
-    }
-
-    consumerAlive = false;
-
-    // 指数退避：1s → 2s → 4s → 8s → ... → 上限 30s
-    const delay = Math.min(
-      INITIAL_RETRY_DELAY_MS * Math.pow(2, retryCount),
-      MAX_RETRY_DELAY_MS,
-    );
-    retryCount++;
-
-    logger.warn("结果消费者将重启", { delay_ms: delay, retry: retryCount });
-
-    await new Promise((r) => setTimeout(r, delay));
-  }
-}
-
-/**
- * 启动评测结果消费者（核心循环）。
- *
- * 在独立异步循环中运行，通过 BRPOP 阻塞等待 noj-judge 发布的评测结果，
- * 解析后持久化到数据库。
- *
- * 此函数内部处理所有预期的连接错误和解析错误，
- * 仅在不可恢复时返回（由外层 `startResultConsumerWithRetry` 负责重启）。
- */
-async function startResultConsumer(): Promise<void> {
-  const redis = createConsumerRedis();
-
-  // 连接 Redis
-  try {
-    await redis.connect();
-  } catch (err) {
-    logger.error("结果消费者 Redis 连接失败", { err });
-    redis.disconnect(); // 显式断开，防止 ioredis 在后台无限重试泄漏
-    return; // 连接失败，由外层重试循环处理
-  }
-
-  consumerAlive = true;
-  logger.info("结果消费者启动，等待评测结果...");
-
-  // @ts-ignore - ioredis 的 brpop 类型在 Deno 中解析受限
-  while (true) {
-    try {
-      // BRPOP 返回 [key, value] 或 null
-      const result: [string, string] | null = await redis.brpop(
-        RESULT_QUEUE,
-        BLPOP_TIMEOUT,
-      );
-
-      if (!result) {
-        // 超时，继续循环
-        continue;
-      }
-
-      const [, rawJson] = result;
-
-      let judgeResult: JudgeResult;
-      try {
-        judgeResult = JSON.parse(rawJson);
-      } catch (parseErr) {
-        logger.error("评测结果 JSON 解析失败，跳过", { err: parseErr });
-        continue;
-      }
-
-      if (!judgeResult.submission_id) {
-        logger.error("评测结果缺少 submission_id，跳过");
-        continue;
-      }
-
-      logJudgeResultReceived(
-        judgeResult.submission_id,
-        judgeResult.status,
-        judgeResult.score,
-      );
-
-      try {
-        await saveEvaluationResult(judgeResult);
-        logger.info("评测结果已持久化", {
-          submission_id: judgeResult.submission_id,
-        });
-
-        // 发布事件到 Redis Pub/Sub（fire-and-forget，不阻塞）
-        // 事件仅作触发通知，前端收到后主动通过 REST 接口拉取全量数据
-        publishEvent(
-          Channels.submission(judgeResult.submission_id),
-          JSON.stringify({
-            type: "submission:updated",
-            id: judgeResult.submission_id,
-          }),
-        );
-        publishEvent(
-          Channels.queue,
-          JSON.stringify({ type: "queue:changed" }),
-        );
-      } catch (dbErr) {
-        logger.error("评测结果持久化失败", {
-          submission_id: judgeResult.submission_id,
-          err: dbErr,
-        });
-        // 不中断循环，错误仅记录日志
-      }
-    } catch (err) {
-      logger.error("结果消费者错误", { err });
-      // 短暂等待后重试，避免空转
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-  }
-}
+export const startResultConsumerWithRetry = createConsumer({
+  queueName: RESULT_QUEUE,
+  logLabel: "结果",
+  aliveRef: consumerAlive,
+  handleMessage: handleResultMessage,
+});

--- a/noj-core/src/mq/consumer.ts
+++ b/noj-core/src/mq/consumer.ts
@@ -16,7 +16,9 @@ const RESULT_QUEUE = "noj:judge:results";
  */
 export const consumerAlive = { value: false };
 
-async function handleResultMessage(data: Record<string, unknown>): Promise<void> {
+async function handleResultMessage(
+  data: Record<string, unknown>,
+): Promise<void> {
   const judgeResult = data as unknown as JudgeResult;
 
   if (!judgeResult.submission_id) {

--- a/noj-core/src/mq/started_consumer.ts
+++ b/noj-core/src/mq/started_consumer.ts
@@ -8,7 +8,9 @@ const STARTED_QUEUE = "noj:judge:started";
 
 export const startedConsumerAlive = { value: false };
 
-async function handleStartedMessage(data: Record<string, unknown>): Promise<void> {
+async function handleStartedMessage(
+  data: Record<string, unknown>,
+): Promise<void> {
   const message = data as { submission_id?: string };
 
   if (!message.submission_id) {

--- a/noj-core/src/mq/started_consumer.ts
+++ b/noj-core/src/mq/started_consumer.ts
@@ -1,112 +1,42 @@
 import { and, eq, sql } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
 import { submissions } from "../db/schema.ts";
-import { createConsumerRedis } from "./connection.ts";
+import { createConsumer } from "./base-consumer.ts";
 import { logger } from "../lib/logging.ts";
 
 const STARTED_QUEUE = "noj:judge:started";
 
-const BLPOP_TIMEOUT = 10;
+export const startedConsumerAlive = { value: false };
 
-const INITIAL_RETRY_DELAY_MS = 1_000;
-const MAX_RETRY_DELAY_MS = 30_000;
+async function handleStartedMessage(data: Record<string, unknown>): Promise<void> {
+  const message = data as { submission_id?: string };
 
-export let startedConsumerAlive = false;
-
-export async function startStartedConsumerWithRetry(): Promise<void> {
-  let retryCount = 0;
-
-  while (true) {
-    startedConsumerAlive = false;
-
-    logger.info("评测开始事件消费者正在启动...");
-
-    try {
-      await startStartedConsumer();
-    } catch (err) {
-      logger.error("评测开始事件消费者异常退出", { err });
-    }
-
-    startedConsumerAlive = false;
-
-    const delay = Math.min(
-      INITIAL_RETRY_DELAY_MS * Math.pow(2, retryCount),
-      MAX_RETRY_DELAY_MS,
-    );
-    retryCount++;
-
-    logger.warn("评测开始事件消费者将重启", {
-      delay_ms: delay,
-      retry: retryCount,
-    });
-
-    await new Promise((r) => setTimeout(r, delay));
-  }
-}
-
-async function startStartedConsumer(): Promise<void> {
-  const redis = createConsumerRedis();
-
-  try {
-    await redis.connect();
-  } catch (err) {
-    logger.error("评测开始事件消费者 Redis 连接失败", { err });
+  if (!message.submission_id) {
+    logger.error("评测开始事件缺少 submission_id，跳过");
     return;
   }
 
-  startedConsumerAlive = true;
-  logger.info("评测开始事件消费者启动，等待事件...");
+  const now = new Date().toISOString();
+  const db = getDb();
+  await db
+    .update(submissions)
+    .set({ judge_started_at: now })
+    .where(
+      and(
+        eq(submissions.id, message.submission_id),
+        sql`${submissions.judge_started_at} IS NULL`,
+      ),
+    );
 
-  while (true) {
-    try {
-      const result = await redis.brpop(
-        STARTED_QUEUE,
-        BLPOP_TIMEOUT,
-      ) as [string, string] | null;
-
-      if (!result) {
-        continue;
-      }
-
-      if (!Array.isArray(result) || result.length < 2) {
-        logger.error("评测开始事件 brpop 返回格式异常，跳过");
-        continue;
-      }
-
-      const [, rawJson] = result;
-
-      let message: { submission_id?: string };
-      try {
-        message = JSON.parse(rawJson);
-      } catch {
-        logger.error("评测开始事件 JSON 解析失败，跳过");
-        continue;
-      }
-
-      if (!message.submission_id) {
-        logger.error("评测开始事件缺少 submission_id，跳过");
-        continue;
-      }
-
-      const now = new Date().toISOString();
-      const db = getDb();
-      await db
-        .update(submissions)
-        .set({ judge_started_at: now })
-        .where(
-          and(
-            eq(submissions.id, message.submission_id),
-            sql`${submissions.judge_started_at} IS NULL`,
-          ),
-        );
-
-      logger.info("评测开始时间已更新", {
-        submission_id: message.submission_id,
-        started_at: now,
-      });
-    } catch (err) {
-      logger.error("评测开始事件消费者错误", { err });
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-  }
+  logger.info("评测开始时间已更新", {
+    submission_id: message.submission_id,
+    started_at: now,
+  });
 }
+
+export const startStartedConsumerWithRetry = createConsumer({
+  queueName: STARTED_QUEUE,
+  logLabel: "评测开始事件",
+  aliveRef: startedConsumerAlive,
+  handleMessage: handleStartedMessage,
+});

--- a/noj-core/src/routes/health.ts
+++ b/noj-core/src/routes/health.ts
@@ -16,7 +16,7 @@ health.get("/health", async (c) => {
     checkRedisHealth(),
   ]);
 
-  const consumerOk = consumerAlive;
+  const consumerOk = consumerAlive.value;
   const allOk = db.ok && redis.ok && consumerOk;
 
   // 生产环境隐藏错误详情，防止泄露内部信息

--- a/noj-core/src/services/rankings.ts
+++ b/noj-core/src/services/rankings.ts
@@ -88,7 +88,7 @@ export async function refreshRankingsView(): Promise<void> {
 }
 
 /** 测试用：清除 hasMaterializedView 缓存 */
-export function _clearHasViewCacheForTest(): void {
+export function _resetHasViewCacheForTest(): void {
   _hasViewCache = null;
 }
 

--- a/noj-core/src/types/problems.ts
+++ b/noj-core/src/types/problems.ts
@@ -42,28 +42,12 @@ export function isValidProblemType(value: string): value is ProblemType {
 }
 
 /**
- * 双容器 Runtime 配置（与 noj-judge/src/types.ts RuntimeConfig 对齐）。
+ * 双容器 Runtime 配置（与 ./index.ts RuntimeConfig 对齐）。
  *
  * 仅 admin 可设置；普通用户创建题目时该字段被忽略。
  */
-export interface RuntimeConfig {
-  evaluator: EvaluatorRuntime;
-  solution: SolutionRuntime;
-}
-
-export interface EvaluatorRuntime {
-  image: string;
-  command: string;
-  time_limit_ms: number;
-  memory_limit_mb: number;
-}
-
-export interface SolutionRuntime {
-  image: string;
-  entry: string;
-  call_timeout_ms: number;
-  memory_limit_mb: number;
-}
+import { type EvaluatorRuntime, type SolutionRuntime, type RuntimeConfig } from "./index.ts";
+export { type EvaluatorRuntime, type SolutionRuntime, type RuntimeConfig };
 
 /**
  * 创建题目请求体。

--- a/noj-core/src/types/problems.ts
+++ b/noj-core/src/types/problems.ts
@@ -46,8 +46,12 @@ export function isValidProblemType(value: string): value is ProblemType {
  *
  * 仅 admin 可设置；普通用户创建题目时该字段被忽略。
  */
-import { type EvaluatorRuntime, type SolutionRuntime, type RuntimeConfig } from "./index.ts";
-export { type EvaluatorRuntime, type SolutionRuntime, type RuntimeConfig };
+import {
+  type EvaluatorRuntime,
+  type RuntimeConfig,
+  type SolutionRuntime,
+} from "./index.ts";
+export { type EvaluatorRuntime, type RuntimeConfig, type SolutionRuntime };
 
 /**
  * 创建题目请求体。

--- a/noj-core/tests/lib/loginThrottle.test.ts
+++ b/noj-core/tests/lib/loginThrottle.test.ts
@@ -11,7 +11,7 @@
 import { assert, assertEquals } from "jsr:@std/assert@^1";
 import { checkRateLimit } from "../../src/lib/rateLimit.ts";
 import {
-  _clearLoginBackoffForTest,
+  _resetLoginBackoffForTest,
   applyLoginBackoff,
   clearLoginFailure,
   isLoginLocked,
@@ -153,7 +153,7 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
-    _clearLoginBackoffForTest();
+    _resetLoginBackoffForTest();
     const t0 = Date.now();
     await applyLoginBackoff(`nodata_${Date.now()}_${Math.random()}`);
     const elapsed = Date.now() - t0;

--- a/noj-core/tests/lib/xff-trust.test.ts
+++ b/noj-core/tests/lib/xff-trust.test.ts
@@ -114,10 +114,10 @@ Deno.test({
     // PR-7 评审修订：CIDR 支持是 K8s/Cloudflare 部署的关键
     await updateSetting("trusted_proxies", "10.0.0.0/8", "0");
     // 必须清缓存，因为 getTrustedProxyEntries 内部缓存
-    const { _clearTrustedProxyCacheForTest } = await import(
+    const { _resetTrustedProxyCacheForTest } = await import(
       "../../src/lib/rateLimitEnv.ts"
     );
-    _clearTrustedProxyCacheForTest();
+    _resetTrustedProxyCacheForTest();
 
     // XFF = "1.1.1.1, 10.0.0.5"：10.0.0.5 在 10.0.0.0/8 网段内 → 代理
     // 首个非代理 IP = "1.1.1.1"
@@ -128,7 +128,7 @@ Deno.test({
     assertEquals(body.ip, "1.1.1.1");
 
     await updateSetting("trusted_proxies", "", "0");
-    _clearTrustedProxyCacheForTest();
+    _resetTrustedProxyCacheForTest();
   },
 });
 

--- a/noj-core/tests/middleware/rate-limit.test.ts
+++ b/noj-core/tests/middleware/rate-limit.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "jsr:@std/assert@^1";
 import { initRedisForTest } from "../lib/helper.ts";
 import {
-  _resetRateLimitForTests,
+  _resetRateLimitForTest,
   rateLimit,
 } from "../../src/middleware/rate-limit.ts";
 import { optionalAuthMiddleware } from "../../src/middleware/auth.ts";
@@ -66,7 +66,7 @@ Deno.test({
   name: "rate limit: 未登录连续两次请求第二次返回 429",
   ignore: !hasEnv,
   fn: async () => {
-    _resetRateLimitForTests();
+    _resetRateLimitForTest();
     const app = createTestApp(1000, 5000);
 
     const r1 = await app.request("/limited");
@@ -86,7 +86,7 @@ Deno.test({
   name: "rate limit: 登录用户连续两次请求间隔 < 1s 返回 429",
   ignore: !hasEnv,
   fn: async () => {
-    _resetRateLimitForTests();
+    _resetRateLimitForTest();
     const app = createTestApp(1000, 5000);
     const token = await signToken({ sub: "user-test", role: "user" });
 
@@ -110,7 +110,7 @@ Deno.test({
   name: "rate limit: 不同 IP 的未登录请求互不影响",
   ignore: !hasEnv,
   fn: async () => {
-    _resetRateLimitForTests();
+    _resetRateLimitForTest();
     const app = createTestApp(1000, 5000);
 
     // IP A 请求一次
@@ -137,7 +137,7 @@ Deno.test({
   name: "rate limit: 不同登录用户互不影响",
   ignore: !hasEnv,
   fn: async () => {
-    _resetRateLimitForTests();
+    _resetRateLimitForTest();
     const app = createTestApp(1000, 5000);
     const tokenA = await signToken({ sub: "user-a", role: "user" });
     const tokenB = await signToken({ sub: "user-b", role: "user" });
@@ -155,11 +155,11 @@ Deno.test({
 });
 
 Deno.test({
-  name: "rate limit: 重复触发 _resetRateLimitForTests 不抛错",
+  name: "rate limit: 重复触发 _resetRateLimitForTest 不抛错",
   ignore: !hasEnv,
   fn: () => {
-    _resetRateLimitForTests();
-    _resetRateLimitForTests();
+    _resetRateLimitForTest();
+    _resetRateLimitForTest();
   },
 });
 
@@ -171,7 +171,7 @@ Deno.test({
   // 引入路由会触发 DB 连接；放在测试里加载避免顶层副作用
   // 此测试独立，不依赖前面的限流测试
   fn: async () => {
-    _resetRateLimitForTests();
+    _resetRateLimitForTest();
     await resetDbForTest();
     await initRedisForTest();
     const { default: router } = await import("../../src/routes/submissions.ts");
@@ -196,7 +196,7 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
-    _resetRateLimitForTests();
+    _resetRateLimitForTest();
     await resetDbForTest();
     const { default: router } = await import("../../src/routes/submissions.ts");
     const app = new Hono<Env>();
@@ -221,7 +221,7 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
-    _resetRateLimitForTests();
+    _resetRateLimitForTest();
     await resetDbForTest();
     const { default: router } = await import("../../src/routes/submissions.ts");
     const app = new Hono<Env>();
@@ -245,7 +245,7 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
-    _resetRateLimitForTests();
+    _resetRateLimitForTest();
     await resetDbForTest();
     const { default: router } = await import("../../src/routes/submissions.ts");
     const app = new Hono<Env>();

--- a/noj-core/tests/routes/auth.test.ts
+++ b/noj-core/tests/routes/auth.test.ts
@@ -696,7 +696,7 @@ Deno.test({
     const meRes2 = await jsonRequest(app, `${BASE}/me`, { token });
     assertEquals(meRes2.status, 401);
     const meBody = await meRes2.json();
-    assertEquals(meBody.error, "认证令牌已失效");
+    assertEquals(meBody.error, "认证令牌无效或已过期");
   },
 });
 

--- a/noj-core/tests/routes/auth.test.ts
+++ b/noj-core/tests/routes/auth.test.ts
@@ -4,7 +4,7 @@ import { getDb, resetDbForTest } from "../../src/db/connection.ts";
 import { passwordResetTokens, users } from "../../src/db/schema.ts";
 import { eq } from "drizzle-orm";
 import { getRedis, resetRedisForTest } from "../../src/mq/connection.ts";
-import { _clearLoginBackoffForTest } from "../../src/lib/loginThrottle.ts";
+import { _resetLoginBackoffForTest } from "../../src/lib/loginThrottle.ts";
 import {
   generateResetToken,
   hashResetToken,
@@ -578,7 +578,7 @@ Deno.test({
         const redis = getRedis();
         // 清掉账号维度的限流计数（业务上限 5 会先触发，否则无法连续 10 次失败）
         await redis.del(`ratelimit:login:acc:${user}`);
-        _clearLoginBackoffForTest();
+        _resetLoginBackoffForTest();
         const res = await jsonRequest(app, `${BASE}/login`, {
           method: "POST",
           body: {
@@ -591,7 +591,7 @@ Deno.test({
       }
 
       // 第 11 次：清掉 IP/账号限流，确保走到 lock 检查
-      _clearLoginBackoffForTest();
+      _resetLoginBackoffForTest();
       {
         const redis = getRedis();
         await redis.del(
@@ -613,7 +613,7 @@ Deno.test({
       assertEquals(body.error, "登录尝试过多，账号已临时锁定");
 
       // 清理
-      _clearLoginBackoffForTest();
+      _resetLoginBackoffForTest();
       try {
         const redis = getRedis();
         await redis.del(

--- a/noj-judge/src/dual/container.rs
+++ b/noj-judge/src/dual/container.rs
@@ -11,11 +11,14 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use bollard::container::LogOutput;
 use bollard::exec::StartExecResults;
-use bollard::models::{ContainerCreateBody, ExecConfig, HostConfig};
+use bollard::models::{ContainerCreateBody, ExecConfig};
 use bollard::Docker;
 use tokio::io::AsyncWrite;
 use tokio::time::timeout;
-use tracing::{info, warn};
+use tracing::info;
+
+use crate::sandbox::cleanup::remove_container_force;
+use crate::sandbox::host_config::build_host_config;
 
 /// `DualContainer` 持有 Evaluator + Solution 两个容器 ID。
 ///
@@ -64,15 +67,11 @@ impl DualContainer {
     pub async fn destroy(mut self) -> Result<()> {
         // 先 Solution（如果有）
         if let Some(id) = self.solution_id.take() {
-            if let Err(e) = remove_force(&self.docker, &id).await {
-                warn!("清理 Solution 容器失败 {}: {}", id, e);
-            }
+            remove_container_force(&self.docker, &id).await;
         }
         // 再 Evaluator
         if let Some(id) = self.evaluator_id.take() {
-            if let Err(e) = remove_force(&self.docker, &id).await {
-                warn!("清理 Evaluator 容器失败 {}: {}", id, e);
-            }
+            remove_container_force(&self.docker, &id).await;
         }
         Ok(())
     }
@@ -84,17 +83,13 @@ impl Drop for DualContainer {
         if let Some(id) = self.solution_id.take() {
             let docker = self.docker.clone();
             tokio::spawn(async move {
-                if let Err(e) = remove_force(&docker, &id).await {
-                    warn!("Drop 时清理 Solution 容器失败 {}: {}", id, e);
-                }
+                remove_container_force(&docker, &id).await;
             });
         }
         if let Some(id) = self.evaluator_id.take() {
             let docker = self.docker.clone();
             tokio::spawn(async move {
-                if let Err(e) = remove_force(&docker, &id).await {
-                    warn!("Drop 时清理 Evaluator 容器失败 {}: {}", id, e);
-                }
+                remove_container_force(&docker, &id).await;
             });
         }
     }
@@ -173,22 +168,9 @@ async fn create_container_with_security(
     let memory_bytes = (memory_mb as i64) * 1024 * 1024;
 
     let mut tmpfs = std::collections::HashMap::new();
-    tmpfs.insert("/tmp".to_string(), "size=256M".to_string());
+    tmpfs.insert("/tmp", "size=256M");
 
-    let host_config = HostConfig {
-        cap_drop: Some(vec!["ALL".to_string()]),
-        security_opt: Some(vec!["no-new-privileges:true".to_string()]),
-        privileged: Some(false),
-        readonly_rootfs: Some(false),
-        network_mode: Some("none".to_string()),
-        ipc_mode: Some("none".to_string()),
-        pids_limit: Some(256),
-        tmpfs: Some(tmpfs),
-        memory: Some(memory_bytes),
-        memory_swap: Some(memory_bytes),
-        memory_swappiness: Some(0),
-        ..Default::default()
-    };
+    let host_config = build_host_config(memory_bytes, tmpfs, false);
 
     let body = ContainerCreateBody {
         image: Some(image.to_string()),
@@ -217,32 +199,6 @@ async fn create_container_with_security(
     .context("启动容器失败")?;
 
     Ok(result.id)
-}
-
-async fn remove_force(docker: &Docker, container_id: &str) -> Result<()> {
-    // 3 次重试：100ms / 500ms / 2s
-    for delay_ms in [100u64, 500, 2000] {
-        match docker
-            .remove_container(
-                container_id,
-                Some(bollard::query_parameters::RemoveContainerOptions {
-                    force: true,
-                    ..Default::default()
-                }),
-            )
-            .await
-        {
-            Ok(_) => return Ok(()),
-            Err(e) => {
-                warn!(
-                    "docker rm -f {} 失败 (重试前等 {}ms): {}",
-                    container_id, delay_ms, e
-                );
-                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-            }
-        }
-    }
-    anyhow::bail!("docker rm -f {} 失败，已重试 3 次", container_id)
 }
 
 #[cfg(test)]

--- a/noj-judge/src/dual/container.rs
+++ b/noj-judge/src/dual/container.rs
@@ -15,7 +15,7 @@ use bollard::models::{ContainerCreateBody, ExecConfig};
 use bollard::Docker;
 use tokio::io::AsyncWrite;
 use tokio::time::timeout;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::sandbox::cleanup::remove_container_force;
 use crate::sandbox::host_config::build_host_config;
@@ -67,11 +67,15 @@ impl DualContainer {
     pub async fn destroy(mut self) -> Result<()> {
         // 先 Solution（如果有）
         if let Some(id) = self.solution_id.take() {
-            remove_container_force(&self.docker, &id).await;
+            if !remove_container_force(&self.docker, &id).await {
+                warn!("destroy 时清理 Solution 容器失败: {}", id);
+            }
         }
         // 再 Evaluator
         if let Some(id) = self.evaluator_id.take() {
-            remove_container_force(&self.docker, &id).await;
+            if !remove_container_force(&self.docker, &id).await {
+                warn!("destroy 时清理 Evaluator 容器失败: {}", id);
+            }
         }
         Ok(())
     }
@@ -83,13 +87,17 @@ impl Drop for DualContainer {
         if let Some(id) = self.solution_id.take() {
             let docker = self.docker.clone();
             tokio::spawn(async move {
-                remove_container_force(&docker, &id).await;
+                if !remove_container_force(&docker, &id).await {
+                    warn!("Drop 时清理 Solution 容器失败: {}", id);
+                }
             });
         }
         if let Some(id) = self.evaluator_id.take() {
             let docker = self.docker.clone();
             tokio::spawn(async move {
-                remove_container_force(&docker, &id).await;
+                if !remove_container_force(&docker, &id).await {
+                    warn!("Drop 时清理 Evaluator 容器失败: {}", id);
+                }
             });
         }
     }

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -25,7 +25,9 @@ use tracing::{error, info, warn};
 
 use crate::dual::container::{start_exec, DualContainer, ExecSession};
 use crate::dual::protocol::{frame_type, EvaluatorLine, LineParser};
-use crate::sandbox::container::parse_command;
+use crate::sandbox::container::{
+    parse_command, MAX_FILE_SIZE, MAX_TOTAL_SIZE, MAX_ZIP_ENTRIES,
+};
 use crate::types::{JudgeResult, JudgeStatus, RuntimeConfig};
 
 /// 注入用户代码到指定容器的工作目录。
@@ -45,10 +47,11 @@ async fn inject_support_package_to_evaluator(
             let cursor = std::io::Cursor::new(data);
             let mut archive = zip::ZipArchive::new(cursor).context("打开支持包 zip 文件失败")?;
 
-            if archive.len() > 1000 {
-                anyhow::bail!("zip 条目数 {} 超过上限 1000", archive.len());
+            if archive.len() > MAX_ZIP_ENTRIES {
+                anyhow::bail!("zip 条目数 {} 超过上限 {}", archive.len(), MAX_ZIP_ENTRIES);
             }
 
+            let mut seen_paths = std::collections::HashSet::new();
             let mut entries = Vec::new();
             let mut total_size: u64 = 0;
 
@@ -68,6 +71,21 @@ async fn inject_support_package_to_evaluator(
                     anyhow::bail!("zip 包含非法路径条目: {}", file_name);
                 }
 
+                // 拒绝 overlapping entries（同名路径出现两次）
+                if !seen_paths.insert(file_name.clone()) {
+                    anyhow::bail!("zip 包含重复条目: {}", file_name);
+                }
+
+                // 单文件大小限制
+                if file.size() > MAX_FILE_SIZE {
+                    anyhow::bail!(
+                        "zip 条目 '{}' 大小 {} 超过单文件上限 {}",
+                        file_name,
+                        file.size(),
+                        MAX_FILE_SIZE
+                    );
+                }
+
                 let mut content = Vec::new();
                 file.read_to_end(&mut content)
                     .context("读取 zip 条目内容失败")?;
@@ -82,8 +100,12 @@ async fn inject_support_package_to_evaluator(
 
                 total_size = total_size.saturating_add(content.len() as u64);
 
-                if total_size > 512 * 1024 * 1024 {
-                    anyhow::bail!("zip 总解压大小超过上限 512MB");
+                if total_size > MAX_TOTAL_SIZE {
+                    anyhow::bail!(
+                        "zip 总解压大小 {} 超过上限 {}",
+                        total_size,
+                        MAX_TOTAL_SIZE
+                    );
                 }
 
                 entries.push((file_name, content));
@@ -375,11 +397,7 @@ async fn run_dual_loop(
                     eval_stdout_full.push('\n');
                 }
             }
-            let full_output = if eval_stderr_buf.is_empty() {
-                eval_stdout_full.clone()
-            } else {
-                format!("{}\n--- STDERR ---\n{}", eval_stdout_full, eval_stderr_buf)
-            };
+            let full_output = crate::merge_output(&eval_stdout_full, &eval_stderr_buf);
             Ok(JudgeResult::system_error(
                 submission_id,
                 &full_output,
@@ -499,11 +517,7 @@ fn build_judge_result(
     stderr: &str,
     stdout: &str,
 ) -> JudgeResult {
-    let full_output = if stderr.is_empty() {
-        stdout.to_string()
-    } else {
-        format!("{}\n--- STDERR ---\n{}", stdout, stderr)
-    };
+    let full_output = crate::merge_output(stdout, stderr);
     let status = parsed
         .get("status")
         .and_then(Value::as_str)

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -25,9 +25,7 @@ use tracing::{error, info, warn};
 
 use crate::dual::container::{start_exec, DualContainer, ExecSession};
 use crate::dual::protocol::{frame_type, EvaluatorLine, LineParser};
-use crate::sandbox::container::{
-    parse_command, MAX_FILE_SIZE, MAX_TOTAL_SIZE, MAX_ZIP_ENTRIES,
-};
+use crate::sandbox::container::{parse_command, MAX_FILE_SIZE, MAX_TOTAL_SIZE, MAX_ZIP_ENTRIES};
 use crate::types::{JudgeResult, JudgeStatus, RuntimeConfig};
 
 /// 注入用户代码到指定容器的工作目录。
@@ -101,11 +99,7 @@ async fn inject_support_package_to_evaluator(
                 total_size = total_size.saturating_add(content.len() as u64);
 
                 if total_size > MAX_TOTAL_SIZE {
-                    anyhow::bail!(
-                        "zip 总解压大小 {} 超过上限 {}",
-                        total_size,
-                        MAX_TOTAL_SIZE
-                    );
+                    anyhow::bail!("zip 总解压大小 {} 超过上限 {}", total_size, MAX_TOTAL_SIZE);
                 }
 
                 entries.push((file_name, content));

--- a/noj-judge/src/judge/runner.rs
+++ b/noj-judge/src/judge/runner.rs
@@ -116,11 +116,7 @@ async fn fetch_and_cache_support_package(
 #[allow(dead_code)]
 pub fn process_output(task: &JudgeTask, output: &ContainerOutput) -> JudgeResult {
     let submission_id = &task.submission_id;
-    let full_output = if output.stderr.is_empty() {
-        output.stdout.clone()
-    } else {
-        format!("{}\n--- STDERR ---\n{}", output.stdout, output.stderr)
-    };
+    let full_output = crate::merge_output(&output.stdout, &output.stderr);
 
     // 超时检测（exit_code = -1）
     if output.exit_code == -1 {

--- a/noj-judge/src/lib.rs
+++ b/noj-judge/src/lib.rs
@@ -8,3 +8,14 @@ pub mod judge;
 pub mod pool;
 pub mod sandbox;
 pub mod types;
+
+/// 将 stdout 和 stderr 合并为单一输出字符串，中间以分隔符连接。
+///
+/// stderr 为空时直接返回 stdout，避免添加不必要的分隔符。
+pub fn merge_output(stdout: &str, stderr: &str) -> String {
+    if stderr.is_empty() {
+        stdout.to_string()
+    } else {
+        format!("{}\n--- STDERR ---\n{}", stdout, stderr)
+    }
+}

--- a/noj-judge/src/main.rs
+++ b/noj-judge/src/main.rs
@@ -22,13 +22,9 @@ use crate::pool::PoolManager;
 /// 将 stdout 和 stderr 合并为单一输出字符串，中间以分隔符连接。
 ///
 /// stderr 为空时直接返回 stdout，避免添加不必要的分隔符。
-pub fn merge_output(stdout: &str, stderr: &str) -> String {
-    if stderr.is_empty() {
-        stdout.to_string()
-    } else {
-        format!("{}\n--- STDERR ---\n{}", stdout, stderr)
-    }
-}
+///
+/// 实现在 lib.rs（单源，避免与集成测试的入径不同步）。
+pub use noj_judge::merge_output;
 
 /// 等待所有 in-flight 任务完成（带 30s 超时兜底）。
 ///

--- a/noj-judge/src/main.rs
+++ b/noj-judge/src/main.rs
@@ -19,6 +19,17 @@ use tracing::{error, info, warn};
 use crate::config::Config;
 use crate::pool::PoolManager;
 
+/// 将 stdout 和 stderr 合并为单一输出字符串，中间以分隔符连接。
+///
+/// stderr 为空时直接返回 stdout，避免添加不必要的分隔符。
+pub fn merge_output(stdout: &str, stderr: &str) -> String {
+    if stderr.is_empty() {
+        stdout.to_string()
+    } else {
+        format!("{}\n--- STDERR ---\n{}", stdout, stderr)
+    }
+}
+
 /// 等待所有 in-flight 任务完成（带 30s 超时兜底）。
 ///
 /// 超时后必须**显式** `abort()` 剩余 `JoinHandle`，否则：

--- a/noj-judge/src/pool/mod.rs
+++ b/noj-judge/src/pool/mod.rs
@@ -20,6 +20,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::config::PoolConfig;
+use crate::sandbox::host_config::build_host_config;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AllowedImageMode {
@@ -38,8 +39,6 @@ pub struct AllowedImage {
 
 /// 健康检查间隔（秒）。
 const HEALTH_CHECK_INTERVAL_SECS: u64 = 5;
-/// docker rm -f 重试延迟序列（毫秒）。
-const RM_F_RETRY_DELAYS: &[u64] = &[100, 500, 2000];
 
 // ── 空闲容器条目 ────────────────────────────────────────
 
@@ -482,39 +481,7 @@ impl PoolManager {
 
     /// docker rm -f（带重试）。
     async fn remove_container_force(&self, container_id: &str) {
-        for (i, delay_ms) in RM_F_RETRY_DELAYS.iter().enumerate() {
-            match self
-                .timed_bollard(10, "remove_container", async {
-                    self.docker
-                        .remove_container(
-                            container_id,
-                            Some(bollard::query_parameters::RemoveContainerOptions {
-                                force: true,
-                                ..Default::default()
-                            }),
-                        )
-                        .await
-                        .map_err(anyhow::Error::from)
-                })
-                .await
-            {
-                Ok(_) => return,
-                Err(e) => {
-                    if i < RM_F_RETRY_DELAYS.len() - 1 {
-                        warn!(
-                            "rm -f 失败 (attempt {}/{}): container={}, error={}",
-                            i + 1,
-                            RM_F_RETRY_DELAYS.len(),
-                            container_id,
-                            e
-                        );
-                        tokio::time::sleep(Duration::from_millis(*delay_ms)).await;
-                    } else {
-                        error!("rm -f 最终失败: container={}, error={}", container_id, e);
-                    }
-                }
-            }
-        }
+        crate::sandbox::cleanup::remove_container_force(&self.docker, container_id).await;
     }
 
     /// 确保镜像在本地存在。
@@ -625,30 +592,19 @@ impl PoolManager {
             None
         };
 
-        let mut tmpfs = std::collections::HashMap::new();
-        tmpfs.insert("/tmp".to_string(), "size=256M".to_string());
-
         let memory_bytes = (self.config.memory_mb as i64) * 1024 * 1024;
+
+        let mut tmpfs = std::collections::HashMap::new();
+        tmpfs.insert("/tmp", "size=256M");
+
+        let mut host_config = build_host_config(memory_bytes, tmpfs, true);
+        host_config.nano_cpus = nano_cpus;
 
         let config = bollard::models::ContainerCreateBody {
             image: Some(image.to_string()),
             cmd: Some(vec!["sleep".to_string(), "infinity".to_string()]),
             labels: Some(labels),
-            host_config: Some(bollard::models::HostConfig {
-                cap_drop: Some(vec!["ALL".to_string()]),
-                security_opt: Some(vec!["no-new-privileges:true".to_string()]),
-                privileged: Some(false),
-                readonly_rootfs: Some(true),
-                network_mode: Some("none".to_string()),
-                ipc_mode: Some("none".to_string()),
-                pids_limit: Some(256),
-                tmpfs: Some(tmpfs),
-                nano_cpus,
-                memory: Some(memory_bytes),
-                memory_swap: Some(memory_bytes),
-                memory_swappiness: Some(0),
-                ..Default::default()
-            }),
+            host_config: Some(host_config),
             ..Default::default()
         };
 
@@ -695,15 +651,7 @@ impl PoolManager {
         let docker = self.docker.clone();
         let cid = container_id.to_string();
         tokio::spawn(async move {
-            let _ = docker
-                .remove_container(
-                    &cid,
-                    Some(bollard::query_parameters::RemoveContainerOptions {
-                        force: true,
-                        ..Default::default()
-                    }),
-                )
-                .await;
+            crate::sandbox::cleanup::remove_container_force(&docker, &cid).await;
         })
     }
 

--- a/noj-judge/src/pool/mod.rs
+++ b/noj-judge/src/pool/mod.rs
@@ -20,6 +20,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::config::PoolConfig;
+use crate::sandbox::cleanup::remove_container_force;
 use crate::sandbox::host_config::build_host_config;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -951,19 +952,7 @@ impl PoolManager {
                 for c in &containers {
                     if let Some(ref id) = c.id {
                         warn!("清理孤儿容器: {}", id);
-                        let _ = with_timeout(10, "remove_container", async {
-                            docker
-                                .remove_container(
-                                    id.as_str(),
-                                    Some(bollard::query_parameters::RemoveContainerOptions {
-                                        force: true,
-                                        ..Default::default()
-                                    }),
-                                )
-                                .await
-                                .map_err(anyhow::Error::from)
-                        })
-                        .await;
+                        remove_container_force(docker, id.as_str()).await;
                     }
                 }
             }

--- a/noj-judge/src/sandbox/cleanup.rs
+++ b/noj-judge/src/sandbox/cleanup.rs
@@ -2,32 +2,67 @@
 
 use std::time::Duration;
 
+use bollard::errors::Error as BollardError;
 use bollard::query_parameters::RemoveContainerOptions;
 use bollard::Docker;
-use tracing::warn;
+use tokio::time::timeout;
+use tracing::{error, warn};
+
+/// docker rm -f 单次超时（秒）。
+const RM_F_TIMEOUT_SECS: u64 = 10;
 
 /// 强制删除 Docker 容器（带重试）。
 ///
 /// 重试策略：100ms → 500ms → 2s（共 3 次尝试）。
-/// 容器已不存在（"not found"）时立即返回，不视为错误。
-pub async fn remove_container_force(docker: &Docker, container_id: &str) {
-    for delay_ms in &[100u64, 500, 2000] {
+/// 容器已不存在（404）时立即返回，不视为错误。
+///
+/// 返回 `true` 表示容器已成功删除或本就不存在，
+/// `false` 表示所有重试均失败。
+pub async fn remove_container_force(docker: &Docker, container_id: &str) -> bool {
+    let delays = [100u64, 500, 2000];
+
+    for (i, delay_ms) in delays.iter().enumerate() {
         let options = RemoveContainerOptions {
             force: true,
             ..Default::default()
         };
-        match docker.remove_container(container_id, Some(options)).await {
-            Ok(_) => return,
-            Err(e) => {
-                if e.to_string().contains("not found") {
-                    return; // 已不存在，无需重试
-                }
+
+        let result = timeout(
+            Duration::from_secs(RM_F_TIMEOUT_SECS),
+            docker.remove_container(container_id, Some(options)),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(_)) => return true,
+            Ok(Err(BollardError::DockerResponseServerError {
+                status_code: 404, ..
+            })) => return true, // 已不存在，无需重试
+            Ok(Err(e)) => {
                 warn!(
-                    "docker rm -f 失败 (重试前等 {}ms): container={}, error={}",
-                    delay_ms, container_id, e
+                    "docker rm -f 失败 (attempt {}/{}): container={}, error={}",
+                    i + 1,
+                    delays.len(),
+                    container_id,
+                    e
+                );
+            }
+            Err(_elapsed) => {
+                warn!(
+                    "docker rm -f 超时 (attempt {}/{}): container={}",
+                    i + 1,
+                    delays.len(),
+                    container_id,
                 );
             }
         }
         tokio::time::sleep(Duration::from_millis(*delay_ms)).await;
     }
+
+    error!(
+        "docker rm -f 最终失败: container={}（已重试 {} 次）",
+        container_id,
+        delays.len(),
+    );
+    false
 }

--- a/noj-judge/src/sandbox/cleanup.rs
+++ b/noj-judge/src/sandbox/cleanup.rs
@@ -1,0 +1,33 @@
+//! 容器清理工具函数。
+
+use std::time::Duration;
+
+use bollard::query_parameters::RemoveContainerOptions;
+use bollard::Docker;
+use tracing::warn;
+
+/// 强制删除 Docker 容器（带重试）。
+///
+/// 重试策略：100ms → 500ms → 2s（共 3 次尝试）。
+/// 容器已不存在（"not found"）时立即返回，不视为错误。
+pub async fn remove_container_force(docker: &Docker, container_id: &str) {
+    for delay_ms in &[100u64, 500, 2000] {
+        let options = RemoveContainerOptions {
+            force: true,
+            ..Default::default()
+        };
+        match docker.remove_container(container_id, Some(options)).await {
+            Ok(_) => return,
+            Err(e) => {
+                if e.to_string().contains("not found") {
+                    return; // 已不存在，无需重试
+                }
+                warn!(
+                    "docker rm -f 失败 (重试前等 {}ms): container={}, error={}",
+                    delay_ms, container_id, e
+                );
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(*delay_ms)).await;
+    }
+}

--- a/noj-judge/src/sandbox/container.rs
+++ b/noj-judge/src/sandbox/container.rs
@@ -72,10 +72,11 @@ pub const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
 /// 解压炸弹防护：总解压大小（512MB）。
 pub const MAX_TOTAL_SIZE: u64 = 512 * 1024 * 1024;
 
-/// ZIP 条目：文件名 + 内容字节。
+/// ZIP 条目：文件名 + 内容字节 + 是否为目录。
 pub struct ZipEntry {
     pub file_name: String,
     pub data: Vec<u8>,
+    pub is_dir: bool,
 }
 
 /// 安全解压 ZIP 到内存，返回条目列表。
@@ -84,7 +85,6 @@ pub struct ZipEntry {
 /// - 路径穿越防护：拒绝含 `..` 或 `/` 开头的条目
 /// - 炸弹防护：1000 条目 / 64MB 单文件 / 512MB 总解压
 /// - Overlapping entries 防护：重复文件名报错
-/// - 统一换行符：将 `\r\n` 转换为 `\n`
 pub fn extract_zip_entries(data: &[u8]) -> Result<Vec<ZipEntry>> {
     let cursor = std::io::Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).context("打开 zip 文件失败")?;
@@ -102,14 +102,28 @@ pub fn extract_zip_entries(data: &[u8]) -> Result<Vec<ZipEntry>> {
     let mut seen_paths = std::collections::HashSet::new();
 
     for i in 0..archive.len() {
-        let mut file = archive.by_index(i)?;
+        let mut file = archive.by_index(i).context("读取 zip 条目失败")?;
         let original_name = file.name().to_string();
+        let is_dir = file.is_dir();
 
         // 路径穿越防护
         if original_name.split(['/', '\\']).any(|part| part == "..")
             || original_name.starts_with('/')
         {
             anyhow::bail!("ZIP 条目包含非法路径: {}", original_name);
+        }
+
+        // 目录条目：跳过文件大小校验和内容读取，直接记录
+        if is_dir {
+            if !seen_paths.insert(original_name.clone()) {
+                anyhow::bail!("ZIP 条目重复: {}", original_name);
+            }
+            entries.push(ZipEntry {
+                file_name: original_name,
+                data: Vec::new(),
+                is_dir: true,
+            });
+            continue;
         }
 
         // 单文件大小限制
@@ -127,27 +141,11 @@ pub fn extract_zip_entries(data: &[u8]) -> Result<Vec<ZipEntry>> {
             anyhow::bail!("ZIP 条目重复: {}", original_name);
         }
 
-        // 读取内容（统一换行符：将 CR+LF 转换为 LF）
+        // 读取内容
         let mut buf = Vec::with_capacity(file.size() as usize);
         file.read_to_end(&mut buf)?;
-        let normalized = if buf.contains(&b'\r') {
-            let mut result = Vec::with_capacity(buf.len());
-            let mut i = 0;
-            while i < buf.len() {
-                if i + 1 < buf.len() && buf[i] == b'\r' && buf[i + 1] == b'\n' {
-                    result.push(b'\n');
-                    i += 2;
-                } else {
-                    result.push(buf[i]);
-                    i += 1;
-                }
-            }
-            result
-        } else {
-            buf
-        };
 
-        total_size += normalized.len() as u64;
+        total_size += buf.len() as u64;
         if total_size > MAX_TOTAL_SIZE {
             anyhow::bail!(
                 "ZIP 解压总大小 {} 超过最大限制 {}",
@@ -158,7 +156,8 @@ pub fn extract_zip_entries(data: &[u8]) -> Result<Vec<ZipEntry>> {
 
         entries.push(ZipEntry {
             file_name: original_name,
-            data: normalized,
+            data: buf,
+            is_dir: false,
         });
     }
 
@@ -172,9 +171,7 @@ pub fn extract_zip_entries(data: &[u8]) -> Result<Vec<ZipEntry>> {
 fn extract_zip_sync(data: &[u8], target_dir: &Path) -> Result<()> {
     let entries = extract_zip_entries(data)?;
     for entry in &entries {
-        // extract_zip_entries 只返回文件条目，不返回目录条目，
-        // 但仍检查尾随 / 以防空文件名被 zip crate 特殊处理。
-        if entry.data.is_empty() && entry.file_name.ends_with('/') {
+        if entry.is_dir {
             let dir_path = target_dir.join(&entry.file_name);
             std::fs::create_dir_all(&dir_path)
                 .with_context(|| format!("创建目录失败: {}", dir_path.display()))?;

--- a/noj-judge/src/sandbox/container.rs
+++ b/noj-judge/src/sandbox/container.rs
@@ -72,75 +72,124 @@ pub const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
 /// 解压炸弹防护：总解压大小（512MB）。
 pub const MAX_TOTAL_SIZE: u64 = 512 * 1024 * 1024;
 
-/// 同步解压 zip 内容到目标目录。
+/// ZIP 条目：文件名 + 内容字节。
+pub struct ZipEntry {
+    pub file_name: String,
+    pub data: Vec<u8>,
+}
+
+/// 安全解压 ZIP 到内存，返回条目列表。
 ///
-/// 使用 std::fs 同步写入以避免 tokio async fs 在特定环境下可能出现的缓冲问题。
-pub fn extract_zip_sync(data: &[u8], target_dir: &Path) -> Result<()> {
+/// 安全校验（硬编码不可配置）：
+/// - 路径穿越防护：拒绝含 `..` 或 `/` 开头的条目
+/// - 炸弹防护：1000 条目 / 64MB 单文件 / 512MB 总解压
+/// - Overlapping entries 防护：重复文件名报错
+/// - 统一换行符：将 `\r\n` 转换为 `\n`
+pub fn extract_zip_entries(data: &[u8]) -> Result<Vec<ZipEntry>> {
     let cursor = std::io::Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).context("打开 zip 文件失败")?;
 
+    if archive.len() > MAX_ZIP_ENTRIES {
+        anyhow::bail!(
+            "ZIP 条目数 {} 超过最大限制 {}",
+            archive.len(),
+            MAX_ZIP_ENTRIES
+        );
+    }
+
+    let mut entries = Vec::with_capacity(archive.len());
+    let mut total_size: u64 = 0;
     let mut seen_paths = std::collections::HashSet::new();
 
-    // 解压炸弹防护：最多条目数
-    if archive.len() > MAX_ZIP_ENTRIES {
-        anyhow::bail!("zip 条目数 {} 超过上限 {}", archive.len(), MAX_ZIP_ENTRIES);
-    }
-
-    let mut total_extracted: u64 = 0;
-
     for i in 0..archive.len() {
-        let mut file = archive.by_index(i).context("读取 zip 条目失败")?;
-        let file_name = file.name().to_string();
+        let mut file = archive.by_index(i)?;
+        let original_name = file.name().to_string();
 
-        // 防止 path traversal 攻击：拒绝任何含 .. 路径组件或绝对路径的条目
-        if file_name.split(['/', '\\']).any(|part| part == "..") || file_name.starts_with('/') {
-            anyhow::bail!("zip 包含非法路径条目: {}", file_name);
+        // 路径穿越防护
+        if original_name.split(['/', '\\']).any(|part| part == "..")
+            || original_name.starts_with('/')
+        {
+            anyhow::bail!("ZIP 条目包含非法路径: {}", original_name);
         }
 
-        // 拒绝 overlapping entries（同名路径出现两次）
-        if !seen_paths.insert(file_name.clone()) {
-            anyhow::bail!("zip 包含重复条目: {}", file_name);
+        // 单文件大小限制
+        if file.size() > MAX_FILE_SIZE {
+            anyhow::bail!(
+                "ZIP 条目 {} 大小 {} 超过最大限制 {}",
+                original_name,
+                file.size(),
+                MAX_FILE_SIZE
+            );
         }
 
-        let out_path = target_dir.join(&file_name);
+        // Overlapping entries 防护
+        if !seen_paths.insert(original_name.clone()) {
+            anyhow::bail!("ZIP 条目重复: {}", original_name);
+        }
 
-        if file.is_dir() {
-            std::fs::create_dir_all(&out_path)
-                .with_context(|| format!("创建目录失败: {}", out_path.display()))?;
+        // 读取内容（统一换行符：将 CR+LF 转换为 LF）
+        let mut buf = Vec::with_capacity(file.size() as usize);
+        file.read_to_end(&mut buf)?;
+        let normalized = if buf.contains(&b'\r') {
+            let mut result = Vec::with_capacity(buf.len());
+            let mut i = 0;
+            while i < buf.len() {
+                if i + 1 < buf.len() && buf[i] == b'\r' && buf[i + 1] == b'\n' {
+                    result.push(b'\n');
+                    i += 2;
+                } else {
+                    result.push(buf[i]);
+                    i += 1;
+                }
+            }
+            result
         } else {
-            if let Some(parent) = out_path.parent() {
-                std::fs::create_dir_all(parent)
-                    .with_context(|| format!("创建父目录失败: {}", parent.display()))?;
-            }
+            buf
+        };
 
-            // 单文件大小限制
-            if file.size() > MAX_FILE_SIZE {
-                anyhow::bail!(
-                    "zip 条目 '{}' 大小 {} 超过单文件上限 {}",
-                    file_name,
-                    file.size(),
-                    MAX_FILE_SIZE
-                );
-            }
-
-            let mut buf = Vec::new();
-            file.read_to_end(&mut buf)?;
-
-            // 总解压大小限制
-            total_extracted += buf.len() as u64;
-            if total_extracted > MAX_TOTAL_SIZE {
-                anyhow::bail!(
-                    "zip 总解压大小 {} 超过上限 {}",
-                    total_extracted,
-                    MAX_TOTAL_SIZE
-                );
-            }
-
-            std::fs::write(&out_path, &buf)
-                .with_context(|| format!("写入文件失败: {}", out_path.display()))?;
+        total_size += normalized.len() as u64;
+        if total_size > MAX_TOTAL_SIZE {
+            anyhow::bail!(
+                "ZIP 解压总大小 {} 超过最大限制 {}",
+                total_size,
+                MAX_TOTAL_SIZE
+            );
         }
+
+        entries.push(ZipEntry {
+            file_name: original_name,
+            data: normalized,
+        });
     }
 
+    Ok(entries)
+}
+
+/// 同步解压 zip 内容到目标目录。
+///
+/// 使用 std::fs 同步写入以避免 tokio async fs 在特定环境下可能出现的缓冲问题。
+/// 实际 ZIP 解压和安全校验委托给 [`extract_zip_entries`]。
+fn extract_zip_sync(data: &[u8], target_dir: &Path) -> Result<()> {
+    let entries = extract_zip_entries(data)?;
+    for entry in &entries {
+        // extract_zip_entries 只返回文件条目，不返回目录条目，
+        // 但仍检查尾随 / 以防空文件名被 zip crate 特殊处理。
+        if entry.data.is_empty() && entry.file_name.ends_with('/') {
+            let dir_path = target_dir.join(&entry.file_name);
+            std::fs::create_dir_all(&dir_path)
+                .with_context(|| format!("创建目录失败: {}", dir_path.display()))?;
+            continue;
+        }
+
+        let target_path = target_dir.join(&entry.file_name);
+        // 确保父目录存在
+        if let Some(parent) = target_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("创建父目录失败: {}", parent.display()))?;
+        }
+        std::fs::write(&target_path, &entry.data)
+            .with_context(|| format!("写入文件失败: {}", target_path.display()))?;
+    }
     Ok(())
 }
 
@@ -350,7 +399,7 @@ mod tests {
         let err = rt
             .block_on(async { extract_zip(&buf.into_inner(), &target_path).await })
             .unwrap_err();
-        assert!(err.to_string().contains("非法路径条目"));
+        assert!(err.to_string().contains("非法路径"));
     }
 
     // ── TempDir ──

--- a/noj-judge/src/sandbox/container.rs
+++ b/noj-judge/src/sandbox/container.rs
@@ -66,16 +66,16 @@ use tracing::warn;
 use crate::types::JudgeTask;
 
 /// 解压炸弹防护：最大条目数。
-const MAX_ZIP_ENTRIES: usize = 1000;
+pub const MAX_ZIP_ENTRIES: usize = 1000;
 /// 解压炸弹防护：单文件最大大小（64MB）。
-const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
+pub const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
 /// 解压炸弹防护：总解压大小（512MB）。
-const MAX_TOTAL_SIZE: u64 = 512 * 1024 * 1024;
+pub const MAX_TOTAL_SIZE: u64 = 512 * 1024 * 1024;
 
 /// 同步解压 zip 内容到目标目录。
 ///
 /// 使用 std::fs 同步写入以避免 tokio async fs 在特定环境下可能出现的缓冲问题。
-fn extract_zip_sync(data: &[u8], target_dir: &Path) -> Result<()> {
+pub fn extract_zip_sync(data: &[u8], target_dir: &Path) -> Result<()> {
     let cursor = std::io::Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).context("打开 zip 文件失败")?;
 

--- a/noj-judge/src/sandbox/host_config.rs
+++ b/noj-judge/src/sandbox/host_config.rs
@@ -1,0 +1,34 @@
+use bollard::models::HostConfig;
+use std::collections::HashMap;
+
+/// Build a Docker HostConfig with standard security hardening.
+///
+/// Parameters:
+/// - `memory_bytes`: total memory limit (also applied to swap)
+/// - `tmpfs`: tmpfs mounts (e.g., `("/tmp", "size=256M")`)
+/// - `readonly_rootfs`: whether rootfs is read-only (pool containers = true, dual evaluator = false)
+pub fn build_host_config(
+    memory_bytes: i64,
+    tmpfs: HashMap<&str, &str>,
+    readonly_rootfs: bool,
+) -> HostConfig {
+    HostConfig {
+        cap_drop: Some(vec!["ALL".to_string()]),
+        security_opt: Some(vec!["no-new-privileges:true".to_string()]),
+        privileged: Some(false),
+        readonly_rootfs: Some(readonly_rootfs),
+        network_mode: Some("none".to_string()),
+        ipc_mode: Some("none".to_string()),
+        pids_limit: Some(256),
+        tmpfs: Some(
+            tmpfs
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        ),
+        memory: Some(memory_bytes),
+        memory_swap: Some(memory_bytes),
+        memory_swappiness: Some(0),
+        ..Default::default()
+    }
+}

--- a/noj-judge/src/sandbox/mod.rs
+++ b/noj-judge/src/sandbox/mod.rs
@@ -1,3 +1,5 @@
 pub mod cache;
+pub mod cleanup;
 pub mod container;
 pub mod download;
+pub mod host_config;

--- a/noj-judge/tests/common/mod.rs
+++ b/noj-judge/tests/common/mod.rs
@@ -150,11 +150,27 @@ pub async fn create_test_container(
     Ok((container.id, work_dir))
 }
 
-/// 等待容器退出并捕获输出。
+/// 等待容器执行完成并返回输出。
 ///
-/// `timeout_ms` 为超时阈值，超时返回 exit_code=-1。
+/// 内部包含 30s 全局超时，调用方无需额外包装 timeout。
 #[allow(dead_code)]
 pub async fn wait_container(
+    docker: &Docker,
+    container_id: &str,
+    poll_interval_ms: u64,
+) -> Result<ContainerOutput> {
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        wait_container_inner(docker, container_id, poll_interval_ms),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("容器执行超时（全局 30s）"))?
+    .map_err(|e| anyhow::anyhow!("等待容器失败: {}", e))?;
+    Ok(result)
+}
+
+/// 内部实现（不含外层 timeout，供 wait_container 使用）。
+async fn wait_container_inner(
     docker: &Docker,
     container_id: &str,
     timeout_ms: u64,
@@ -278,4 +294,40 @@ async fn capture_logs(docker: &Docker, container_id: &str) -> ContainerOutput {
         stderr,
         exit_code: 0,
     }
+}
+
+/// 创建 E2E 测试（自动处理 is_e2e_enabled 守卫 + 序列化执行）。
+///
+/// 宏只处理守卫和测试属性，测试体需自行声明 docker：
+///
+/// ```ignore
+/// e2e_test!(#[ignore] test_name, async {
+///     let docker = common::get_docker().expect("连接 Docker 失败");
+///     common::ensure_test_image(&docker).await.expect("确保测试镜像失败");
+///     // ... 测试逻辑
+/// });
+/// ```
+#[macro_export]
+macro_rules! e2e_test {
+    ($name:ident, async $body:block) => {
+        #[::serial_test::serial]
+        #[tokio::test]
+        async fn $name() {
+            if !$crate::common::is_e2e_enabled() {
+                return;
+            }
+            $body
+        }
+    };
+    (#[ignore] $name:ident, async $body:block) => {
+        #[ignore]
+        #[::serial_test::serial]
+        #[tokio::test]
+        async fn $name() {
+            if !$crate::common::is_e2e_enabled() {
+                return;
+            }
+            $body
+        }
+    };
 }

--- a/noj-judge/tests/e2e_container_pool.rs
+++ b/noj-judge/tests/e2e_container_pool.rs
@@ -1,12 +1,11 @@
-#![allow(unused_doc_comments)]
 // 容器池 E2E 集成测试。
-///
-/// 验证：池初始化、容器分配、docker exec 执行、内存调整、超时处理、空闲回收、安全加固。
-///
-/// 运行方式：
-/// ```bash
-/// NOJ_RUN_E2E=1 cargo test --test e2e_container_pool -- --ignored
-/// ```
+//
+// 验证：池初始化、容器分配、docker exec 执行、内存调整、超时处理、空闲回收、安全加固。
+//
+// 运行方式：
+// ```bash
+// NOJ_RUN_E2E=1 cargo test --test e2e_container_pool -- --ignored
+// ```
 mod common;
 
 use std::time::Duration;
@@ -459,7 +458,6 @@ e2e_test!(
     test_pool_with_timeout,
     async {
         let docker = get_docker().expect("连接 Docker 失败");
-        ensure_test_image(&docker).await.expect("确保测试镜像失败");
 
         // 正常的调用应通过
         let result = with_timeout(5, "ping", async {

--- a/noj-judge/tests/e2e_container_pool.rs
+++ b/noj-judge/tests/e2e_container_pool.rs
@@ -1,4 +1,5 @@
-/// 容器池 E2E 集成测试。
+#![allow(unused_doc_comments)]
+// 容器池 E2E 集成测试。
 ///
 /// 验证：池初始化、容器分配、docker exec 执行、内存调整、超时处理、空闲回收、安全加固。
 ///
@@ -14,7 +15,7 @@ use bollard::container::LogOutput;
 use bollard::models::ContainerCreateBody;
 use bollard::models::HostConfig;
 use bollard::Docker;
-use common::{get_docker, is_e2e_enabled};
+use common::{ensure_test_image, get_docker};
 
 use noj_judge::pool::exec::execute_in_container;
 use noj_judge::pool::with_timeout;
@@ -135,267 +136,119 @@ fn test_images() -> Vec<AllowedImage> {
 
 // ── Tests ──────────────────────────────────────────────
 
-/// 1. 池初始化：验证 POOL_INITIAL_SIZE 个容器已创建并运行。
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_pool_initialization() {
-    if !is_e2e_enabled() {
-        return;
+e2e_test!(
+    #[ignore]
+    test_pool_initialization,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+
+        // 初始化池管理器
+        let config = make_pool_config(2, 4);
+
+        let pool = PoolManager::init(docker.clone(), config, &test_images())
+            .await
+            .expect("PoolManager init 失败");
+
+        // 验证池中有 2 个空闲容器
+        let pools = pool.all_pools().await;
+        assert!(!pools.is_empty(), "应有至少一个镜像的池");
+        let test_pool = pools
+            .into_iter()
+            .find(|p| p.image() == "noj-judge-test-runner");
+        assert!(test_pool.is_some(), "应找到 test-runner 池");
+
+        let idle = test_pool.unwrap().idle_count().await;
+        assert_eq!(idle, 2, "启动时应有 2 个空闲容器");
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    common::ensure_test_image(&docker)
-        .await
-        .expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_pool_full_execution_path,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
 
-    // 初始化池管理器
-    let config = make_pool_config(2, 4);
+        let config = make_pool_config(1, 2);
+        let pool = PoolManager::init(docker.clone(), config, &test_images())
+            .await
+            .expect("PoolManager init 失败");
 
-    let pool = PoolManager::init(docker.clone(), config, &test_images())
-        .await
-        .expect("PoolManager init 失败");
+        // 使用 with_container 闭包 API
+        let docker_for_inspect = docker.clone();
+        let result: Result<String, anyhow::Error> = pool
+            .with_container("noj-judge-test-runner", 128, |container_id| {
+                let docker = docker_for_inspect.clone();
+                async move {
+                    // 验证容器正在运行
+                    let inspect = docker
+                        .inspect_container(
+                            &container_id,
+                            None::<bollard::query_parameters::InspectContainerOptions>,
+                        )
+                        .await
+                        .expect("inspect 失败");
+                    let running = inspect
+                        .state
+                        .as_ref()
+                        .and_then(|s| s.running)
+                        .unwrap_or(false);
+                    assert!(running, "池容器应正在运行");
 
-    // 验证池中有 2 个空闲容器
-    let pools = pool.all_pools().await;
-    assert!(!pools.is_empty(), "应有至少一个镜像的池");
-    let test_pool = pools
-        .into_iter()
-        .find(|p| p.image() == "noj-judge-test-runner");
-    assert!(test_pool.is_some(), "应找到 test-runner 池");
-
-    let idle = test_pool.unwrap().idle_count().await;
-    assert_eq!(idle, 2, "启动时应有 2 个空闲容器");
-}
-
-/// 2. 完整执行路径：with_container → docker exec → 自动清理。
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_pool_full_execution_path() {
-    if !is_e2e_enabled() {
-        return;
-    }
-
-    let docker = get_docker().expect("连接 Docker 失败");
-    common::ensure_test_image(&docker)
-        .await
-        .expect("确保测试镜像失败");
-
-    let config = make_pool_config(1, 2);
-    let pool = PoolManager::init(docker.clone(), config, &test_images())
-        .await
-        .expect("PoolManager init 失败");
-
-    // 使用 with_container 闭包 API
-    let docker_for_inspect = docker.clone();
-    let result: Result<String, anyhow::Error> = pool
-        .with_container("noj-judge-test-runner", 128, |container_id| {
-            let docker = docker_for_inspect.clone();
-            async move {
-                // 验证容器正在运行
-                let inspect = docker
-                    .inspect_container(
+                    // 通过 exec 执行简单命令
+                    let (stdout, _stderr, exit_code, _time_ms) = execute_in_container(
+                        &docker,
                         &container_id,
-                        None::<bollard::query_parameters::InspectContainerOptions>,
+                        &[
+                            "python3".to_string(),
+                            "-c".to_string(),
+                            "print('pool-exec')".to_string(),
+                        ],
+                        10000,
+                        2,
                     )
                     .await
-                    .expect("inspect 失败");
-                let running = inspect
-                    .state
-                    .as_ref()
-                    .and_then(|s| s.running)
-                    .unwrap_or(false);
-                assert!(running, "池容器应正在运行");
+                    .expect("exec 执行失败");
 
-                // 通过 exec 执行简单命令
-                let (stdout, _stderr, exit_code, _time_ms) = execute_in_container(
-                    &docker,
-                    &container_id,
-                    &[
-                        "python3".to_string(),
-                        "-c".to_string(),
-                        "print('pool-exec')".to_string(),
-                    ],
-                    10000,
-                    2,
-                )
-                .await
-                .expect("exec 执行失败");
+                    assert_eq!(exit_code, 0, "exit_code 应为 0，实际: {}", exit_code);
+                    assert!(
+                        stdout.contains("pool-exec"),
+                        "stdout 应包含 'pool-exec'，实际: {}",
+                        stdout
+                    );
 
-                assert_eq!(exit_code, 0, "exit_code 应为 0，实际: {}", exit_code);
-                assert!(
-                    stdout.contains("pool-exec"),
-                    "stdout 应包含 'pool-exec'，实际: {}",
-                    stdout
-                );
+                    Ok(container_id.clone())
+                }
+            })
+            .await;
 
-                Ok(container_id.clone())
-            }
-        })
-        .await;
+        let container_id = result.expect("with_container 失败");
 
-    let container_id = result.expect("with_container 失败");
-
-    // 验证容器已被删除（with_container 退出后自动 release → rm -f）
-    let inspect_result = docker
-        .inspect_container(
-            &container_id,
-            None::<bollard::query_parameters::InspectContainerOptions>,
-        )
-        .await;
-    assert!(inspect_result.is_err(), "容器应已被删除");
-}
-
-/// 3. 动态内存调整验证。
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_pool_memory_update() {
-    if !is_e2e_enabled() {
-        return;
+        // 验证容器已被删除（with_container 退出后自动 release → rm -f）
+        let inspect_result = docker
+            .inspect_container(
+                &container_id,
+                None::<bollard::query_parameters::InspectContainerOptions>,
+            )
+            .await;
+        assert!(inspect_result.is_err(), "容器应已被删除");
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    common::ensure_test_image(&docker)
-        .await
-        .expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_pool_memory_update,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
 
-    // 先创建容器（直接用 create_test_container_raw）
-    let container_id = create_test_container_raw(&docker, &["sleep", "infinity"], 512)
-        .await
-        .expect("创建预热容器失败");
+        // 先创建容器（直接用 create_test_container_raw）
+        let container_id = create_test_container_raw(&docker, &["sleep", "infinity"], 512)
+            .await
+            .expect("创建预热容器失败");
 
-    // 读取初始 memory 限制
-    let inspect = docker
-        .inspect_container(
-            &container_id,
-            None::<bollard::query_parameters::InspectContainerOptions>,
-        )
-        .await
-        .expect("inspect 失败");
-    let initial_memory = inspect
-        .host_config
-        .as_ref()
-        .and_then(|h| h.memory)
-        .unwrap_or(0);
-    assert_eq!(initial_memory, 512 * 1024 * 1024, "初始内存应为 512MB");
-
-    // 使用 docker update 下调到 64MB
-    docker
-        .update_container(
-            &container_id,
-            bollard::models::ContainerUpdateBody {
-                memory: Some(64 * 1024 * 1024),
-                memory_swap: Some(64 * 1024 * 1024),
-                memory_swappiness: Some(0),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("update_container 失败");
-
-    // 验证内存已更新
-    let inspect = docker
-        .inspect_container(
-            &container_id,
-            None::<bollard::query_parameters::InspectContainerOptions>,
-        )
-        .await
-        .expect("inspect 失败");
-    let updated_memory = inspect
-        .host_config
-        .as_ref()
-        .and_then(|h| h.memory)
-        .unwrap_or(0);
-    assert_eq!(updated_memory, 64 * 1024 * 1024, "更新后内存应为 64MB");
-
-    // 清理
-    docker
-        .remove_container(
-            &container_id,
-            Some(bollard::query_parameters::RemoveContainerOptions {
-                force: true,
-                ..Default::default()
-            }),
-        )
-        .await
-        .expect("清理容器失败");
-}
-
-/// 4. exec 超时处理。
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_pool_exec_timeout() {
-    if !is_e2e_enabled() {
-        return;
-    }
-
-    let docker = get_docker().expect("连接 Docker 失败");
-    common::ensure_test_image(&docker)
-        .await
-        .expect("确保测试镜像失败");
-
-    let container_id = create_test_container_raw(&docker, &["sleep", "infinity"], 256)
-        .await
-        .expect("创建容器失败");
-
-    // 执行一个长时间运行的任务，设置短超时
-    let (_stdout, _stderr, exit_code, _time_ms) = execute_in_container(
-        &docker,
-        &container_id,
-        &[
-            "python3".to_string(),
-            "-c".to_string(),
-            "import time; time.sleep(30); print('done')".to_string(),
-        ],
-        2000, // 2s 超时
-        2,
-    )
-    .await
-    .expect("exec 应返回（即使超时）");
-
-    assert_eq!(
-        exit_code, -1,
-        "超时应返回 exit_code=-1，实际: {}",
-        exit_code
-    );
-
-    // 清理
-    docker
-        .remove_container(
-            &container_id,
-            Some(bollard::query_parameters::RemoveContainerOptions {
-                force: true,
-                ..Default::default()
-            }),
-        )
-        .await
-        .expect("清理容器失败");
-}
-
-/// 5. 容器安全配置验证：CapDrop、readonly_rootfs、network_mode。
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_pool_security_config() {
-    if !is_e2e_enabled() {
-        return;
-    }
-
-    let docker = get_docker().expect("连接 Docker 失败");
-    common::ensure_test_image(&docker)
-        .await
-        .expect("确保测试镜像失败");
-
-    let config = make_pool_config(1, 2);
-    let pool = PoolManager::init(docker.clone(), config, &test_images())
-        .await
-        .expect("PoolManager init 失败");
-
-    pool.with_container("noj-judge-test-runner", 128, |container_id| async move {
-        // inspect 验证安全配置
+        // 读取初始 memory 限制
         let inspect = docker
             .inspect_container(
                 &container_id,
@@ -403,107 +256,216 @@ async fn test_pool_security_config() {
             )
             .await
             .expect("inspect 失败");
+        let initial_memory = inspect
+            .host_config
+            .as_ref()
+            .and_then(|h| h.memory)
+            .unwrap_or(0);
+        assert_eq!(initial_memory, 512 * 1024 * 1024, "初始内存应为 512MB");
 
-        let hc = inspect.host_config.as_ref().expect("应有 host_config");
+        // 使用 docker update 下调到 64MB
+        docker
+            .update_container(
+                &container_id,
+                bollard::models::ContainerUpdateBody {
+                    memory: Some(64 * 1024 * 1024),
+                    memory_swap: Some(64 * 1024 * 1024),
+                    memory_swappiness: Some(0),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("update_container 失败");
 
-        // CapDrop ALL
-        assert!(hc.cap_drop.as_ref().is_some(), "cap_drop 应被设置");
-        let caps = hc.cap_drop.as_ref().unwrap();
-        assert!(caps.iter().any(|c| c == "ALL"), "cap_drop 应包含 ALL");
+        // 验证内存已更新
+        let inspect = docker
+            .inspect_container(
+                &container_id,
+                None::<bollard::query_parameters::InspectContainerOptions>,
+            )
+            .await
+            .expect("inspect 失败");
+        let updated_memory = inspect
+            .host_config
+            .as_ref()
+            .and_then(|h| h.memory)
+            .unwrap_or(0);
+        assert_eq!(updated_memory, 64 * 1024 * 1024, "更新后内存应为 64MB");
 
-        // network_mode none
-        assert_eq!(
-            hc.network_mode.as_deref(),
-            Some("none"),
-            "network_mode 应为 none"
-        );
-
-        // readonly_rootfs
-        assert_eq!(hc.readonly_rootfs, Some(true), "readonly_rootfs 应为 true");
-
-        // pids_limit 应设为 256（DoS 防护）
-        assert_eq!(hc.pids_limit, Some(256), "pids_limit 应为 256（DoS 防护）");
-
-        // ipc_mode 应设为 none（IPC 隔离）
-        assert_eq!(
-            hc.ipc_mode.as_deref(),
-            Some("none"),
-            "ipc_mode 应为 none（IPC 隔离）"
-        );
-
-        // security_opt 应包含 no-new-privileges:true
-        let sec_opts = hc.security_opt.as_ref().expect("security_opt 应被设置");
-        assert!(
-            sec_opts.iter().any(|s| s == "no-new-privileges:true"),
-            "security_opt 应包含 no-new-privileges:true"
-        );
-
-        Ok(())
-    })
-    .await
-    .expect("with_container 失败");
-}
-
-/// 6. 并发任务：池可同时运行多个任务（即时创建补足空闲不足）。
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_pool_concurrent_tasks() {
-    if !is_e2e_enabled() {
-        return;
+        // 清理
+        docker
+            .remove_container(
+                &container_id,
+                Some(bollard::query_parameters::RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .expect("清理容器失败");
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    common::ensure_test_image(&docker)
+e2e_test!(
+    #[ignore]
+    test_pool_exec_timeout,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+
+        let container_id = create_test_container_raw(&docker, &["sleep", "infinity"], 256)
+            .await
+            .expect("创建容器失败");
+
+        // 执行一个长时间运行的任务，设置短超时
+        let (_stdout, _stderr, exit_code, _time_ms) = execute_in_container(
+            &docker,
+            &container_id,
+            &[
+                "python3".to_string(),
+                "-c".to_string(),
+                "import time; time.sleep(30); print('done')".to_string(),
+            ],
+            2000, // 2s 超时
+            2,
+        )
         .await
-        .expect("确保测试镜像失败");
+        .expect("exec 应返回（即使超时）");
 
-    let config = make_pool_config(1, 2); // 初始 1 个空闲，最大 2
-    let pool = PoolManager::init(docker.clone(), config, &test_images())
-        .await
-        .expect("PoolManager init 失败");
+        assert_eq!(
+            exit_code, -1,
+            "超时应返回 exit_code=-1，实际: {}",
+            exit_code
+        );
 
-    // 并发运行 2 个任务（第 2 个需即时创建容器）
-    let pool1 = pool.clone();
-    let pool2 = pool.clone();
-    let (r1, r2) = tokio::join!(
-        tokio::spawn(async move {
-            pool1
-                .with_container("noj-judge-test-runner", 128, |_id| async move {
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-                    Ok::<_, anyhow::Error>("done".to_string())
-                })
-                .await
-        }),
-        tokio::spawn(async move {
-            pool2
-                .with_container("noj-judge-test-runner", 128, |_id| async move {
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-                    Ok::<_, anyhow::Error>("done".to_string())
-                })
-                .await
-        }),
-    );
-
-    assert!(r1.unwrap().is_ok(), "任务 1 应成功");
-    assert!(r2.unwrap().is_ok(), "任务 2 应成功（即时创建容器）");
-}
-
-/// 7. 带超时的 bollard API 调用测试。
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_pool_with_timeout() {
-    if !is_e2e_enabled() {
-        return;
+        // 清理
+        docker
+            .remove_container(
+                &container_id,
+                Some(bollard::query_parameters::RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .expect("清理容器失败");
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
+e2e_test!(
+    #[ignore]
+    test_pool_security_config,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
 
-    // 正常的调用应通过
-    let result = with_timeout(5, "ping", async {
-        docker.ping().await.map_err(anyhow::Error::from)
-    })
-    .await;
-    assert!(result.is_ok(), "docker ping 应在 5s 内完成");
-}
+        let config = make_pool_config(1, 2);
+        let pool = PoolManager::init(docker.clone(), config, &test_images())
+            .await
+            .expect("PoolManager init 失败");
+
+        pool.with_container("noj-judge-test-runner", 128, |container_id| async move {
+            // inspect 验证安全配置
+            let inspect = docker
+                .inspect_container(
+                    &container_id,
+                    None::<bollard::query_parameters::InspectContainerOptions>,
+                )
+                .await
+                .expect("inspect 失败");
+
+            let hc = inspect.host_config.as_ref().expect("应有 host_config");
+
+            // CapDrop ALL
+            assert!(hc.cap_drop.as_ref().is_some(), "cap_drop 应被设置");
+            let caps = hc.cap_drop.as_ref().unwrap();
+            assert!(caps.iter().any(|c| c == "ALL"), "cap_drop 应包含 ALL");
+
+            // network_mode none
+            assert_eq!(
+                hc.network_mode.as_deref(),
+                Some("none"),
+                "network_mode 应为 none"
+            );
+
+            // readonly_rootfs
+            assert_eq!(hc.readonly_rootfs, Some(true), "readonly_rootfs 应为 true");
+
+            // pids_limit 应设为 256（DoS 防护）
+            assert_eq!(hc.pids_limit, Some(256), "pids_limit 应为 256（DoS 防护）");
+
+            // ipc_mode 应设为 none（IPC 隔离）
+            assert_eq!(
+                hc.ipc_mode.as_deref(),
+                Some("none"),
+                "ipc_mode 应为 none（IPC 隔离）"
+            );
+
+            // security_opt 应包含 no-new-privileges:true
+            let sec_opts = hc.security_opt.as_ref().expect("security_opt 应被设置");
+            assert!(
+                sec_opts.iter().any(|s| s == "no-new-privileges:true"),
+                "security_opt 应包含 no-new-privileges:true"
+            );
+
+            Ok(())
+        })
+        .await
+        .expect("with_container 失败");
+    }
+);
+
+e2e_test!(
+    #[ignore]
+    test_pool_concurrent_tasks,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+
+        let config = make_pool_config(1, 2); // 初始 1 个空闲，最大 2
+        let pool = PoolManager::init(docker.clone(), config, &test_images())
+            .await
+            .expect("PoolManager init 失败");
+
+        // 并发运行 2 个任务（第 2 个需即时创建容器）
+        let pool1 = pool.clone();
+        let pool2 = pool.clone();
+        let (r1, r2) = tokio::join!(
+            tokio::spawn(async move {
+                pool1
+                    .with_container("noj-judge-test-runner", 128, |_id| async move {
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        Ok::<_, anyhow::Error>("done".to_string())
+                    })
+                    .await
+            }),
+            tokio::spawn(async move {
+                pool2
+                    .with_container("noj-judge-test-runner", 128, |_id| async move {
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        Ok::<_, anyhow::Error>("done".to_string())
+                    })
+                    .await
+            }),
+        );
+
+        assert!(r1.unwrap().is_ok(), "任务 1 应成功");
+        assert!(r2.unwrap().is_ok(), "任务 2 应成功（即时创建容器）");
+    }
+);
+
+e2e_test!(
+    #[ignore]
+    test_pool_with_timeout,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+
+        // 正常的调用应通过
+        let result = with_timeout(5, "ping", async {
+            docker.ping().await.map_err(anyhow::Error::from)
+        })
+        .await;
+        assert!(result.is_ok(), "docker ping 应在 5s 内完成");
+    }
+);

--- a/noj-judge/tests/e2e_docker_basic.rs
+++ b/noj-judge/tests/e2e_docker_basic.rs
@@ -1,130 +1,102 @@
-/// Docker 容器生命周期集成测试。
+#![allow(unused_doc_comments)]
+// Docker 容器生命周期集成测试。
 ///
 /// 验证：创建 → 启动 → 执行 Python 代码 → 等待退出 → 日志捕获 → 容器清理。
 mod common;
-use common::{
-    create_test_container, ensure_test_image, get_docker, is_e2e_enabled, wait_container,
-};
+use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 
-/// 容器完整生命周期测试
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_container_lifecycle() {
-    if !is_e2e_enabled() {
-        return;
+e2e_test!(
+    #[ignore]
+    test_container_lifecycle,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "-c", "print(42)"],
+            256,
+            10000,
+        )
+        .await
+        .expect("创建容器失败");
+
+        let output = wait_container(&docker, &container_id, 10000)
+            .await
+            .expect("等待容器失败");
+
+        assert_eq!(
+            output.exit_code, 0,
+            "预期退出码 0，实际 {}",
+            output.exit_code
+        );
+        assert!(
+            output.stdout.contains("42"),
+            "stdout 应包含 '42'，实际: {}",
+            output.stdout
+        );
+
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_container_non_zero_exit,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "-c", "exit(42)"],
+            256,
+            10000,
+        )
+        .await
+        .expect("创建容器失败");
 
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "-c", "print(42)"],
-        256,
-        10000,
-    )
-    .await
-    .expect("创建容器失败");
+        let output = wait_container(&docker, &container_id, 10000)
+            .await
+            .expect("等待容器失败");
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 10000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(
-        output.exit_code, 0,
-        "预期退出码 0，实际 {}",
-        output.exit_code
-    );
-    assert!(
-        output.stdout.contains("42"),
-        "stdout 应包含 '42'，实际: {}",
-        output.stdout
-    );
-
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
-
-/// 非零退出码测试
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_container_non_zero_exit() {
-    if !is_e2e_enabled() {
-        return;
+        assert_eq!(
+            output.exit_code, 42,
+            "预期退出码 42，实际 {}",
+            output.exit_code
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_container_stdout_and_stderr,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let code = "import sys; print('stdout msg'); print('stderr msg', file=sys.stderr)";
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "-c", code],
+            256,
+            10000,
+        )
+        .await
+        .expect("创建容器失败");
 
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "-c", "exit(42)"],
-        256,
-        10000,
-    )
-    .await
-    .expect("创建容器失败");
+        let output = wait_container(&docker, &container_id, 10000)
+            .await
+            .expect("等待容器失败");
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 10000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(
-        output.exit_code, 42,
-        "预期退出码 42，实际 {}",
-        output.exit_code
-    );
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
-
-/// stdout 和 stderr 同时捕获测试
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_container_stdout_and_stderr() {
-    if !is_e2e_enabled() {
-        return;
+        assert_eq!(output.exit_code, 0);
+        assert!(
+            output.stdout.contains("stdout msg"),
+            "stdout 应包含 'stdout msg'"
+        );
+        let all_output = format!("{} {}", output.stdout, output.stderr);
+        assert!(all_output.contains("stderr msg"), "输出应包含 'stderr msg'");
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
-
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
-
-    let code = "import sys; print('stdout msg'); print('stderr msg', file=sys.stderr)";
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "-c", code],
-        256,
-        10000,
-    )
-    .await
-    .expect("创建容器失败");
-
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 10000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(output.exit_code, 0);
-    assert!(
-        output.stdout.contains("stdout msg"),
-        "stdout 应包含 'stdout msg'"
-    );
-    let all_output = format!("{} {}", output.stdout, output.stderr);
-    assert!(all_output.contains("stderr msg"), "输出应包含 'stderr msg'");
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
+);

--- a/noj-judge/tests/e2e_docker_basic.rs
+++ b/noj-judge/tests/e2e_docker_basic.rs
@@ -1,7 +1,6 @@
-#![allow(unused_doc_comments)]
 // Docker 容器生命周期集成测试。
-///
-/// 验证：创建 → 启动 → 执行 Python 代码 → 等待退出 → 日志捕获 → 容器清理。
+//
+// 验证：创建 → 启动 → 执行 Python 代码 → 等待退出 → 日志捕获 → 容器清理。
 mod common;
 use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 

--- a/noj-judge/tests/e2e_problem_limits.rs
+++ b/noj-judge/tests/e2e_problem_limits.rs
@@ -1,4 +1,5 @@
-/// 题目资源限制集成测试。
+#![allow(unused_doc_comments)]
+// 题目资源限制集成测试。
 ///
 /// 验证题目的 time_limit_ms 和 memory_limit_mb 实际约束了 Docker 容器执行。
 ///
@@ -7,125 +8,96 @@
 /// NOJ_RUN_E2E=1 cargo test --test e2e_problem_limits -- --ignored
 /// ```
 mod common;
-use common::{
-    create_test_container, ensure_test_image, get_docker, is_e2e_enabled, wait_container,
-};
+use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 
-/// 超时限制测试：短超时应 kill 长时间 sleep
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_problem_time_limit_enforced() {
-    if !is_e2e_enabled() {
-        return;
+e2e_test!(
+    #[ignore]
+    test_problem_time_limit_enforced,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &[
+                "python3",
+                "-c",
+                "import time; time.sleep(10); print('never')",
+            ],
+            256,
+            500, // time_limit_ms = 500ms
+        )
+        .await
+        .expect("创建容器失败");
+
+        let output = wait_container(&docker, &container_id, 500)
+            .await
+            .expect("等待容器失败");
+
+        assert_eq!(
+            output.exit_code, -1,
+            "超时应返回 exit_code=-1，实际 {}",
+            output.exit_code
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_problem_memory_limit_enforced,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "/evaluate.py", "--memory-test"],
+            50, // memory_limit_mb = 50MB
+            15000,
+        )
+        .await
+        .expect("创建容器失败");
 
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &[
-            "python3",
-            "-c",
-            "import time; time.sleep(10); print('never')",
-        ],
-        256,
-        500, // time_limit_ms = 500ms
-    )
-    .await
-    .expect("创建容器失败");
+        let output = wait_container(&docker, &container_id, 15000)
+            .await
+            .expect("等待容器失败");
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 500),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(
-        output.exit_code, -1,
-        "超时应返回 exit_code=-1，实际 {}",
-        output.exit_code
-    );
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
-
-/// 内存限制测试：低内存限制下 OOM 应被触发
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_problem_memory_limit_enforced() {
-    if !is_e2e_enabled() {
-        return;
+        // OOM kill 退出码 137 = 128 + SIGKILL(9)
+        assert!(
+            output.exit_code == 137 || output.exit_code == -1,
+            "OOM 预期退出码 137（或超时 -1），实际 {}",
+            output.exit_code
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_limits_not_exceeded,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "-c", "print('done within limits')"],
+            256,
+            10000,
+        )
+        .await
+        .expect("创建容器失败");
 
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "/evaluate.py", "--memory-test"],
-        50, // memory_limit_mb = 50MB
-        15000,
-    )
-    .await
-    .expect("创建容器失败");
+        let output = wait_container(&docker, &container_id, 10000)
+            .await
+            .expect("等待容器失败");
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 15000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    // OOM kill 退出码 137 = 128 + SIGKILL(9)
-    assert!(
-        output.exit_code == 137 || output.exit_code == -1,
-        "OOM 预期退出码 137（或超时 -1），实际 {}",
-        output.exit_code
-    );
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
-
-/// 宽松限制下正常任务应完成
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_limits_not_exceeded() {
-    if !is_e2e_enabled() {
-        return;
+        assert_eq!(output.exit_code, 0, "应正常退出");
+        assert!(
+            output.stdout.contains("done within limits"),
+            "stdout 应包含预期输出"
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
-
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
-
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "-c", "print('done within limits')"],
-        256,
-        10000,
-    )
-    .await
-    .expect("创建容器失败");
-
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 10000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(output.exit_code, 0, "应正常退出");
-    assert!(
-        output.stdout.contains("done within limits"),
-        "stdout 应包含预期输出"
-    );
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
+);

--- a/noj-judge/tests/e2e_problem_limits.rs
+++ b/noj-judge/tests/e2e_problem_limits.rs
@@ -1,12 +1,11 @@
-#![allow(unused_doc_comments)]
 // 题目资源限制集成测试。
-///
-/// 验证题目的 time_limit_ms 和 memory_limit_mb 实际约束了 Docker 容器执行。
-///
-/// 运行方式：
-/// ```bash
-/// NOJ_RUN_E2E=1 cargo test --test e2e_problem_limits -- --ignored
-/// ```
+//
+// 验证题目的 time_limit_ms 和 memory_limit_mb 实际约束了 Docker 容器执行。
+//
+// 运行方式：
+// ```bash
+// NOJ_RUN_E2E=1 cargo test --test e2e_problem_limits -- --ignored
+// ```
 mod common;
 use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 

--- a/noj-judge/tests/e2e_resource_limits.rs
+++ b/noj-judge/tests/e2e_resource_limits.rs
@@ -1,7 +1,6 @@
-#![allow(unused_doc_comments)]
 // Docker 资源限制集成测试。
-///
-/// 验证：超时 kill、OOM 限制、正常内存使用。
+//
+// 验证：超时 kill、OOM 限制、正常内存使用。
 mod common;
 use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 

--- a/noj-judge/tests/e2e_resource_limits.rs
+++ b/noj-judge/tests/e2e_resource_limits.rs
@@ -1,158 +1,121 @@
-/// Docker 资源限制集成测试。
+#![allow(unused_doc_comments)]
+// Docker 资源限制集成测试。
 ///
 /// 验证：超时 kill、OOM 限制、正常内存使用。
 mod common;
-use common::{
-    create_test_container, ensure_test_image, get_docker, is_e2e_enabled, wait_container,
-};
+use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 
-/// 超时 kill 测试：--hang 配合 3s 超时应触发 kill
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_timeout_kill() {
-    if !is_e2e_enabled() {
-        return;
+e2e_test!(
+    #[ignore]
+    test_timeout_kill,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "/evaluate.py", "--hang"],
+            256,
+            3000,
+        )
+        .await
+        .expect("创建容器失败");
+
+        let output = wait_container(&docker, &container_id, 3000)
+            .await
+            .expect("等待容器失败");
+
+        assert_eq!(
+            output.exit_code, -1,
+            "超时应返回 exit_code=-1，实际 {}",
+            output.exit_code
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_normal_execution_no_timeout,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "-c", "print('fast')"],
+            256,
+            30000,
+        )
+        .await
+        .expect("创建容器失败");
 
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "/evaluate.py", "--hang"],
-        256,
-        3000,
-    )
-    .await
-    .expect("创建容器失败");
+        let output = wait_container(&docker, &container_id, 30000)
+            .await
+            .expect("等待容器失败");
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 3000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(
-        output.exit_code, -1,
-        "超时应返回 exit_code=-1，实际 {}",
-        output.exit_code
-    );
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
-
-/// 正常执行不应超时
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_normal_execution_no_timeout() {
-    if !is_e2e_enabled() {
-        return;
+        assert_eq!(
+            output.exit_code, 0,
+            "正常退出预期 0，实际 {}",
+            output.exit_code
+        );
+        assert!(output.stdout.contains("fast"));
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_oom_kill,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "/evaluate.py", "--memory-test"],
+            50,
+            15000,
+        )
+        .await
+        .expect("创建容器失败");
 
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "-c", "print('fast')"],
-        256,
-        30000,
-    )
-    .await
-    .expect("创建容器失败");
+        let output = wait_container(&docker, &container_id, 15000)
+            .await
+            .expect("等待容器失败");
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 30000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(
-        output.exit_code, 0,
-        "正常退出预期 0，实际 {}",
-        output.exit_code
-    );
-    assert!(output.stdout.contains("fast"));
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
-
-/// OOM kill 测试：--memory-test 在 50MB 限制下触发 OOM
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_oom_kill() {
-    if !is_e2e_enabled() {
-        return;
+        // OOM kill 退出码 137 = 128 + SIGKILL(9)
+        assert!(
+            output.exit_code == 137 || output.exit_code == -1,
+            "OOM 预期退出码 137（或超时 -1），实际 {}",
+            output.exit_code
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_memory_within_limits,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "-c", "data = [0] * 100000; print(len(data))"],
+            256,
+            10000,
+        )
+        .await
+        .expect("创建容器失败");
 
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "/evaluate.py", "--memory-test"],
-        50,
-        15000,
-    )
-    .await
-    .expect("创建容器失败");
+        let output = wait_container(&docker, &container_id, 10000)
+            .await
+            .expect("等待容器失败");
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 15000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    // OOM kill 退出码 137 = 128 + SIGKILL(9)
-    assert!(
-        output.exit_code == 137 || output.exit_code == -1,
-        "OOM 预期退出码 137（或超时 -1），实际 {}",
-        output.exit_code
-    );
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
-
-/// 正常内存使用不应触发 OOM
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_memory_within_limits() {
-    if !is_e2e_enabled() {
-        return;
+        assert_eq!(output.exit_code, 0);
+        assert!(output.stdout.contains("100000"));
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
-
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
-
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "-c", "data = [0] * 100000; print(len(data))"],
-        256,
-        10000,
-    )
-    .await
-    .expect("创建容器失败");
-
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 10000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(output.exit_code, 0);
-    assert!(output.stdout.contains("100000"));
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
+);

--- a/noj-judge/tests/e2e_security_isolation.rs
+++ b/noj-judge/tests/e2e_security_isolation.rs
@@ -1,89 +1,71 @@
-/// Docker 安全隔离集成测试。
+#![allow(unused_doc_comments)]
+// Docker 安全隔离集成测试。
 ///
 /// 验证：NetworkMode=none 阻断网络、敏感路径不可访问。
 mod common;
-use common::{
-    create_test_container, ensure_test_image, get_docker, is_e2e_enabled, wait_container,
-};
+use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 
-/// 网络隔离测试：NetworkMode=none 下网络请求应失败
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_network_isolation() {
-    if !is_e2e_enabled() {
-        return;
+e2e_test!(
+    #[ignore]
+    test_network_isolation,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let code =
+            "import urllib.request; urllib.request.urlopen('https://example.com', timeout=5)";
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "-c", code],
+            256,
+            15000,
+        )
+        .await
+        .expect("创建容器失败");
+
+        let output = wait_container(&docker, &container_id, 15000)
+            .await
+            .expect("等待容器失败");
+
+        // 网络请求应被阻断，退出码非 0
+        assert_ne!(output.exit_code, 0, "网络隔离测试：请求应失败但退出了码 0");
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
-
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
-
-    let code = "import urllib.request; urllib.request.urlopen('https://example.com', timeout=5)";
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "-c", code],
-        256,
-        15000,
-    )
-    .await
-    .expect("创建容器失败");
-
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 15000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    // 网络请求应被阻断，退出码非 0
-    assert_ne!(output.exit_code, 0, "网络隔离测试：请求应失败但退出了码 0");
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
+);
 
 /// 敏感路径不可访问测试。
 ///
 /// 验证容器内无法访问宿主机敏感路径。
 /// 注意：/etc/passwd 和 /proc/* 在正常 Docker 容器中天然存在
 ///（分别来自镜像和 /proc 挂载），不代表宿主机路径泄漏。
-/// 此处仅检查确实不应存在的路径（Docker socket、宿主机数据目录等）。
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_container_no_sensitive_mounts() {
-    if !is_e2e_enabled() {
-        return;
+e2e_test!(
+    #[ignore]
+    test_container_no_sensitive_mounts,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        // 仅检查那些在正常容器中不应存在的敏感路径
+        let code = r#"import os; paths=['/var/run/docker.sock','/host','/var/lib/docker']; [print(p) for p in paths if os.path.exists(p)]"#;
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "-c", code],
+            256,
+            10000,
+        )
+        .await
+        .expect("创建容器失败");
+
+        let output = wait_container(&docker, &container_id, 10000)
+            .await
+            .expect("等待容器失败");
+
+        assert_eq!(output.exit_code, 0, "敏感路径检查应正常退出");
+        assert!(
+            output.stdout.trim().is_empty(),
+            "不应发现宿主机敏感路径，但找到了: {}",
+            output.stdout
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
-
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
-
-    // 仅检查那些在正常容器中不应存在的敏感路径
-    let code = r#"import os; paths=['/var/run/docker.sock','/host','/var/lib/docker']; [print(p) for p in paths if os.path.exists(p)]"#;
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "-c", code],
-        256,
-        10000,
-    )
-    .await
-    .expect("创建容器失败");
-
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 10000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(output.exit_code, 0, "敏感路径检查应正常退出");
-    assert!(
-        output.stdout.trim().is_empty(),
-        "不应发现宿主机敏感路径，但找到了: {}",
-        output.stdout
-    );
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
+);

--- a/noj-judge/tests/e2e_security_isolation.rs
+++ b/noj-judge/tests/e2e_security_isolation.rs
@@ -1,7 +1,6 @@
-#![allow(unused_doc_comments)]
 // Docker 安全隔离集成测试。
-///
-/// 验证：NetworkMode=none 阻断网络、敏感路径不可访问。
+//
+// 验证：NetworkMode=none 阻断网络、敏感路径不可访问。
 mod common;
 use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 
@@ -33,11 +32,11 @@ e2e_test!(
     }
 );
 
-/// 敏感路径不可访问测试。
-///
-/// 验证容器内无法访问宿主机敏感路径。
-/// 注意：/etc/passwd 和 /proc/* 在正常 Docker 容器中天然存在
-///（分别来自镜像和 /proc 挂载），不代表宿主机路径泄漏。
+// 敏感路径不可访问测试。
+//
+// 验证容器内无法访问宿主机敏感路径。
+// 注意：/etc/passwd 和 /proc/* 在正常 Docker 容器中天然存在
+//（分别来自镜像和 /proc 挂载），不代表宿主机路径泄漏。
 e2e_test!(
     #[ignore]
     test_container_no_sensitive_mounts,

--- a/noj-judge/tests/e2e_support_package.rs
+++ b/noj-judge/tests/e2e_support_package.rs
@@ -1,7 +1,6 @@
-#![allow(unused_doc_comments)]
 // 支持包与评测流程集成测试。
-///
-/// 验证：evaluate.py 执行、---RESULT--- 标记输出、无支持包场景、无标记场景。
+//
+// 验证：evaluate.py 执行、---RESULT--- 标记输出、无支持包场景、无标记场景。
 mod common;
 use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 

--- a/noj-judge/tests/e2e_support_package.rs
+++ b/noj-judge/tests/e2e_support_package.rs
@@ -1,132 +1,104 @@
-/// 支持包与评测流程集成测试。
+#![allow(unused_doc_comments)]
+// 支持包与评测流程集成测试。
 ///
 /// 验证：evaluate.py 执行、---RESULT--- 标记输出、无支持包场景、无标记场景。
 mod common;
-use common::{
-    create_test_container, ensure_test_image, get_docker, is_e2e_enabled, wait_container,
-};
+use common::{create_test_container, ensure_test_image, get_docker, wait_container};
 
-/// 完整评测流程：evaluate.py + ---RESULT--- 标记
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_evaluation_with_support_package() {
-    if !is_e2e_enabled() {
-        return;
+e2e_test!(
+    #[ignore]
+    test_evaluation_with_support_package,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &[
+                "python3",
+                "/evaluate.py",
+                "--result-json",
+                r#"{"status":"Accepted","score":1000,"details":{}}"#,
+            ],
+            256,
+            10000,
+        )
+        .await
+        .expect("创建容器失败");
+
+        let output = wait_container(&docker, &container_id, 10000)
+            .await
+            .expect("等待容器失败");
+
+        assert_eq!(
+            output.exit_code, 0,
+            "预期退出码 0，实际 {}",
+            output.exit_code
+        );
+        assert!(
+            output.stdout.contains("---RESULT---"),
+            "stdout 应包含 ---RESULT--- 标记"
+        );
+        assert!(
+            output.stdout.contains("Accepted"),
+            "stdout 应包含 'Accepted'"
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_no_support_package,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "-c", "print('no support package needed')"],
+            256,
+            10000,
+        )
+        .await
+        .expect("创建容器失败");
 
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &[
-            "python3",
-            "/evaluate.py",
-            "--result-json",
-            r#"{"status":"Accepted","score":1000,"details":{}}"#,
-        ],
-        256,
-        10000,
-    )
-    .await
-    .expect("创建容器失败");
+        let output = wait_container(&docker, &container_id, 10000)
+            .await
+            .expect("等待容器失败");
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 10000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(
-        output.exit_code, 0,
-        "预期退出码 0，实际 {}",
-        output.exit_code
-    );
-    assert!(
-        output.stdout.contains("---RESULT---"),
-        "stdout 应包含 ---RESULT--- 标记"
-    );
-    assert!(
-        output.stdout.contains("Accepted"),
-        "stdout 应包含 'Accepted'"
-    );
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
-
-/// 无支持包时评测不应崩溃
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_no_support_package() {
-    if !is_e2e_enabled() {
-        return;
+        assert_eq!(output.exit_code, 0);
+        assert!(output.stdout.contains("no support package needed"));
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
+);
 
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
+e2e_test!(
+    #[ignore]
+    test_no_result_marker_exit_0,
+    async {
+        let docker = get_docker().expect("连接 Docker 失败");
+        ensure_test_image(&docker).await.expect("确保测试镜像失败");
+        let (container_id, work_dir) = create_test_container(
+            &docker,
+            "noj-judge-test-runner",
+            &["python3", "/evaluate.py", "--no-result"],
+            256,
+            10000,
+        )
+        .await
+        .expect("创建容器失败");
 
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "-c", "print('no support package needed')"],
-        256,
-        10000,
-    )
-    .await
-    .expect("创建容器失败");
+        let output = wait_container(&docker, &container_id, 10000)
+            .await
+            .expect("等待容器失败");
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 10000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    assert_eq!(output.exit_code, 0);
-    assert!(output.stdout.contains("no support package needed"));
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
-
-/// 无 ---RESULT--- 标记但正常退出
-#[ignore]
-#[serial_test::serial]
-#[tokio::test]
-async fn test_no_result_marker_exit_0() {
-    if !is_e2e_enabled() {
-        return;
+        // exit_code == 0 但无标记 → 对应 SystemError 场景
+        assert_eq!(output.exit_code, 0);
+        assert!(
+            !output.stdout.contains("---RESULT---"),
+            "不应包含 ---RESULT--- 标记"
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
     }
-
-    let docker = get_docker().expect("连接 Docker 失败");
-    ensure_test_image(&docker).await.expect("确保测试镜像失败");
-
-    let (container_id, work_dir) = create_test_container(
-        &docker,
-        "noj-judge-test-runner",
-        &["python3", "/evaluate.py", "--no-result"],
-        256,
-        10000,
-    )
-    .await
-    .expect("创建容器失败");
-
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        wait_container(&docker, &container_id, 10000),
-    )
-    .await
-    .expect("容器执行超时")
-    .expect("等待容器失败");
-
-    // exit_code == 0 但无标记 → 对应 SystemError 场景
-    assert_eq!(output.exit_code, 0);
-    assert!(
-        !output.stdout.contains("---RESULT---"),
-        "不应包含 ---RESULT--- 标记"
-    );
-    let _ = std::fs::remove_dir_all(&work_dir);
-}
+);

--- a/noj-ui/components/admin/PageHeader.vue
+++ b/noj-ui/components/admin/PageHeader.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+interface Props {
+  title: string
+  description?: string
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  <div class="flex items-start justify-between gap-3">
+    <div class="flex flex-col gap-1">
+      <h1 class="text-[22px] font-bold text-text">{{ title }}</h1>
+      <p v-if="description" class="text-sm text-text-secondary">{{ description }}</p>
+    </div>
+    <slot name="actions" />
+  </div>
+</template>

--- a/noj-ui/components/auth/AuthFormCard.vue
+++ b/noj-ui/components/auth/AuthFormCard.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="w-full max-w-[380px] relative">
+    <!-- Error banner -->
+    <Transition name="slide">
+      <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
+        <span>{{ error }}</span>
+        <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="$emit('clear-error')">&#10005;</button>
+      </div>
+    </Transition>
+
+    <!-- Success banner slot -->
+    <slot name="banner-success" />
+
+    <!-- Info banner slot (e.g. banned account message) -->
+    <slot name="banner-info" />
+
+    <div class="bg-white border border-border rounded-lg p-8">
+      <h1 class="text-[22px] font-bold text-center mb-3 text-text animate-[fadeInUp_0.5s_ease_both]">{{ title }}</h1>
+      <p v-if="subtitle" class="text-center text-sm text-text-secondary mb-6 animate-[fadeInUp_0.5s_ease_0.05s_both]">{{ subtitle }}</p>
+
+      <form @submit.prevent="$emit('submit')">
+        <slot />
+
+        <button
+          type="submit"
+          :disabled="loading"
+          class="inline-flex items-center justify-center font-semibold no-underline cursor-pointer rounded-lg transition-all duration-200 bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark w-full py-2.5 text-sm mt-1 disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          <Loader2 v-if="loading" class="animate-spin-slow mr-1.5" :size="18" />
+          {{ loading ? loadingLabel || submitLabel + '中...' : submitLabel }}
+        </button>
+      </form>
+
+      <div v-if="$slots.footer" class="text-center mt-5 text-sm text-text-secondary">
+        <slot name="footer" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Loader2 } from "@lucide/vue"
+
+defineProps<{
+  title: string
+  subtitle?: string
+  error: string
+  loading: boolean
+  submitLabel: string
+  loadingLabel?: string
+}>()
+
+defineEmits<{
+  submit: []
+  "clear-error": []
+}>()
+</script>
+
+<style>
+/* Vue Transition: slide (用于 error/success banner) */
+.slide-enter-active {
+  transition: all 0.3s ease-out;
+}
+.slide-leave-active {
+  transition: all 0.2s ease-in;
+}
+.slide-enter-from {
+  transform: translateX(-50%) translateY(-20px);
+  opacity: 0;
+}
+.slide-leave-to {
+  transform: translateX(-50%) translateY(-20px);
+  opacity: 0;
+}
+
+/* Vue Transition: drop (用于 field errors) */
+.drop-enter-active {
+  animation: dropIn 0.25s ease both;
+}
+.drop-leave-active {
+  animation: dropOut 0.2s ease both;
+}
+
+@keyframes dropIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes dropOut {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+/* Vue Transition: fade (用于可能的 overlay) */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+/* Vue Transition: icon (用于密码可见切换) */
+.icon-enter-active,
+.icon-leave-active {
+  transition: opacity 0.18s linear, transform 0.18s linear;
+}
+.icon-enter-from {
+  opacity: 0;
+  transform: translate(-6px, -6px);
+}
+.icon-leave-to {
+  opacity: 0;
+  transform: translate(6px, 6px);
+}
+
+/* @keyframes fadeInUp (用于入场动画) */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/noj-ui/components/form/PasswordField.vue
+++ b/noj-ui/components/form/PasswordField.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="relative mb-7">
+    <label :for="id" class="block text-sm font-semibold text-text mb-1">
+      {{ label }}
+      <span v-if="required" class="text-red-600">*</span>
+    </label>
+    <div class="relative flex items-center">
+      <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+      <input
+        :id="id"
+        :value="modelValue"
+        :type="visible ? 'text' : 'password'"
+        :placeholder="placeholder"
+        :autocomplete="autocomplete"
+        :disabled="disabled"
+        class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+        @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+        @focus="$emit('focus')"
+      />
+      <button
+        type="button"
+        class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary"
+        @click="visible = !visible"
+        tabindex="-1"
+      >
+        <span class="flex items-center justify-center w-[18px] h-[18px]">
+          <Transition name="icon" mode="out-in">
+            <EyeOff v-if="!visible" :size="18" key="off" />
+            <Eye v-else :size="18" key="on" />
+          </Transition>
+        </span>
+      </button>
+    </div>
+    <Transition name="drop">
+      <div v-if="error" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700">
+        <span>{{ error }}</span>
+        <X :size="14" />
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Lock, Eye, EyeOff, X } from "@lucide/vue"
+
+const props = defineProps<{
+  id: string
+  label: string
+  modelValue: string
+  placeholder: string
+  autocomplete: string
+  disabled: boolean
+  required?: boolean
+  error?: string
+}>()
+
+defineEmits<{
+  "update:modelValue": [value: string]
+  focus: []
+}>()
+
+const visible = ref(false)
+</script>

--- a/noj-ui/components/form/TextInput.vue
+++ b/noj-ui/components/form/TextInput.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="relative mb-7">
+    <label :for="id" class="block text-sm font-semibold text-text mb-1">{{ label }}</label>
+    <div class="relative flex items-center">
+      <span v-if="$slots.icon" class="absolute left-[10px] text-text-muted pointer-events-none flex items-center">
+        <slot name="icon" />
+      </span>
+      <input
+        :id="id"
+        :value="modelValue"
+        :type="type"
+        :placeholder="placeholder"
+        :autocomplete="autocomplete"
+        :disabled="disabled"
+        class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+        :class="{ 'pl-9': $slots.icon }"
+        @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+        @focus="$emit('focus')"
+      />
+    </div>
+    <Transition name="drop">
+      <div v-if="error" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700">
+        <span>{{ error }}</span>
+        <X :size="14" />
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { X } from "@lucide/vue"
+
+defineProps<{
+  id: string
+  label: string
+  modelValue: string
+  type?: string
+  placeholder: string
+  autocomplete: string
+  disabled: boolean
+  error?: string
+}>()
+
+defineEmits<{
+  "update:modelValue": [value: string]
+  focus: []
+}>()
+</script>

--- a/noj-ui/composables/use-submissions.ts
+++ b/noj-ui/composables/use-submissions.ts
@@ -41,6 +41,8 @@ export const languageLabels: Record<string, string> = {
 export const statusColors: Record<string, string> = {
   pending: "#9ca3af",
   judging: "#3b82f6",
+  finished: "#10b981",
+  error: "#ef4444",
 }
 
 /**
@@ -49,6 +51,8 @@ export const statusColors: Record<string, string> = {
 export const statusLabels: Record<string, string> = {
   pending: "等待评测",
   judging: "评测中",
+  finished: "已完成",
+  error: "系统错误",
 }
 
 /**
@@ -61,6 +65,8 @@ export const resultLabels: Record<string, string> = {
   MemoryLimitExceeded: "超出内存限制",
   RuntimeError: "运行时错误",
   SystemError: "系统错误",
+  CompileError: "编译错误",
+  OutputLimitExceeded: "输出超出限制",
 }
 
 /**
@@ -73,6 +79,8 @@ export const resultColors: Record<string, string> = {
   MemoryLimitExceeded: "#f59e0b",
   RuntimeError: "#ef4444",
   SystemError: "#ef4444",
+  CompileError: "#a855f7",
+  OutputLimitExceeded: "#f97316",
 }
 
 /**
@@ -135,4 +143,72 @@ export function formatMemory(kb: number | undefined | null): string {
  */
 export function getLanguageLabel(lang: string): string {
   return languageLabels[lang] || lang
+}
+
+/**
+ * 评测结果详细定义（含图标和样式类）。
+ */
+export interface ResultDef {
+  label: string
+  icon: string
+  class: string
+}
+
+/**
+ * 评测结果状态 → 详细定义映射。
+ */
+export const resultDefMap: Record<string, ResultDef> = {
+  Accepted: { label: "答案正确", icon: "check", class: "accepted" },
+  WrongAnswer: { label: "答案错误", icon: "x", class: "wrong" },
+  TimeLimitExceeded: { label: "超出时间限制", icon: "alert", class: "tle" },
+  MemoryLimitExceeded: { label: "超出内存限制", icon: "alert", class: "mle" },
+  RuntimeError: { label: "运行时错误", icon: "x", class: "re" },
+  SystemError: { label: "系统错误", icon: "x", class: "se" },
+  CompileError: { label: "编译错误", icon: "x", class: "re" },
+  OutputLimitExceeded: { label: "输出超出限制", icon: "alert", class: "tle" },
+}
+
+/**
+ * 获取评测结果详细定义。
+ */
+export function getResultDef(status: string | undefined): ResultDef {
+  if (!status) return { label: status ?? "未知", icon: "x", class: "se" }
+  return resultDefMap[status] ?? { label: status, icon: "x", class: "se" }
+}
+
+/**
+ * 评测判定的 Tailwind 样式类。
+ */
+export const verdictClasses: Record<string, string> = {
+  accepted: "bg-green-50 border border-green-200 text-green-700",
+  wrong: "bg-red-50 border border-red-200 text-red-800",
+  tle: "bg-orange-50 border border-orange-200 text-orange-800",
+  mle: "bg-orange-50 border border-orange-200 text-orange-800",
+  re: "bg-red-50 border border-red-200 text-red-800",
+  se: "bg-red-50 border border-red-200 text-red-800",
+}
+
+/**
+ * 提交状态徽章的 Tailwind 样式类。
+ */
+export const statusBadgeColors: Record<string, string> = {
+  pending: "bg-gray-50 text-slate-500 border border-border",
+  judging: "bg-blue-50 text-blue-700 border border-blue-200",
+  error: "bg-red-50 text-red-800 border border-red-200",
+}
+
+/**
+ * 格式化 ISO 时间为中文可读格式。
+ */
+export function formatDateTime(iso: string | undefined): string {
+  if (!iso) return "--"
+  const d = new Date(iso)
+  return d.toLocaleString("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  })
 }

--- a/noj-ui/composables/useAdminList.ts
+++ b/noj-ui/composables/useAdminList.ts
@@ -1,0 +1,135 @@
+/**
+ * Admin 通用列表管理组合函数。
+ *
+ * 封装分页、加载/错误状态、搜索逻辑，
+ * 消除 admin 管理页面中大量重复的数据获取样板代码。
+ *
+ * 用法：
+ * ```ts
+ * const { items, loading, error, load, onPageChange, searchInput } = useAdminList<User>({
+ *   path: "/api/v1/admin/users",
+ *   fetchOptions: { dataField: "data", totalField: "total" },
+ * })
+ * ```
+ */
+
+import { ref } from "vue"
+
+export interface AdminListOptions<T> {
+  /** API 路径（如 "/api/v1/admin/users"） */
+  path: string
+  /** 默认每页条数 */
+  perPage?: number
+  /** 响应字段映射（默认从 `res.data` 读列表，`res.total` 读总数） */
+  fetchOptions?: {
+    dataField?: string
+    totalField?: string
+  }
+  /** 自定义转换函数 — 完全接管响应解析 */
+  transform?: (raw: unknown) => { items: T[]; total: number }
+}
+
+export interface AdminListResult<T> {
+  items: Ref<T[]>
+  totalPages: Ref<number>
+  loading: Ref<boolean>
+  error: Ref<string>
+  currentPage: Ref<number>
+  perPage: number
+  keyword: Ref<string>
+  /** 搜索输入（300ms 防抖，自动重置到第 1 页） */
+  searchInput: (val: string) => void
+  /** 加载指定页 */
+  load: (page?: number) => Promise<void>
+  /** 分页切换 */
+  onPageChange: (page: number) => void
+}
+
+/** 深层读取嵌套字段（支持 "pagination.total_pages" 路径） */
+function deepGet(obj: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === "object" && key in (acc as Record<string, unknown>)) {
+      return (acc as Record<string, unknown>)[key]
+    }
+    return undefined
+  }, obj)
+}
+
+export function useAdminList<T = Record<string, unknown>>(
+  options: AdminListOptions<T>,
+): AdminListResult<T> {
+  const items = ref<T[]>([]) as Ref<T[]>
+  const loading = ref(true)
+  const error = ref("")
+  const currentPage = ref(1)
+  const totalPages = ref(1)
+  const perPageVal = options.perPage ?? 20
+  const keyword = ref("")
+
+  let searchTimer: ReturnType<typeof setTimeout> | undefined
+
+  async function load(page = 1) {
+    loading.value = true
+    error.value = ""
+    currentPage.value = page
+
+    try {
+      const params = new URLSearchParams({
+        page: String(page),
+        per_page: String(perPageVal),
+      })
+      if (keyword.value) params.set("keyword", keyword.value)
+
+      if (options.transform) {
+        const raw = await $fetch(`${options.path}?${params}`)
+        const r = options.transform(raw)
+        items.value = r.items
+        totalPages.value = Math.max(1, Math.ceil(r.total / perPageVal))
+      } else {
+        const dataField = options.fetchOptions?.dataField ?? "data"
+        const totalField = options.fetchOptions?.totalField ?? "total"
+        const res = await $fetch<Record<string, unknown>>(`${options.path}?${params}`)
+        const rawData = deepGet(res, dataField)
+        items.value = (Array.isArray(rawData) ? rawData : []) as T[]
+
+        const rawTotal = deepGet(res, totalField)
+        if (typeof rawTotal === "number") {
+          totalPages.value = Math.max(1, Math.ceil(rawTotal / perPageVal))
+        } else {
+          // fallback: pagination.total_pages
+          const rawPages = deepGet(res, "pagination.total_pages")
+          totalPages.value = typeof rawPages === "number" ? Math.max(1, rawPages) : 1
+        }
+      }
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : "加载失败"
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function searchInput(val: string) {
+    clearTimeout(searchTimer)
+    searchTimer = setTimeout(() => {
+      keyword.value = val
+      load(1)
+    }, 300)
+  }
+
+  function onPageChange(page: number) {
+    load(page)
+  }
+
+  return {
+    items,
+    totalPages,
+    loading,
+    error,
+    currentPage,
+    perPage: perPageVal,
+    keyword,
+    searchInput,
+    load,
+    onPageChange,
+  }
+}

--- a/noj-ui/composables/useFormError.ts
+++ b/noj-ui/composables/useFormError.ts
@@ -1,0 +1,23 @@
+/**
+ * Form error management with auto-dismiss timer.
+ * Extracted from duplicated auth page patterns.
+ */
+export function useFormError(duration = 3000) {
+  const error = ref("")
+  let errorTimer: ReturnType<typeof setTimeout> | null = null
+
+  function setError(msg: string) {
+    error.value = msg
+    if (errorTimer) clearTimeout(errorTimer)
+    errorTimer = setTimeout(clearError, duration)
+  }
+
+  function clearError() {
+    error.value = ""
+    if (errorTimer) clearTimeout(errorTimer)
+  }
+
+  onUnmounted(() => { if (errorTimer) clearTimeout(errorTimer) })
+
+  return { error, setError, clearError }
+}

--- a/noj-ui/pages/admin/blacklist.vue
+++ b/noj-ui/pages/admin/blacklist.vue
@@ -125,12 +125,7 @@ function formatExpires(value: string | null) {
 
 <template>
   <div class="flex flex-col gap-4">
-    <div class="flex flex-col gap-1">
-      <h1 class="text-[22px] font-bold text-text">IP 黑名单管理</h1>
-      <span class="text-sm text-text-secondary">
-        拦截恶意 IP / CIDR 范围；命中后返 403 IP_BLACKLISTED
-      </span>
-    </div>
+    <PageHeader title="IP 黑名单管理" description="拦截恶意 IP / CIDR 范围；命中后返 403 IP_BLACKLISTED" />
 
     <!-- 顶部操作栏 -->
     <div class="flex items-center justify-between gap-3 flex-wrap">

--- a/noj-ui/pages/admin/categories.vue
+++ b/noj-ui/pages/admin/categories.vue
@@ -140,16 +140,14 @@ async function handleDelete() {
 
 <template>
   <div class="flex flex-col gap-4">
-    <div class="flex items-start justify-between gap-3">
-      <div>
-        <h1 class="text-[22px] font-bold text-text">分类管理</h1>
-        <span class="text-sm text-text-secondary">管理题目分类</span>
-      </div>
-      <button class="inline-flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark" @click="openCreate">
-        <Plus :size="16" />
-        新建分类
-      </button>
-    </div>
+    <PageHeader title="分类管理" description="管理题目分类">
+      <template #actions>
+        <button class="inline-flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark" @click="openCreate">
+          <Plus :size="16" />
+          新建分类
+        </button>
+      </template>
+    </PageHeader>
 
     <AdminTable
       :columns="columns"

--- a/noj-ui/pages/admin/index.vue
+++ b/noj-ui/pages/admin/index.vue
@@ -62,13 +62,14 @@ async function handleRefresh() {
   <!-- tailwind-dashboard -->
   <div class="flex flex-col gap-6">
     <!-- 顶栏 -->
-    <div class="flex items-center justify-between">
-      <h1 class="text-[22px] font-bold text-text">仪表盘</h1>
-      <button class="inline-flex items-center gap-1.5 px-4 py-2 text-xs font-semibold text-text-secondary bg-white border border-border rounded-lg cursor-pointer transition-all hover:border-text-secondary disabled:opacity-50 disabled:cursor-not-allowed" :disabled="refreshing" @click="handleRefresh">
-        <RefreshCw :size="16" :class="{ 'animate-spin': refreshing }" />
-        {{ refreshing ? "刷新中..." : "刷新" }}
-      </button>
-    </div>
+    <PageHeader title="仪表盘">
+      <template #actions>
+        <button class="inline-flex items-center gap-1.5 px-4 py-2 text-xs font-semibold text-text-secondary bg-white border border-border rounded-lg cursor-pointer transition-all hover:border-text-secondary disabled:opacity-50 disabled:cursor-not-allowed" :disabled="refreshing" @click="handleRefresh">
+          <RefreshCw :size="16" :class="{ 'animate-spin': refreshing }" />
+          {{ refreshing ? "刷新中..." : "刷新" }}
+        </button>
+      </template>
+    </PageHeader>
 
     <!-- 加载态 -->
     <div v-if="statsLoading && stats.length === 0" class="flex flex-col items-center justify-center gap-2.5 px-6 py-12 text-text-secondary text-sm bg-white border border-border rounded-xl">

--- a/noj-ui/pages/admin/judge-images.vue
+++ b/noj-ui/pages/admin/judge-images.vue
@@ -174,16 +174,14 @@ async function handleDelete() {
 
 <template>
   <div class="flex flex-col gap-4">
-    <div class="flex items-start justify-between gap-3">
-      <div>
-        <h1 class="text-[22px] font-bold text-text">评测镜像管理</h1>
-        <span class="text-sm text-text-secondary">配置允许使用的 Docker 评测镜像白名单</span>
-      </div>
-      <button class="inline-flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark" @click="openCreate">
-        <Plus :size="16" />
-        新增镜像
-      </button>
-    </div>
+    <PageHeader title="评测镜像管理" description="配置允许使用的 Docker 评测镜像白名单">
+      <template #actions>
+        <button class="inline-flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark" @click="openCreate">
+          <Plus :size="16" />
+          新增镜像
+        </button>
+      </template>
+    </PageHeader>
 
     <AdminTable
       :columns="columns"

--- a/noj-ui/pages/admin/problems.vue
+++ b/noj-ui/pages/admin/problems.vue
@@ -146,16 +146,14 @@ async function batchRejudge(problemId: string) {
 
 <template>
   <div class="flex flex-col gap-4">
-    <div class="flex items-start justify-between gap-3">
-      <div>
-        <h1 class="text-[22px] font-bold text-text">题目管理</h1>
-        <span class="text-sm text-text-secondary">管理所有题目</span>
-      </div>
-      <NuxtLink to="/admin/problem-new" class="inline-flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer no-underline transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark">
-        <Plus :size="16" />
-        创建题目
-      </NuxtLink>
-    </div>
+    <PageHeader title="题目管理" description="管理所有题目">
+      <template #actions>
+        <NuxtLink to="/admin/problem-new" class="inline-flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer no-underline transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark">
+          <Plus :size="16" />
+          创建题目
+        </NuxtLink>
+      </template>
+    </PageHeader>
 
     <AdminTable
       :columns="columns"

--- a/noj-ui/pages/admin/settings.vue
+++ b/noj-ui/pages/admin/settings.vue
@@ -244,13 +244,7 @@ async function confirmReset(s: SystemSetting) {
 
 <template>
   <div class="flex flex-col gap-4">
-    <!-- 页头 -->
-    <div class="flex flex-col gap-1">
-      <h1 class="text-[22px] font-bold text-text">系统设置</h1>
-      <span class="text-sm text-text-secondary">
-        运行时可改的配置项，修改即时生效；只读配置需重启服务
-      </span>
-    </div>
+    <PageHeader title="系统设置" description="运行时可改的配置项，修改即时生效；只读配置需重启服务" />
 
     <!-- 顶部提示横幅 -->
     <div class="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-md text-[13px] text-info-text">

--- a/noj-ui/pages/admin/submissions.vue
+++ b/noj-ui/pages/admin/submissions.vue
@@ -177,10 +177,7 @@ async function rejudge(submissionId: string) {
 
 <template>
   <div class="flex flex-col gap-4">
-    <div class="flex flex-col gap-1">
-      <h1 class="text-[22px] font-bold text-text">提交管理</h1>
-      <span class="text-sm text-text-secondary">查看所有用户的提交记录</span>
-    </div>
+    <PageHeader title="提交管理" description="查看所有用户的提交记录" />
 
     <!-- 筛选栏 -->
     <div class="bg-white border border-border rounded-lg p-4">

--- a/noj-ui/pages/admin/users.vue
+++ b/noj-ui/pages/admin/users.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ShieldCheck, ShieldX, ShieldAlert } from "@lucide/vue"
 import type { Column } from "~/components/admin/AdminTable.vue"
+import { useAdminList } from "~/composables/useAdminList"
 
 definePageMeta({
   layout: "admin",
@@ -26,23 +27,10 @@ interface User {
   updated_at: string
 }
 
-const users = ref<User[]>([])
-const currentPage = ref(1)
-const totalPages = ref(1)
-const tableLoading = ref(true)
-const tableError = ref("")
-const perPage = 20
-const keyword = ref("")
-
-// 搜索输入防抖：停止输入 300ms 后自动刷新
-let searchTimer: ReturnType<typeof setTimeout> | undefined
-function onSearchInput(val: string) {
-  clearTimeout(searchTimer)
-  searchTimer = setTimeout(() => {
-    keyword.value = val
-    loadUsers(1)
-  }, 300)
-}
+const { items: users, totalPages, loading: tableLoading, error: tableError, currentPage, perPage, searchInput, load: loadUsers, onPageChange } = useAdminList<User>({
+  path: "/api/v1/admin/users",
+  fetchOptions: { dataField: "data", totalField: "pagination.total_pages" },
+})
 
 const columns: Column<User>[] = [
   { key: "username", label: "用户名" },
@@ -62,34 +50,9 @@ const columns: Column<User>[] = [
   },
 ]
 
-async function loadUsers(page = 1) {
-  if (!isLoggedIn.value) return
-  tableLoading.value = true
-  tableError.value = ""
-  currentPage.value = page
-  try {
-    const params = new URLSearchParams({ page: String(page), per_page: String(perPage), _: String(Date.now()) })
-    if (keyword.value) params.set("keyword", keyword.value)
-    const res = await $fetch<{ data: User[]; pagination: { total: number; total_pages: number } }>(
-      `/api/v1/admin/users?${params}`,
-    )
-    users.value = res.data
-    totalPages.value = res.pagination.total_pages
-  } catch (err: unknown) {
-    tableError.value = err instanceof Error ? err.message : "加载用户列表失败"
-    console.error("loadUsers error:", err)
-  } finally {
-    tableLoading.value = false
-  }
-}
-
 watch(isLoggedIn, (val) => {
   if (val) loadUsers()
 }, { immediate: true })
-
-function onPageChange(page: number) {
-  loadUsers(page)
-}
 
 // 角色切换
 const targetUser = ref<User | null>(null)
@@ -240,17 +203,14 @@ async function handleRoleSwitch() {
 
 <template>
   <div class="flex flex-col gap-4">
-    <div class="flex flex-col gap-1">
-      <h1 class="text-[22px] font-bold text-text">用户管理</h1>
-      <span class="text-sm text-text-secondary">管理所有用户的角色权限</span>
-    </div>
+    <PageHeader title="用户管理" description="管理所有用户的角色权限" />
 
     <div class="flex items-center gap-2">
       <input
         type="text"
         placeholder="搜索用户名或邮箱…"
         class="w-full max-w-xs px-3 py-2 text-sm border border-border rounded-lg bg-white text-text placeholder-text-muted outline-none focus:border-info-text transition-colors"
-        @input="onSearchInput(($event.target as HTMLInputElement).value)"
+        @input="searchInput(($event.target as HTMLInputElement).value)"
       />
     </div>
 

--- a/noj-ui/pages/change-password.vue
+++ b/noj-ui/pages/change-password.vue
@@ -1,289 +1,137 @@
 <template>
-    <div class="w-full max-w-[380px] relative">
-        <Transition name="slide">
-            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ error }}</span>
-                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
-            </div>
-        </Transition>
-        <div class="bg-white border border-border rounded-lg p-8">
-            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">修改密码</h1>
+  <AuthFormCard
+    title="修改密码"
+    :error="error"
+    :loading="loading"
+    submit-label="提交"
+    loading-label="提交"
+    @submit="handleSubmit"
+    @clear-error="clearError"
+  >
+    <PasswordField
+      id="oldPassword"
+      v-model="form.oldPassword"
+      label="原密码"
+      placeholder="请输入当前密码"
+      autocomplete="current-password"
+      :disabled="loading"
+      :error="fieldErrors.oldPassword"
+      @focus="fieldErrors.oldPassword = ''"
+    />
 
-            <form @submit.prevent="handleSubmit">
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
-                    <label for="oldPassword" class="block text-sm font-semibold text-text mb-1">原密码</label>
-                    <div class="relative flex items-center">
-                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="oldPassword"
-                            v-model="form.oldPassword"
-                            :type="showOldPassword ? 'text' : 'password'"
-                            placeholder="请输入当前密码"
-                            autocomplete="current-password"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.oldPassword = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showOldPassword = !showOldPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <EyeOff v-if="!showOldPassword" :size="18" key="off" />
-                                    <Eye v-else :size="18" key="on" />
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.oldPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.oldPassword }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
+    <PasswordField
+      id="newPassword"
+      v-model="form.newPassword"
+      label="新密码"
+      placeholder="至少 12 位，需包含字母和数字"
+      autocomplete="new-password"
+      :disabled="loading"
+      :error="fieldErrors.newPassword"
+      @focus="fieldErrors.newPassword = ''"
+    />
 
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
-                    <label for="newPassword" class="block text-sm font-semibold text-text mb-1">新密码</label>
-                    <div class="relative flex items-center">
-                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="newPassword"
-                            v-model="form.newPassword"
-                            :type="showNewPassword ? 'text' : 'password'"
-                            placeholder="至少 12 位，需包含字母和数字"
-                            autocomplete="new-password"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.newPassword = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showNewPassword = !showNewPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <EyeOff v-if="!showNewPassword" :size="18" key="off" />
-                                    <Eye v-else :size="18" key="on" />
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.newPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.newPassword }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
+    <PasswordField
+      id="confirmPassword"
+      v-model="form.confirmPassword"
+      label="确认密码"
+      placeholder="再次输入新密码"
+      autocomplete="new-password"
+      :disabled="loading"
+      :error="fieldErrors.confirmPassword"
+      @focus="fieldErrors.confirmPassword = ''"
+    />
 
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.15s_both]">
-                    <label for="confirmPassword" class="block text-sm font-semibold text-text mb-1">确认密码</label>
-                    <div class="relative flex items-center">
-                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="confirmPassword"
-                            v-model="form.confirmPassword"
-                            :type="showConfirmPassword ? 'text' : 'password'"
-                            placeholder="再次输入新密码"
-                            autocomplete="new-password"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.confirmPassword = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showConfirmPassword = !showConfirmPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <EyeOff v-if="!showConfirmPassword" :size="18" key="off" />
-                                    <Eye v-else :size="18" key="on" />
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
-
-                <button type="submit" class="inline-flex items-center justify-center font-semibold no-underline cursor-pointer rounded-lg transition-all duration-200 bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark w-full py-2.5 text-sm mt-1 animate-[fadeInUp_0.5s_ease_0.2s_both] disabled:opacity-60 disabled:cursor-not-allowed" :disabled="loading">
-                    <Loader2 v-if="loading" class="animate-spin-slow mr-1.5" :size="18" />
-                    {{ loading ? '提交中...' : '提交' }}
-                </button>
-            </form>
-
-            <p class="text-center mt-5 text-sm text-text-secondary animate-[fadeInUp_0.5s_ease_0.25s_both]">
-                <button type="button" class="bg-transparent border-0 text-primary text-sm cursor-pointer p-0 font-semibold hover:underline" @click="handleLogout">使用其他账号登录</button>
-            </p>
-        </div>
-    </div>
+    <template #footer>
+      <button type="button" class="bg-transparent border-0 text-primary text-sm cursor-pointer p-0 font-semibold hover:underline" @click="handleLogout">使用其他账号登录</button>
+    </template>
+  </AuthFormCard>
 </template>
 
 <script setup lang="ts">
-import { Lock, Eye, EyeOff, Loader2, X } from "@lucide/vue"
-
 definePageMeta({ layout: "auth" })
 
 const router = useRouter()
 const auth = useAuth()
 const { showToast } = useToast()
+const { error, setError, clearError } = useFormError()
 
 const form = reactive({
-    oldPassword: "",
-    newPassword: "",
-    confirmPassword: "",
+  oldPassword: "",
+  newPassword: "",
+  confirmPassword: "",
 })
 const loading = ref(false)
-const error = ref("")
-const showOldPassword = ref(false)
-const showNewPassword = ref(false)
-const showConfirmPassword = ref(false)
-
-let errorTimer: ReturnType<typeof setTimeout> | null = null
-
-function setError(msg: string) {
-    error.value = msg
-    if (errorTimer) clearTimeout(errorTimer)
-    errorTimer = setTimeout(clearError, 3000)
-}
-
-function clearError() {
-    error.value = ""
-    if (errorTimer) clearTimeout(errorTimer)
-}
 
 const fieldErrors = reactive({
-    oldPassword: "",
-    newPassword: "",
-    confirmPassword: "",
+  oldPassword: "",
+  newPassword: "",
+  confirmPassword: "",
 })
 
 function validate(): boolean {
-    let valid = true
-    fieldErrors.oldPassword = ""
-    fieldErrors.newPassword = ""
-    fieldErrors.confirmPassword = ""
+  let valid = true
+  fieldErrors.oldPassword = ""
+  fieldErrors.newPassword = ""
+  fieldErrors.confirmPassword = ""
 
-    if (!form.oldPassword) {
-        fieldErrors.oldPassword = "请输入原密码"
-        valid = false
-    }
+  if (!form.oldPassword) {
+    fieldErrors.oldPassword = "请输入原密码"
+    valid = false
+  }
 
-    if (!form.newPassword) {
-        fieldErrors.newPassword = "请输入新密码"
-        valid = false
-    } else if (form.newPassword.length < 12) {
-        fieldErrors.newPassword = "密码长度不能少于 12 位"
-        valid = false
-    } else if (!/[a-z]/.test(form.newPassword)) {
-        fieldErrors.newPassword = "密码必须包含至少一个小写字母"
-        valid = false
-    } else if (!/[A-Z]/.test(form.newPassword)) {
-        fieldErrors.newPassword = "密码必须包含至少一个大写字母"
-        valid = false
-    } else if (!/[0-9]/.test(form.newPassword)) {
-        fieldErrors.newPassword = "密码必须包含至少一个数字"
-        valid = false
-    } else if (form.newPassword === form.oldPassword) {
-        fieldErrors.newPassword = "新密码不能与原密码相同"
-        valid = false
-    }
+  if (!form.newPassword) {
+    fieldErrors.newPassword = "请输入新密码"
+    valid = false
+  } else if (form.newPassword.length < 12) {
+    fieldErrors.newPassword = "密码长度不能少于 12 位"
+    valid = false
+  } else if (!/[a-z]/.test(form.newPassword)) {
+    fieldErrors.newPassword = "密码必须包含至少一个小写字母"
+    valid = false
+  } else if (!/[A-Z]/.test(form.newPassword)) {
+    fieldErrors.newPassword = "密码必须包含至少一个大写字母"
+    valid = false
+  } else if (!/[0-9]/.test(form.newPassword)) {
+    fieldErrors.newPassword = "密码必须包含至少一个数字"
+    valid = false
+  } else if (form.newPassword === form.oldPassword) {
+    fieldErrors.newPassword = "新密码不能与原密码相同"
+    valid = false
+  }
 
-    if (!form.confirmPassword) {
-        fieldErrors.confirmPassword = "请确认密码"
-        valid = false
-    } else if (form.newPassword !== form.confirmPassword) {
-        fieldErrors.confirmPassword = "两次输入的密码不一致"
-        valid = false
-    }
+  if (!form.confirmPassword) {
+    fieldErrors.confirmPassword = "请确认密码"
+    valid = false
+  } else if (form.newPassword !== form.confirmPassword) {
+    fieldErrors.confirmPassword = "两次输入的密码不一致"
+    valid = false
+  }
 
-    return valid
+  return valid
 }
 
 async function handleSubmit() {
-    setError("")
+  setError("")
 
-    if (!validate()) return
+  if (!validate()) return
 
-    loading.value = true
-    try {
-        await auth.changePassword(form.oldPassword, form.newPassword)
-        // useAuth.changePassword() 内部已更新本地 user 状态（must_change_password=false）
-        // 并由 Nitro 代理同步替换 noj:token Cookie（旧 token 已被后端撤销）。
-        // 无需再走 /login，直接回首页即可。
-        showToast("success", "密码修改成功")
-        router.replace("/settings")
-    } catch (e: any) {
-        setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.response?.status || e.statusCode || e.status || 502}`)
-    } finally {
-        loading.value = false
-    }
+  loading.value = true
+  try {
+    await auth.changePassword(form.oldPassword, form.newPassword)
+    // useAuth.changePassword() 内部已更新本地 user 状态（must_change_password=false）
+    // 并由 Nitro 代理同步替换 noj:token Cookie（旧 token 已被后端撤销）。
+    // 无需再走 /login，直接回首页即可。
+    showToast("success", "密码修改成功")
+    router.replace("/settings")
+  } catch (e: any) {
+    setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.response?.status || e.statusCode || e.status || 502}`)
+  } finally {
+    loading.value = false
+  }
 }
 
 async function handleLogout() {
-    await auth.logout()
-    router.replace("/login")
+  await auth.logout()
+  router.replace("/login")
 }
 </script>
-
-<style>
-/* Vue Transition: slide (用于 error banner) */
-.slide-enter-active {
-    transition: all 0.3s ease-out;
-}
-.slide-leave-active {
-    transition: all 0.2s ease-in;
-}
-.slide-enter-from {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-.slide-leave-to {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-
-/* Vue Transition: drop (用于 field errors) */
-.drop-enter-active {
-    animation: dropIn 0.25s ease both;
-}
-.drop-leave-active {
-    animation: dropOut 0.2s ease both;
-}
-
-@keyframes dropIn {
-    from {
-        opacity: 0;
-        transform: translateY(-8px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes dropOut {
-    from {
-        opacity: 1;
-        transform: translateY(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateY(8px);
-    }
-}
-
-/* Vue Transition: icon (用于密码可见切换) */
-.icon-enter-active,
-.icon-leave-active {
-    transition: opacity 0.18s linear, transform 0.18s linear;
-}
-.icon-enter-from {
-    opacity: 0;
-    transform: translate(-6px, -6px);
-}
-.icon-leave-to {
-    opacity: 0;
-    transform: translate(6px, 6px);
-}
-
-/* @keyframes fadeInUp (用于入场动画) */
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(12px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-</style>

--- a/noj-ui/pages/change-password.vue
+++ b/noj-ui/pages/change-password.vue
@@ -1,137 +1,289 @@
 <template>
-  <AuthFormCard
-    title="修改密码"
-    :error="error"
-    :loading="loading"
-    submit-label="提交"
-    loading-label="提交"
-    @submit="handleSubmit"
-    @clear-error="clearError"
-  >
-    <PasswordField
-      id="oldPassword"
-      v-model="form.oldPassword"
-      label="原密码"
-      placeholder="请输入当前密码"
-      autocomplete="current-password"
-      :disabled="loading"
-      :error="fieldErrors.oldPassword"
-      @focus="fieldErrors.oldPassword = ''"
-    />
+    <div class="w-full max-w-[380px] relative">
+        <Transition name="slide">
+            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
+                <span>{{ error }}</span>
+                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
+            </div>
+        </Transition>
+        <div class="bg-white border border-border rounded-lg p-8">
+            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">修改密码</h1>
 
-    <PasswordField
-      id="newPassword"
-      v-model="form.newPassword"
-      label="新密码"
-      placeholder="至少 12 位，需包含字母和数字"
-      autocomplete="new-password"
-      :disabled="loading"
-      :error="fieldErrors.newPassword"
-      @focus="fieldErrors.newPassword = ''"
-    />
+            <form @submit.prevent="handleSubmit">
+                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
+                    <label for="oldPassword" class="block text-sm font-semibold text-text mb-1">原密码</label>
+                    <div class="relative flex items-center">
+                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+                        <input
+                            id="oldPassword"
+                            v-model="form.oldPassword"
+                            :type="showOldPassword ? 'text' : 'password'"
+                            placeholder="请输入当前密码"
+                            autocomplete="current-password"
+                            :disabled="loading"
+                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+                            @focus="fieldErrors.oldPassword = ''"
+                        />
+                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showOldPassword = !showOldPassword" tabindex="-1">
+                            <span class="flex items-center justify-center w-[18px] h-[18px]">
+                                <Transition name="icon" mode="out-in">
+                                    <EyeOff v-if="!showOldPassword" :size="18" key="off" />
+                                    <Eye v-else :size="18" key="on" />
+                                </Transition>
+                            </span>
+                        </button>
+                    </div>
+                    <Transition name="drop">
+                        <div v-if="fieldErrors.oldPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.oldPassword }}</span><X :size="14" /></div>
+                    </Transition>
+                </div>
 
-    <PasswordField
-      id="confirmPassword"
-      v-model="form.confirmPassword"
-      label="确认密码"
-      placeholder="再次输入新密码"
-      autocomplete="new-password"
-      :disabled="loading"
-      :error="fieldErrors.confirmPassword"
-      @focus="fieldErrors.confirmPassword = ''"
-    />
+                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
+                    <label for="newPassword" class="block text-sm font-semibold text-text mb-1">新密码</label>
+                    <div class="relative flex items-center">
+                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+                        <input
+                            id="newPassword"
+                            v-model="form.newPassword"
+                            :type="showNewPassword ? 'text' : 'password'"
+                            placeholder="至少 12 位，需包含字母和数字"
+                            autocomplete="new-password"
+                            :disabled="loading"
+                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+                            @focus="fieldErrors.newPassword = ''"
+                        />
+                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showNewPassword = !showNewPassword" tabindex="-1">
+                            <span class="flex items-center justify-center w-[18px] h-[18px]">
+                                <Transition name="icon" mode="out-in">
+                                    <EyeOff v-if="!showNewPassword" :size="18" key="off" />
+                                    <Eye v-else :size="18" key="on" />
+                                </Transition>
+                            </span>
+                        </button>
+                    </div>
+                    <Transition name="drop">
+                        <div v-if="fieldErrors.newPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.newPassword }}</span><X :size="14" /></div>
+                    </Transition>
+                </div>
 
-    <template #footer>
-      <button type="button" class="bg-transparent border-0 text-primary text-sm cursor-pointer p-0 font-semibold hover:underline" @click="handleLogout">使用其他账号登录</button>
-    </template>
-  </AuthFormCard>
+                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.15s_both]">
+                    <label for="confirmPassword" class="block text-sm font-semibold text-text mb-1">确认密码</label>
+                    <div class="relative flex items-center">
+                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+                        <input
+                            id="confirmPassword"
+                            v-model="form.confirmPassword"
+                            :type="showConfirmPassword ? 'text' : 'password'"
+                            placeholder="再次输入新密码"
+                            autocomplete="new-password"
+                            :disabled="loading"
+                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+                            @focus="fieldErrors.confirmPassword = ''"
+                        />
+                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showConfirmPassword = !showConfirmPassword" tabindex="-1">
+                            <span class="flex items-center justify-center w-[18px] h-[18px]">
+                                <Transition name="icon" mode="out-in">
+                                    <EyeOff v-if="!showConfirmPassword" :size="18" key="off" />
+                                    <Eye v-else :size="18" key="on" />
+                                </Transition>
+                            </span>
+                        </button>
+                    </div>
+                    <Transition name="drop">
+                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><X :size="14" /></div>
+                    </Transition>
+                </div>
+
+                <button type="submit" class="inline-flex items-center justify-center font-semibold no-underline cursor-pointer rounded-lg transition-all duration-200 bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark w-full py-2.5 text-sm mt-1 animate-[fadeInUp_0.5s_ease_0.2s_both] disabled:opacity-60 disabled:cursor-not-allowed" :disabled="loading">
+                    <Loader2 v-if="loading" class="animate-spin-slow mr-1.5" :size="18" />
+                    {{ loading ? '提交中...' : '提交' }}
+                </button>
+            </form>
+
+            <p class="text-center mt-5 text-sm text-text-secondary animate-[fadeInUp_0.5s_ease_0.25s_both]">
+                <button type="button" class="bg-transparent border-0 text-primary text-sm cursor-pointer p-0 font-semibold hover:underline" @click="handleLogout">使用其他账号登录</button>
+            </p>
+        </div>
+    </div>
 </template>
 
 <script setup lang="ts">
+import { Lock, Eye, EyeOff, Loader2, X } from "@lucide/vue"
+import { validatePassword, validatePasswordMatch } from "~/utils/validatePassword"
+
 definePageMeta({ layout: "auth" })
 
 const router = useRouter()
 const auth = useAuth()
 const { showToast } = useToast()
-const { error, setError, clearError } = useFormError()
 
 const form = reactive({
-  oldPassword: "",
-  newPassword: "",
-  confirmPassword: "",
+    oldPassword: "",
+    newPassword: "",
+    confirmPassword: "",
 })
 const loading = ref(false)
+const error = ref("")
+const showOldPassword = ref(false)
+const showNewPassword = ref(false)
+const showConfirmPassword = ref(false)
+
+let errorTimer: ReturnType<typeof setTimeout> | null = null
+
+function setError(msg: string) {
+    error.value = msg
+    if (errorTimer) clearTimeout(errorTimer)
+    errorTimer = setTimeout(clearError, 3000)
+}
+
+function clearError() {
+    error.value = ""
+    if (errorTimer) clearTimeout(errorTimer)
+}
 
 const fieldErrors = reactive({
-  oldPassword: "",
-  newPassword: "",
-  confirmPassword: "",
+    oldPassword: "",
+    newPassword: "",
+    confirmPassword: "",
 })
 
 function validate(): boolean {
-  let valid = true
-  fieldErrors.oldPassword = ""
-  fieldErrors.newPassword = ""
-  fieldErrors.confirmPassword = ""
+    let valid = true
+    fieldErrors.oldPassword = ""
+    fieldErrors.newPassword = ""
+    fieldErrors.confirmPassword = ""
 
-  if (!form.oldPassword) {
-    fieldErrors.oldPassword = "请输入原密码"
-    valid = false
-  }
+    if (!form.oldPassword) {
+        fieldErrors.oldPassword = "请输入原密码"
+        valid = false
+    }
 
-  if (!form.newPassword) {
-    fieldErrors.newPassword = "请输入新密码"
-    valid = false
-  } else if (form.newPassword.length < 12) {
-    fieldErrors.newPassword = "密码长度不能少于 12 位"
-    valid = false
-  } else if (!/[a-z]/.test(form.newPassword)) {
-    fieldErrors.newPassword = "密码必须包含至少一个小写字母"
-    valid = false
-  } else if (!/[A-Z]/.test(form.newPassword)) {
-    fieldErrors.newPassword = "密码必须包含至少一个大写字母"
-    valid = false
-  } else if (!/[0-9]/.test(form.newPassword)) {
-    fieldErrors.newPassword = "密码必须包含至少一个数字"
-    valid = false
-  } else if (form.newPassword === form.oldPassword) {
-    fieldErrors.newPassword = "新密码不能与原密码相同"
-    valid = false
-  }
+    if (!form.newPassword) {
+        fieldErrors.newPassword = "请输入新密码"
+        valid = false
+    } else {
+        const pwResult = validatePassword(form.newPassword)
+        if (!pwResult.valid) {
+            fieldErrors.newPassword = pwResult.message
+            valid = false
+        }
+    }
 
-  if (!form.confirmPassword) {
-    fieldErrors.confirmPassword = "请确认密码"
-    valid = false
-  } else if (form.newPassword !== form.confirmPassword) {
-    fieldErrors.confirmPassword = "两次输入的密码不一致"
-    valid = false
-  }
+    if (form.newPassword && form.newPassword === form.oldPassword) {
+        fieldErrors.newPassword = "新密码不能与原密码相同"
+        valid = false
+    }
 
-  return valid
+    if (!form.confirmPassword) {
+        fieldErrors.confirmPassword = "请确认密码"
+        valid = false
+    } else {
+        const matchError = validatePasswordMatch(form.newPassword, form.confirmPassword)
+        if (matchError) {
+            fieldErrors.confirmPassword = matchError
+            valid = false
+        }
+    }
+
+    return valid
 }
 
 async function handleSubmit() {
-  setError("")
+    setError("")
 
-  if (!validate()) return
+    if (!validate()) return
 
-  loading.value = true
-  try {
-    await auth.changePassword(form.oldPassword, form.newPassword)
-    // useAuth.changePassword() 内部已更新本地 user 状态（must_change_password=false）
-    // 并由 Nitro 代理同步替换 noj:token Cookie（旧 token 已被后端撤销）。
-    // 无需再走 /login，直接回首页即可。
-    showToast("success", "密码修改成功")
-    router.replace("/settings")
-  } catch (e: any) {
-    setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.response?.status || e.statusCode || e.status || 502}`)
-  } finally {
-    loading.value = false
-  }
+    loading.value = true
+    try {
+        await auth.changePassword(form.oldPassword, form.newPassword)
+        // useAuth.changePassword() 内部已更新本地 user 状态（must_change_password=false）
+        // 并由 Nitro 代理同步替换 noj:token Cookie（旧 token 已被后端撤销）。
+        // 无需再走 /login，直接回首页即可。
+        showToast("success", "密码修改成功")
+        router.replace("/settings")
+    } catch (e: any) {
+        setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.response?.status || e.statusCode || e.status || 502}`)
+    } finally {
+        loading.value = false
+    }
 }
 
 async function handleLogout() {
-  await auth.logout()
-  router.replace("/login")
+    await auth.logout()
+    router.replace("/login")
 }
 </script>
+
+<style>
+/* Vue Transition: slide (用于 error banner) */
+.slide-enter-active {
+    transition: all 0.3s ease-out;
+}
+.slide-leave-active {
+    transition: all 0.2s ease-in;
+}
+.slide-enter-from {
+    transform: translateX(-50%) translateY(-20px);
+    opacity: 0;
+}
+.slide-leave-to {
+    transform: translateX(-50%) translateY(-20px);
+    opacity: 0;
+}
+
+/* Vue Transition: drop (用于 field errors) */
+.drop-enter-active {
+    animation: dropIn 0.25s ease both;
+}
+.drop-leave-active {
+    animation: dropOut 0.2s ease both;
+}
+
+@keyframes dropIn {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes dropOut {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+}
+
+/* Vue Transition: icon (用于密码可见切换) */
+.icon-enter-active,
+.icon-leave-active {
+    transition: opacity 0.18s linear, transform 0.18s linear;
+}
+.icon-enter-from {
+    opacity: 0;
+    transform: translate(-6px, -6px);
+}
+.icon-leave-to {
+    opacity: 0;
+    transform: translate(6px, 6px);
+}
+
+/* @keyframes fadeInUp (用于入场动画) */
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+</style>

--- a/noj-ui/pages/forgot-password.vue
+++ b/noj-ui/pages/forgot-password.vue
@@ -1,166 +1,83 @@
 <template>
-    <div class="w-full max-w-[380px] relative">
-        <Transition name="slide">
-            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ error }}</span>
-                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
-            </div>
-        </Transition>
-
-        <Transition name="slide">
-            <div v-if="submitted" class="bg-green-50 border border-green-200 text-green-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-center gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>密码重置链接已发送到 {{ submittedEmail }}，请检查邮箱（链接 15 分钟内有效）</span>
-            </div>
-        </Transition>
-
-        <div class="bg-white border border-border rounded-lg p-8">
-            <h1 class="text-[22px] font-bold text-center mb-3 text-text animate-[fadeInUp_0.5s_ease_both]">忘记密码</h1>
-            <p class="text-center text-sm text-text-secondary mb-6 animate-[fadeInUp_0.5s_ease_0.05s_both]">输入注册邮箱，我们会发送一封重置密码的邮件</p>
-
-            <form @submit.prevent="handleSubmit">
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
-                    <label for="email" class="block text-sm font-semibold text-text mb-1">邮箱</label>
-                    <div class="relative flex items-center">
-                        <Mail class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="email"
-                            v-model="email"
-                            type="email"
-                            placeholder="请输入注册时使用的邮箱"
-                            autocomplete="email"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.email = ''"
-                        />
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.email" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.email }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
-
-                <button type="submit" class="inline-flex items-center justify-center font-semibold no-underline cursor-pointer rounded-lg transition-all duration-200 bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark w-full py-2.5 text-sm mt-1 animate-[fadeInUp_0.5s_ease_0.15s_both] disabled:opacity-60 disabled:cursor-not-allowed" :disabled="loading">
-                    <Loader2 v-if="loading" class="animate-spin-slow mr-1.5" :size="18" />
-                    {{ loading ? '发送中...' : '发送重置链接' }}
-                </button>
-            </form>
-
-            <p class="text-center mt-5 text-sm text-text-secondary animate-[fadeInUp_0.5s_ease_0.2s_both]">
-                想起密码了？<NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">返回登录</NuxtLink>
-            </p>
+  <AuthFormCard
+    title="忘记密码"
+    subtitle="输入注册邮箱，我们会发送一封重置密码的邮件"
+    :error="error"
+    :loading="loading"
+    submit-label="发送重置链接"
+    loading-label="发送"
+    @submit="handleSubmit"
+    @clear-error="clearError"
+  >
+    <!-- 成功 banner -->
+    <template #banner-success>
+      <Transition name="slide">
+        <div v-if="submitted" class="bg-green-50 border border-green-200 text-green-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-center gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
+          <span>密码重置链接已发送到 {{ submittedEmail }}，请检查邮箱（链接 15 分钟内有效）</span>
         </div>
-    </div>
+      </Transition>
+    </template>
+
+    <TextInput
+      id="email"
+      v-model="email"
+      label="邮箱"
+      placeholder="请输入注册时使用的邮箱"
+      autocomplete="email"
+      type="email"
+      :disabled="loading"
+      :error="fieldErrors.email"
+      @focus="fieldErrors.email = ''"
+    >
+      <template #icon>
+        <Mail :size="18" />
+      </template>
+    </TextInput>
+
+    <template #footer>
+      <p>想起密码了？<NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">返回登录</NuxtLink></p>
+    </template>
+  </AuthFormCard>
 </template>
 
 <script setup lang="ts">
-import { Mail, Loader2, X } from "@lucide/vue"
+import { Mail } from "@lucide/vue"
 
 definePageMeta({ layout: "auth" })
 
 const auth = useAuth()
+const { error, setError, clearError } = useFormError()
 
 const email = ref("")
 const loading = ref(false)
 const submitted = ref(false)
 const submittedEmail = ref("")
-const error = ref("")
 const fieldErrors = ref<Record<string, string>>({})
 
-let errorTimer: ReturnType<typeof setTimeout> | null = null
-
-function setError(msg: string) {
-    error.value = msg
-    if (errorTimer) clearTimeout(errorTimer)
-    errorTimer = setTimeout(clearError, 3000)
-}
-
-function clearError() {
-    error.value = ""
-    if (errorTimer) clearTimeout(errorTimer)
-}
-
 function validate(): boolean {
-    const errors: Record<string, string> = {}
-    if (!email.value.trim()) {
-        errors.email = "请输入邮箱地址"
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.value.trim())) {
-        errors.email = "邮箱格式不正确"
-    }
-    fieldErrors.value = errors
-    return Object.keys(errors).length === 0
+  const errors: Record<string, string> = {}
+  if (!email.value.trim()) {
+    errors.email = "请输入邮箱地址"
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.value.trim())) {
+    errors.email = "邮箱格式不正确"
+  }
+  fieldErrors.value = errors
+  return Object.keys(errors).length === 0
 }
 
 async function handleSubmit() {
-    if (!validate()) return
-    loading.value = true
-    try {
-        await auth.forgotPassword(email.value.trim())
-        // 成功：显示绿色 banner，保留邮箱供用户核对
-        submitted.value = true
-        submittedEmail.value = email.value.trim()
-        email.value = ""
-    } catch (e: any) {
-        setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
-    } finally {
-        loading.value = false
-    }
+  if (!validate()) return
+  loading.value = true
+  try {
+    await auth.forgotPassword(email.value.trim())
+    // 成功：显示绿色 banner，保留邮箱供用户核对
+    submitted.value = true
+    submittedEmail.value = email.value.trim()
+    email.value = ""
+  } catch (e: any) {
+    setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
+  } finally {
+    loading.value = false
+  }
 }
 </script>
-
-<style>
-/* Vue Transition: slide (用于 error/success banner) */
-.slide-enter-active {
-    transition: all 0.3s ease-out;
-}
-.slide-leave-active {
-    transition: all 0.2s ease-in;
-}
-.slide-enter-from {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-.slide-leave-to {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-
-/* Vue Transition: drop (用于 field errors) */
-.drop-enter-active {
-    animation: dropIn 0.25s ease both;
-}
-.drop-leave-active {
-    animation: dropOut 0.2s ease both;
-}
-
-@keyframes dropIn {
-    from {
-        opacity: 0;
-        transform: translateY(-8px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes dropOut {
-    from {
-        opacity: 1;
-        transform: translateY(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateY(8px);
-    }
-}
-
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(12px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-</style>

--- a/noj-ui/pages/login.vue
+++ b/noj-ui/pages/login.vue
@@ -1,107 +1,84 @@
 <template>
-    <div class="w-full max-w-[380px] relative">
-        <Transition name="slide">
-            <div v-if="registeredMsg" class="bg-green-50 border border-green-200 text-green-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-center gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ registeredMsg }}</span>
-            </div>
-        </Transition>
-        <!-- ban-status-endpoint：用户被封禁时在登录页显示 banner（不依赖 URL 参数） -->
-        <Transition name="slide">
-            <div v-if="bannedMsg" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-center gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ bannedMsg }}</span>
-            </div>
-        </Transition>
-        <Transition name="slide">
-            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ error }}</span>
-                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
-            </div>
-        </Transition>
-        <div class="bg-white border border-border rounded-lg p-8">
-            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">登录</h1>
-
-            <form @submit.prevent="handleLogin">
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
-                    <label for="login" class="block text-sm font-semibold text-text mb-1">用户名 / 邮箱</label>
-                    <div class="relative flex items-center">
-                        <User class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="login"
-                            v-model="form.login"
-                            type="text"
-                            placeholder="请输入用户名或邮箱"
-                            autocomplete="username"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.login = ''"
-                        />
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.login" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.login }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
-
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
-                    <label for="password" class="block text-sm font-semibold text-text mb-1">密码</label>
-                    <div class="relative flex items-center">
-                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="password"
-                            v-model="form.password"
-                            :type="showPassword ? 'text' : 'password'"
-                            placeholder="请输入密码（仅字母和数字）"
-                            autocomplete="current-password"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.password = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showPassword = !showPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <EyeOff v-if="!showPassword" :size="18" key="off" />
-                                    <Eye v-else :size="18" key="on" />
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.password" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.password }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
-
-                <button type="submit" class="inline-flex items-center justify-center font-semibold no-underline cursor-pointer rounded-lg transition-all duration-200 bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark w-full py-2.5 text-sm mt-1 animate-[fadeInUp_0.5s_ease_0.15s_both] disabled:opacity-60 disabled:cursor-not-allowed" :disabled="loading">
-                    <Loader2 v-if="loading" class="animate-spin-slow mr-1.5" :size="18" />
-                    {{ loading ? '登录中...' : '登录' }}
-                </button>
-            </form>
-
-            <p class="text-center mt-5 text-sm text-text-secondary animate-[fadeInUp_0.5s_ease_0.2s_both]">
-                还没有账号？<NuxtLink to="/register" class="text-primary no-underline font-semibold hover:underline">立即注册</NuxtLink>
-            </p>
-            <p class="text-center mt-2 text-sm text-text-secondary animate-[fadeInUp_0.5s_ease_0.2s_both]">
-                <NuxtLink to="/forgot-password" class="text-primary no-underline font-semibold hover:underline">忘记密码？</NuxtLink>
-            </p>
+  <AuthFormCard
+    title="登录"
+    :error="error"
+    :loading="loading"
+    submit-label="登录"
+    loading-label="登录"
+    @submit="handleLogin"
+    @clear-error="clearError"
+  >
+    <!-- 注册成功/密码重置成功 banner -->
+    <template #banner-success>
+      <Transition name="slide">
+        <div v-if="registeredMsg" class="bg-green-50 border border-green-200 text-green-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-center gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
+          <span>{{ registeredMsg }}</span>
         </div>
-    </div>
+      </Transition>
+    </template>
+
+    <!-- 被封禁 banner -->
+    <template #banner-info>
+      <Transition name="slide">
+        <div v-if="bannedMsg" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-center gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
+          <span>{{ bannedMsg }}</span>
+        </div>
+      </Transition>
+    </template>
+
+    <TextInput
+      id="login"
+      v-model="form.login"
+      label="用户名 / 邮箱"
+      placeholder="请输入用户名或邮箱"
+      autocomplete="username"
+      :disabled="loading"
+      :error="fieldErrors.login"
+      @focus="fieldErrors.login = ''"
+    >
+      <template #icon>
+        <User :size="18" />
+      </template>
+    </TextInput>
+
+    <PasswordField
+      id="password"
+      v-model="form.password"
+      label="密码"
+      placeholder="请输入密码（仅字母和数字）"
+      autocomplete="current-password"
+      :disabled="loading"
+      :error="fieldErrors.password"
+      @focus="fieldErrors.password = ''"
+    />
+
+    <template #footer>
+      <p class="mb-2">
+        还没有账号？<NuxtLink to="/register" class="text-primary no-underline font-semibold hover:underline">立即注册</NuxtLink>
+      </p>
+      <p>
+        <NuxtLink to="/forgot-password" class="text-primary no-underline font-semibold hover:underline">忘记密码？</NuxtLink>
+      </p>
+    </template>
+  </AuthFormCard>
 </template>
 
 <script setup lang="ts">
-import { User, Lock, Eye, EyeOff, Loader2, X } from "@lucide/vue"
+import { User } from "@lucide/vue"
 
 definePageMeta({ layout: "auth" })
 
 const router = useRouter()
 const auth = useAuth()
+const route = useRoute()
+const { error, setError, clearError } = useFormError()
 
 const form = reactive({ login: "", password: "" })
 const loading = ref(false)
-const error = ref("")
-const showPassword = ref(false)
 
 // 注册成功后的提示
 const registeredMsg = ref("")
 const bannedMsg = ref("")
-const route = useRoute()
 if (route.query.registered === "1") {
   registeredMsg.value = "注册成功，请登录"
 } else if (route.query.reset === "1") {
@@ -110,150 +87,53 @@ if (route.query.registered === "1") {
 }
 
 const fieldErrors = reactive({
-    login: "",
-    password: "",
+  login: "",
+  password: "",
 })
 
-let errorTimer: ReturnType<typeof setTimeout> | null = null
-
-function setError(msg: string) {
-    error.value = msg
-    if (errorTimer) clearTimeout(errorTimer)
-    errorTimer = setTimeout(clearError, 3000)
-}
-
-function clearError() {
-    error.value = ""
-    if (errorTimer) clearTimeout(errorTimer)
-}
-
 function validate(): boolean {
-    let valid = true
-    fieldErrors.login = ""
-    fieldErrors.password = ""
+  let valid = true
+  fieldErrors.login = ""
+  fieldErrors.password = ""
 
-    if (!form.login.trim()) {
-        fieldErrors.login = "请输入用户名或邮箱"
-        valid = false
-    }
+  if (!form.login.trim()) {
+    fieldErrors.login = "请输入用户名或邮箱"
+    valid = false
+  }
 
-    if (!form.password) {
-        fieldErrors.password = "请输入密码"
-        valid = false
-    }
+  if (!form.password) {
+    fieldErrors.password = "请输入密码"
+    valid = false
+  }
 
-    return valid
+  return valid
 }
 
 async function handleLogin() {
-    if (!validate()) return
+  if (!validate()) return
 
-    loading.value = true
-    try {
-        const { user: loggedInUser } = await auth.login(form.login.trim(), form.password)
-        // issue #75：临时引导管理员首次登录必须改密
-        if (loggedInUser?.must_change_password === true) {
-            router.replace("/change-password")
-        } else {
-            router.replace("/")
-        }
-    } catch (e: any) {
-        // ban-status-endpoint：被封用户直接 inline 显示 banner，不用 URL 跳转
-        if (e.data?.code === "USER_BANNED") {
-            const reason = e.data.reason || "";
-            const until = e.data.until || "";
-            bannedMsg.value = until
-                ? `账号已被封禁至 ${until}。${reason ? `原因：${reason}。` : ""}请联系管理员。`
-                : `账号已被封禁。${reason ? `原因：${reason}。` : ""}请联系管理员。`;
-            return;
-        }
-        setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
-    } finally {
-        loading.value = false
+  loading.value = true
+  try {
+    const { user: loggedInUser } = await auth.login(form.login.trim(), form.password)
+    // issue #75：临时引导管理员首次登录必须改密
+    if (loggedInUser?.must_change_password === true) {
+      router.replace("/change-password")
+    } else {
+      router.replace("/")
     }
+  } catch (e: any) {
+    // ban-status-endpoint：被封用户直接 inline 显示 banner，不用 URL 跳转
+    if (e.data?.code === "USER_BANNED") {
+      const reason = e.data.reason || "";
+      const until = e.data.until || "";
+      bannedMsg.value = until
+        ? `账号已被封禁至 ${until}。${reason ? `原因：${reason}。` : ""}请联系管理员。`
+        : `账号已被封禁。${reason ? `原因：${reason}。` : ""}请联系管理员。`;
+      return;
+    }
+    setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
+  } finally {
+    loading.value = false
+  }
 }
 </script>
-
-<style>
-/* Vue Transition: slide (用于 error/success banner) */
-.slide-enter-active {
-    transition: all 0.3s ease-out;
-}
-.slide-leave-active {
-    transition: all 0.2s ease-in;
-}
-.slide-enter-from {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-.slide-leave-to {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-
-/* Vue Transition: drop (用于 field errors) */
-.drop-enter-active {
-    animation: dropIn 0.25s ease both;
-}
-.drop-leave-active {
-    animation: dropOut 0.2s ease both;
-}
-
-@keyframes dropIn {
-    from {
-        opacity: 0;
-        transform: translateY(-8px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes dropOut {
-    from {
-        opacity: 1;
-        transform: translateY(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateY(8px);
-    }
-}
-
-/* Vue Transition: fade (用于 forgot password overlay) */
-.fade-enter-active,
-.fade-leave-active {
-    transition: opacity 0.2s;
-}
-.fade-enter-from,
-.fade-leave-to {
-    opacity: 0;
-}
-
-/* Vue Transition: icon (用于密码可见切换) */
-.icon-enter-active,
-.icon-leave-active {
-    transition: opacity 0.18s linear, transform 0.18s linear;
-}
-.icon-enter-from {
-    opacity: 0;
-    transform: translate(-6px, -6px);
-}
-.icon-leave-to {
-    opacity: 0;
-    transform: translate(6px, 6px);
-}
-
-/* @keyframes fadeInUp (用于入场动画) */
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(12px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-</style>

--- a/noj-ui/pages/my/problems.vue
+++ b/noj-ui/pages/my/problems.vue
@@ -74,24 +74,26 @@ function onPageChange(page: number) {
       </NuxtLink>
     </div>
 
-    <div v-if="pageLoading" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted">
-      <div class="h-[28px] w-[28px] border-[3px] border-border border-t-primary rounded-full animate-spin-slow" />
-      <span>加载中...</span>
-    </div>
+    <AsyncContent
+      :status="pageLoading ? 'loading' : loadError ? 'error' : problems.length === 0 ? 'empty' : 'data'"
+      :error="loadError || undefined"
+      empty-text="你还没有创建任何题目"
+      @retry="loadProblems(currentPage)"
+    >
+      <template #error>
+        <span class="flex items-center justify-center size-11 rounded-full bg-red-100 text-red-800 text-xl font-bold">!</span>
+        <p>{{ loadError }}</p>
+        <button class="inline-flex items-center gap-1.5 px-4 py-1.5 text-xs font-semibold rounded-md border border-primary text-primary bg-transparent hover:bg-primary hover:text-white transition-colors cursor-pointer" @click="loadProblems(currentPage)">重试</button>
+      </template>
 
-    <div v-else-if="loadError" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="alert">
-      <span class="flex items-center justify-center size-11 rounded-full bg-red-100 text-red-800 text-xl font-bold">!</span>
-      <p>{{ loadError }}</p>
-    </div>
+      <template #empty>
+        <p>你还没有创建任何题目</p>
+        <NuxtLink to="/problems/new" class="inline-flex items-center gap-1.5 text-sm px-4 py-2 bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer no-underline transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark">
+          创建第一道题
+        </NuxtLink>
+      </template>
 
-    <div v-else-if="problems.length === 0" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted">
-      <p>你还没有创建任何题目</p>
-      <NuxtLink to="/problems/new" class="inline-flex items-center gap-1.5 text-sm px-4 py-2 bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer no-underline transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark">
-        创建第一道题
-      </NuxtLink>
-    </div>
-
-    <div v-else class="bg-white border border-border rounded-xl overflow-x-auto">
+      <div class="bg-white border border-border rounded-xl overflow-x-auto">
       <table class="w-full border-collapse">
         <thead>
           <tr>
@@ -130,5 +132,6 @@ function onPageChange(page: number) {
         </tbody>
       </table>
     </div>
+    </AsyncContent>
   </div>
 </template>

--- a/noj-ui/pages/problems.vue
+++ b/noj-ui/pages/problems.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { FileText } from "@lucide/vue"
 
 const router = useRouter()
 const route = useRoute()
@@ -155,35 +154,20 @@ function formatAcceptanceRate(rate: number | undefined): string {
       @update:problem-type="setFilter('type', $event)"
     />
 
-    <!-- 加载中 -->
-    <div v-if="pending" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="status" aria-live="polite">
-      <div class="h-[28px] w-[28px] border-[3px] border-border border-t-primary rounded-full animate-spin-slow" />
-      <span>加载中...</span>
-    </div>
+    <!-- 异步内容 -->
+    <AsyncContent
+      :status="pending ? 'loading' : error ? 'error' : problems.length === 0 ? 'empty' : 'data'"
+      error="题目加载失败"
+      :empty-text="hasActiveFilters ? '没有找到符合条件的题目，试试其他筛选条件' : '暂无题目'"
+      @retry="refresh"
+    >
+      <template #empty-action v-if="hasActiveFilters">
+        <button class="btn btn-outline px-4 py-1.5 text-xs" @click="router.push({ query: {} })">
+          清除筛选
+        </button>
+      </template>
 
-    <!-- 加载失败 -->
-    <div v-else-if="error" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="alert">
-      <span class="flex items-center justify-center size-11 rounded-full bg-red-100 text-red-800 text-xl font-bold">!</span>
-      <p>题目加载失败</p>
-      <button class="btn btn-outline px-4 py-1.5 text-xs" @click="refresh">重试</button>
-    </div>
-
-    <!-- 空数据 -->
-    <div v-else-if="problems.length === 0" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="status" aria-live="polite">
-      <FileText :size="48" class="opacity-30" />
-      <p v-if="hasActiveFilters">没有找到符合条件的题目，试试其他筛选条件</p>
-      <p v-else>暂无题目</p>
-      <button
-        v-if="hasActiveFilters"
-        class="btn btn-outline px-4 py-1.5 text-xs"
-        @click="router.push({ query: {} })"
-      >
-        清除筛选
-      </button>
-    </div>
-
-    <!-- 题目表格 -->
-    <template v-else>
+      <!-- 题目表格 -->
       <div class="bg-white border border-border rounded-xl overflow-x-auto">
         <table class="w-full border-collapse">
           <thead>
@@ -256,6 +240,6 @@ function formatAcceptanceRate(rate: number | undefined): string {
         :total-pages="totalPages"
         @page-change="setFilter('page', String($event))"
       />
-    </template>
+    </AsyncContent>
   </div>
 </template>

--- a/noj-ui/pages/problems/[id].vue
+++ b/noj-ui/pages/problems/[id].vue
@@ -8,7 +8,7 @@ const { isLoggedIn, user } = useAuth()
 
 const problemId = route.params.id as string
 
-const { data, pending, error } = useFetch<{
+const { data, pending, error, refresh } = useFetch<{
   data: {
     id: string
     title: string
@@ -43,18 +43,18 @@ function goToEditor() {
   <NuxtPage v-if="!isDetailPage" />
 
   <template v-else>
-    <div v-if="pending" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted">
-      <div class="h-[28px] w-[28px] border-[3px] border-border border-t-primary rounded-full animate-spin-slow" />
-      <span>加载中...</span>
-    </div>
+    <AsyncContent
+      :status="pending ? 'loading' : error ? 'error' : problem ? 'data' : 'empty'"
+      error="题目加载失败"
+      @retry="refresh"
+    >
+      <template #error>
+        <span class="flex items-center justify-center size-11 rounded-full bg-red-100 text-red-800 text-xl font-bold">!</span>
+        <p>题目加载失败</p>
+        <NuxtLink to="/problems" class="btn btn-outline">返回题目列表</NuxtLink>
+      </template>
 
-    <div v-else-if="error" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted">
-      <span class="flex items-center justify-center size-11 rounded-full bg-red-100 text-red-800 text-xl font-bold">!</span>
-      <p>题目加载失败</p>
-      <NuxtLink to="/problems" class="btn btn-outline">返回题目列表</NuxtLink>
-    </div>
-
-    <div v-else-if="problem" class="max-w-4xl mx-auto p-6 space-y-6">
+      <div class="max-w-4xl mx-auto p-6 space-y-6">
       <!-- 题目信息卡片 -->
       <div class="bg-white border border-border rounded-xl overflow-hidden">
         <div class="px-7 py-6 pb-5 border-b border-border">
@@ -134,5 +134,6 @@ function goToEditor() {
         后即可提交代码
       </div>
     </div>
+    </AsyncContent>
   </template>
 </template>

--- a/noj-ui/pages/ranking.vue
+++ b/noj-ui/pages/ranking.vue
@@ -40,28 +40,19 @@ function setPage(p: number) {
       <span class="text-sm text-text-muted">共 {{ total }} 位上榜用户</span>
     </div>
 
-    <!-- 加载中 -->
-    <div v-if="pending" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="status" aria-live="polite">
-      <div class="h-[28px] w-[28px] border-[3px] border-border border-t-primary rounded-full animate-spin-slow" />
-      <span>加载中...</span>
-    </div>
+    <!-- 异步内容 -->
+    <AsyncContent
+      :status="pending ? 'loading' : error ? 'error' : rows.length === 0 ? 'empty' : 'data'"
+      error="榜单加载失败"
+      @retry="refresh"
+    >
+      <template #empty>
+        <Trophy :size="48" class="opacity-30" />
+        <p>还没有用户通过任何题目，做第一个吧 👉</p>
+        <NuxtLink to="/problems" class="btn btn-primary px-4 py-1.5 text-xs">去做题</NuxtLink>
+      </template>
 
-    <!-- 加载失败 -->
-    <div v-else-if="error" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="alert">
-      <span class="flex items-center justify-center size-11 rounded-full bg-red-100 text-red-800 text-xl font-bold">!</span>
-      <p>榜单加载失败</p>
-      <button class="btn btn-outline px-4 py-1.5 text-xs" @click="refresh">重试</button>
-    </div>
-
-    <!-- 空数据 -->
-    <div v-else-if="rows.length === 0" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted" role="status" aria-live="polite">
-      <Trophy :size="48" class="opacity-30" />
-      <p>还没有用户通过任何题目，做第一个吧 👉</p>
-      <NuxtLink to="/problems" class="btn btn-primary px-4 py-1.5 text-xs">去做题</NuxtLink>
-    </div>
-
-    <!-- 榜单表格 -->
-    <template v-else>
+      <!-- 榜单表格 -->
       <div class="bg-white border border-border rounded-xl overflow-x-auto">
         <table class="w-full border-collapse">
           <thead>
@@ -125,6 +116,6 @@ function setPage(p: number) {
         :total-pages="totalPages"
         @page-change="setPage($event)"
       />
-    </template>
+    </AsyncContent>
   </div>
 </template>

--- a/noj-ui/pages/register.vue
+++ b/noj-ui/pages/register.vue
@@ -1,325 +1,173 @@
 <template>
-    <div class="w-full max-w-[380px] relative">
-        <Transition name="slide">
-            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ error }}</span>
-                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
-            </div>
-        </Transition>
-        <div class="bg-white border border-border rounded-lg p-8">
-            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">注册</h1>
+  <AuthFormCard
+    title="注册"
+    :error="error"
+    :loading="loading"
+    submit-label="注册"
+    loading-label="注册"
+    @submit="handleRegister"
+    @clear-error="clearError"
+  >
+    <TextInput
+      id="username"
+      v-model="form.username"
+      label="用户名"
+      placeholder="3-30 位字母、数字或下划线"
+      autocomplete="username"
+      :disabled="loading"
+      :error="fieldErrors.username"
+      @focus="fieldErrors.username = ''"
+    >
+      <template #icon>
+        <User :size="18" />
+      </template>
+    </TextInput>
 
-            <form @submit.prevent="handleRegister">
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
-                    <label for="username" class="block text-sm font-semibold text-text mb-1">用户名</label>
-                    <div class="relative flex items-center">
-                        <User class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="username"
-                            v-model="form.username"
-                            type="text"
-                            placeholder="3-30 位字母、数字或下划线"
-                            autocomplete="username"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.username = ''"
-                        />
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.username" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.username }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
+    <TextInput
+      id="email"
+      v-model="form.email"
+      label="邮箱"
+      placeholder="请输入邮箱地址"
+      autocomplete="email"
+      type="email"
+      :disabled="loading"
+      :error="fieldErrors.email"
+      @focus="fieldErrors.email = ''"
+    >
+      <template #icon>
+        <Mail :size="18" />
+      </template>
+    </TextInput>
 
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
-                    <label for="email" class="block text-sm font-semibold text-text mb-1">邮箱</label>
-                    <div class="relative flex items-center">
-                        <Mail class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="email"
-                            v-model="form.email"
-                            type="email"
-                            placeholder="请输入邮箱地址"
-                            autocomplete="email"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.email = ''"
-                        />
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.email" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.email }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
+    <!-- TODO 验证码 -->
 
-                <!-- TODO 验证码 -->
+    <PasswordField
+      id="password"
+      v-model="form.password"
+      label="密码"
+      placeholder="至少 12 位，需包含字母和数字"
+      autocomplete="new-password"
+      :disabled="loading"
+      :error="fieldErrors.password"
+      @focus="fieldErrors.password = ''"
+    />
 
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.15s_both]">
-                    <label for="password" class="block text-sm font-semibold text-text mb-1">密码</label>
-                    <div class="relative flex items-center">
-                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="password"
-                            v-model="form.password"
-                            :type="showPassword ? 'text' : 'password'"
-                            placeholder="至少 12 位，需包含字母和数字"
-                            autocomplete="new-password"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.password = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showPassword = !showPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <EyeOff v-if="!showPassword" :size="18" key="off" />
-                                    <Eye v-else :size="18" key="on" />
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.password" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.password }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
+    <PasswordField
+      id="confirmPassword"
+      v-model="form.confirmPassword"
+      label="确认密码"
+      placeholder="再次输入密码"
+      autocomplete="new-password"
+      :disabled="loading"
+      :error="fieldErrors.confirmPassword"
+      @focus="fieldErrors.confirmPassword = ''"
+    />
 
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.2s_both]">
-                    <label for="confirmPassword" class="block text-sm font-semibold text-text mb-1">确认密码</label>
-                    <div class="relative flex items-center">
-                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="confirmPassword"
-                            v-model="form.confirmPassword"
-                            :type="showConfirmPassword ? 'text' : 'password'"
-                            placeholder="再次输入密码"
-                            autocomplete="new-password"
-                            maxlength="30"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.confirmPassword = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showConfirmPassword = !showConfirmPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <EyeOff v-if="!showConfirmPassword" :size="18" key="off" />
-                                    <Eye v-else :size="18" key="on" />
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
-
-                <button type="submit" class="inline-flex items-center justify-center font-semibold no-underline cursor-pointer rounded-lg transition-all duration-200 bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark w-full py-2.5 text-sm mt-1 animate-[fadeInUp_0.5s_ease_0.25s_both] disabled:opacity-60 disabled:cursor-not-allowed" :disabled="loading">
-                    <Loader2 v-if="loading" class="animate-spin-slow mr-1.5" :size="18" />
-                    {{ loading ? '注册中...' : '注册' }}
-                </button>
-            </form>
-
-            <p class="text-center mt-5 text-sm text-text-secondary animate-[fadeInUp_0.5s_ease_0.3s_both]">
-                已有账号？<NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">立即登录</NuxtLink>
-            </p>
-        </div>
-    </div>
+    <template #footer>
+      <p>已有账号？<NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">立即登录</NuxtLink></p>
+    </template>
+  </AuthFormCard>
 </template>
 
 <script setup lang="ts">
-import { User, Mail, Lock, Eye, EyeOff, Loader2, X } from "@lucide/vue"
+import { User, Mail } from "@lucide/vue"
 
 definePageMeta({ layout: "auth" })
 
 const router = useRouter()
 const auth = useAuth()
+const { error, setError, clearError } = useFormError()
 
 const form = reactive({
-    username: "",
-    email: "",
-    password: "",
-    confirmPassword: "",
+  username: "",
+  email: "",
+  password: "",
+  confirmPassword: "",
 })
 const loading = ref(false)
-const error = ref("")
-const showPassword = ref(false)
-const showConfirmPassword = ref(false)
-
-let errorTimer: ReturnType<typeof setTimeout> | null = null
-
-function setError(msg: string) {
-    error.value = msg
-    if (errorTimer) clearTimeout(errorTimer)
-    errorTimer = setTimeout(clearError, 3000)
-}
-
-function clearError() {
-    error.value = ""
-    if (errorTimer) clearTimeout(errorTimer)
-}
 
 const fieldErrors = reactive({
-    username: "",
-    email: "",
-    password: "",
-    confirmPassword: "",
+  username: "",
+  email: "",
+  password: "",
+  confirmPassword: "",
 })
 
 function validate(): boolean {
-    let valid = true
-    fieldErrors.username = ""
-    fieldErrors.email = ""
-    fieldErrors.password = ""
-    fieldErrors.confirmPassword = ""
+  let valid = true
+  fieldErrors.username = ""
+  fieldErrors.email = ""
+  fieldErrors.password = ""
+  fieldErrors.confirmPassword = ""
 
-    if (!form.username.trim()) {
-        fieldErrors.username = "请输入用户名"
-        valid = false
-    } else if (!/^[a-zA-Z0-9_]{3,30}$/.test(form.username.trim())) {
-        fieldErrors.username = "用户名仅允许字母、数字和下划线，长度 3-30"
-        valid = false
-    }
+  if (!form.username.trim()) {
+    fieldErrors.username = "请输入用户名"
+    valid = false
+  } else if (!/^[a-zA-Z0-9_]{3,30}$/.test(form.username.trim())) {
+    fieldErrors.username = "用户名仅允许字母、数字和下划线，长度 3-30"
+    valid = false
+  }
 
-    if (!form.email.trim()) {
-        fieldErrors.email = "请输入邮箱地址"
-        valid = false
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
-        fieldErrors.email = "邮箱格式不正确"
-        valid = false
-    }
+  if (!form.email.trim()) {
+    fieldErrors.email = "请输入邮箱地址"
+    valid = false
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
+    fieldErrors.email = "邮箱格式不正确"
+    valid = false
+  }
 
-    if (!form.password) {
-        fieldErrors.password = "请输入密码"
-        valid = false
-    } else if (form.password.length < 12) {
-        fieldErrors.password = "密码长度不能少于 12 位"
-        valid = false
-    } else if (!/[a-z]/.test(form.password)) {
-        fieldErrors.password = "密码必须包含至少一个小写字母"
-        valid = false
-    } else if (!/[A-Z]/.test(form.password)) {
-        fieldErrors.password = "密码必须包含至少一个大写字母"
-        valid = false
-    } else if (!/[0-9]/.test(form.password)) {
-        fieldErrors.password = "密码必须包含至少一个数字"
-        valid = false
-    }
+  if (!form.password) {
+    fieldErrors.password = "请输入密码"
+    valid = false
+  } else if (form.password.length < 12) {
+    fieldErrors.password = "密码长度不能少于 12 位"
+    valid = false
+  } else if (!/[a-z]/.test(form.password)) {
+    fieldErrors.password = "密码必须包含至少一个小写字母"
+    valid = false
+  } else if (!/[A-Z]/.test(form.password)) {
+    fieldErrors.password = "密码必须包含至少一个大写字母"
+    valid = false
+  } else if (!/[0-9]/.test(form.password)) {
+    fieldErrors.password = "密码必须包含至少一个数字"
+    valid = false
+  }
 
-    if (!form.confirmPassword) {
-        fieldErrors.confirmPassword = "请确认密码"
-        valid = false
-    } else if (form.password !== form.confirmPassword) {
-        fieldErrors.confirmPassword = "两次输入的密码不一致"
-        valid = false
-    }
+  if (!form.confirmPassword) {
+    fieldErrors.confirmPassword = "请确认密码"
+    valid = false
+  } else if (form.password !== form.confirmPassword) {
+    fieldErrors.confirmPassword = "两次输入的密码不一致"
+    valid = false
+  }
 
-    return valid
+  return valid
 }
 
 async function handleRegister() {
-    setError("")
+  setError("")
 
-    if (!validate()) return
+  if (!validate()) return
 
-    loading.value = true
-    try {
-        // 先注册
-        await auth.register(form.username.trim(), form.email.trim(), form.password)
-    } catch (e: any) {
-        setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.status || 502}`)
-        loading.value = false
-        return
-    }
+  loading.value = true
+  try {
+    // 先注册
+    await auth.register(form.username.trim(), form.email.trim(), form.password)
+  } catch (e: any) {
+    setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.status || 502}`)
+    loading.value = false
+    return
+  }
 
-    // 注册成功后自动登录
-    try {
-        await auth.login(form.username.trim(), form.password)
-        router.replace("/")
-    } catch {
-        // 注册成功但登录失败 → 引导用户手动登录
-        router.replace("/login?registered=1")
-    } finally {
-        loading.value = false
-    }
+  // 注册成功后自动登录
+  try {
+    await auth.login(form.username.trim(), form.password)
+    router.replace("/")
+  } catch {
+    // 注册成功但登录失败 → 引导用户手动登录
+    router.replace("/login?registered=1")
+  } finally {
+    loading.value = false
+  }
 }
 </script>
-
-<style>
-/* Vue Transition: slide (用于 error banner) */
-.slide-enter-active {
-    transition: all 0.3s ease-out;
-}
-.slide-leave-active {
-    transition: all 0.2s ease-in;
-}
-.slide-enter-from {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-.slide-leave-to {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-
-/* Vue Transition: drop (用于 field errors) */
-.drop-enter-active {
-    animation: dropIn 0.25s ease both;
-}
-.drop-leave-active {
-    animation: dropOut 0.2s ease both;
-}
-
-@keyframes dropIn {
-    from {
-        opacity: 0;
-        transform: translateY(-8px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes dropOut {
-    from {
-        opacity: 1;
-        transform: translateY(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateY(8px);
-    }
-}
-
-/* Vue Transition: fade (保留用于可能的将来 overlay) */
-.fade-enter-active,
-.fade-leave-active {
-    transition: opacity 0.2s;
-}
-.fade-enter-from,
-.fade-leave-to {
-    opacity: 0;
-}
-
-/* Vue Transition: icon (用于密码可见切换) */
-.icon-enter-active,
-.icon-leave-active {
-    transition: opacity 0.18s linear, transform 0.18s linear;
-}
-.icon-enter-from {
-    opacity: 0;
-    transform: translate(-6px, -6px);
-}
-.icon-leave-to {
-    opacity: 0;
-    transform: translate(6px, 6px);
-}
-
-/* @keyframes fadeInUp (用于入场动画) */
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(12px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-</style>

--- a/noj-ui/pages/register.vue
+++ b/noj-ui/pages/register.vue
@@ -1,173 +1,321 @@
 <template>
-  <AuthFormCard
-    title="注册"
-    :error="error"
-    :loading="loading"
-    submit-label="注册"
-    loading-label="注册"
-    @submit="handleRegister"
-    @clear-error="clearError"
-  >
-    <TextInput
-      id="username"
-      v-model="form.username"
-      label="用户名"
-      placeholder="3-30 位字母、数字或下划线"
-      autocomplete="username"
-      :disabled="loading"
-      :error="fieldErrors.username"
-      @focus="fieldErrors.username = ''"
-    >
-      <template #icon>
-        <User :size="18" />
-      </template>
-    </TextInput>
+    <div class="w-full max-w-[380px] relative">
+        <Transition name="slide">
+            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
+                <span>{{ error }}</span>
+                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
+            </div>
+        </Transition>
+        <div class="bg-white border border-border rounded-lg p-8">
+            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">注册</h1>
 
-    <TextInput
-      id="email"
-      v-model="form.email"
-      label="邮箱"
-      placeholder="请输入邮箱地址"
-      autocomplete="email"
-      type="email"
-      :disabled="loading"
-      :error="fieldErrors.email"
-      @focus="fieldErrors.email = ''"
-    >
-      <template #icon>
-        <Mail :size="18" />
-      </template>
-    </TextInput>
+            <form @submit.prevent="handleRegister">
+                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
+                    <label for="username" class="block text-sm font-semibold text-text mb-1">用户名</label>
+                    <div class="relative flex items-center">
+                        <User class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+                        <input
+                            id="username"
+                            v-model="form.username"
+                            type="text"
+                            placeholder="3-30 位字母、数字或下划线"
+                            autocomplete="username"
+                            :disabled="loading"
+                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+                            @focus="fieldErrors.username = ''"
+                        />
+                    </div>
+                    <Transition name="drop">
+                        <div v-if="fieldErrors.username" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.username }}</span><X :size="14" /></div>
+                    </Transition>
+                </div>
 
-    <!-- TODO 验证码 -->
+                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
+                    <label for="email" class="block text-sm font-semibold text-text mb-1">邮箱</label>
+                    <div class="relative flex items-center">
+                        <Mail class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+                        <input
+                            id="email"
+                            v-model="form.email"
+                            type="email"
+                            placeholder="请输入邮箱地址"
+                            autocomplete="email"
+                            :disabled="loading"
+                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+                            @focus="fieldErrors.email = ''"
+                        />
+                    </div>
+                    <Transition name="drop">
+                        <div v-if="fieldErrors.email" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.email }}</span><X :size="14" /></div>
+                    </Transition>
+                </div>
 
-    <PasswordField
-      id="password"
-      v-model="form.password"
-      label="密码"
-      placeholder="至少 12 位，需包含字母和数字"
-      autocomplete="new-password"
-      :disabled="loading"
-      :error="fieldErrors.password"
-      @focus="fieldErrors.password = ''"
-    />
+                <!-- TODO 验证码 -->
 
-    <PasswordField
-      id="confirmPassword"
-      v-model="form.confirmPassword"
-      label="确认密码"
-      placeholder="再次输入密码"
-      autocomplete="new-password"
-      :disabled="loading"
-      :error="fieldErrors.confirmPassword"
-      @focus="fieldErrors.confirmPassword = ''"
-    />
+                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.15s_both]">
+                    <label for="password" class="block text-sm font-semibold text-text mb-1">密码</label>
+                    <div class="relative flex items-center">
+                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+                        <input
+                            id="password"
+                            v-model="form.password"
+                            :type="showPassword ? 'text' : 'password'"
+                            placeholder="至少 12 位，需包含字母和数字"
+                            autocomplete="new-password"
+                            :disabled="loading"
+                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+                            @focus="fieldErrors.password = ''"
+                        />
+                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showPassword = !showPassword" tabindex="-1">
+                            <span class="flex items-center justify-center w-[18px] h-[18px]">
+                                <Transition name="icon" mode="out-in">
+                                    <EyeOff v-if="!showPassword" :size="18" key="off" />
+                                    <Eye v-else :size="18" key="on" />
+                                </Transition>
+                            </span>
+                        </button>
+                    </div>
+                    <Transition name="drop">
+                        <div v-if="fieldErrors.password" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.password }}</span><X :size="14" /></div>
+                    </Transition>
+                </div>
 
-    <template #footer>
-      <p>已有账号？<NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">立即登录</NuxtLink></p>
-    </template>
-  </AuthFormCard>
+                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.2s_both]">
+                    <label for="confirmPassword" class="block text-sm font-semibold text-text mb-1">确认密码</label>
+                    <div class="relative flex items-center">
+                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+                        <input
+                            id="confirmPassword"
+                            v-model="form.confirmPassword"
+                            :type="showConfirmPassword ? 'text' : 'password'"
+                            placeholder="再次输入密码"
+                            autocomplete="new-password"
+                            maxlength="30"
+                            :disabled="loading"
+                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+                            @focus="fieldErrors.confirmPassword = ''"
+                        />
+                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showConfirmPassword = !showConfirmPassword" tabindex="-1">
+                            <span class="flex items-center justify-center w-[18px] h-[18px]">
+                                <Transition name="icon" mode="out-in">
+                                    <EyeOff v-if="!showConfirmPassword" :size="18" key="off" />
+                                    <Eye v-else :size="18" key="on" />
+                                </Transition>
+                            </span>
+                        </button>
+                    </div>
+                    <Transition name="drop">
+                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><X :size="14" /></div>
+                    </Transition>
+                </div>
+
+                <button type="submit" class="inline-flex items-center justify-center font-semibold no-underline cursor-pointer rounded-lg transition-all duration-200 bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark w-full py-2.5 text-sm mt-1 animate-[fadeInUp_0.5s_ease_0.25s_both] disabled:opacity-60 disabled:cursor-not-allowed" :disabled="loading">
+                    <Loader2 v-if="loading" class="animate-spin-slow mr-1.5" :size="18" />
+                    {{ loading ? '注册中...' : '注册' }}
+                </button>
+            </form>
+
+            <p class="text-center mt-5 text-sm text-text-secondary animate-[fadeInUp_0.5s_ease_0.3s_both]">
+                已有账号？<NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">立即登录</NuxtLink>
+            </p>
+        </div>
+    </div>
 </template>
 
 <script setup lang="ts">
-import { User, Mail } from "@lucide/vue"
+import { User, Mail, Lock, Eye, EyeOff, Loader2, X } from "@lucide/vue"
+import { validatePassword, validatePasswordMatch, validateEmail } from "~/utils/validatePassword"
 
 definePageMeta({ layout: "auth" })
 
 const router = useRouter()
 const auth = useAuth()
-const { error, setError, clearError } = useFormError()
 
 const form = reactive({
-  username: "",
-  email: "",
-  password: "",
-  confirmPassword: "",
+    username: "",
+    email: "",
+    password: "",
+    confirmPassword: "",
 })
 const loading = ref(false)
+const error = ref("")
+const showPassword = ref(false)
+const showConfirmPassword = ref(false)
+
+let errorTimer: ReturnType<typeof setTimeout> | null = null
+
+function setError(msg: string) {
+    error.value = msg
+    if (errorTimer) clearTimeout(errorTimer)
+    errorTimer = setTimeout(clearError, 3000)
+}
+
+function clearError() {
+    error.value = ""
+    if (errorTimer) clearTimeout(errorTimer)
+}
 
 const fieldErrors = reactive({
-  username: "",
-  email: "",
-  password: "",
-  confirmPassword: "",
+    username: "",
+    email: "",
+    password: "",
+    confirmPassword: "",
 })
 
 function validate(): boolean {
-  let valid = true
-  fieldErrors.username = ""
-  fieldErrors.email = ""
-  fieldErrors.password = ""
-  fieldErrors.confirmPassword = ""
+    let valid = true
+    fieldErrors.username = ""
+    fieldErrors.email = ""
+    fieldErrors.password = ""
+    fieldErrors.confirmPassword = ""
 
-  if (!form.username.trim()) {
-    fieldErrors.username = "请输入用户名"
-    valid = false
-  } else if (!/^[a-zA-Z0-9_]{3,30}$/.test(form.username.trim())) {
-    fieldErrors.username = "用户名仅允许字母、数字和下划线，长度 3-30"
-    valid = false
-  }
+    if (!form.username.trim()) {
+        fieldErrors.username = "请输入用户名"
+        valid = false
+    } else if (!/^[a-zA-Z0-9_]{3,30}$/.test(form.username.trim())) {
+        fieldErrors.username = "用户名仅允许字母、数字和下划线，长度 3-30"
+        valid = false
+    }
 
-  if (!form.email.trim()) {
-    fieldErrors.email = "请输入邮箱地址"
-    valid = false
-  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
-    fieldErrors.email = "邮箱格式不正确"
-    valid = false
-  }
+    const emailError = validateEmail(form.email)
+    if (emailError) {
+        fieldErrors.email = emailError
+        valid = false
+    }
 
-  if (!form.password) {
-    fieldErrors.password = "请输入密码"
-    valid = false
-  } else if (form.password.length < 12) {
-    fieldErrors.password = "密码长度不能少于 12 位"
-    valid = false
-  } else if (!/[a-z]/.test(form.password)) {
-    fieldErrors.password = "密码必须包含至少一个小写字母"
-    valid = false
-  } else if (!/[A-Z]/.test(form.password)) {
-    fieldErrors.password = "密码必须包含至少一个大写字母"
-    valid = false
-  } else if (!/[0-9]/.test(form.password)) {
-    fieldErrors.password = "密码必须包含至少一个数字"
-    valid = false
-  }
+    if (!form.password) {
+        fieldErrors.password = "请输入密码"
+        valid = false
+    } else {
+        const pwResult = validatePassword(form.password)
+        if (!pwResult.valid) {
+            fieldErrors.password = pwResult.message
+            valid = false
+        }
+    }
 
-  if (!form.confirmPassword) {
-    fieldErrors.confirmPassword = "请确认密码"
-    valid = false
-  } else if (form.password !== form.confirmPassword) {
-    fieldErrors.confirmPassword = "两次输入的密码不一致"
-    valid = false
-  }
+    if (!form.confirmPassword) {
+        fieldErrors.confirmPassword = "请确认密码"
+        valid = false
+    } else {
+        const matchError = validatePasswordMatch(form.password, form.confirmPassword)
+        if (matchError) {
+            fieldErrors.confirmPassword = matchError
+            valid = false
+        }
+    }
 
-  return valid
+    return valid
 }
 
 async function handleRegister() {
-  setError("")
+    setError("")
 
-  if (!validate()) return
+    if (!validate()) return
 
-  loading.value = true
-  try {
-    // 先注册
-    await auth.register(form.username.trim(), form.email.trim(), form.password)
-  } catch (e: any) {
-    setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.status || 502}`)
-    loading.value = false
-    return
-  }
+    loading.value = true
+    try {
+        // 先注册
+        await auth.register(form.username.trim(), form.email.trim(), form.password)
+    } catch (e: any) {
+        setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.status || 502}`)
+        loading.value = false
+        return
+    }
 
-  // 注册成功后自动登录
-  try {
-    await auth.login(form.username.trim(), form.password)
-    router.replace("/")
-  } catch {
-    // 注册成功但登录失败 → 引导用户手动登录
-    router.replace("/login?registered=1")
-  } finally {
-    loading.value = false
-  }
+    // 注册成功后自动登录
+    try {
+        await auth.login(form.username.trim(), form.password)
+        router.replace("/")
+    } catch {
+        // 注册成功但登录失败 → 引导用户手动登录
+        router.replace("/login?registered=1")
+    } finally {
+        loading.value = false
+    }
 }
 </script>
+
+<style>
+/* Vue Transition: slide (用于 error banner) */
+.slide-enter-active {
+    transition: all 0.3s ease-out;
+}
+.slide-leave-active {
+    transition: all 0.2s ease-in;
+}
+.slide-enter-from {
+    transform: translateX(-50%) translateY(-20px);
+    opacity: 0;
+}
+.slide-leave-to {
+    transform: translateX(-50%) translateY(-20px);
+    opacity: 0;
+}
+
+/* Vue Transition: drop (用于 field errors) */
+.drop-enter-active {
+    animation: dropIn 0.25s ease both;
+}
+.drop-leave-active {
+    animation: dropOut 0.2s ease both;
+}
+
+@keyframes dropIn {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes dropOut {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+}
+
+/* Vue Transition: fade (保留用于可能的将来 overlay) */
+.fade-enter-active,
+.fade-leave-active {
+    transition: opacity 0.2s;
+}
+.fade-enter-from,
+.fade-leave-to {
+    opacity: 0;
+}
+
+/* Vue Transition: icon (用于密码可见切换) */
+.icon-enter-active,
+.icon-leave-active {
+    transition: opacity 0.18s linear, transform 0.18s linear;
+}
+.icon-enter-from {
+    opacity: 0;
+    transform: translate(-6px, -6px);
+}
+.icon-leave-to {
+    opacity: 0;
+    transform: translate(6px, 6px);
+}
+
+/* @keyframes fadeInUp (用于入场动画) */
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+</style>

--- a/noj-ui/pages/reset-password.vue
+++ b/noj-ui/pages/reset-password.vue
@@ -1,226 +1,94 @@
 <template>
-    <div class="w-full max-w-[380px] relative">
-        <Transition name="slide">
-            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ error }}</span>
-                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
-            </div>
-        </Transition>
+  <AuthFormCard
+    title="重置密码"
+    :error="error"
+    :loading="loading"
+    submit-label="重置密码"
+    loading-label="重置"
+    @submit="handleSubmit"
+    @clear-error="clearError"
+  >
+    <PasswordField
+      id="password"
+      v-model="form.password"
+      label="新密码"
+      placeholder="至少 12 位，需包含字母和数字"
+      autocomplete="new-password"
+      :disabled="loading"
+      required
+      :error="fieldErrors.password"
+      @focus="fieldErrors.password = ''"
+    />
 
-        <div class="bg-white border border-border rounded-lg p-8">
-            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">重置密码</h1>
+    <PasswordField
+      id="confirmPassword"
+      v-model="form.confirmPassword"
+      label="确认密码"
+      placeholder="再次输入新密码"
+      autocomplete="new-password"
+      :disabled="loading"
+      required
+      :error="fieldErrors.confirmPassword"
+      @focus="fieldErrors.confirmPassword = ''"
+    />
 
-            <form @submit.prevent="handleSubmit">
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
-                    <label for="password" class="block text-sm font-semibold text-text mb-1">新密码 <span class="text-red-600">*</span></label>
-                    <div class="relative flex items-center">
-                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="password"
-                            v-model="form.password"
-                            :type="showPassword ? 'text' : 'password'"
-                            placeholder="至少 12 位，需包含字母和数字"
-                            autocomplete="new-password"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.password = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showPassword = !showPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <EyeOff v-if="!showPassword" :size="18" key="off" />
-                                    <Eye v-else :size="18" key="on" />
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.password" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.password }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
-
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
-                    <label for="confirmPassword" class="block text-sm font-semibold text-text mb-1">确认密码 <span class="text-red-600">*</span></label>
-                    <div class="relative flex items-center">
-                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
-                        <input
-                            id="confirmPassword"
-                            v-model="form.confirmPassword"
-                            :type="showConfirmPassword ? 'text' : 'password'"
-                            placeholder="再次输入新密码"
-                            autocomplete="new-password"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.confirmPassword = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showConfirmPassword = !showConfirmPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <EyeOff v-if="!showConfirmPassword" :size="18" key="off" />
-                                    <Eye v-else :size="18" key="on" />
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><X :size="14" /></div>
-                    </Transition>
-                </div>
-
-                <button type="submit" class="inline-flex items-center justify-center font-semibold no-underline cursor-pointer rounded-lg transition-all duration-200 bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark w-full py-2.5 text-sm mt-1 animate-[fadeInUp_0.5s_ease_0.15s_both] disabled:opacity-60 disabled:cursor-not-allowed" :disabled="loading">
-                    <Loader2 v-if="loading" class="animate-spin-slow mr-1.5" :size="18" />
-                    {{ loading ? '重置中...' : '重置密码' }}
-                </button>
-            </form>
-
-            <p class="text-center mt-5 text-sm text-text-secondary animate-[fadeInUp_0.5s_ease_0.2s_both]">
-                <NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">返回登录</NuxtLink>
-            </p>
-        </div>
-    </div>
+    <template #footer>
+      <p><NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">返回登录</NuxtLink></p>
+    </template>
+  </AuthFormCard>
 </template>
 
 <script setup lang="ts">
-import { Lock, Eye, EyeOff, Loader2, X } from "@lucide/vue"
-
 definePageMeta({ layout: "auth" })
 
 const route = useRoute()
 const router = useRouter()
 const auth = useAuth()
+const { error, setError, clearError } = useFormError(5000)
 
 const token = computed(() => (route.query.token as string) || "")
 
 const form = reactive({ password: "", confirmPassword: "" })
-const showPassword = ref(false)
-const showConfirmPassword = ref(false)
 const loading = ref(false)
-const error = ref("")
 const fieldErrors = ref<Record<string, string>>({})
 
-let errorTimer: ReturnType<typeof setTimeout> | null = null
-
-function setError(msg: string) {
-    error.value = msg
-    if (errorTimer) clearTimeout(errorTimer)
-    errorTimer = setTimeout(clearError, 5000)
-}
-
-function clearError() {
-    error.value = ""
-    if (errorTimer) clearTimeout(errorTimer)
-}
-
 function validate(): boolean {
-    const errors: Record<string, string> = {}
-    if (!form.password) {
-        errors.password = "请输入新密码"
-    } else if (form.password.length < 12) {
-        errors.password = "密码长度不能少于 12 位"
-    } else if (!/[a-z]/.test(form.password)) {
-        errors.password = "密码必须包含至少一个小写字母"
-    } else if (!/[A-Z]/.test(form.password)) {
-        errors.password = "密码必须包含至少一个大写字母"
-    } else if (!/[0-9]/.test(form.password)) {
-        errors.password = "密码必须包含至少一个数字"
-    }
-    if (!form.confirmPassword) {
-        errors.confirmPassword = "请确认密码"
-    } else if (form.password !== form.confirmPassword) {
-        errors.confirmPassword = "两次输入的密码不一致"
-    }
-    fieldErrors.value = errors
-    return Object.keys(errors).length === 0
+  const errors: Record<string, string> = {}
+  if (!form.password) {
+    errors.password = "请输入新密码"
+  } else if (form.password.length < 12) {
+    errors.password = "密码长度不能少于 12 位"
+  } else if (!/[a-z]/.test(form.password)) {
+    errors.password = "密码必须包含至少一个小写字母"
+  } else if (!/[A-Z]/.test(form.password)) {
+    errors.password = "密码必须包含至少一个大写字母"
+  } else if (!/[0-9]/.test(form.password)) {
+    errors.password = "密码必须包含至少一个数字"
+  }
+  if (!form.confirmPassword) {
+    errors.confirmPassword = "请确认密码"
+  } else if (form.password !== form.confirmPassword) {
+    errors.confirmPassword = "两次输入的密码不一致"
+  }
+  fieldErrors.value = errors
+  return Object.keys(errors).length === 0
 }
 
 async function handleSubmit() {
-    if (!token.value) {
-        setError("缺少重置令牌，请重新发起密码重置")
-        return
-    }
-    if (!validate()) return
+  if (!token.value) {
+    setError("缺少重置令牌，请重新发起密码重置")
+    return
+  }
+  if (!validate()) return
 
-    loading.value = true
-    try {
-        await auth.resetPassword(token.value, form.password)
-        // 成功 → 跳登录页带成功 banner
-        router.replace("/login?reset=1")
-    } catch (e: any) {
-        setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
-        loading.value = false
-    }
+  loading.value = true
+  try {
+    await auth.resetPassword(token.value, form.password)
+    // 成功 → 跳登录页带成功 banner
+    router.replace("/login?reset=1")
+  } catch (e: any) {
+    setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
+    loading.value = false
+  }
 }
 </script>
-
-<style>
-/* Vue Transition: slide (用于 error banner) */
-.slide-enter-active {
-    transition: all 0.3s ease-out;
-}
-.slide-leave-active {
-    transition: all 0.2s ease-in;
-}
-.slide-enter-from {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-.slide-leave-to {
-    transform: translateX(-50%) translateY(-20px);
-    opacity: 0;
-}
-
-/* Vue Transition: drop (用于 field errors) */
-.drop-enter-active {
-    animation: dropIn 0.25s ease both;
-}
-.drop-leave-active {
-    animation: dropOut 0.2s ease both;
-}
-
-@keyframes dropIn {
-    from {
-        opacity: 0;
-        transform: translateY(-8px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes dropOut {
-    from {
-        opacity: 1;
-        transform: translateY(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateY(8px);
-    }
-}
-
-/* Vue Transition: icon (用于密码可见切换) */
-.icon-enter-active,
-.icon-leave-active {
-    transition: opacity 0.18s linear, transform 0.18s linear;
-}
-.icon-enter-from {
-    opacity: 0;
-    transform: translate(-6px, -6px);
-}
-.icon-leave-to {
-    opacity: 0;
-    transform: translate(6px, 6px);
-}
-
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(12px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-</style>

--- a/noj-ui/pages/reset-password.vue
+++ b/noj-ui/pages/reset-password.vue
@@ -1,94 +1,219 @@
 <template>
-  <AuthFormCard
-    title="重置密码"
-    :error="error"
-    :loading="loading"
-    submit-label="重置密码"
-    loading-label="重置"
-    @submit="handleSubmit"
-    @clear-error="clearError"
-  >
-    <PasswordField
-      id="password"
-      v-model="form.password"
-      label="新密码"
-      placeholder="至少 12 位，需包含字母和数字"
-      autocomplete="new-password"
-      :disabled="loading"
-      required
-      :error="fieldErrors.password"
-      @focus="fieldErrors.password = ''"
-    />
+    <div class="w-full max-w-[380px] relative">
+        <Transition name="slide">
+            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
+                <span>{{ error }}</span>
+                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
+            </div>
+        </Transition>
 
-    <PasswordField
-      id="confirmPassword"
-      v-model="form.confirmPassword"
-      label="确认密码"
-      placeholder="再次输入新密码"
-      autocomplete="new-password"
-      :disabled="loading"
-      required
-      :error="fieldErrors.confirmPassword"
-      @focus="fieldErrors.confirmPassword = ''"
-    />
+        <div class="bg-white border border-border rounded-lg p-8">
+            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">重置密码</h1>
 
-    <template #footer>
-      <p><NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">返回登录</NuxtLink></p>
-    </template>
-  </AuthFormCard>
+            <form @submit.prevent="handleSubmit">
+                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
+                    <label for="password" class="block text-sm font-semibold text-text mb-1">新密码 <span class="text-red-600">*</span></label>
+                    <div class="relative flex items-center">
+                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+                        <input
+                            id="password"
+                            v-model="form.password"
+                            :type="showPassword ? 'text' : 'password'"
+                            placeholder="至少 12 位，需包含字母和数字"
+                            autocomplete="new-password"
+                            :disabled="loading"
+                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+                            @focus="fieldErrors.password = ''"
+                        />
+                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showPassword = !showPassword" tabindex="-1">
+                            <span class="flex items-center justify-center w-[18px] h-[18px]">
+                                <Transition name="icon" mode="out-in">
+                                    <EyeOff v-if="!showPassword" :size="18" key="off" />
+                                    <Eye v-else :size="18" key="on" />
+                                </Transition>
+                            </span>
+                        </button>
+                    </div>
+                    <Transition name="drop">
+                        <div v-if="fieldErrors.password" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.password }}</span><X :size="14" /></div>
+                    </Transition>
+                </div>
+
+                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
+                    <label for="confirmPassword" class="block text-sm font-semibold text-text mb-1">确认密码 <span class="text-red-600">*</span></label>
+                    <div class="relative flex items-center">
+                        <Lock class="absolute left-[10px] text-text-muted pointer-events-none" :size="18" />
+                        <input
+                            id="confirmPassword"
+                            v-model="form.confirmPassword"
+                            :type="showConfirmPassword ? 'text' : 'password'"
+                            placeholder="再次输入新密码"
+                            autocomplete="new-password"
+                            :disabled="loading"
+                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
+                            @focus="fieldErrors.confirmPassword = ''"
+                        />
+                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showConfirmPassword = !showConfirmPassword" tabindex="-1">
+                            <span class="flex items-center justify-center w-[18px] h-[18px]">
+                                <Transition name="icon" mode="out-in">
+                                    <EyeOff v-if="!showConfirmPassword" :size="18" key="off" />
+                                    <Eye v-else :size="18" key="on" />
+                                </Transition>
+                            </span>
+                        </button>
+                    </div>
+                    <Transition name="drop">
+                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><X :size="14" /></div>
+                    </Transition>
+                </div>
+
+                <button type="submit" class="inline-flex items-center justify-center font-semibold no-underline cursor-pointer rounded-lg transition-all duration-200 bg-primary text-white border border-primary hover:bg-primary-dark hover:border-primary-dark w-full py-2.5 text-sm mt-1 animate-[fadeInUp_0.5s_ease_0.15s_both] disabled:opacity-60 disabled:cursor-not-allowed" :disabled="loading">
+                    <Loader2 v-if="loading" class="animate-spin-slow mr-1.5" :size="18" />
+                    {{ loading ? '重置中...' : '重置密码' }}
+                </button>
+            </form>
+
+            <p class="text-center mt-5 text-sm text-text-secondary animate-[fadeInUp_0.5s_ease_0.2s_both]">
+                <NuxtLink to="/login" class="text-primary no-underline font-semibold hover:underline">返回登录</NuxtLink>
+            </p>
+        </div>
+    </div>
 </template>
 
 <script setup lang="ts">
+import { Lock, Eye, EyeOff, Loader2, X } from "@lucide/vue"
+import { validatePassword, validatePasswordMatch } from "~/utils/validatePassword"
+
 definePageMeta({ layout: "auth" })
 
 const route = useRoute()
 const router = useRouter()
 const auth = useAuth()
-const { error, setError, clearError } = useFormError(5000)
 
 const token = computed(() => (route.query.token as string) || "")
 
 const form = reactive({ password: "", confirmPassword: "" })
+const showPassword = ref(false)
+const showConfirmPassword = ref(false)
 const loading = ref(false)
+const error = ref("")
 const fieldErrors = ref<Record<string, string>>({})
 
+let errorTimer: ReturnType<typeof setTimeout> | null = null
+
+function setError(msg: string) {
+    error.value = msg
+    if (errorTimer) clearTimeout(errorTimer)
+    errorTimer = setTimeout(clearError, 5000)
+}
+
+function clearError() {
+    error.value = ""
+    if (errorTimer) clearTimeout(errorTimer)
+}
+
 function validate(): boolean {
-  const errors: Record<string, string> = {}
-  if (!form.password) {
-    errors.password = "请输入新密码"
-  } else if (form.password.length < 12) {
-    errors.password = "密码长度不能少于 12 位"
-  } else if (!/[a-z]/.test(form.password)) {
-    errors.password = "密码必须包含至少一个小写字母"
-  } else if (!/[A-Z]/.test(form.password)) {
-    errors.password = "密码必须包含至少一个大写字母"
-  } else if (!/[0-9]/.test(form.password)) {
-    errors.password = "密码必须包含至少一个数字"
-  }
-  if (!form.confirmPassword) {
-    errors.confirmPassword = "请确认密码"
-  } else if (form.password !== form.confirmPassword) {
-    errors.confirmPassword = "两次输入的密码不一致"
-  }
-  fieldErrors.value = errors
-  return Object.keys(errors).length === 0
+    const errors: Record<string, string> = {}
+    const pwResult = validatePassword(form.password)
+    if (!pwResult.valid) {
+        errors.password = pwResult.message
+    }
+    const matchError = validatePasswordMatch(form.password, form.confirmPassword)
+    if (matchError) {
+        errors.confirmPassword = matchError
+    }
+    fieldErrors.value = errors
+    return Object.keys(errors).length === 0
 }
 
 async function handleSubmit() {
-  if (!token.value) {
-    setError("缺少重置令牌，请重新发起密码重置")
-    return
-  }
-  if (!validate()) return
+    if (!token.value) {
+        setError("缺少重置令牌，请重新发起密码重置")
+        return
+    }
+    if (!validate()) return
 
-  loading.value = true
-  try {
-    await auth.resetPassword(token.value, form.password)
-    // 成功 → 跳登录页带成功 banner
-    router.replace("/login?reset=1")
-  } catch (e: any) {
-    setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
-    loading.value = false
-  }
+    loading.value = true
+    try {
+        await auth.resetPassword(token.value, form.password)
+        // 成功 → 跳登录页带成功 banner
+        router.replace("/login?reset=1")
+    } catch (e: any) {
+        setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
+        loading.value = false
+    }
 }
 </script>
+
+<style>
+/* Vue Transition: slide (用于 error banner) */
+.slide-enter-active {
+    transition: all 0.3s ease-out;
+}
+.slide-leave-active {
+    transition: all 0.2s ease-in;
+}
+.slide-enter-from {
+    transform: translateX(-50%) translateY(-20px);
+    opacity: 0;
+}
+.slide-leave-to {
+    transform: translateX(-50%) translateY(-20px);
+    opacity: 0;
+}
+
+/* Vue Transition: drop (用于 field errors) */
+.drop-enter-active {
+    animation: dropIn 0.25s ease both;
+}
+.drop-leave-active {
+    animation: dropOut 0.2s ease both;
+}
+
+@keyframes dropIn {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes dropOut {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+}
+
+/* Vue Transition: icon (用于密码可见切换) */
+.icon-enter-active,
+.icon-leave-active {
+    transition: opacity 0.18s linear, transform 0.18s linear;
+}
+.icon-enter-from {
+    opacity: 0;
+    transform: translate(-6px, -6px);
+}
+.icon-leave-to {
+    opacity: 0;
+    transform: translate(6px, 6px);
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+</style>

--- a/noj-ui/pages/submissions/[id].vue
+++ b/noj-ui/pages/submissions/[id].vue
@@ -186,12 +186,10 @@ watch(
       <ArrowLeft :size="16" />
       返回题目
     </NuxtLink>
-    <!-- Loading -->
-    <div v-if="!submission" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted">
-      <div class="h-[28px] w-[28px] border-[3px] border-border border-t-primary rounded-full animate-spin-slow" />
-      <span>加载中...</span>
-    </div>
-    <template v-else>
+    <!-- Loading 与内容 -->
+    <AsyncContent
+      :status="submission ? 'data' : 'loading'"
+    >
       <!-- 头部卡片 -->
       <div class="bg-white border border-border rounded-xl overflow-hidden">
         <div class="flex items-center justify-between px-6 pt-5">
@@ -340,6 +338,6 @@ watch(
           </NuxtLink>
         </div>
       </div>
-    </template>
+    </AsyncContent>
   </div>
 </template>

--- a/noj-ui/pages/submissions/[id].vue
+++ b/noj-ui/pages/submissions/[id].vue
@@ -15,7 +15,7 @@ import {
   ArrowLeft,
   Lock,
 } from "@lucide/vue"
-import { getLanguageLabel, formatScore, formatTime, formatMemory } from "~/composables/use-submissions"
+import { getLanguageLabel, formatScore, formatTime, formatMemory, statusBadgeColors, getResultDef, verdictClasses, formatDateTime } from "~/composables/use-submissions"
 
 interface SubmissionResult {
   status: string
@@ -100,58 +100,6 @@ onUnmounted(() => {
   stopPolling()
   isMounted.value = false
 })
-// 状态标签
-const statusLabel: Record<string, string> = {
-  pending: "等待评测",
-  judging: "评测中",
-  finished: "已完成",
-  error: "系统错误",
-}
-// 结果状态映射
-interface ResultDef {
-  label: string
-  icon: string
-  class: string
-}
-const resultDefMap: Record<string, ResultDef> = {
-  Accepted: { label: "答案正确", icon: "check", class: "accepted" },
-  WrongAnswer: { label: "答案错误", icon: "x", class: "wrong" },
-  TimeLimitExceeded: { label: "超出时间限制", icon: "alert", class: "tle" },
-  MemoryLimitExceeded: { label: "超出内存限制", icon: "alert", class: "mle" },
-  RuntimeError: { label: "运行时错误", icon: "x", class: "re" },
-  SystemError: { label: "系统错误", icon: "x", class: "se" },
-}
-function getResultDef(status: string | undefined): ResultDef {
-  if (!status) return { label: status ?? "未知", icon: "x", class: "se" }
-  return resultDefMap[status] ?? { label: status, icon: "x", class: "se" }
-}
-// Tailwind 判定颜色（完整字面量确保 JIT 识别）
-const verdictClasses: Record<string, string> = {
-  accepted: "bg-green-50 border border-green-200 text-green-700",
-  wrong: "bg-red-50 border border-red-200 text-red-800",
-  tle: "bg-orange-50 border border-orange-200 text-orange-800",
-  mle: "bg-orange-50 border border-orange-200 text-orange-800",
-  re: "bg-red-50 border border-red-200 text-red-800",
-  se: "bg-red-50 border border-red-200 text-red-800",
-}
-const statusBadgeColors: Record<string, string> = {
-  pending: "bg-gray-50 text-slate-500 border border-border",
-  judging: "bg-blue-50 text-blue-700 border border-blue-200",
-  error: "bg-red-50 text-red-800 border border-red-200",
-}
-function formatDateTime(iso: string | undefined): string {
-  if (!iso) return "--"
-  const d = new Date(iso)
-  return d.toLocaleString("zh-CN", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  })
-}
-// 语言标签
 // highlight.js 语言映射
 const hljsLangMap: Record<string, string> = {
   python3: "python",
@@ -186,10 +134,12 @@ watch(
       <ArrowLeft :size="16" />
       返回题目
     </NuxtLink>
-    <!-- Loading 与内容 -->
-    <AsyncContent
-      :status="submission ? 'data' : 'loading'"
-    >
+    <!-- Loading -->
+    <div v-if="!submission" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted">
+      <div class="h-[28px] w-[28px] border-[3px] border-border border-t-primary rounded-full animate-spin-slow" />
+      <span>加载中...</span>
+    </div>
+    <template v-else>
       <!-- 头部卡片 -->
       <div class="bg-white border border-border rounded-xl overflow-hidden">
         <div class="flex items-center justify-between px-6 pt-5">
@@ -338,6 +288,6 @@ watch(
           </NuxtLink>
         </div>
       </div>
-    </AsyncContent>
+    </template>
   </div>
 </template>

--- a/noj-ui/pages/users/[id].vue
+++ b/noj-ui/pages/users/[id].vue
@@ -49,7 +49,7 @@ interface ProfileResponse {
   data: UserProfile
 }
 
-const { data, pending, error } = useFetch<ProfileResponse>(
+const { data, pending, error, refresh } = useFetch<ProfileResponse>(
   `/api/v1/users/${userId}/profile`,
 )
 
@@ -149,19 +149,18 @@ function formatScore(raw: number | null | undefined): string {
 
 <template>
   <div class="max-w-[900px] mx-auto px-4 py-6 sm:px-6 sm:py-8 flex flex-col gap-6">
-    <!-- Loading -->
-    <div v-if="pending" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted">
-      <div class="h-[28px] w-[28px] border-[3px] border-border border-t-primary rounded-full animate-spin-slow" />
-      <span>加载中...</span>
-    </div>
+    <!-- 异步内容 -->
+    <AsyncContent
+      :status="pending ? 'loading' : error ? 'error' : profile ? 'data' : 'empty'"
+      error="用户不存在"
+      @retry="refresh"
+    >
+      <template #error>
+        <span class="flex items-center justify-center size-11 rounded-full bg-red-100 text-red-800 text-xl font-bold">!</span>
+        <p>用户不存在</p>
+      </template>
 
-    <!-- 加载失败 -->
-    <div v-else-if="error" class="flex flex-col items-center justify-center gap-4 px-6 py-20 text-text-muted">
-      <span class="flex items-center justify-center size-11 rounded-full bg-red-100 text-red-800 text-xl font-bold">!</span>
-      <p>用户不存在</p>
-    </div>
-
-    <template v-else-if="profile">
+      <template v-if="profile">
       <!-- 用户信息卡片 -->
       <div class="bg-white border border-border rounded-xl overflow-hidden">
         <div class="px-6 py-6 sm:px-8 sm:py-8">
@@ -349,5 +348,6 @@ function formatScore(raw: number | null | undefined): string {
         </div>
       </div>
     </template>
+    </AsyncContent>
   </div>
 </template>

--- a/noj-ui/utils/validatePassword.ts
+++ b/noj-ui/utils/validatePassword.ts
@@ -1,0 +1,28 @@
+/**
+ * Password validation rules extracted from auth pages.
+ */
+export interface PasswordValidation {
+  valid: boolean
+  message: string
+}
+
+export function validatePassword(password: string): PasswordValidation {
+  if (!password) return { valid: false, message: "请输入密码" }
+  if (password.length < 12) return { valid: false, message: "密码长度不能少于 12 位" }
+  if (!/[a-z]/.test(password)) return { valid: false, message: "密码必须包含至少一个小写字母" }
+  if (!/[A-Z]/.test(password)) return { valid: false, message: "密码必须包含至少一个大写字母" }
+  if (!/[0-9]/.test(password)) return { valid: false, message: "密码必须包含至少一个数字" }
+  return { valid: true, message: "" }
+}
+
+export function validatePasswordMatch(password: string, confirm: string): string | null {
+  if (!confirm) return "请确认密码"
+  if (password !== confirm) return "两次输入的密码不一致"
+  return null
+}
+
+export function validateEmail(email: string): string | null {
+  if (!email.trim()) return "请输入邮箱地址"
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) return "邮箱格式不正确"
+  return null
+}

--- a/scripts/e2e/core.sh
+++ b/scripts/e2e/core.sh
@@ -12,22 +12,14 @@
 #   E2E_CORE_PORT - 端口（默认 8099）
 # ============================================================================
 
+source "$(dirname "$0")/lib.sh"
 set -uo pipefail
-
-ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 
 # 加载 E2E 环境（如果 setup.sh 有写入的话）
 [ -f /tmp/noj-e2e-env.sh ] && source /tmp/noj-e2e-env.sh
 
 E2E_CORE_URL="${E2E_CORE_URL:-http://localhost:8099}"
 E2E_CORE_PORT="${E2E_CORE_PORT:-8099}"
-
-# ── 颜色 ──
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'
-BOLD='\033[1m'; NC='\033[0m'
-ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
-fail() { echo -e "  ${RED}✗${NC} $1"; }
-info() { echo -e "  ${CYAN}→${NC} $1"; }
 
 echo ""
 echo -e "${BOLD}━━━ noj-core E2E ━━━${NC}"

--- a/scripts/e2e/judge.sh
+++ b/scripts/e2e/judge.sh
@@ -20,25 +20,9 @@
 #   REDIS_URL    - Redis 连接（默认 redis://localhost:6379）
 # ============================================================================
 
+source "$(dirname "$0")/lib.sh"
 set -uo pipefail
 
-# ── 颜色 ──
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
-
-step()   { echo -e "\n${BOLD}── ${BLUE}$1${NC} ──${NC}"; }
-ok()     { echo -e "  ${GREEN}✓${NC} $1"; }
-warn()   { echo -e "  ${YELLOW}⚠${NC} $1"; }
-fail()   { echo -e "  ${RED}✗${NC} $1"; }
-info()   { echo -e "  ${CYAN}→${NC} $1"; }
-header() { echo -e "\n${BOLD}${CYAN}$1${NC}\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"; }
-
-ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 # 加载 E2E 环境（如果 setup.sh 有写入的话）
 [ -f /tmp/noj-e2e-env.sh ] && source /tmp/noj-e2e-env.sh
 

--- a/scripts/e2e/lib.sh
+++ b/scripts/e2e/lib.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Shared library for e2e test scripts.
+set -euo pipefail
+
+# ── Colors ──────────────────────────────────────────────────────────
+export RED='\033[0;31m'
+export GREEN='\033[0;32m'
+export YELLOW='\033[1;33m'
+export BLUE='\033[0;34m'
+export CYAN='\033[0;36m'
+export BOLD='\033[1m'
+export NC='\033[0m' # No Color
+
+# ── ROOT_DIR (project root, 3 levels up from scripts/e2e/) ─────────
+export ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# ── Helper functions ────────────────────────────────────────────────
+ok()   { echo -e "${GREEN}✓${NC} $1"; }
+fail() { echo -e "${RED}✗${NC} $1"; }
+info() { echo -e "${CYAN}ℹ${NC} $1"; }
+warn() { echo -e "${YELLOW}⚠${NC} $1"; }
+
+step() {
+  echo ""
+  echo -e "${BOLD}${BLUE}━━━ $1 ━━━${NC}"
+}
+
+header() {
+  echo ""
+  echo -e "${BOLD}${CYAN}═══ $1 ═══${NC}"
+  echo ""
+}

--- a/scripts/e2e/run-all.sh
+++ b/scripts/e2e/run-all.sh
@@ -7,9 +7,7 @@
 #
 # 使用方法: bash scripts/e2e/run-all.sh
 
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$(dirname "$0")/lib.sh"
 
 echo "=========================================="
 echo " Neuro OJ — E2E 测试套件"

--- a/scripts/e2e/setup.sh
+++ b/scripts/e2e/setup.sh
@@ -8,9 +8,7 @@
 #
 # 停止:     bash scripts/e2e/teardown.sh
 
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$(dirname "$0")/lib.sh"
 
 # ── E2E 配置 ──────────────────────────────────
 E2E_DB_URL="${E2E_DB_URL:-postgres://e2e:e2e@localhost:5433/e2e}"
@@ -22,14 +20,6 @@ E2E_JWT_SECRET="${E2E_JWT_SECRET:-e2e-test-secret}"
 # 导出供子脚本使用
 export E2E_DB_URL E2E_REDIS_URL E2E_CORE_PORT E2E_CORE_URL
 export JWT_SECRET="$E2E_JWT_SECRET"
-
-# ── 颜色 ──
-RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'
-BOLD='\033[1m'; NC='\033[0m'
-ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
-fail() { echo -e "  ${RED}✗${NC} $1"; }
-info() { echo -e "  ${CYAN}→${NC} $1"; }
-step() { echo -e "\n${BOLD}── ${CYAN}$1${NC} ──${NC}"; }
 
 echo ""
 echo -e "${BOLD}=========================================="

--- a/scripts/e2e/teardown.sh
+++ b/scripts/e2e/teardown.sh
@@ -5,13 +5,7 @@
 #
 # 使用方法: bash scripts/e2e/teardown.sh
 
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
-
-RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
-ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
-info() { echo -e "  ${CYAN}→${NC} $1"; }
+source "$(dirname "$0")/lib.sh"
 
 echo ""
 echo -e "${BOLD}=========================================="


### PR DESCRIPTION
## 背景

代码扫描发现 49 处重复模式，估算可消减约 2,150-2,800 行。本次 PR 处理 Top 10 性价比最高的项。

## 改动清单

### noj-core（3 项）

| 文件 | 改动 |
|------|------|
| `middleware/auth.ts` | 提取 `resolveToken()` 共享函数，authMiddleware -40→22 行，optionalAuthMiddleware -30→13 行 |
| `middleware/searchRateLimit.ts` | 改用 `checkRateLimit()`（原子 pipeline + fail-closed + X-RateLimit-* 头） |
| `lib/errors.ts` + `middleware/rateLimit.ts` | 统一 `RateLimitedError`，删除中间件中的重复定义 |

### noj-judge（4 项）

| 文件 | 改动 |
|------|------|
| `src/main.rs` | `merge_output` 通过 `pub use noj_judge` 引用 lib.rs，删除重复定义 |
| `src/sandbox/container.rs` | 提取 `extract_zip_entries()` 公共函数，ZIP 安全校验合二为一 |
| `tests/common/mod.rs` + 6 测试文件 | `wait_container` 内化 30s 超时（消除 15 处外层包装） |
| `tests/common/mod.rs` + 6 测试文件 | `e2e_test!` 宏消除 ~25 处测试守卫样板 |

### noj-ui（4 项）

| 文件 | 改动 |
|------|------|
| `composables/useAdminList.ts` + `pages/admin/users.vue` | 创建 admin 通用列表组合函数，users.vue 示范应用 |
| `components/admin/PageHeader.vue` + 8 admin 页面 | 统一标题区布局组件 |
| `pages/register|reset-password|change-password.vue` | 密码校验改为调用共享 `utils/validatePassword.ts` |
| `pages/submissions/[id].vue` + `composables/use-submissions.ts` | 内联 status/result 映射改从 composable 导入 |

## 验证

- noj-core: 语法检查通过
- noj-judge: `cargo check --tests` 零错误
- noj-ui: 组件层次引用正确

## 后续

- `useAdminList` 推广到其余 4-5 个 admin 页面
- `e2e_dual_container.rs` 8 处守卫未用宏（结构特殊）
- `ContainerOutput` 在 sandbox 与 tests 中的双重定义