### PR TITLE
docs: 同步 PR #157 后的脚本目录结构与 noj-tests 测试任务名

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,12 +283,11 @@ neuro-oj/
 │       ├── user-ranking/  # 活跃变更（当前开发中）
 │       └── archive/       # 已归档变更（35 个）
 │
-├── scripts/               # 构建与维护脚本
-│   ├── build-packages.sh
-│   ├── migrate.sh, seed.sh
-│   └── e2e/               # E2E 编排脚本
-│       ├── setup.sh, teardown.sh, run-all.sh
-│       ├── core.sh, judge.sh
+├── scripts/               # 构建与运维脚本(详见 scripts/README.md)
+│   ├── dev/               # 本地开发运行:一键启停 core/ui/judge(后台守护 + PID + 日志归集)
+│   ├── db/                # 数据库迁移(migrate.sh)与种子(seed.sh)
+│   ├── build/             # 题目支持包构建(build-packages.sh)
+│   └── e2e/               # 跨模块 E2E 编排脚本(setup/teardown/core/judge/run-all)
 │
 ├── .github/workflows/
 │   ├── ci.yml             # PR/推送: 并行检查三个模块
@@ -386,6 +385,24 @@ cargo run               # 需要 Docker daemon
 
 # 三模块可独立启动，开发时可以只跑需要的部分
 ```
+
+### 一键启动（推荐：scripts/dev/）
+
+上述手动启动需要多个终端窗口。仓库根 `scripts/dev/` 提供了一键启停封装
+（日志与 PID 文件统一托管在 `scripts/dev/logs/`），适合本地日常开发：
+
+```bash
+bash scripts/dev/install-deps.sh      # 检测 Deno / Rust / Docker / zip
+cp scripts/dev/env.example noj-core/.env   # 必填 DATABASE_URL 与 JWT_SECRET
+
+bash scripts/dev/start-all.sh         # infra + core + ui + judge 一键启动
+bash scripts/dev/status.sh            # 查看运行状态
+bash scripts/dev/stop-all.sh          # 一键停止
+```
+
+> 脚本仅封装原生命令 + 后台守护 + PID/日志归集。调试或单模块迭代时仍推荐
+> 直接 `deno task dev` / `cargo run` 前台运行以观察实时输出。
+> 详细 FAQ 见 `scripts/dev/README.md`。
 
 ### 创建第一个管理员
 
@@ -616,10 +633,11 @@ NOJ_RUN_E2E=1 cargo test --test e2e_docker_basic -- --ignored
 
 ```bash
 cd noj-tests
-NOJ_RUN_E2E=1 deno task test:e2e
+NOJ_RUN_E2E=1 deno task test
 ```
 
 覆盖场景：Accepted / WrongAnswer / TLE / MQ 可靠性 / 无效消息容错
+/ 鉴权守卫 / S3 存储 / SSE 等 18 个全链路测试文件
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,11 @@ neuro-oj/
 ├── noj-docs/          # 正式文档站 — 做题人/运营者/出题人文档 (MkDocs Material)
 ├── noj-tests/         # 跨模块全链路 E2E 测试
 ├── openspec/          # OpenSpec 规范驱动开发（38 specs + 变化管理）
-├── scripts/           # 构建与维护脚本
+├── scripts/           # 构建与维护脚本（详见 scripts/README.md）
+│   ├── dev/           #   本地开发运行（一键启停 noj-core / noj-ui / noj-judge）
+│   ├── db/            #   数据库迁移与种子
+│   ├── build/         #   题目支持包构建
+│   └── e2e/           #   跨模块 E2E 编排
 ├── docker-compose.yml # 开发基础设施 (PostgreSQL + Redis)
 └── docker-compose.e2e.yml # E2E 测试编排
 ```
@@ -117,6 +121,20 @@ neuro-oj/
 
 ```bash
 docker compose up -d    # PostgreSQL:5432 + Redis:6379
+```
+
+### 一键启动整套开发环境
+
+仓库根目录提供了封装好的本地开发脚本（日志与 PID 文件统一托管在
+`scripts/dev/logs/`）：
+
+```bash
+bash scripts/dev/install-deps.sh      # 检测 Deno / Rust / Docker / zip
+cp scripts/dev/env.example noj-core/.env   # 配置环境变量（必填 DATABASE_URL 与 JWT_SECRET）
+
+bash scripts/dev/start-all.sh         # 一键启动 infra + core + ui + judge
+bash scripts/dev/status.sh            # 查看运行状态
+bash scripts/dev/stop-all.sh          # 一键停止
 ```
 
 ### 启动后端 (noj-core)
@@ -185,10 +203,11 @@ mkdocs build --strict
 
 ```bash
 cd noj-tests
-NOJ_RUN_E2E=1 deno task test:e2e
+NOJ_RUN_E2E=1 deno task test
 ```
 
