### PR TITLE
docs(root): 重写 README 与 AGENTS 文档结构,基于实际代码校正事实

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,12 +283,11 @@ neuro-oj/
 │       ├── user-ranking/  # 活跃变更（当前开发中）
 │       └── archive/       # 已归档变更（35 个）
 │
-├── scripts/               # 构建与维护脚本
-│   ├── build-packages.sh
-│   ├── migrate.sh, seed.sh
-│   └── e2e/               # E2E 编排脚本
-│       ├── setup.sh, teardown.sh, run-all.sh
-│       ├── core.sh, judge.sh
+├── scripts/               # 构建与运维脚本(详见 scripts/README.md)
+│   ├── dev/               # 本地开发运行:一键启停 core/ui/judge(后台守护 + PID + 日志归集)
+│   ├── db/                # 数据库迁移(migrate.sh)与种子(seed.sh)
+│   ├── build/             # 题目支持包构建(build-packages.sh)
+│   └── e2e/               # 跨模块 E2E 编排脚本(setup/teardown/core/judge/run-all)
 │
 ├── .github/workflows/
 │   ├── ci.yml             # PR/推送: 并行检查三个模块
@@ -386,6 +385,24 @@ cargo run               # 需要 Docker daemon
 
 # 三模块可独立启动，开发时可以只跑需要的部分
 ```
+
+### 一键启动（推荐：scripts/dev/）
+
+上述手动启动需要多个终端窗口。仓库根 `scripts/dev/` 提供了一键启停封装
+（日志与 PID 文件统一托管在 `scripts/dev/logs/`），适合本地日常开发：
+
+```bash
+bash scripts/dev/install-deps.sh      # 检测 Deno / Rust / Docker / zip
+cp scripts/dev/env.example noj-core/.env   # 必填 DATABASE_URL 与 JWT_SECRET
+
+bash scripts/dev/start-all.sh         # infra + core + ui + judge 一键启动
+bash scripts/dev/status.sh            # 查看运行状态
+bash scripts/dev/stop-all.sh          # 一键停止
+```
+
+> 脚本仅封装原生命令 + 后台守护 + PID/日志归集。调试或单模块迭代时仍推荐
+> 直接 `deno task dev` / `cargo run` 前台运行以观察实时输出。
+> 详细 FAQ 见 `scripts/dev/README.md`。
 
 ### 创建第一个管理员
 
@@ -616,10 +633,11 @@ NOJ_RUN_E2E=1 cargo test --test e2e_docker_basic -- --ignored
 
 ```bash
 cd noj-tests
-NOJ_RUN_E2E=1 deno task test:e2e
+NOJ_RUN_E2E=1 deno task test
 ```
 
 覆盖场景：Accepted / WrongAnswer / TLE / MQ 可靠性 / 无效消息容错
+/ 鉴权守卫 / S3 存储 / SSE 等 18 个全链路测试文件
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
-# Neuro OJ (NOJ) — 完整项目知识库
+# Neuro OJ (NOJ) — AI 编码助手项目知识库
 
-Neuro OJ 是一个为 LMCC（CCF 大语言模型能力认证）设计的在线评测（Online Judge）系统。
+> 本文档面向 AI 编码助手（Claude Code、OpenCode 等）撰写，记录项目架构、规范、AI 必须遵守的要求与开发约定。
+
+Neuro OJ 是一个面向 LMCC（CCF 大语言模型能力认证）的在线评测（Online Judge）系统。
 
 > **注意：** Neuro OJ 与 CCF 及 LMCC 无任何官方关系，为独立社区项目。
 
@@ -8,28 +10,33 @@ Neuro OJ 是一个为 LMCC（CCF 大语言模型能力认证）设计的在线�
 
 ## 目录
 
-1. [架构总览](#1-架构总览)
-2. [目录结构](#2-目录结构)
-3. [技术栈](#3-技术栈)
-4. [基础设施与启动](#4-基础设施与启动)
-5. [版本控制约定](#5-版本控制约定)
-6. [贡献流程](#6-贡献流程)
-7. [安全模型总览](#7-安全模型总览)
-8. [测试体系](#8-测试体系)
-9. [CI/CD](#9-cicd)
+1. [项目架构](#1-项目架构)
+2. [AI 工具集成](#2-ai-工具集成)
+3. [目录结构](#3-目录结构)
+4. [技术栈与依赖](#4-技术栈与依赖)
+5. [基础设施与启动](#5-基础设施与启动)
+6. [数据库 Schema](#6-数据库-schema)
+7. [版本控制与提交规范](#7-版本控制与提交规范)
+8. [AI 必须遵守的要求](#8-ai-必须遵守的要求)
+9. [贡献流程](#9-贡献流程)
 10. [OpenSpec 开发工作流](#10-openspec-开发工作流)
-11. [项目状态与路线图](#11-项目状态与路线图)
+11. [安全模型](#11-安全模型)
+12. [测试体系](#12-测试体系)
+13. [CI/CD](#13-cicd)
+14. [故障排查速查](#14-故障排查速查)
+15. [项目状态与路线图](#15-项目状态与路线图)
+16. [参考文档](#16-参考文档)
 
 ---
 
-## 1. 架构总览
+## 1. 项目架构
 
 NOJ 分为三个核心模块，通过 RESTful API 和 Redis 消息队列协作：
 
 ```
 +----------+   RESTful API   +----------+   Redis MQ    +--------------+
 |  noj-ui  | <-------------> | noj-core | --Producer--> |  noj-judge   |
-|  Nuxt.js  |                 |Deno+Hono | <--Consumer--|  Rust+Docker |
+|  Nuxt 4  |                 |Deno+Hono | <--Consumer--|  Rust+Docker |
 +----------+                 +----------+               +--------------+
                                    |
                               +----+----+
@@ -37,20 +44,27 @@ NOJ 分为三个核心模块，通过 RESTful API 和 Redis 消息队列协作�
                               +---------+
 ```
 
-### 消息流
+### 1.1 模块职责
+
+| 模块 | 运行时 | 职责 |
+|------|--------|------|
+| **noj-core** | Deno 2 + Hono | RESTful API、JWT 鉴权、用户/题目/提交/榜单 CRUD、Redis MQ Producer 与 Consumer、审计日志 |
+| **noj-ui** | Nuxt 4 + Vue 3 | Web 前端、Nitro 反向代理注入 JWT Cookie、SSR + SPA 混合 |
+| **noj-judge** | Rust 2021 + Tokio | Docker 沙箱评测、Redis MQ Consumer、容器池（懒回补 + 健康检查）、双容器架构（dual container） |
+| **基础设施** | — | PostgreSQL 16（持久化） + Redis 7（MQ + 缓存） |
+
+### 1.2 消息流（Producer-Consumer）
 
 1. 用户通过 noj-ui 提交代码
-2. noj-core 接收请求，将评测任务发布到 Redis MQ（LPUSH `noj:judge:queue`）
-3. noj-judge 从 MQ 拉取任务（BRPOP `noj:judge:queue`）
-4. noj-judge 在 Docker 容器中执行评测
-5. 结果通过 Redis MQ 返回（LPUSH `noj:judge:results`）
-6. noj-core 消费结果（BRPOP `noj:judge:results`），持久化到数据库
+2. noj-core 接收请求，将评测任务 `LPUSH` 到 `noj:judge:queue`
+3. noj-judge `BRPOP` 拉取任务
+4. noj-judge 在 Docker 容器中执行评测（资源隔离、网络关闭）
+5. 结果 `LPUSH` 到 `noj:judge:results`
+6. noj-core `BRPOP` 消费结果并持久化到 PostgreSQL
 
-架构遵循 **Producer-Consumer** 模式，支持多个 noj-judge 实例水平扩展。
+支持多个 noj-judge 实例水平扩展。
 
-### 提交流程详解
-
-用户提交代码后，noj-core 组装 JudgeTask 消息推送到 Redis MQ：
+### 1.3 JudgeTask 消息结构
 
 ```json
 {
@@ -67,437 +81,489 @@ NOJ 分为三个核心模块，通过 RESTful API 和 Redis 消息队列协作�
 }
 ```
 
-noj-judge 收到任务后执行：
+### 1.4 双层 URL 设计
 
-1. **获取支持包** -- 解析 `download_url`（`noj-download://` URL），按 host 分派：
-   - `noj-download://base64/` — 提取 `content` 参数，base64 解码
-   - `noj-download://s3` — 提取 `url` 参数（percent 解码），HTTP 下载 presigned URL
-2. **SHA-256 校验** -- 校验通过后写入磁盘缓存（内容寻址，LRU 淘汰）
-3. **注入用户代码** -- 将 code 以 file_name 命名写入工作目录（覆盖/补全支持包文件）
-4. **执行评测** -- 在 Docker 容器中运行 judge_command（evaluate.py 负责读取测试用例并评分）
-5. **返回结果** -- 将 stdout/stderr、得分、耗时、内存等打包为 JudgeResult 发回 Redis MQ
+| 层级 | URL 前缀 | 用途 | 字段 |
+|------|---------|------|------|
+| **DB 存储层** | `noj-storage://` | 标识资源在存储后端的位置 | `support_package_storage_url` |
+| **Judge 交付层** | `noj-download://` | 描述 judge 如何获取支持包内容 | `JudgeTask.download_url` |
 
-### 两层 URL 概念
-
-系统使用两种 URL 空间分离持久存储与 Judge 交付：
-
-| 层级 | URL 前缀 | 用途 | local 模式 | S3 模式 |
-|------|---------|------|-----------|---------|
-| **DB 存储层** | `noj-storage://` | 标识资源在存储后端的位置，存入 `support_package_storage_url` 字段 | `noj-storage://local/<base64>?checksum_sha256=...` | `noj-storage://s3/<key>?checksum_sha256=...` |
-| **Judge 交付层** | `noj-download://` | 描述 judge 如何获取支持包内容，放入 JudgeTask.download_url | `noj-download://base64/?content=[base64]&checksum_sha256=...` | `noj-download://s3?url=[encoded-presigned-URL]&checksum_sha256=...` |
-
-支持包（zip）由 `deno task build-packages` 从 `data/problems-src/<id>/` 构建。
-用户提交的代码（如 `submission.py`）**不**包含在支持包中 -- 由 noj-judge 在运行时放入。
+- `local` 模式：`noj-storage://local/<base64>` ↔ `noj-download://base64/?content=[base64]`
+- `s3` 模式：`noj-storage://s3/<key>` ↔ `noj-download://s3?url=[presigned]`
+- SHA-256 校验贯穿两个层级，支持内容寻址缓存
+- 用户提交的代码**不**进支持包，由 noj-judge 运行时注入
+- 支持包（zip）由 `deno task build-packages` 从 `data/problems-src/<id>/` 构建
 
 ---
 
