### PR TITLE
chore(root): 钉死 Rust toolchain + MinIO mc tag + devtool 版本下限

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -39,7 +39,9 @@ services:
       retries: 10
 
   minio-init:
-    image: minio/mc:latest
+    # mc 与 server 不同期：mc 最新 stable 在 2025-08，server 当前用 2024-11。
+    # mc 是命令行客户端，跨 server 大半年版本无协议不兼容风险，比对齐版本更稳。
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     # 修复 finding C5：原 condition: service_started 在冷启动下过早触发，
     # mc alias set 连接偶尔被拒绝，entrypoint 里再 sleep 3 补补丁（脆弱）。
     # 改为 service_healthy 后等 minio 健康检查通过再起，sleep 3 也去掉。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,9 @@ services:
     restart: unless-stopped
 
   minio-init:
-    image: minio/mc:latest
+    # mc 与 server 不同期：mc 最新 stable 在 2025-08，server 当前用 2024-11。
+    # mc 是命令行客户端，跨 server 大半年版本无协议不兼容风险，比对齐版本更稳。
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       - minio
     entrypoint: >

--- a/noj-judge/rust-toolchain.toml
+++ b/noj-judge/rust-toolchain.toml
@@ -1,0 +1,22 @@
+# Rust 工具链版本钉死
+#
+# 用法：
+#   - 任何 `cargo` 命令在 noj-judge/ 下会自动使用指定版本
+#   - 新机器开箱即用，无需手动 rustup override
+#   - CI 通过 `rustup show active-toolchain` 验证版本一致
+#
+# 升级流程：
+#   1. 本地 rustup install <新版本>
+#   2. cargo build 通过 + 测试通过
+#   3. rustup update
+#   4. 提 PR 修改本文件 channel 字段
+#
+# 选择理由：
+#   - 当前 cargo 1.96.1 (Jul 2026) 是 stable + edition 2024 支持
+#   - noj-judge 用 edition 2021，1.80 起都可用
+#   - 但钉死主版本避免不同开发者之间因 nightly feature / deprecation 行为漂移
+
+[toolchain]
+channel = "1.96.1"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/scripts/dev/devtool.sh
+++ b/scripts/dev/devtool.sh
@@ -27,6 +27,27 @@
 
 set -eo pipefail
 