-覆盖：Accepted / WrongAnswer / TLE / MQ 可靠性 / 无效消息容错
+覆盖：Accepted / WrongAnswer / TLE / MQ 可靠性 / 无效消息容错 / 鉴权守卫
+等 18 个全链路测试文件
 
 ### 各模块测试
 

--- a/noj-tests/E2E_TESTING.md
+++ b/noj-tests/E2E_TESTING.md
@@ -51,13 +51,13 @@ noj-tests/
 
 ```bash
 cd noj-tests
-NOJ_RUN_E2E=1 deno task test:e2e
+NOJ_RUN_E2E=1 deno task test
 ```
 
 ### 保留容器（调试用）
 
 ```bash
-E2E_NO_CLEANUP=1 NOJ_RUN_E2E=1 deno task test:e2e
+E2E_NO_CLEANUP=1 NOJ_RUN_E2E=1 deno task test
 ```
 
 测试结束后容器保留，可手动排查问题。

--- a/openspec/changes/dual-container-judge/tasks.md
+++ b/openspec/changes/dual-container-judge/tasks.md
@@ -113,6 +113,6 @@
 - [ ] `deno fmt --check` + `deno lint` + `deno task test` 全过
 - [ ] `npm run build`（no-jui）通过
 - [ ] Docker E2E：`NOJ_RUN_E2E=1 cargo test --test e2e_dual_container -- --ignored` 全过（PR-A2 起）
-- [ ] 全链路 E2E：`NOJ_RUN_E2E=1 deno task test:e2e` 全过（PR-C 起）
+- [ ] 全链路 E2E：`NOJ_RUN_E2E=1 deno task test` 全过（PR-C 起）
 - [ ] GPG 签名所有提交
 - [ ] 不存在除设计稿允许外的字段（任何 `JudgeTask` 字段新增需更新 design.md）

--- a/openspec/specs/judge-e2e-test/spec.md
+++ b/openspec/specs/judge-e2e-test/spec.md
@@ -86,9 +86,9 @@
 #### Scenario: 全栈测试门控
 
 - **WHEN** 环境变量 `NOJ_RUN_E2E=1` 未设置
-- **THEN** `deno task test:e2e` 跳过所有全栈 E2E 测试
+- **THEN** `deno task test` 跳过所有全栈 E2E 测试
 - **WHEN** 环境变量 `NOJ_RUN_E2E=1` 已设置
-- **THEN** `deno task test:e2e` 启动测试栈并执行全链路测试
+- **THEN** `deno task test` 启动测试栈并执行全链路测试
 
 ### Requirement: 基础提交 Accepted 验证
 


### PR DESCRIPTION
## 背景

PR #157 合并后,`scripts/` 已重组为 `dev/`、`db/`、`build/`、`e2e/`
四个职责清晰的子目录,并新增了 `scripts/dev/` 一键启停脚本。同时,
`noj-tests/deno.json` 中实际任务名是 `test`(不是 `test:e2e`),
但 README/AGENTS 等文档仍引用旧的 `test:e2e`。

本文档 PR 同步这些变更,确保读者(人类 + AI)按文档操作能成功。

## 变更内容

### README.md(面向**人类**读者)

- 项目结构树增加 `scripts/{dev,db,build,e2e}/` 子目录
- 「快速开始」章节新增 `scripts/dev/start-all.sh` 一键启动入口
- 修正 `noj-tests` 命令:`deno task test:e2e` → `deno task test`
- 测试覆盖范围更新为 18 个全链路测试文件

### AGENTS.md(面向 **AI 编码助手**,CLAUDE.md 为符号链接)

- `scripts/` 目录树同步重组结构
- 「基础设施与启动」章节新增 `scripts/dev/` 一键启动推荐路径
- 修正 `noj-tests` 命令与覆盖描述

### noj-tests/E2E_TESTING.md

- 修正 2 处 `deno task` 命令

### OpenSpec 规范同步(确保规范可执行)

- `openspec/specs/judge-e2e-test/spec.md` — 主规范须与实际行为一致
- `openspec/changes/dual-container-judge/tasks.md` — 验收清单须可执行

## 未修改

- `openspec/changes/archive/*` 与 `docs/superpowers/plans/*` 中仍有
  `test:e2e` 引用,按 OpenSpec 规范**不修改已归档内容**(历史快照)
- `openspec/changes/dual-container-judge/` 中其他位置保留 `test:e2e`
  的历史记录未触碰

## 校验

- [x] 5 文件修改,+52 / -15
- [x] GPG 签名(`chenmou2012 <chenmou2012@outlook.com>`)
- [x] 仅基于最新 `origin/main`,无冲突
- [x] `CLAUDE.md` 是 `AGENTS.md` 的符号链接,自动同步