-## 2. 目录结构
+## 2. AI 工具集成
+
+本项目同时支持 **Claude Code**（`.claude/`）与 **OpenCode**（`.opencode/`），二者镜像配置。
+
+### 2.1 AI 技能（按需通过 Skill 工具加载）
+
+位于 `.claude/skills/` 与 `.opencode/skills/`，AI 应在相关任务中主动加载：
+
+| 技能 | 适用场景 |
+|------|---------|
+| `deno-expert` | noj-core / noj-ui 的 Deno/TypeScript 开发 |
+| `nuxt` / `vue` | noj-ui 前端开发 |
+| `hono` | noj-core 后端路由开发 |
+| `redis-core` | Redis MQ / 缓存相关 |
+| `docker-expert` | noj-judge 沙箱、docker-compose |
+| `supabase-postgres-best-practices` | PostgreSQL + Drizzle ORM |
+| `review` | 代码评审 |
+| `openspec-explore` / `openspec-propose` / `openspec-apply-change` / `openspec-archive-change` / `openspec-sync-specs` | OpenSpec 规范驱动开发全流程 |
+
+### 2.2 AI 命令（通过 `/` 触发）
+
+| 命令 | 作用 |
+|------|------|
+| `/opsx:explore` | 探索现有规范 |
+| `/opsx:propose` | 起草变更提案 |
+| `/opsx:apply` | 实施已批准变更 |
+| `/opsx:archive` | 归档已完成变更 |
+| `/opsx:sync` | 同步 spec 增量到主规范 |
+
+### 2.3 子模块文档优先加载
+
+工作目录决定上下文优先级：
+
+| 当前路径 | 优先加载 |
+|---------|---------|
+| `/noj-core/` | `noj-core/CLAUDE.md` |
+| `/noj-ui/` | `noj-ui/CLAUDE.md` |
+| `/noj-judge/` | `noj-judge/CLAUDE.md` |
+| 仓库根目录 | 本文档 |
+
+子模块文档包含：API 端点、Schema 字段、组件层级、模块特有规范，进入模块目录前应先读取对应 `CLAUDE.md`。
+
+---
+
+## 3. 目录结构
 
 ```
 neuro-oj/
-├── noj-core/             # 核心后端 (Deno + Hono)
-│   ├── deno.json         # 项目配置 + 导入映射
-│   ├── deno.lock         # 依赖锁定（提交到 git，用于 CI 缓存）
-│   ├── drizzle.config.ts # Drizzle Kit 配置
-│   ├── drizzle/          # SQL 迁移文件（自动生成，勿手动编辑 _journal.json）
-│   │   ├── meta/_journal.json
-│   │   └── 0000_*.sql    # 截至 0010 共 12 个迁移文件
-│   ├── .env.example      # 环境变量模板（不提交 .env）
+├── noj-core/                  # 核心后端 Deno + Hono
+│   ├── deno.json              # 项目配置 + 导入映射
+│   ├── deno.lock              # 依赖锁定（提交到 git，用于 CI 缓存）
+│   ├── drizzle.config.ts      # Drizzle Kit 配置
+│   ├── drizzle/               # 26 个 SQL 迁移文件（自动生成，勿手改 _journal.json）
+│   ├── .env.example           # 环境变量模板（不提交 .env）
 │   ├── src/
-│   │   ├── main.ts       # 入口（启动校验 + 初始化顺序）
-│   │   ├── app.ts        # Hono 应用工厂（CORS + 路由 + 错误处理）
-│   │   ├── mod.ts        # 公共导出
-│   │   ├── routes/       # 路由层（参数校验 + 调用 service）
-│   │   │   ├── admin.ts, auth.ts, categories.ts
-│   │   │   ├── checkin.ts, conversations.ts
-│   │   │   ├── health.ts, problems.ts, queue.ts
-│   │   │   ├── rankings.ts, sse.ts
-│   │   │   ├── submissions.ts, users.ts
-│   │   ├── services/     # 业务逻辑层（数据库读写）
-│   │   │   ├── auth.ts, categories.ts, checkin.ts
-│   │   │   ├── conversations.ts, judge-images.ts
-│   │   │   ├── passwordReset.ts, problems.ts
-│   │   │   ├── queue.ts, rankings.ts, sse.ts
-│   │   │   ├── submissions.ts, support-package.ts
-│   │   │   ├── users.ts
+│   │   ├── main.ts            # 入口（启动校验 + 初始化顺序）
+│   │   ├── app.ts             # Hono 应用工厂（CORS + 路由 + 错误处理）
+│   │   ├── mod.ts             # 公共导出
+│   │   ├── routes/            # 11 个路由：admin / auth / categories / checkin / conversations / health / problems / queue / rankings / sse / submissions / users
+│   │   ├── services/          # 业务逻辑层：auth / categories / checkin / conversations / judge-images / passwordReset / problems / queue / rankings / sse / submissions / support-package / users / system-settings / audit-log
 │   │   ├── db/
-│   │   │   ├── connection.ts  # 数据库连接管理（单例模式）
-│   │   │   ├── migrate.ts     # 迁移执行器（绝对路径解析，不依赖 CWD）
-│   │   │   └── schema.ts      # Drizzle 表定义（13 张表）
-│   │   ├── middleware/
-│   │   │   └── auth.ts        # JWT 认证中间件
+│   │   │   ├── connection.ts  # 数据库连接管理（单例）
+│   │   │   ├── migrate.ts     # 迁移执行器（绝对路径解析）
+│   │   │   └── schema.ts      # Drizzle 表定义（17 张表）
+│   │   ├── middleware/auth.ts # JWT 认证中间件
 │   │   ├── mq/
-│   │   │   ├── connection.ts  # Redis 连接管理（shared + consumer 双连接）
-│   │   │   ├── consumer.ts    # 评测结果消费者（BRPOP 阻塞）
-│   │   │   └── producer.ts    # 评测任务生产者（LPUSH）
+│   │   │   ├── connection.ts  # Redis 连接（shared + consumer 双连接）
+│   │   │   ├── consumer.ts    # 评测结果消费者
+│   │   │   ├── producer.ts    # 评测任务生产者
+│   │   │   ├── started_consumer.ts # 评测启动事件消费者
+│   │   │   └── judge-rpc.ts   # Judge RPC 处理
 │   │   ├── lib/
-│   │   │   ├── errors.ts      # AppError 继承体系（6 个子类）
+│   │   │   ├── errors.ts      # AppError 继承体系
 │   │   │   ├── jwt.ts         # JWT 签发/验证（HS256, iss/aud 校验）
 │   │   │   ├── password.ts    # bcrypt 哈希/比对（cost 12）
 │   │   │   ├── request.ts     # parseJsonBody<T>() 安全 JSON 解析
-│   │   │   ├── logging.ts     # 生产安全日志（UUID 截断、分值隐藏）
+│   │   │   ├── logging.ts     # 生产安全日志（UUID 截断、score 隐藏）
+│   │   │   ├── event-bus.ts   # 进程内事件总线（SSE 推送）
+│   │   │   ├── env-snapshot.ts# 环境变量快照（启动期记录）
+│   │   │   ├── settings-registry.ts # 系统设置注册表
 │   │   │   └── storage/       # 抽象存储层（StorageProvider）
-│   │   │       ├── types.ts   #   StorageProvider 接口 + URL 工具
-│   │   │       ├── local.ts   #   LocalStorageProvider（dev 专用）
-│   │   │       ├── s3.ts      #   S3StorageProvider（生产环境）
-│   │   │       ├── factory.ts #   工厂函数（环境变量选择实现）
+│   │   │       ├── types.ts   #   接口 + URL 工具
+│   │   │       ├── local.ts   #   LocalStorageProvider
+│   │   │       ├── s3.ts      #   S3StorageProvider
+│   │   │       ├── factory.ts #   工厂函数
 │   │   │       └── mod.ts     #   公共导出
-│   │   └── types/
-│   │       ├── index.ts       # JudgeTask, JudgeResult, SubmissionStatus, LANGUAGE_EXT_MAP
-│   │       ├── auth.ts        # RegisterInput, LoginInput, UserResponse
-│   │       └── problems.ts    # CreateProblemInput, DIFFICULTIES, PROBLEM_TYPES
+│   │   └── types/             # 跨模块类型：JudgeTask / JudgeResult / SubmissionStatus / LANGUAGE_EXT_MAP / 各类 Input/Response
 │   ├── scripts/
 │   │   ├── seed.ts            # 数据库种子（幂等，ON CONFLICT DO NOTHING）
-│   │   ├── build-packages.ts  # 构建支持包 zip（调用系统 zip 命令）
-│   │   └── migrate.ts         # 迁移脚本（日志中脱敏数据库密码）
+│   │   ├── build-packages.ts  # 构建支持包 zip（调用系统 zip）
+│   │   └── migrate.ts         # 迁移脚本（密码脱敏）
 │   ├── data/
-│   │   ├── problems-src/      # 题目源文件（仅样例题，版本控制）
+│   │   ├── problems-src/      # 题目源文件（版本控制）
 │   │   │   ├── 1001/          # "星港舱门报码归一化" (easy)
 │   │   │   ├── 1002/          # "传感器数据滤波" (medium, 无支持包)
 │   │   │   └── 1003/          # "A+B Problem" (easy)
-│   │   └── packages/          # 构建产物 (gitignored，local 模式使用)
-│   └── tests/                 # 测试文件（与 src 镜像结构）
-│       ├── 00_migrate_test.ts # 最先执行：迁移 + seed root 用户
-│       ├── services/          # 服务层测试（auth, problems, submissions 等）
-│       ├── routes/            # 路由层测试（使用 jsonRequest() 辅助函数）
-│       └── lib/               # 工具函数测试
+│   │   └── packages/          # 构建产物 (gitignored，local 模式)
+│   └── tests/                 # 67 个测试文件（与 src 镜像结构）
+│       ├── 00_migrate_test.ts # 迁移 + seed root 用户（最先执行）
+│       ├── app.test.ts, smoke.test.ts
+│       ├── services/          # 服务层测试
+│       ├── routes/            # 路由层测试（jsonRequest() 辅助）
+│       ├── lib/               # 工具函数测试
+│       ├── middleware/, mq/, db/, types/, perf/, data/
 │
-├── noj-ui/               # 前端界面 (Nuxt 4 + Vue 3)
-│   ├── deno.json         # 任务定义 + npm 兼容配置
-│   ├── package.json      # @noj/ui v0.1.0
-│   ├── nuxt.config.ts    # Nuxt 配置（vite, nitro preset, runtimeConfig）
-│   ├── tailwind.config.ts # Tailwind 主题扩展（含 prose-neuro 排版插件）
-│   ├── app.vue           # 根组件 + CSS 变量定义
-│   ├── pages/            # 文件路由（Nuxt 自动路由）
-│   │   ├── index.vue           # 首页（Hero + 动画背景）
-│   │   ├── login.vue           # 登录（3s 自动消失错误提示）
-│   │   ├── register.vue        # 注册（复杂密码校验 + 自动登录）
-│   │   ├── problems.vue        # 题目列表（URL 驱动筛选）
-│   │   ├── problems/[id].vue   # 题目详情 + Monaco 代码提交
-│   │   ├── problems/new.vue    # 创建题目（ssr: false）
-│   │   ├── problems/[id]/edit.vue # 编辑题目（ssr: false）
-│   │   ├── submissions/        # 提交历史（筛选/状态标签/分页）
-│   │   ├── submissions/[id].vue # 提交详情（1.5s 轮询+高亮代码）
-│   │   ├── change-password.vue  # 强制改密（首次登录）
-│   │   ├── forgot-password.vue  # 忘记密码
-│   │   ├── reset-password.vue   # 重置密码
-│   │   ├── queue.vue           # 队列状态（2s 轮询）
-│   │   ├── ranking.vue         # 用户榜单
-│   │   ├── about.vue, settings.vue
-│   │   ├── users/[id].vue      # 用户主页
-│   │   ├── my/problems.vue     # 我的题目（U 型）
-│   │   └── admin/              # 管理后台（ssr: false）
-│   │       ├── index.vue, users.vue, problems.vue
-│   │       ├── categories.vue, submissions.vue
-│   │       ├── problem-new.vue, problem-edit/[id].vue
-│   ├── components/
-│   │   ├── Navbar.vue          # 固定顶栏 + 用户菜单
-│   │   ├── FooterBar.vue       # 深色底栏
-│   │   ├── Sidebar.vue         # 折叠侧栏（15px/200px）
-│   │   ├── MarkdownRenderer.vue # Markdown + KaTeX + DOMPurify
-│   │   ├── MonacoEditor.vue    # CDN 加载 Monaco Editor
-│   │   ├── ProblemEditor.vue   # 题目编辑器（创建/编辑双模式）
-│   │   ├── ProblemFilterBar.vue # 搜索 + 类型 + 难度 + 分类
-│   │   ├── ProblemId.vue       # 彩色题号（U=蓝, P=紫）
-│   │   ├── StatusBadge.vue     # 解决状态标签
-│   │   ├── PaginationNav.vue   # 智能分页
-│   │   ├── ui/AsyncContent.vue # 异步内容容器（loading/error/empty/data）
-│   │   ├── ui/BaseButton.vue   # 智能按钮（NuxtLink/a/button）
-│   │   ├── admin/AdminTable.vue # 通用管理表格
-│   │   └── admin/AdminModal.vue # 确认弹窗
-│   ├── composables/
-│   │   ├── useAuth.ts          # 认证状态管理（useState + Cookie）
-│   │   ├── usePolling.ts       # setInterval 轮询 + 竞态保护
-│   │   ├── useToast.ts         # SweetAlert2 Toast
-│   │   ├── useDialog.ts        # SweetAlert2 弹窗
-│   │   ├── useProblemFilters.ts # URL 驱动筛选
-│   │   └── use-submissions.ts  # 提交数据/格式函数
-│   ├── layouts/
-│   │   ├── default.vue         # 默认布局（Navbar + Footer）
-│   │   ├── auth.vue            # 认证布局（登录/注册）
-│   │   └── admin.vue           # 管理布局（侧栏 + 顶栏）
+├── noj-ui/                    # 前端 Nuxt 4 + Vue 3
+│   ├── deno.json              # 任务 + npm 兼容（nodeModulesDir: auto）
+│   ├── package.json           # @noj/ui v0.1.0
+│   ├── nuxt.config.ts         # vite, nitro preset, runtimeConfig
+│   ├── tailwind.config.ts     # Tailwind 主题（含 prose-neuro）
+│   ├── app.vue                # 根组件 + CSS 变量
+│   ├── pages/                 # 文件路由
+│   ├── components/            # Navbar / FooterBar / Sidebar / MonacoEditor / ProblemEditor / MarkdownRenderer / StatusBadge / PaginationNav / ProblemFilterBar / ProblemId / ui/* / admin/*
+│   ├── composables/           # useAuth / usePolling / useToast / useDialog / useProblemFilters / use-submissions
+│   ├── layouts/               # default / auth / admin
 │   ├── server/
-│   │   ├── api/[...slug].ts    # Nitro 代理（拦截登录 + JWT Cookie 注入）
-│   │   └── api/auth/logout.post.ts # 本地注销（清除 Cookie）
-│   ├── middleware/             # Nuxt 路由守卫
-│   │   ├── auth.ts             # 登录守卫（5s 超时）
-│   │   └── admin.ts            # 管理员守卫（静默重定向）
-│   ├── utils/sanitize.ts       # HTML 清洗（DOMPurify 异步加载）
-│   └── assets/                 # 静态资源（logo.jpg 等）
+│   │   ├── api/[...slug].ts   # Nitro 代理（拦截登录 + JWT 注入）
+│   │   └── api/auth/logout.post.ts # 本地注销
+│   ├── middleware/            # auth（5s 超时）+ admin（静默重定向）
+│   ├── utils/sanitize.ts      # DOMPurify 异步加载
+│   └── assets/                # 静态资源（logo.jpg 等）
 │
-├── noj-judge/             # 评测 Worker (Rust + Docker)
-│   ├── Cargo.toml         # 依赖：tokio, bollard, redis-rs, axum
-│   ├── Cargo.lock         # 版本锁定（提交到 git）
-│   ├── .dockerignore      # 排除 target/ tests/ docker/（800MB -> 200KB）
-│   ├── Dockerfile.e2e     # E2E 测试用多阶段构建
-│   ├── docker/
-│   │   └── python/Dockerfile  # 评测运行时（python:3.12-slim）
+├── noj-judge/                 # 评测 Worker Rust + Docker
+│   ├── Cargo.toml             # 依赖：tokio, bollard, redis-rs, reqwest, axum, zip, tar, ...
+│   ├── Cargo.lock             # 版本锁定（提交到 git）
+│   ├── .dockerignore          # 排除 target/ tests/ docker/
+│   ├── Dockerfile.e2e         # E2E 测试多阶段构建
+│   ├── docker/python/Dockerfile  # 评测运行时（python:3.12-slim）
 │   ├── src/
-│   │   ├── main.rs        # 入口（容器池模式，无 Semaphore 退化路径）
-│   │   ├── lib.rs          # 库入口（暴露模块给集成测试）
-│   │   ├── config.rs       # 环境变量配置（PoolConfig + 全局配置）
-│   │   ├── types.rs        # JudgeTask, JudgeResult, CaseResult
-│   │   ├── mq.rs           # Redis MQ 拉取/推送（重试 + fallback 文件）
-│   │   ├── mq/
-│   │   │   └── rpc.rs      # Redis RPC 客户端（core↔judge 通信）
-│   │   ├── sandbox/
+│   │   ├── main.rs            # 入口（容器池 + dual container）
+│   │   ├── lib.rs             # 库入口（暴露给集成测试）
+│   │   ├── config.rs          # 环境变量配置
+│   │   ├── types.rs           # JudgeTask / JudgeResult / CaseResult
+│   │   ├── mq.rs              # Redis MQ 拉取/推送（重试 + 文件 fallback）
+│   │   ├── mq/rpc.rs          # Redis RPC（core↔judge）
+│   │   ├── sandbox/           # 沙箱
 │   │   │   ├── mod.rs
-│   │   │   └── container.rs # 容器生命周期 + zip 解压 + 命令解析
-│   │   ├── judge/
+│   │   │   ├── container.rs   # 容器生命周期 + zip 解压
+│   │   │   ├── download.rs    # noj-download:// 下载（base64 / s3）
+│   │   │   └── cache.rs       # 内容寻址缓存
+│   │   ├── judge/             # 评测核心
 │   │   │   ├── mod.rs
-│   │   │   └── runner.rs    # 评测逻辑（---RESULT--- 解析 + 超时/OOM 检测）
-│   │   └── pool/
-│   │       ├── mod.rs       # PoolManager（固定池，懒回补 + 健康检查）
-│   │       ├── copy.rs      # tar 打包 + docker exec 注入文件
-│   │       └── exec.rs      # docker exec + cgroup 内存峰值读取
-│   └── tests/
-│       ├── common/mod.rs    # 测试公共辅助函数
-│       ├── e2e/
-│       │   ├── Dockerfile.test-runner  # 测试用 Python 镜像
-│       │   └── evaluate.py  # 测试用评测脚本（--hang/--memory-test 等标志）
-│       ├── e2e_docker_basic.rs
-│       ├── e2e_resource_limits.rs
-│       ├── e2e_security_isolation.rs
-│       ├── e2e_support_package.rs
-│       ├── e2e_container_pool.rs
-│       └── e2e_problem_limits.rs
+│   │   │   └── runner.rs      # ---RESULT--- 解析 + 超时/OOM 检测
+│   │   ├── pool/              # 容器池
+│   │   │   ├── mod.rs         # PoolManager（懒回补 + 健康检查）
+│   │   │   ├── copy.rs        # tar 打包 + docker exec 注入
+│   │   │   └── exec.rs        # docker exec + cgroup 内存读取
+│   │   └── dual/              # 双容器架构（新）
+│   │       ├── mod.rs
+│   │       ├── container.rs
+│   │       └── protocol.rs
+│   └── tests/                 # 7 个 E2E 测试 + common/
 │
-├── noj-tests/             # 跨模块全链路 E2E 测试
-│   ├── deno.json
-│   ├── E2E_TESTING.md
-│   ├── run-e2e.sh
-│   └── e2e/
-│       ├── helper.ts
-│       ├── 01_categories.test.ts
-│       ├── 02_problems.test.ts
-│       ├── 03_auth.test.ts
-│       ├── 04_submissions.test.ts
-│       ├── 05_profile.test.ts
-│       ├── 06_pipeline.test.ts
-│       └── 07_queue.test.ts
+├── noj-tests/                 # 跨模块全链路 E2E 测试
+│   ├── deno.json              # task: deno test -A --env-file=../env.e2e.template e2e/
+│   ├── E2E_TESTING.md         # 测试指南
+│   ├── run-e2e.sh             # 启动脚本
+│   └── e2e/                   # 17 个 .test.ts（含 helper.ts）
+│       ├── 01_categories.test.ts ... 07_queue.test.ts
+│       ├── 08_password_change_guard / 08_problem_template / 08_search
+│       ├── 09_checkin / 10_sse / 11_messaging / 12_audit_log
+│       ├── 13_support_package_s3 / 14_rejudge / 15_dual_container_judge
 │
-├── openspec/              # OpenSpec 规范驱动开发
-│   ├── config.yaml
-│   ├── specs/             # 主规范（38 个）
-│   └── changes/           # 变更提案
-│       ├── user-ranking/  # 活跃变更（当前开发中）
-│       └── archive/       # 已归档变更（35 个）
+├── openspec/                  # OpenSpec 规范驱动开发
+│   ├── config.yaml            # schema: spec-driven
+│   ├── specs/                 # 56 个主规范
+│   └── changes/               # 49 个已归档 + 4 个活跃
+│       ├── add-noj-docs
+│       ├── dual-container-judge
+│       ├── remove-single-container-mode
+│       └── archive/
 │
-├── scripts/               # 构建与运维脚本(详见 scripts/README.md)
-│   ├── dev/               # 本地开发运行:一键启停 core/ui/judge(后台守护 + PID + 日志归集)
-│   ├── db/                # 数据库迁移(migrate.sh)与种子(seed.sh)
-│   ├── build/             # 题目支持包构建(build-packages.sh)
-│   └── e2e/               # 跨模块 E2E 编排脚本(setup/teardown/core/judge/run-all)
+├── scripts/                   # 构建与运维脚本
+│   ├── dev/                   # 本地一键启停 core/ui/judge（13 个脚本）
+│   ├── db/                    # 数据库迁移与种子
+│   ├── build/                 # 题目支持包构建
+│   └── e2e/                   # E2E 编排（setup / teardown / core / judge / run-all）
 │
 ├── .github/workflows/
-│   ├── ci.yml             # PR/推送: 并行检查三个模块
-│   └── e2e.yml            # 全链路管道 E2E（15min/5-8min 缓存命中）
+│   ├── ci.yml                 # PR/推送：并行 fmt + lint + test + build
+│   └── e2e.yml                # 全链路管道（17 + 7 ≈ 24 个测试，5-15min）
 │
-├── docker-compose.yml     # 开发基础设施（PG:5432 + Redis:6379）
-├── docker-compose.e2e.yml # E2E 测试编排（含 noj-core + noj-judge）
-├── env.e2e.template       # E2E 测试环境变量模板
-├── .gitignore
-├── AGENTS.md              # 本文档
-├── CLAUDE.md -> AGENTS.md # AI 编码助手入口
-├── LICENSE                # AGPL-3.0
-├── README.md              # 项目 README
-├── ROADMAP.md             # 开发路线图
-├── skills-lock.json       # Claude Code 技能锁定
-└── .opencode/             # OpenSpec 技能配置（与 .claude/ 镜像结构）
-
----
-
-## 3. 技术栈
-
-| 模块      | 语言/运行时          | 核心框架       | 关键依赖               |
-| --------- | -------------------- | -------------- | ---------------------- |
-| noj-core  | Deno / TypeScript    | Hono           | Drizzle ORM, ioredis, Jose (JWT), postgres.js, bcryptjs |
-| noj-ui    | Deno / TypeScript | Nuxt 4 / Vue 3 | Tailwind CSS, Monaco Editor, Lucide Icons, SweetAlert2, markdown-it, KaTeX, highlight.js, DOMPurify |
-| noj-judge | Rust (Edition 2021)  | Tokio          | bollard (Docker API), redis-rs, serde, axum (metrics), zip, tar |
-| 基础设施  | PostgreSQL 16 + Redis 7 | docker-compose | Drizzle Kit (迁移) |
-
-### 关键依赖版本
-
-**noj-core** (deno.lock)：hono@^4, drizzle-orm@0.45.2, postgres@3.4.5, ioredis@5.11.1, bcryptjs@^2.4.3, jose@^5, jsr:@std/encoding@^1
-
-**noj-ui** (package.json)：nuxt@^4.0.0, vue@latest, tailwindcss, @nuxtjs/tailwindcss, @tailwindcss/typography, monaco-editor, sweetalert2, markdown-it, katex, highlight.js, dompurify, @lucide/vue
-
-**noj-judge** (Cargo.toml)：redis@0.27 (tokio-comp), tokio@1 (full), bollard@0.21, serde@1, serde_json@1, anyhow@1, tracing@0.1, uuid@1 (v4), base64@0.22, zip@2 (deflate), tar@0.4, axum@0.8
-
----
-
-## 4. 基础设施与启动
-
-### Docker Compose 开发环境
-
-```bash
-docker compose up -d    # 启动 PostgreSQL:5432 + Redis:6379
-docker compose down     # 停止
+├── docker-compose.yml         # 开发基础设施（PG:5432 + Redis:6379）
+├── docker-compose.e2e.yml     # E2E 测试编排（含 noj-core + noj-judge）
+├── env.e2e.template           # E2E 环境变量模板（DATABASE_URL=e2e@5433）
+│
+├── .claude/                   # Claude Code 配置（skills / commands / settings / workflows / worktrees）
+├── .opencode/                 # OpenCode 配置（commands / skills）
+├── skills-lock.json           # 技能锁定
+│
+├── AGENTS.md                  # 本文档（AI 入口）
+├── CLAUDE.md -> AGENTS.md     # Claude Code 软链
+├── README.md                  # 用户面向 README
+├── ROADMAP.md                 # 开发路线图
+└── LICENSE                    # AGPL-3.0
 ```
 
-| 服务 | 镜像 | 端口 | 默认凭据 |
-|------|------|------|----------|
-| PostgreSQL | postgres:16-alpine | 5432 | noj / noj / 数据库 noj |
-| Redis | redis:7-alpine | 6379 | 无认证 |
+---
 
-数据卷持久化：redis-data、postgres-data（docker compose down 不丢失）。
+## 4. 技术栈与依赖
 
-### 启动顺序
+### 4.1 关键依赖版本
 
-**noj-core 启动顺序**（main.ts 严格遵循以下步骤）：
+**noj-core**（`deno.lock` + `deno.json`）：
 
-1. **JWT_SECRET 强度校验** -- HS256 要求 >= 32 字符，不足则 Deno.exit(1) 拒绝启动
-2. **数据库迁移** -- 失败为致命错误，终止启动
-3. **确保 root 系统用户存在** -- UID=0，admin 角色，随机密码不可登录
-4. **连接 Redis** -- 失败则 degraded 模式（HTTP 仍启动，评测功能不可用）
-5. **启动评测结果消费者** -- 后台自动重连（指数退避 1s -> 2s -> 4s -> ... -> 30s）
-6. **启动 HTTP 服务** -- Deno.serve({ port }, app.fetch)
+| 依赖 | 版本 | 用途 |
+|------|------|------|
+| hono | ^4 | Web 框架 |
+| drizzle-orm | 0.45.2 | ORM |
+| postgres | 3.4.5 | PG 驱动 |
+| ioredis | 5.11.1 | Redis 客户端 |
+| bcryptjs | ^2.4.3 | 密码哈希 |
+| jose | ^5 | JWT |
+| @std/encoding | ^1 | base64 / hex |
+| @alicloud/dm20151123 | ^1.10.2 | 阿里云邮件 |
+| @electric-sql/pglite | ^0.5.3 | 测试用嵌入式 PG |
+| @aws-sdk/client-s3 + s3-request-presigner | ^3 | S3 对象存储 |
 
-**noj-judge 启动顺序**（main.rs）：
+**noj-ui**（`package.json` + `deno.json`）：nuxt@^4, vue, tailwindcss, @nuxtjs/tailwindcss, @tailwindcss/typography, monaco-editor, sweetalert2, markdown-it, katex, highlight.js, dompurify, @lucide/vue
+
+**noj-judge**（`Cargo.toml`）：
+
+| 依赖 | 版本 | 用途 |
+|------|------|------|
+| redis | 0.27 (tokio-comp) | Redis 客户端 |
+| tokio | 1 (full) | 异步运行时 |
+| bollard | 0.21 | Docker API |
+| reqwest | 0.12 (rustls-tls) | HTTP 客户端（presigned 下载） |
+| zip | 2 (deflate) | 支持包解压 |
+| serde / serde_json | 1 | 序列化 |
+| anyhow | 1 | 错误处理 |
+| tracing / tracing-subscriber | 0.1 / 0.3 | 日志 |
+| uuid | 1 (v4) | UUID |
+| base64 | 0.22 | base64 编码 |
+| tar | 0.4 | tar 打包 |
+| axum | 0.8 | metrics 端点 |
+
+### 4.2 关键 deno.json 任务（noj-core）
+
+```
+dev          deno run --watch --env-file=.env -A src/main.ts
+start        deno run --env-file=.env -A src/main.ts
+setup        deno task build-packages && deno task seed
+seed         deno run --env-file=.env -A scripts/seed.ts   # 已自动加载 .env
+build-packages  deno run -A scripts/build-packages.ts
+db:generate  deno -A npm:drizzle-kit generate --config=./drizzle.config.ts
+migrate      deno run -A scripts/migrate.ts --env-file=.env
+test:smoke   deno test -A --no-check tests/smoke.test.ts
+```
+
+---
+
+## 5. 基础设施与启动
+
+### 5.1 Docker Compose 默认凭据
+
+| 服务 | 镜像 | 端口 | 凭据 |
+|------|------|------|------|
+| PostgreSQL | `postgres:16-alpine` | 5432 | `noj / noj / noj`（用户 / 密码 / 数据库） |
+| Redis | `redis:7-alpine` | 6379 | 无认证 |
+
+数据卷：`redis-data`、`postgres-data`（`docker compose down` 不丢失；`-v` 才删）。
+
+### 5.2 启动顺序（严格）
+
+**noj-core（main.ts）**：
+
+1. JWT_SECRET 强度校验（HS256 ≥ 32 字符，失败则 `Deno.exit(1)`）
+2. 数据库迁移（失败为致命错误）
+3. 确保 root 系统用户存在（UID=0，admin 角色，随机密码不可登录）
+4. 连接 Redis（失败 → degraded 模式，HTTP 仍启动但评测不可用）
+5. 启动评测结果消费者（指数退避 1s → 2s → 4s → ... → 30s 自动重连）
+6. 启动 HTTP 服务（`Deno.serve({ port }, app.fetch)`）
+
+**noj-judge（main.rs）**：
 
 1. 创建 Tokio 运行时
 2. 初始化 tracing 日志
-3. 从环境变量加载配置
-4. 连接 Redis + PING 验证
-5. 连接 Docker + PING 验证
-6. PoolManager::init（启动后台任务 -> 事件循环）
-7. ctrl_c() 信号处理（SIGINT）触发优雅关闭
+3. 加载环境变量配置
+4. Redis PING 验证
+5. Docker PING 验证
+6. `PoolManager::init`（启动后台任务 + 事件循环）
+7. `ctrl_c()` 优雅关闭
 
-### 快速启动
+### 5.3 一键脚本（推荐）
 
-```bash
-# 启动基础设施
-docker compose up -d
-
-# 启动 noj-core
-cd noj-core
-deno task setup          # build-packages + seed
-deno task dev            # 热重载
-
-# 启动 noj-ui
-cd noj-ui
-deno install
-deno task dev            # 默认 http://localhost:3000
-
-# 启动 noj-judge
-cd noj-judge
-cargo run               # 需要 Docker daemon
-
-# 三模块可独立启动，开发时可以只跑需要的部分
-```
-
-### 一键启动（推荐：scripts/dev/）
-
-上述手动启动需要多个终端窗口。仓库根 `scripts/dev/` 提供了一键启停封装
-（日志与 PID 文件统一托管在 `scripts/dev/logs/`），适合本地日常开发：
+`scripts/dev/` 提供 13 个启停脚本，统一管理日志与 PID：
 
 ```bash