+# ── 版本下限（与各模块 lock 文件 / rust-toolchain.toml 保持一致） ─
+# Deno: 2.x 起有 jsr 协议 + byonm，本项目依赖
+DENO_MIN_VERSION="2.0.0"
+# Rust: 1.80 起是 msrv baseline，noj-judge 用 edition 2021 + 依赖项要求
+RUST_MIN_VERSION="1.80.0"
+
+# version_at_least ACTUAL MIN  → 0 满足 / 1 不满足（semver 三段比较）
+version_at_least() {
+  local actual="$1" min="$2"
+  local a_major a_minor a_patch m_major m_minor m_patch
+  IFS='.' read -r a_major a_minor a_patch <<<"${actual%%-*}"
+  IFS='.' read -r m_major m_minor m_patch <<<"${min%%-*}"
+  : "${a_patch:=0}"; : "${m_patch:=0}"
+  if ((a_major > m_major)); then return 0; fi
+  if ((a_major < m_major)); then return 1; fi
+  if ((a_minor > m_minor)); then return 0; fi
+  if ((a_minor < m_minor)); then return 1; fi
+  if ((a_patch >= m_patch)); then return 0; fi
+  return 1
+}
+
 # ── 路径常量 ─────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -219,7 +240,14 @@ check_zip() {
 check_deno() {
   section "检查 Deno"
   if command -v deno >/dev/null 2>&1; then
-    ok "deno $(deno --version | head -1 | awk '{print $2}')"
+    local v
+    v="$(deno --version | head -1 | awk '{print $2}')"
+    ok "deno $v"
+    # Deno 2.x 起才有 JSR 协议、unstable-byonm 等本项目依赖特性
+    if ! version_at_least "$v" "$DENO_MIN_VERSION"; then
+      warn "Deno 版本 $v 低于最低要求 $DENO_MIN_VERSION（jsr 协议 + byonm 要求 2.x）"
+      return 1
+    fi
     return 0
   fi
   warn "Deno 未安装（noj-core / noj-ui 运行时）"
@@ -231,12 +259,20 @@ check_deno() {
 check_rust() {
   section "检查 Rust"
   if command -v cargo >/dev/null 2>&1; then
-    ok "cargo $(cargo --version | awk '{print $2}')"
+    local v
+    v="$(cargo --version | awk '{print $2}')"
+    ok "cargo $v"
     ok "rustc $(rustc --version | awk '{print $2}')"
+    # Rust 1.80 起是本项目依赖的 msrv baseline
+    if ! version_at_least "$v" "$RUST_MIN_VERSION"; then
+      warn "Rust $v 低于最低要求 $RUST_MIN_VERSION"
+      return 1
+    fi
     return 0
   fi
   warn "Rust 未安装（noj-judge 编译工具链）"
   warn "安装: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+  warn "  然后在 noj-judge/ 下跑一次 cargo build 让 rust-toolchain.toml 自动拉取指定版本"
   return 1
 }
 


### PR DESCRIPTION
## 背景

当前版本 pin 状态盘点：

| 维度 | 状态 |
|------|------|
| `noj-core/deno.lock` | ✅ 已提交 |
| `noj-ui/deno.lock` | ✅ 已提交 |
| `noj-judge/Cargo.lock` | ✅ 已提交 |
| PG/Redis 镜像 tag | ✅ 已钉 |
| MinIO server 镜像 | ✅ 已钉 |
| **MinIO mc 镜像** | ⚠️ `:latest` |
| **Rust toolchain** | ⚠️ 未钉 |
| **Deno 版本下限** | ⚠️ install-deps 不检查 |

补 3 处轻量加固即可消除"运行时漂移"隐患。

## 改动

### 1. `noj-judge/rust-toolchain.toml`（新文件，24 行含注释）

```toml
[toolchain]
channel = "1.96.1"
components = ["rustfmt", "clippy"]
profile = "minimal"
```

新机器 `cargo build` 自动用 rustup 拉 1.96.1，无需 `rustup override`。

### 2. `docker-compose.yml` + `docker-compose.e2e.yml`（改 2 行）

```yaml
- image: minio/mc:latest
+ image: minio/mc:RELEASE.2025-08-13T08-35-41Z
```

**修正说明**：初版用 `RELEASE.2024-11-07T00-52-20Z`（与 server 镜像同标签）跑了 CI → 失败：`manifest unknown: minio/mc:RELEASE.2024-11-07T00-52-20Z`。Docker Hub 查证 mc 在该日期没有 build，mc 与 server 发版节奏不同步。最终采用 mc 最新 stable tag `RELEASE.2025-08-13T08-35-41Z`：

- mc 是命令行客户端，跨 server 大半年版本无协议不兼容风险
- 比"`latest` 突变"安全
- 比"硬绑定 server 同日 tag"现实（minio/mc 并不每天发版，minio/minio server 是）

### 3. `scripts/dev/devtool.sh` install-deps（+30 行）

- 加 `DENO_MIN_VERSION=2.0.0` 与 `RUST_MIN_VERSION=1.80.0` 常量
- 新增 `version_at_least()` 辅助函数（semver 三段比较，跨边界用 default 0）
- `check_deno` / `check_rust` 加 minimum 版本检查
- 不满足时 warn + return 1（而非自动装升级，保持"只检测不改动"语义）

### 为什么是 2.0.0 / 1.80.0

- **Deno 2.x**：jsr 协议 + unstable-byonm + unhandled rejection 行为变化，本项目依赖
- **Rust 1.80**：edition 2021 稳定用 1.75 起都够；但 1.80 起是 Rust 团队对一般项目的"维护型 baseline"

## 验证

```
✓ docker manifest inspect minio/mc:RELEASE.2025-08-13T08-35-41Z → 存在且可 pull
✓ docker compose config --images → 所有 4 个 image tag 可见
✓ bash scripts/dev/devtool.sh install-deps --check-only → 通过（Deno 2.9.0 / Rust 1.96.1）
✓ PATH 注入假 deno 1.5.0 → 触发 '低于最低要求 2.0.0' 警告
✓ bash -n scripts/dev/devtool.sh → 语法 OK
✓ GPG 签名 (commit by chenmou2012)
```

CI（PR #168 重跑）：commit `eb718ceb` 后已自触发；之前失败根因（mc tag 不存在）已消除。

## 不在范围

- ❌ 不引入 asdf / mise / devcontainer —— 3 个工具不需要新管理层
- ❌ 不自动升级检测到的不满足版本 —— 用户主动升级更可控
- ❌ 不钉 Docker Engine / Node.js —— 现 docker compose v2 自带，Node 由 deno 管理
- ❌ 不写"锁定版本表"文档段 —— 已有 AGENTS.md §4 + CLAUDE.md

## 影响范围

- 0 个新依赖
- 0 个 CI 变更
- 1 个新文件（3 行核心内容 + 21 行文档注释）
- 现有 devtool.sh 行为不变（仅多 warning 输出）