-bash scripts/dev/install-deps.sh      # 检测 Deno / Rust / Docker / zip
-cp scripts/dev/env.example noj-core/.env   # 必填 DATABASE_URL 与 JWT_SECRET
+bash scripts/dev/install-deps.sh      # 检测/安装 zip、提示其他依赖
+cp scripts/dev/env.example noj-core/.env   # 必填 DATABASE_URL 与 JWT_SECRET（≥32 字符）
 
-bash scripts/dev/start-all.sh         # infra + core + ui + judge 一键启动
+bash scripts/dev/start-all.sh         # infra → core → ui → judge
 bash scripts/dev/status.sh            # 查看运行状态
 bash scripts/dev/stop-all.sh          # 一键停止
 ```
 
-> 脚本仅封装原生命令 + 后台守护 + PID/日志归集。调试或单模块迭代时仍推荐
-> 直接 `deno task dev` / `cargo run` 前台运行以观察实时输出。
-> 详细 FAQ 见 `scripts/dev/README.md`。
+日志位置：`scripts/dev/logs/{core,ui,judge}.log`（infra 由 docker compose 管理）。
 
-### 创建第一个管理员
-
-首次运行 `deno task setup` 后，若未设置 `ADMIN_EMAIL`/`ADMIN_PASS` 环境变量，seed 脚本会自动创建引导管理员（仅限无任何可登录 admin 时）：
+### 5.4 手动分步启动
 
 ```bash
-cd noj-core && deno task setup
-# 终端输出类似：
-# ⚠ 已创建临时引导管理员（首次登录后必须修改密码）
-#   username: admin
-#   email:    admin@noj.local
-#   password: <24字符 base64url 随机>
+# 基础设施
+docker compose up -d
+
+# 后端
+cd noj-core && deno task setup && deno task dev   # http://localhost:8000
+
+# 前端
+cd ../noj-ui && deno task dev                    # http://localhost:3000
+
+# 评测 Worker
+cd ../noj-judge && cargo run                      # 需要 Docker daemon
 ```
 
-引导管理员登录后**必须**立即修改密码，否则无法访问受保护页面（自动强制跳转 `/change-password`）。
-
-**推荐做法**：在 `.env` 中设置 `ADMIN_EMAIL` 和 `ADMIN_PASS`，运行 seed 后直接使用固定凭据登录：
-
-```bash
-echo 'ADMIN_EMAIL=admin@example.com' >> noj-core/.env
-echo 'ADMIN_PASS=YourSecurePass123!' >> noj-core/.env
-cd noj-core && deno task seed
-```
-
-详见 [issue #75](https://github.com/Neuro-OJ/neuro-oj/issues/75)。
+三模块可独立启动；只调前端可省 noj-judge。
 
 ---
 
-## 5. 版本控制约定
+## 6. 数据库 Schema
 
-### 使用 Jujutsu (jj)
+### 6.1 表清单（17 张）
 
-本机使用 **jj**（Jujutsu）管理本地仓库，推送到远程使用 `jj git push`。
+| 表 | 用途 |
+|----|------|
+| `users` | 用户账户（密码、角色、封禁状态） |
+| `problems` | 题目（含 type: U/P 双题库） |
+| `judgeImages` | 评测镜像白名单 |
+| `categories` | 题目分类（支持父子层级） |
+| `problemsCategories` | 题目-分类多对多关联 |
+| `submissions` | 用户提交 |
+| `evaluationResults` | 评测结果（耗时/内存/得分） |
+| `checkIns` | 每日签到 |
+| `passwordResetTokens` | 密码重置令牌 |
+| `conversations` | 站内私信会话 |
+| `messages` | 站内私信消息 |
+| `conversationReads` | 已读状态 |
+| `messageDeletions` | 消息删除记录 |
+| `systemSettings` | 系统设置（运行时可改） |
+| `auditLogs` | 审计日志（90 天保留，可配置） |
+| `ipBans` | IP 黑名单 |
+| `userBans` | 用户封禁记录 |
 
-- 无需暂存区：直接 `jj describe` 设置提交信息，`jj new` 创建新提交
-- 误操作使用 `jj undo` 回退
-- 推送到远程使用 `jj git push`
+### 6.2 迁移
 
-### 提交信息规范
+- 共 26 个迁移文件（`drizzle/0000_*.sql` 起）
+- 由 `deno task db:generate` 自动生成，**勿手动编辑 `_journal.json`**
+- 迁移顺序严格按编号；新迁移只能追加
 
-遵循 Conventional Commits 规范：
+### 6.3 核心关系
+
+```
+users ─< submissions >─ problems
+problems >─< problemsCategories >─ categories  (categories 自引用 parent)
+users ─< checkIns
+users ─< conversations ─< messages
+users ─< auditLogs
+users ─< userBans / ipBans
+submissions ─1:1─ evaluationResults
+```
+
+U 型（用户题）：owner/admin 可 CRUD；P 型（主题题）：仅 admin 可 CRUD。
+
+---
+
+## 7. 版本控制与提交规范
+
+### 7.1 Jujutsu (jj)
+
+本地使用 **jj** 管理仓库，推送使用 `jj git push`：
+
+- 无暂存区：`jj describe` 设提交信息，`jj new` 创建新提交
+- 误操作：`jj undo` 回退
+- 远程：`jj git push`
+
+### 7.2 提交信息（Conventional Commits）
 
 - 格式：`<type>(<scope>): <description>`
 - type：`feat` `fix` `docs` `style` `refactor` `perf` `test` `chore` `ci` `build`
-- scope 可选：`core` `ui` `judge` `root`；多 scope 使用逗号分隔：`fix(core,ui): 描述`
+- scope：`core` / `ui` / `judge` / `root`；多 scope 用逗号：`fix(core,ui): 描述`
 - description 使用**中文**
 - 示例：`feat(core): 添加评测任务分发 API` / `fix(judge): 修复容器超时未清理`
 
-### 项目语言
+### 7.3 项目语言
 
-项目主要语言为**中文**。以下必须使用中文：
-- 提交信息（type 保留英文，description 使用中文）
+主要语言为**中文**，以下必须中文：
+
+- 提交信息（type 英文，description 中文）
 - 代码注释
-- 文档（README、AGENTS.md 等）
-- PR 描述和 Issue
-- 例外：代码标识符（变量名、函数名）使用英文
+- 文档（README、AGENTS.md、ROADMAP.md 等）
+- PR 描述与 Issue
+- **例外**：代码标识符（变量名、函数名）使用英文
 
-### GPG 签名要求（强制）
+### 7.4 GPG 签名（强制）
 
-所有提交必须使用 GPG 密钥签名。详见 README.md 中的必要性说明。
+所有提交必须 GPG 签名。AI 在修改代码前必须先确认用户已配置签名。
 
 ---
 
-## 6. 贡献流程
+## 8. AI 必须遵守的要求
 
-**所有代码必须以 Pull Request 形式提交，禁止直接推送到 main 分支。**
+### 8.1 不可逾越的红线
 
-**所有提交必须使用 GPG 密钥签名。**
+1. **禁止直接推送到 `main`** — 所有变更通过 PR 合入
+2. **禁止未签名提交** — GPG 未就绪时不得提交代码，应引导用户配置
+3. **禁止跳过 OpenSpec** — 功能性变更必须先有 `/opsx:propose` 提案
+4. **禁止修改 `_journal.json`** — Drizzle 迁移元数据由工具管理
+5. **禁止修改 `deno.lock` / `Cargo.lock` 手动内容** — 通过 `deno cache` / `cargo update` 更新
+6. **禁止在 `.env` 中硬编码真实凭据** — 用 `.env.example` 模板 + `gitignore`
+7. **禁止向生产数据库直连变更 schema** — 走 Drizzle 迁移流程
 
-### Agent 职责
+### 8.2 编码规范
 
-AI 编码助手在修改代码前必须检查 GPG 配置：
+- **TypeScript/Deno**：遵循 `deno fmt` + `deno lint`（CI 强制）
+- **Rust**：遵循 `cargo fmt` + `cargo clippy`（CI 强制）
+- **Vue**：遵循 `deno lint` + `deno fmt`（`include: ["*.vue", "*.ts"]`）
+- **中文注释 + 英文标识符**：参考既有代码风格
+- **错误处理**：Deno 用 `AppError` 继承体系；Rust 用 `anyhow::Result`
+- **日志**：生产环境 `logger` 自动 UUID 截断 + score 隐藏，不得直接 `console.log` 输出敏感字段
+
+### 8.3 修改前必读
+
+进入模块目录前，**先读对应 `CLAUDE.md`**：
+
+| 路径 | 必读 |
+|------|------|
+| 仓库根 | 本文档 |
+| `noj-core/` | `noj-core/CLAUDE.md` |
+| `noj-ui/` | `noj-ui/CLAUDE.md` |
+| `noj-judge/` | `noj-judge/CLAUDE.md` |
+
+涉及对应领域时主动加载技能：
+
+- TypeScript / Hono / Drizzle → `deno-expert` / `hono` / `supabase-postgres-best-practices`
+- Nuxt / Vue → `nuxt` / `vue`
+- Rust / Docker / Redis → `docker-expert` / `redis-core`
+- 规范变更 → `openspec-*` 技能
+
+### 8.4 改动检查清单
+
+每次完成任务前自查：
+
+- [ ] `deno fmt` / `cargo fmt` 已运行
+- [ ] `deno lint` / `cargo clippy` 无警告
+- [ ] 新功能/修复有对应测试（core 走 `tests/services`/`routes`；judge 走单元 + E2E）
+- [ ] 新表/字段已通过 `deno task db:generate` 生成迁移
+- [ ] 新环境变量已加入 `.env.example` + `scripts/dev/env.example`
+- [ ] 中文提交描述符合 Conventional Commits
+- [ ] GPG 签名可用
+- [ ] 若是功能变更，OpenSpec 变更已 `/opsx:propose` 起草
+
+---
+
+## 9. 贡献流程
+
+### 9.1 PR 工作流
 
 ```bash
-gpg --list-secret-keys --keyid-format LONG
-git config --global user.signingkey
-git config --global commit.gpgsign
-jj config get signing.key 2>/dev/null
-```
-
-未配置签名时，说明必要性后引导用户完成配置。不得在签名就绪前提交代码。
-
-### PR 工作流
-
-```bash
-# 1. 创建分支（使用 jj）
+# 1. 基于 main 创建分支
 jj new main
-jj describe
+jj describe                            # 中文 Conventional Commits
 
-# 2. 推送分支
+# 2. 推送分支（触发 PR 触发器）
 jj git push -b <branch-name>
 
 # 3. 创建 PR
-gh pr create --draft      # Draft PR
-gh pr create --fill       # 直接创建
+gh pr create --draft                   # Draft PR
+gh pr create --fill                    # 直接创建
 
 # 4. 迭代修复
 jj new
@@ -510,233 +576,271 @@ jj new main
 jj git push
 ```
 
-### 子模块文档
+### 9.2 Agent GPG 检查
 
-各子模块有独立的 AGENTS.md/CLAUDE.md：
-
-- `noj-core/CLAUDE.md` -- Deno + Hono 后端完整约定
-- `noj-ui/CLAUDE.md` -- Nuxt + Vue 前端完整约定
-- `noj-judge/CLAUDE.md` -- Rust Worker 完整约定
-
-在特定模块目录下工作时会优先加载，提供更精准的上下文。
-
-
----
-
-## 7. 安全模型总览
-
-### 认证
-
-- JWT HS256，iss/aud 校验（iss=nj-core, aud=nj-ui）
-- HTTP-only Cookie（noj:token），JS 不可见，防 XSS 窃取
-- 无刷新令牌机制（JWT 过期需重新登录）
-- 无 JWT 撤销机制（jti 已生成但未持久化校验）
-- 24h 过期（JWT_EXPIRES_IN 可配置）
-- 登录时设置两个 Cookie：noj:token（HTTP-only）+ noj:session（可读，仅用于 UI 快速判断）
-
-### 密码安全
-
-- bcrypt cost 12（约 250-300ms 单次哈希，OWASP 2025+ 最低建议）
-- 最小长度 12 字符，含大小写字母+数字
-- 不能与用户名/邮箱前缀相同
-
-### 防枚举
-
-- 登录失败统一返回"用户名或密码错误"，不区分用户是否存在
-- 无速率限制 / IP 封禁 / CAPTCHA（已知限制）
-
-### 容器安全（noj-judge）
-
-- cap_drop ALL -- 移除所有 Linux 能力
-- no-new-privileges -- 禁止子进程获得更高权限
-- network_mode none -- 完全隔离网络
-- ipc_mode none -- 禁止 IPC 命名空间共享
-- pids_limit 256 -- 限制进程数
-- tmpfs /tmp (256M) -- 临时文件系统
-
-### ZIP 安全（硬编码不可配置）
-
-- 路径穿越防护：拒绝含 .. 或 / 开头的条目
-- 炸弹防护：1000 条目 / 64MB 单文件 / 512MB 总解压
-
-### XSS 防护
-
-- HTTP-only Cookie（JWT 对 JS 不可见）
-- DOMPurify 清洗 Markdown 渲染
-
-### CSRF
-
-- Cookie sameSite: 'lax' 提供基础防护
-- 无 CSRF token（已知限制）
-
-### 授权
-
-- 服务端强制校验角色（UI session cookie 仅用于展示）
-- admin 可创建任意 type，普通用户仅限 U 型
-- P 型仅 admin 可 CRUD，U 型 owner/admin 可 CRUD
-- 禁止降级最后一个可登录 admin
-- root 用户（UID=0）不计入管理员统计
-
-### CORS
-
-- 开发环境：Access-Control-Allow-Origin: *
-- 生产环境：仅白名单域名
-- credentials: true, maxAge: 86400
-
-### 日志安全（NOJ_ENV=production）
-
-- submission_id 截断至前 8 字符
-- score 在日志中隐藏
-- 数据库密码在迁移脚本中脱敏
-
-### 已知限制（设计决策）
-
-- 无刷新令牌机制
-- 无 JWT 撤销机制（jti 未持久化）
-- 无速率限制 / IP 封禁 / CAPTCHA
-- 无 CSRF token（依赖 sameSite: 'lax'）
-- 注册存在 TOCTOU 竞争条件（DB 唯一约束为最终保障）
-- 审计日志保留 90 天（`AUDIT_LOG_RETENTION_DAYS` 可配置；0 = 禁用）
-
----
-
-## 8. 测试体系
-
-### noj-core 测试（Deno，37 个测试文件）
+AI 在修改代码前必须执行：
 
 ```bash
-cd noj-core && deno task test
+gpg --list-secret-keys --keyid-format LONG
+git config --global user.signingkey
+git config --global commit.gpgsign
+jj config get signing.key 2>/dev/null
 ```
 
-- DB 依赖测试检查 DATABASE_URL/JWT_SECRET，缺失时静默跳过
-- sanitizeResources: false, sanitizeOps: false
-- 路由测试使用 jsonRequest() 辅助函数
-- 测试数据使用 Date.now() 生成唯一用户名/邮箱
-
-### noj-judge 测试（Rust）
-
-**单元测试**（无需 Docker）：
-```bash
-cd noj-judge && cargo test --lib
-```
-
-**Docker 沙箱 E2E 测试**：
-```bash
-NOJ_RUN_E2E=1 cargo test --test e2e_docker_basic -- --ignored
-```
-
-- 集成测试使用 #[ignore] + NOJ_RUN_E2E=1 守卫
-- #[serial_test::serial] 序列化执行，避免 Docker 资源竞争
-- 30 秒外层超时：tokio::time::timeout(30s, ...)
-
-### 跨模块全链路 E2E 测试（noj-tests）
-
-```bash
-cd noj-tests
-NOJ_RUN_E2E=1 deno task test
-```
-
-覆盖场景：Accepted / WrongAnswer / TLE / MQ 可靠性 / 无效消息容错
-/ 鉴权守卫 / S3 存储 / SSE 等 18 个全链路测试文件
-
----
-
-## 9. CI/CD
-
-### GitHub Actions
-
-**ci.yml** -- 每个 PR/推送触发，并行检查三个模块：
-
-| Job | 检查项 | 需要服务 |
-|-----|--------|----------|
-| core-test | deno fmt, deno lint, deno test | PostgreSQL + Redis |
-| ui-check | npm install, nuxt build | 无 |
-| judge-check | cargo fmt, clippy, build, test | 无 |
-| judge-e2e | cargo test --ignored | Docker（手动触发） |
-
-**e2e.yml** -- 全链路管道测试，PR/推送 main 时运行：
-- 构建支持包 + 评测镜像 + Docker Compose
-- 启动完整评测栈（noj-core + noj-judge + PG + Redis）
-- 运行 noj-tests E2E（70 个测试）
-- 运行 noj-judge Docker 沙箱 E2E（12 个测试）
-- 首次 ~15min，缓存命中后 ~5-8min
-- 超时 60min，always() 输出诊断日志
+未配置时，说明必要性并引导用户配置，**不得**在签名就绪前提交。
 
 ---
 
 ## 10. OpenSpec 开发工作流
 
-本项目使用 OpenSpec 进行规范驱动开发。
-
-### 目录结构
+### 10.1 目录结构
 
 ```
 openspec/
-├── config.yaml          # OpenSpec 配置
-├── specs/               # 主规范（38 个活跃 spec）
-│   ├── database-schema/ # 数据库 Schema
-│   ├── user-auth/       # 用户认证
-│   ├── problem-*/       # 题目管理相关
-│   ├── judge-*/         # 评测相关
-│   ├── admin-*/         # 管理后台
-│   ├── container-pool/  # 容器池
-│   ├── checkin/         # 每日签到
-│   ├── private-messaging/  # 站内私信
-│   ├── sse-*/           # SSE 推送
-│   └── ...
-└── changes/             # 变更提案
-    ├── user-ranking/  # 活跃变更（用户榜单）
-    └── archive/         # 35 个已归档变更
+├── config.yaml              # schema: spec-driven
+├── specs/                   # 56 个主规范（活跃）
+│   ├── database-schema/     # DB Schema
+│   ├── user-auth/           # 用户认证
+│   ├── problem-*/           # 题目管理
+│   ├── judge-*/             # 评测相关
+│   ├── admin-*/             # 管理后台
+│   ├── container-pool/      # 容器池
+│   ├── checkin/             # 每日签到
+│   ├── private-messaging/   # 站内私信
+│   ├── sse-*/               # SSE 推送
+│   ├── ranking/             # 榜单
+│   └── ...（共 56 个）
+└── changes/                 # 变更提案
+    ├── add-noj-docs/        # 活跃
+    ├── dual-container-judge/# 活跃
+    ├── remove-single-container-mode/  # 活跃
+    └── archive/            # 49 个已归档
 ```
 
-### 开发历史（按时间线）
+### 10.2 工作流（强制）
 
-1. 2026-06-20: infra-database-redis-mq + user-auth + noj-judge-basic + problems-submissions-api
-2. 2026-06-21: admin-crud + submission-list-api + user-profile-api
-3. 2026-06-22: container-pool + resource-metrics + migrate-to-tailwind + user-profile-bio
-4. 2026-06-23: judge-queue-visibility
-5. 2026-06-24: e2e-tests + ui-problem-list + migrate-to-cookies
-6. 2026-06-25: admin-panel-frontend + submission-history
-7. 2026-06-27: u-p-problem-bank-split + enrich-admin-api（双题库分离+管理API增强）
-8. 2026-06-29: email-provider + password-reset + sse-push-fallback（邮件服务+密码重置+SSE推送）
-9. 2026-06-30: admin-bootstrap-force-password + daily-checkin + submission-rejudge（引导管理员+签到+重测）
-10. 2026-07-02: container-pool-simplify + semaphore-remove + image-whitelist + support-package-upload（容器池重构+镜像白名单+支持包上传）
-11. 2026-07-03: private-messaging + pglite-test-migration + user-ranking（站内私信+PGlite测试迁移+用户榜单）
+任何功能性变更**必须**按以下顺序：
 
----
+1. **`/opsx:explore`** — 探索现有相关规范
+2. **`/opsx:propose`** — 起草变更提案（含设计文档 + Delta 规范 + 任务拆分）
+3. 评审 → 实现
+4. **`/opsx:apply`** — 实施（按任务推进）
+5. 测试通过后 **`/opsx:archive`** — 归档变更
 
-## 11. 项目状态与路线图
+`/opsx:sync` 用于把已归档变更的增量同步到主规范。
 
-当前处于 **Phase 1（MVP）** 阶段
+### 10.3 活跃变更示例
 
-| 阶段 | 交付标准 |
-|------|----------|
-| Phase 0 | 浏览器注册 -> 做题 -> 提交 -> 看到评测结果 |
-| Phase 1 | 榜单可查，题目可筛选，管理后台可用 |
-| Phase 2 | 可创建比赛 -> 用户参赛 -> 实时榜单 -> 赛后复盘 |
-| Phase 3 | 多 Worker 并发评测，99.5% 可用性 |
+当前活跃变更集中在评测容器架构演进：
 
-### 已知遗留问题
-
-
-**前端已知限制**：
-- 无 SEO 优化（无 OG 标签、sitemap）
-- 无图片优化（仅 logo.jpg）
-- 无 web fonts（使用系统字体栈）
-- 无单独 types/ 目录（类型在组件内或 composables 中）
-- Composable 命名不一致：camelCase（useAuth）vs kebab-case（use-submissions）
+- `add-noj-docs` — 增加文档站（MkDocs Material）
+- `dual-container-judge` — 评测从单容器迁移到双容器
+- `remove-single-container-mode` — 移除单容器兼容路径
 
 ---
 
-## 参考文档
+## 11. 安全模型
 
-- [noj-core 详细文档](noj-core/CLAUDE.md)
-- [noj-ui 详细文档](noj-ui/CLAUDE.md)
-- [noj-judge 详细文档](noj-judge/CLAUDE.md)
-- [E2E 测试指南](noj-tests/E2E_TESTING.md)
-- [开发路线图](ROADMAP.md)
-- [项目 README](README.md)
+### 11.1 认证
+
+- JWT HS256，iss/aud 校验（iss=`nj-core`，aud=`nj-ui`）
+- HTTP-only Cookie `noj:token`（JS 不可见，防 XSS）
+- 登录额外设置可读 Cookie `noj:session`（仅用于 UI 快速判断）
+- 24h 过期（`JWT_EXPIRES_IN` 可配）
+- 无刷新令牌；无 jti 持久化（已知限制）
+
+### 11.2 密码安全
+
+- bcrypt cost 12（OWASP 2025+ 最低）
+- 最小 12 字符，含大小写字母 + 数字
+- 不能与 username/email 前缀相同
+
+### 11.3 速率限制（`noj-core/.env`）
+
+```
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_LOGIN_IP_WINDOW=30         # 30s 窗口
+RATE_LIMIT_LOGIN_IP_MAX=10            # 单 IP 最多 10 次
+RATE_LIMIT_LOGIN_ACC_WINDOW=30        # 30s 窗口
+RATE_LIMIT_LOGIN_ACC_MAX=5            # 单账号最多 5 次
+RATE_LIMIT_LOGIN_BACKOFF_SEC=15       # 每次失败 +15s 退避
+RATE_LIMIT_LOGIN_LOCK_THRESHOLD=10    # 连续 10 次失败锁定
+RATE_LIMIT_LOGIN_LOCK_SECONDS=3600    # 锁定 1 小时
+TRUSTED_PROXIES=                      # 留空则开发模式直接信任 XFF；生产必须配置
+NOJ_ENV=test 时强制关闭
+```
+
+### 11.4 容器安全（noj-judge）
+
+- `cap_drop ALL` — 移除所有 Linux 能力
+- `no-new-privileges` — 禁止提权
+- `network_mode none` — 完全隔离网络
+- `ipc_mode none` — 禁止 IPC 共享
+- `pids_limit 256`
+- `tmpfs /tmp`（256M）
+
+### 11.5 ZIP 安全（硬编码）
+
+- 路径穿越防护：拒绝 `..` 或 `/` 开头的条目
+- 炸弹防护：1000 条目 / 64MB 单文件 / 512MB 总解压
+
+### 11.6 存储与邮件 Provider
+
+```
+STORAGE_PROVIDER=local | s3           # 必填
+EMAIL_PROVIDER=mock | aliyun | tencent # 默认 mock（仅输出到控制台）
+```
+
+S3 配置：`S3_ENDPOINT / S3_REGION / S3_ACCESS_KEY / S3_SECRET_KEY / S3_BUCKET / S3_FORCE_PATH_STYLE`。
+
+### 11.7 授权与防护
+
+- 服务端强制校验角色（UI session cookie 仅展示）
+- admin 可创建任意 type；普通用户仅限 U 型
+- P 型仅 admin CRUD；U 型 owner/admin CRUD
+- 禁止降级最后一个可登录 admin
+- root 用户（UID=0）不计入管理员统计
+- XSS：HTTP-only Cookie + DOMPurify Markdown 清洗
+- CSRF：Cookie `sameSite: 'lax'`（已知无 token）
+- CORS：开发 `*`；生产仅白名单域名；`credentials: true, maxAge: 86400`
+- 日志安全（`NOJ_ENV=production`）：submission_id 截断前 8 字符、score 隐藏、DB 密码脱敏
+- 审计日志保留 90 天（`AUDIT_LOG_RETENTION_DAYS` 可配置；0 = 禁用）
+
+### 11.8 已知限制（设计决策）
+
+- 无刷新令牌 / 无 JWT 撤销
+- 无 CSRF token（依赖 sameSite）
+- 无速率限制图形验证码
+- 注册存在 TOCTOU 竞争（DB 唯一约束为最终保障）
 
 ---
 
-*本文档为顶层概要。各模块的详细开发约定、API 文档、环境变量、源代码结构请参考对应子目录的 CLAUDE.md。*
+## 12. 测试体系
+
+### 12.1 noj-core（67 个测试文件）
+
+```bash
+cd noj-core && deno task test
+```
+
+- DB 依赖测试检查 `DATABASE_URL` / `JWT_SECRET`，缺失时静默跳过
+- `sanitizeResources: false, sanitizeOps: false`
+- 路由测试使用 `jsonRequest()` 辅助函数
+- 测试数据用 `Date.now()` 生成唯一 username/email
+- 单元模块测试：`tests/lib/`、`tests/services/`、`tests/middleware/`
+- 集成测试：`tests/routes/`、`tests/mq/`
+- 性能测试：`tests/perf/`
+- 冒烟测试：`deno task test:smoke`
+
+### 12.2 noj-judge
+
+**单元测试**（无需 Docker）：
+
+```bash
+cd noj-judge && cargo test --lib
+```
+
+**Docker 沙箱 E2E**（7 个 `e2e_*.rs`）：
+
+```bash
+cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e -- --ignored
+```
+
+- 集成测试 `#[ignore]` + `NOJ_RUN_E2E=1` 守卫
+- `#[serial_test::serial]` 序列化执行避免 Docker 资源竞争
+- 30s 外层超时：`tokio::time::timeout(30s, ...)`
+
+### 12.3 跨模块 E2E（noj-tests，17 个测试文件）
+
+```bash
+cd noj-tests && deno task test
+```
+
+- `deno.json` task 已自动 `--env-file=../env.e2e.template`，**无需前缀 `NOJ_RUN_E2E=1`**
+- 覆盖：Accepted / WrongAnswer / TLE / MQ 可靠性 / 无效消息容错 / 鉴权守卫 / S3 存储 / SSE / 私信 / 审计日志 / 重测 / 双容器等
+- 辅助启动：`./run-e2e.sh`
+
+---
+
+## 13. CI/CD
+
+### 13.1 GitHub Actions
+
+**`ci.yml`** — PR/推送触发，并行检查三个模块：
+
+| Job | 检查项 | 依赖服务 |
+|-----|--------|----------|
+| core-test | deno fmt, deno lint, deno test | PostgreSQL + Redis |
+| ui-check | deno lint, deno fmt, npm install, nuxt build | 无 |
+| judge-check | cargo fmt, clippy, build, test | 无 |
+| judge-e2e | cargo test --ignored | Docker（手动触发 workflow_dispatch） |
+
+**`e2e.yml`** — 全链路管道测试（PR/推送 main）：
+
+- 构建支持包 + 评测镜像 + Docker Compose
+- 启动完整评测栈（noj-core + noj-judge + PG:5433 + Redis:6380）
+- 运行 noj-tests E2E（17 个测试）
+- 运行 noj-judge Docker 沙箱 E2E（7 个测试）
+- 首次 ~15min，缓存命中后 ~5-8min
+- 超时 60min，`always()` 输出诊断日志
+- env：`JWT_SECRET=e2e-ci-secret-fixed-value-with-32-chars-min-abc`（≥32 字符，main.ts 强校验）
+
+---
+
+## 14. 故障排查速查
+
+| 现象 | 处理 |
+|------|------|
+| `JWT_SECRET 长度不足 32` | 在 `noj-core/.env` 设置 32+ 字符随机串（`openssl rand -base64 48`） |
+| `DATABASE_URL` 连接拒绝 | `docker compose ps` 确认 PG 启动；端口 5432 未占用 |
+| `zip: command not found` | `sudo apt install -y zip unzip` 或先跑 `install-deps.sh` |
+| `Cannot connect to Docker daemon` | 启动 Docker Desktop 或 `sudo systemctl start docker` |
+| 端口 3000 / 8000 冲突 | `lsof -i :3000` 杀掉占用或修改 `PORT` |
+| 提交后长时间 `Pending` | noj-judge 未启/未连 Redis；查 `scripts/dev/logs/judge.log` |
+| 队列堆积 | `redis-cli LLEN noj:judge:queue`；重启 noj-judge 触发自动重连 |
+| `noj-download://` 解码失败 | `deno task build-packages` 重建支持包 |
+| `image not found` | 默认镜像 `noj-judge-python`；检查 `noj-judge/docker/` 构建脚本 |
+| 迁移失败 | `cd noj-core && deno task migrate` 看脱敏日志 |
+| 种子数据缺失 | 确认 `noj-core/.env` 已配 `ADMIN_EMAIL`；重新 `deno task seed` |
+| 想清空重置 | `docker compose down -v` 删卷后 `up -d` + `deno task setup` |
+| `deno task migrate` 不读 .env | deno.json task 已显式 `--env-file=.env`，正常应工作 |
+
+日志位置：`scripts/dev/logs/{core,ui,judge}.log`；前端队列状态页：<http://localhost:3000/queue>。
+
+---
+
+## 15. 项目状态与路线图
+
+当前处于 **Phase 1（MVP）** 阶段——已打通"注册 → 做题 → 提交 → 评测结果"闭环，具备题目筛选、管理后台、用户榜单、每日签到、站内私信。
+
+| 阶段 | 交付标准 | 状态 |
+|------|---------|------|
+| **Phase 0** | 浏览器注册 → 做题 → 提交 → 看到评测结果 | ✅ 完成 |
+| **Phase 1** | 榜单可查，题目可筛选，管理后台可用 | 🚧 进行中（遗留：多语言 C++/Java/Node.js、SPJ） |
+| **Phase 2** | 可创建比赛 → 用户参赛 → 实时榜单 → 赛后复盘 | ⏳ 规划 |
+| **Phase 3** | 多 Worker 并发评测，99.5% 可用性 | ⏳ 规划 |
+
+详见 [`ROADMAP.md`](./ROADMAP.md)。
+
+### 已知遗留
+
+- **前端**：无 SEO（无 OG 标签 / sitemap）、无图片优化、无 web fonts（系统字体栈）、无单独 `types/` 目录、Composable 命名不一致（`useAuth` vs `use-submissions`）
+
+---
+
+## 16. 参考文档
+
+| 文档 | 路径 | 用途 |
+|------|------|------|
+| 用户 README | [`README.md`](./README.md) | 用户面向的项目说明 |
+| noj-core 详细文档 | [`noj-core/CLAUDE.md`](./noj-core/CLAUDE.md) | Deno + Hono 后端完整约定 |
+| noj-ui 详细文档 | [`noj-ui/CLAUDE.md`](./noj-ui/CLAUDE.md) | Nuxt + Vue 前端完整约定 |
+| noj-judge 详细文档 | [`noj-judge/CLAUDE.md`](./noj-judge/CLAUDE.md) | Rust Worker 完整约定 |
+| E2E 测试指南 | [`noj-tests/E2E_TESTING.md`](./noj-tests/E2E_TESTING.md) | 跨模块 E2E 测试方法 |
+| 开发路线图 | [`ROADMAP.md`](./ROADMAP.md) | 阶段规划与待办 |
+| AI 入口（本文档） | [`AGENTS.md`](./AGENTS.md) | AI 编码助手项目知识库 |
+| OpenSpec 主规范 | [`openspec/specs/`](./openspec/) | 56 个行为规范 |
+
+---
+
+*本文档为顶层 AI 入口。各模块详细约定、API 端点、Schema 字段、组件层级请参考对应子目录 `CLAUDE.md`。*

--- a/README.md
+++ b/README.md
@@ -87,7 +87,11 @@ neuro-oj/
 ├── noj-docs/          # 正式文档站 — 做题人/运营者/出题人文档 (MkDocs Material)
 ├── noj-tests/         # 跨模块全链路 E2E 测试
 ├── openspec/          # OpenSpec 规范驱动开发（38 specs + 变化管理）
-├── scripts/           # 构建与维护脚本
+├── scripts/           # 构建与维护脚本（详见 scripts/README.md）
+│   ├── dev/           #   本地开发运行（一键启停 noj-core / noj-ui / noj-judge）
+│   ├── db/            #   数据库迁移与种子
+│   ├── build/         #   题目支持包构建
+│   └── e2e/           #   跨模块 E2E 编排
 ├── docker-compose.yml # 开发基础设施 (PostgreSQL + Redis)
 └── docker-compose.e2e.yml # E2E 测试编排
 ```
@@ -117,6 +121,20 @@ neuro-oj/
 
 ```bash
 docker compose up -d    # PostgreSQL:5432 + Redis:6379
+```
+
+### 一键启动整套开发环境
+
+仓库根目录提供了封装好的本地开发脚本（日志与 PID 文件统一托管在
+`scripts/dev/logs/`）：
+
+```bash
+bash scripts/dev/install-deps.sh      # 检测 Deno / Rust / Docker / zip
+cp scripts/dev/env.example noj-core/.env   # 配置环境变量（必填 DATABASE_URL 与 JWT_SECRET）
+
+bash scripts/dev/start-all.sh         # 一键启动 infra + core + ui + judge
+bash scripts/dev/status.sh            # 查看运行状态
+bash scripts/dev/stop-all.sh          # 一键停止
 ```
 
 ### 启动后端 (noj-core)
@@ -185,10 +203,11 @@ mkdocs build --strict
 
 ```bash
 cd noj-tests
-NOJ_RUN_E2E=1 deno task test:e2e
+NOJ_RUN_E2E=1 deno task test
 ```
 
-覆盖：Accepted / WrongAnswer / TLE / MQ 可靠性 / 无效消息容错
+覆盖：Accepted / WrongAnswer / TLE / MQ 可靠性 / 无效消息容错 / 鉴权守卫
+等 18 个全链路测试文件
 
 ### 各模块测试
 

--- a/README.md
+++ b/README.md
@@ -16,22 +16,24 @@
 
 ## 什么是 Neuro OJ？
 
-Neuro OJ（NOJ）是一个面向**大模型实操能力评测**场景的在线评测系统。与传统的算法竞赛 OJ 不同，NOJ 评测的是指令微调、提示工程、Agent 构建、模型对齐等编程任务——这些任务需要灵活的评测逻辑、资源隔离和可扩展的 Worker 架构。
+Neuro OJ（NOJ）是一个面向**大模型实操能力评测**场景的在线评测系统。与传统算法竞赛 OJ 不同，NOJ 评测的是指令微调、提示工程、Agent 构建、模型对齐等编程任务——这些任务需要灵活的评测逻辑、严格的资源隔离和可水平扩展的 Worker 架构。
 
 ### 典型场景
 
 - **教学实训** — 大模型课程中的编程作业自动评测
-- **能力认证** — 支持类似 LMCC 第二轮编程题的机考环境
-- **模型评测** — 自动化评估模型在特定任务上的表现
+- **能力认证** — 复现类似 LMCC 第二轮编程题的机考环境
+- **模型评测** — 自动化评估模型在特定任务上的代码能力
+
+---
 
 ## 系统架构
 
-NOJ 由三个核心模块组成，通过 RESTful API 和 Redis 消息队列协作：
+NOJ 由三个模块通过 RESTful API 和 Redis 消息队列协作：
 
 ```
 +----------+   RESTful API   +----------+   Redis MQ    +--------------+
 |  noj-ui  | <-------------> | noj-core | --Producer--> |  noj-judge   |
-|  Nuxt 4  |                 | Deno+Hon | <--Consumer--|  Rust+Docker  |
+|  Nuxt 4  |                 | Deno+Hono| <--Consumer--|  Rust+Docker  |
 +----------+                 +----------+               +--------------+
                                    |
                               +----+----+
@@ -39,214 +41,225 @@ NOJ 由三个核心模块组成，通过 RESTful API 和 Redis 消息队列协�
                               +---------+
 ```
 
-### 消息流
+- **noj-ui**（Nuxt 4 + Vue 3）— Web 前端，提供题目列表、代码编辑器、提交结果页、管理后台等。
+- **noj-core**（Deno + Hono）— RESTful API 服务，负责用户/题目/提交/榜单等业务，并作为 Redis MQ 的生产者与消费者。
+- **noj-judge**（Rust + Tokio）— 评测 Worker，从 MQ 拉取任务，在 Docker 沙箱中执行评测脚本并回传结果。
+- **PostgreSQL 16** — 持久化存储；**Redis 7** — 消息队列与缓存。
 
-1. 用户通过 noj-ui 提交代码
-2. noj-core 接收请求，将评测任务发布到 Redis MQ（`noj:judge:queue`）
-3. noj-judge Worker 从 MQ 拉取任务（BRPOP）
-4. Worker 在 Docker 容器中执行评测（资源隔离、安全沙箱）
-5. 结果通过 Redis MQ 返回（`noj:judge:results`）
-6. noj-core 消费结果，持久化到 PostgreSQL
+### 评测消息流
 
-### Judge Worker 容器池模式
+1. 用户在 noj-ui 提交代码
+2. noj-core 接收请求，将评测任务发布到 Redis 队列（`noj:judge:queue`）
+3. noj-judge 从队列拉取任务
+4. Worker 在 Docker 容器中执行评测脚本（资源隔离、网络关闭）
+5. 结果回写 Redis（`noj:judge:results`）
+6. noj-core 消费结果并持久化到数据库
 
-- **Pool 模式** — 预创建固定容器池，懒回补，健康检查，RAII 自动回收（Semaphore 退化路径已移除）
+---
 
-## 技术栈
+## 环境要求
 
-| 模块 | 语言/运行时 | 核心框架 | 关键依赖 |
-|------|------------|----------|----------|
-| **noj-core** | Deno / TypeScript | Hono 4 | Drizzle ORM, postgres.js, ioredis, Jose (JWT), bcryptjs |
-| **noj-ui** | Deno / TypeScript | Nuxt 4 / Vue 3 | Tailwind CSS, Monaco Editor, Lucide Icons, SweetAlert2, markdown-it, KaTeX, highlight.js, DOMPurify |
-| **noj-judge** | Rust (Edition 2021) | Tokio | bollard (Docker API), redis-rs, serde, axum (metrics), zip, tar |
-| **基础设施** | — | — | PostgreSQL 16 / Redis 7 |
+| 组件 | 版本 / 说明 |
+|------|------------|
+| 操作系统 | Linux / macOS（推荐 Ubuntu 22.04+） |
+| [Deno](https://deno.com) | 2.x（运行 noj-core 与 noj-ui） |
+| [Rust](https://www.rust-lang.org/) | toolchain stable（编译 noj-judge） |
+| [Docker](https://www.docker.com/) | 20.10+，含 Docker Compose v2 |
+| zip / unzip | 系统命令行工具（构建支持包依赖，`install-deps.sh` 会自动安装） |
+| Git | 2.x |
+| 内存 | ≥ 4 GB（运行全部模块 + Postgres + Redis） |
+| 端口 | 3000（前端）/ 8000（后端）/ 5432（PG）/ 6379（Redis） |
 
-## 数据库 Schema
+> 一键检测脚本：`bash scripts/dev/install-deps.sh`，会自动安装 zip/unzip，并对其他依赖给出安装指引。
 
-```mermaid
-erDiagram
-    users ||--o{ submissions : ""
-    problems ||--o{ submissions : ""
-    submissions ||--|| evaluation_results : ""
-    problems }|--|{ categories : "problems_categories"
-    categories ||--o{ categories : "parent"
-    users ||--o{ check_ins : ""
-    users ||--o{ conversations : ""
-    conversations ||--o{ messages : ""
-```
-
-核心 7 张表 + 6 张辅助表：`users`, `problems`, `categories`, `problems_categories`, `submissions`, `evaluation_results`, `check_ins`, `judge_images`, `password_reset_tokens`, `conversations`, `messages`, `conversation_reads`, `message_deletions`。支持 U/P 双题库（用户题/主题题）、分类体系、每日签到、站内私信。
-
-## 项目结构
-
-```
-neuro-oj/
-├── noj-core/          # 核心后端 — RESTful API 服务 (Deno + Hono)
-├── noj-ui/            # 前端界面 — 用户交互 (Nuxt 4 + Vue 3)
-├── noj-judge/         # 评测 Worker — Docker 沙箱执行 (Rust + Tokio)
-├── noj-docs/          # 正式文档站 — 做题人/运营者/出题人文档 (MkDocs Material)
-├── noj-tests/         # 跨模块全链路 E2E 测试
-├── openspec/          # OpenSpec 规范驱动开发（38 specs + 变化管理）
-├── scripts/           # 构建与维护脚本（详见 scripts/README.md）
-│   ├── dev/           #   本地开发运行（一键启停 noj-core / noj-ui / noj-judge）
-│   ├── db/            #   数据库迁移与种子
-│   ├── build/         #   题目支持包构建
-│   └── e2e/           #   跨模块 E2E 编排
-├── docker-compose.yml # 开发基础设施 (PostgreSQL + Redis)
-└── docker-compose.e2e.yml # E2E 测试编排
-```
-
-## 安全模型
-
-| 维度 | 措施 |
-|------|------|
-| **认证** | JWT HS256, iss/aud 校验, HTTP-only Cookie, 24h 过期 |
-| **密码** | bcrypt cost 12, 最小 12 字符含大小写+数字 |
-| **容器** | cap_drop ALL, no-new-privileges, network_mode none, pids_limit 256, tmpfs /tmp |
-| **ZIP** | 路径穿越防护, 1000 条目 / 64MB 单文件 / 512MB 总解压上限 |
-| **XSS** | HTTP-only Cookie + DOMPurify Markdown 清洗 |
-| **授权** | 服务端强制角色校验, U/P 双题库权限隔离 |
-
-详见 [AGENTS.md](./AGENTS.md#7-安全模型总览)。
+---
 
 ## 快速开始
 
-### 环境要求
+### 方式 A：一键脚本（推荐）
 
-- [Deno](https://deno.com) 2.x
-- [Rust](https://www.rust-lang.org/)
-- [Docker](https://www.docker.com/)
-
-### 启动基础设施
+适合本地日常开发。脚本统一管理后台进程、PID 与日志到 `scripts/dev/logs/`。
 
 ```bash
-docker compose up -d    # PostgreSQL:5432 + Redis:6379
+# 1. 检测环境（自动安装 zip/unzip，提示其他依赖）
+bash scripts/dev/install-deps.sh
+
+# 2. 准备环境变量（必填 DATABASE_URL 与 JWT_SECRET，至少 32 字符）
+cp scripts/dev/env.example noj-core/.env
+$EDITOR noj-core/.env
+
+# 3. 一键启动整套环境（infra → core → ui → judge）
+bash scripts/dev/start-all.sh
+
+# 4. 查看状态
+bash scripts/dev/status.sh
+
+# 5. 停止全部模块
+bash scripts/dev/stop-all.sh
 ```
 
-### 一键启动整套开发环境
+启动完成后：
 
-仓库根目录提供了封装好的本地开发脚本（日志与 PID 文件统一托管在
-`scripts/dev/logs/`）：
+- 前端：<http://localhost:3000>
+- 后端 API：<http://localhost:8000>
+- 健康检查：`curl http://localhost:8000/health`
 
-```bash
-bash scripts/dev/install-deps.sh      # 检测 Deno / Rust / Docker / zip
-cp scripts/dev/env.example noj-core/.env   # 配置环境变量（必填 DATABASE_URL 与 JWT_SECRET）
+### 方式 B：手动分步启动
 
-bash scripts/dev/start-all.sh         # 一键启动 infra + core + ui + judge
-bash scripts/dev/status.sh            # 查看运行状态
-bash scripts/dev/stop-all.sh          # 一键停止
-```
-
-### 启动后端 (noj-core)
+需要单独调试某个模块时使用前台运行，实时查看日志。
 
 ```bash
+# 1. 基础设施
+docker compose up -d          # PostgreSQL + Redis
+
+# 2. 后端 noj-core
 cd noj-core
-deno task setup         # 构建支持包 + 填充种子数据
-deno task dev           # 热重载 (http://localhost:8000)
+deno task setup               # 构建支持包 + 填充种子数据
+deno task dev                 # 热重载 http://localhost:8000
+
+# 3. 前端 noj-ui（新开终端）
+cd ../noj-ui
+deno task dev                 # http://localhost:3000（首次运行会自动拉取依赖）
+
+# 4. 评测 Worker noj-judge（新开终端）
+cd ../noj-judge
+cargo run                     # 需 Docker daemon 运行中
 ```
 
-### 启动前端 (noj-ui)
+三模块相互独立，可只启动需要的部分（如只调试前端时无需启动 noj-judge）。
+
+### 首个管理员账号
+
+`deno task seed` 的行为依赖 `ADMIN_EMAIL` 是否设置：
+
+- **未设置 `ADMIN_EMAIL`** — 自动创建引导管理员（密码 24 位随机写入终端输出，**首次登录后必须修改**）。
+- **设置了 `ADMIN_EMAIL` 但未设置 `ADMIN_PASS`** — 仅提升该邮箱用户为管理员，不创建新用户。
+- **同时设置 `ADMIN_EMAIL` 和 `ADMIN_PASS`** — 用户不存在时自动创建并设为 admin。
+
+推荐做法——把凭据写进 `noj-core/.env` 后再运行 seed：
 
 ```bash
-cd noj-ui
-deno install
-deno task dev           # http://localhost:3000
+echo 'ADMIN_EMAIL=admin@example.com' >> noj-core/.env
+echo 'ADMIN_PASS=YourSecurePass123!' >> noj-core/.env
+cd noj-core && deno task seed
 ```
 
-### 启动评测 Worker (noj-judge)
+---
 
-```bash
-cd noj-judge
-cargo run               # 需要 Docker daemon
-```
+## 故障排查
 
-三模块可独立启动，开发时可以只跑需要的部分。
+### 启动相关
 
-## 文档站
+| 现象 | 可能原因 / 处理 |
+|------|----------------|
+| `JWT_SECRET 长度不足 32` | 在 `noj-core/.env` 设置 32+ 字符的随机字符串 |
+| `DATABASE_URL` 报错 / 连接拒绝 | 确认 `docker compose ps` 中 Postgres 已启动；端口 5432 未被占用 |
+| `deno task setup` 卡在 `zip: command not found` | `sudo apt install -y zip unzip` 后重试（或先跑 `install-deps.sh`） |
+| `cargo run` 报 `Cannot connect to Docker daemon` | 启动 Docker Desktop，或 `sudo systemctl start docker` |
+| 端口 3000 / 8000 冲突 | 修改对应模块配置，或先 `lsof -i :3000` 杀掉占用进程 |
+| 一键启动后某模块长时间未就绪 | 查看 `scripts/dev/status.sh` 输出与对应日志 |
 
-面向做题人、运营者和出题人的正式文档位于 [`noj-docs/`](./noj-docs/)。
+### 评测相关
 
-```bash
-cd noj-docs
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-mkdocs serve
-```
+| 现象 | 可能原因 / 处理 |
+|------|----------------|
+| 提交后状态长时间停留在 `Pending` | noj-judge 未启动或未连上 Redis；检查 `bash scripts/dev/status.sh` 与 `scripts/dev/logs/judge.log` |
+| 结果丢失 / 队列堆积 | 查看 Redis 长度：`redis-cli LLEN noj:judge:queue`；必要时重启 `noj-judge` 触发自动重连 |
+| 评测结果报错 `noj-download://` 解码失败 | `deno task build-packages` 重新构建题目支持包 |
+| 容器启动失败 `image not found` | 默认评测镜像为本地 `noj-judge-python`；检查 `noj-judge/docker/` 构建脚本 |
 
-提交文档变更前建议运行：
+### 数据库相关
 
-```bash
-cd noj-docs
-mkdocs build --strict
-```
+| 现象 | 可能原因 / 处理 |
+|------|----------------|
+| 迁移失败 | `cd noj-core && deno task migrate` 查看脱敏日志；常见原因是顺序错乱或与已应用迁移冲突 |
+| 种子数据缺失 / 管理员未创建 | 确认 `noj-core/.env` 已配置 `ADMIN_EMAIL`；必要时重新运行 `deno task seed` |
+| 想清空重置 | `docker compose down -v` 删除数据卷后重新 `up -d` + `deno task setup` |
+
+### 日志位置
+
+- 一键脚本：`scripts/dev/logs/{core,ui,judge}.log`（infra 由 docker compose 管理，无单独日志文件）
+- 手动运行：直接查看前台终端
+- 队列状态页：<http://localhost:3000/queue>（前端）
+
+更多 FAQ 见 [`scripts/dev/README.md`](./scripts/dev/README.md) 与 [`noj-docs/`](./noj-docs/) 文档站。
+
+---
 
 ## 开发流程
 
-本项目采用 **OpenSpec 规范驱动开发**：
+本项目使用 OpenSpec 规范驱动开发：
 
-1. 在 `openspec/specs/` 中定义行为规范
+1. 在 `openspec/specs/` 定义行为规范
 2. 创建变更提案 `openspec/changes/<name>/`
-3. 编写设计文档 + Delta 规范 + 任务拆分
-4. 实现 → 测试 → 归档
+3. 实现 → 测试 → 归档变更
 
 ### 版本控制
 
-- **Jujutsu (jj)** 管理本地仓库
-- **GPG 签名** 所有提交必须签名
-- **Conventional Commits** — `feat(core): 添加XX功能`
-- **PR 流程** — 禁止直接推送 main，所有变更通过 PR 合入
+- 本地使用 **Jujutsu (jj)** 管理仓库，推送使用 `jj git push`
+- 所有提交必须 **GPG 签名**，`Conventional Commits` 规范（中文描述）
+- 禁止直接推送到 `main`，所有变更通过 PR 合入
 
-## 测试体系
+完整的开发约定见 [`AGENTS.md`](./AGENTS.md) 以及各子模块的 `CLAUDE.md`：
+[`noj-core`](./noj-core/CLAUDE.md) · [`noj-ui`](./noj-ui/CLAUDE.md) · [`noj-judge`](./noj-judge/CLAUDE.md)。
 
-### 跨模块全链路 E2E 测试
-
-```bash
-cd noj-tests
-NOJ_RUN_E2E=1 deno task test
-```
-
-覆盖：Accepted / WrongAnswer / TLE / MQ 可靠性 / 无效消息容错 / 鉴权守卫
-等 18 个全链路测试文件
-
-### 各模块测试
+### 测试
 
 ```bash
-# noj-core（37 个测试文件）
+# noj-core 单元 + 集成测试（67 个测试文件）
 cd noj-core && deno task test
 
 # noj-judge 单元测试
 cd noj-judge && cargo test --lib
 
-# noj-judge Docker 沙箱 E2E
-cd noj-judge && NOJ_RUN_E2E=1 cargo test -- --ignored
+# noj-judge Docker 沙箱 E2E（需要 Docker 与 NOJ_RUN_E2E=1，7 个测试）
+cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e -- --ignored
+
+# 跨模块全链路 E2E（17 个测试文件，需先启动完整环境）
+cd noj-tests && deno task test
 ```
 
-### CI/CD
+CI 通过 GitHub Actions 双重流水线保证质量：
 
-GitHub Actions 双流水线：
-- **ci.yml** — PR/推送触发，并行检查三个模块（fmt + lint + test + build）
-- **e2e.yml** — 全链路管道测试（70 API 测试 + 12 Docker 沙箱测试，5-15min）
+- **`ci.yml`** — PR/推送触发，并行检查三个模块（fmt + lint + test + build）
+- **`e2e.yml`** — 全链路管道测试（首次 ~15min，缓存命中后 ~5-8min）
 
-## 项目状态
+---
 
-当前处于 **Phase 1（MVP）** 阶段——注册 → 做题 → 提交 → 评测结果闭环已打通，题目筛选、管理后台可用。
+## 项目状态与路线图
 
-| 阶段 | 交付标准 |
-|------|----------|
-| Phase 0 | 浏览器注册 → 做题 → 提交 → 看到评测结果 |
-| Phase 1 | 榜单可查，题目可筛选，管理后台可用 |
-| Phase 2 | 可创建比赛 → 用户参赛 → 实时榜单 → 赛后复盘 |
-| Phase 3 | 多 Worker 并发评测，99.5% 可用性 |
+当前处于 **Phase 1（MVP）** 阶段——已打通"注册 → 做题 → 提交 → 评测结果"闭环，并具备题目筛选、管理后台、用户榜单、每日签到、站内私信等核心功能。当前遗留项：多语言评测（C++/Java/Node.js）、SPJ（Special Judge）。
 
-详见 [ROADMAP.md](./ROADMAP.md)。
+| 阶段 | 交付标准 | 状态 |
+|------|---------|------|
+| **Phase 0** | 浏览器注册 → 做题 → 提交 → 看到评测结果 | ✅ 完成 |
+| **Phase 1** | 榜单可查，题目可筛选，管理后台可用 | 🚧 进行中 |
+| **Phase 2** | 可创建比赛 → 用户参赛 → 实时榜单 → 赛后复盘 | ⏳ 规划 |
+| **Phase 3** | 多 Worker 并发评测，99.5% 可用性 | ⏳ 规划 |
+
+详见 [`ROADMAP.md`](./ROADMAP.md)。
+
+---
+
+## 文档
+
+- 用户文档站（做题人 / 运营者 / 出题人）：[`noj-docs/`](./noj-docs/)
+- 开发者总览：[`AGENTS.md`](./AGENTS.md)
+- 各模块详细约定：[`noj-core/CLAUDE.md`](./noj-core/CLAUDE.md) · [`noj-ui/CLAUDE.md`](./noj-ui/CLAUDE.md) · [`noj-judge/CLAUDE.md`](./noj-judge/CLAUDE.md)
+- 跨模块 E2E 测试指南：[`noj-tests/E2E_TESTING.md`](./noj-tests/E2E_TESTING.md)
+
+---
 
 ## 贡献
 
-- **GPG 签名** — 所有提交必须使用 GPG 密钥签名
-- **PR 流程** — 禁止直接推送 main 分支
-- 详细的开发约定见 [AGENTS.md](./AGENTS.md)
+欢迎以 PR 形式贡献代码。请先阅读 [`AGENTS.md`](./AGENTS.md) 中的贡献流程，重点关注：
+
+- 所有提交必须 GPG 签名
+- 通过 PR 合入，禁止直推 `main`
+- 遵循 OpenSpec 规范驱动流程
+
+---
 
 ## 许可证
 
-[GNU Affero General Public License v3.0](./LICENSE)
+本项目基于 [GNU Affero General Public License v3.0](./LICENSE) 开源。

--- a/noj-tests/E2E_TESTING.md
+++ b/noj-tests/E2E_TESTING.md
@@ -51,13 +51,13 @@ noj-tests/
 
 ```bash
 cd noj-tests
-NOJ_RUN_E2E=1 deno task test:e2e
+NOJ_RUN_E2E=1 deno task test
 ```
 
 ### 保留容器（调试用）
 
 ```bash
-E2E_NO_CLEANUP=1 NOJ_RUN_E2E=1 deno task test:e2e
+E2E_NO_CLEANUP=1 NOJ_RUN_E2E=1 deno task test
 ```
 
 测试结束后容器保留，可手动排查问题。

--- a/openspec/changes/dual-container-judge/tasks.md
+++ b/openspec/changes/dual-container-judge/tasks.md
@@ -113,6 +113,6 @@
 - [ ] `deno fmt --check` + `deno lint` + `deno task test` 全过
 - [ ] `npm run build`（no-jui）通过
 - [ ] Docker E2E：`NOJ_RUN_E2E=1 cargo test --test e2e_dual_container -- --ignored` 全过（PR-A2 起）
-- [ ] 全链路 E2E：`NOJ_RUN_E2E=1 deno task test:e2e` 全过（PR-C 起）
+- [ ] 全链路 E2E：`NOJ_RUN_E2E=1 deno task test` 全过（PR-C 起）
 - [ ] GPG 签名所有提交
 - [ ] 不存在除设计稿允许外的字段（任何 `JudgeTask` 字段新增需更新 design.md）

--- a/openspec/specs/judge-e2e-test/spec.md
+++ b/openspec/specs/judge-e2e-test/spec.md
@@ -86,9 +86,9 @@
 #### Scenario: 全栈测试门控
 
 - **WHEN** 环境变量 `NOJ_RUN_E2E=1` 未设置
-- **THEN** `deno task test:e2e` 跳过所有全栈 E2E 测试
+- **THEN** `deno task test` 跳过所有全栈 E2E 测试
 - **WHEN** 环境变量 `NOJ_RUN_E2E=1` 已设置
-- **THEN** `deno task test:e2e` 启动测试栈并执行全链路测试
+- **THEN** `deno task test` 启动测试栈并执行全链路测试
 
 ### Requirement: 基础提交 Accepted 验证
 


### PR DESCRIPTION
## 背景

`README.md` 与 `AGENTS.md` 内容已与代码实际状态出现偏差:
- 测试计数(37/18/12 → 67/17/7)、数据库表(13 → 17)、Drizzle 迁移(12 → 26)、OpenSpec 数量(38/35 → 56/49) 与实际不符
- README 偏向开发者视角,缺少用户场景的运行/排障指引
- AGENTS.md 缺少 AI 工具专属章节(技能/命令/红线清单)

## 变更内容

### README.md (用户面向)
- 删除 DB Schema mermaid、安全模型细节表、OpenSpec 流程、jj/GPG 详细说明等开发者专属内容
- 新增一键脚本启动方式、手动分步启动、首个管理员账号引导流程
- 新增故障排查速查表(启动/评测/数据库/日志位置)
- 修正 E2E 命令格式、测试数、日志路径等过时描述

### AGENTS.md (AI 工具知识库)
- 新增 §2 AI 工具集成:13 个技能、5 个 `/opsx:*` 命令、`.claude/` ↔ `.opencode/` 双平台、子模块 CLAUDE.md 优先加载
- 新增 §6 数据库 Schema:完整列出 17 张表
- 新增 §8 AI 必须遵守的要求:红线清单 + 编码规范 + 9 项修改前后自查清单
- §11 安全模型补充 RATE_LIMIT_*/STORAGE_PROVIDER/EMAIL_PROVIDER 环境变量
- 修正活跃变更(`user-ranking` → `add-noj-docs`/`dual-container-judge`/`remove-single-container-mode`)
- 修正 Cargo 依赖版本(`reqwest 0.12` 替换 `axum 0.21` 等过时描述)

## 验证

- [x] 两文件均经实际代码核查(deno.json / Cargo.toml / docker-compose.yml / schema.ts / openspec/ / 实际测试文件清单)
- [x] GPG 签名:ed25519 `0F49774CB31F6CF1`
- [x] 中文 Conventional Commits 格式

## 影响范围

仅文档变更,不影响代码逻辑、构建产物或运行时行为。