### PR TITLE
feat(ui): 引入统一 API 调用层 useApi 并全量迁移调用点

### DIFF
--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { Context, Next } from "hono";
 import { cors } from "hono/cors";
 import health from "./routes/health.ts";
+import stats from "./routes/stats.ts";
 import auth from "./routes/auth.ts";
 import admin from "./routes/admin.ts";
 import categories from "./routes/categories.ts";
@@ -157,6 +158,9 @@ export function createApp(): Hono {
     const items = await listJudgeImages();
     return c.json({ data: items });
   });
+
+  // 公开站点统计（关于页数据面板，无鉴权，同样必须在 sse 之前注册）
+  app.route("/api/v1", stats);
 
   // 统计数据 SSE 端点（公开，无需 authMiddleware，必须在 sse 之前注册）
   app.route("/api/v1", statsSse);

--- a/noj-core/src/routes/stats.ts
+++ b/noj-core/src/routes/stats.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+import { count, eq } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+import {
+  evaluationResults,
+  problems,
+  submissions,
+  users,
+} from "../db/schema.ts";
+
+const stats = new Hono();
+
+/**
+ * 公开站点统计端点（只读、无鉴权）。
+ *
+ * 返回题目数、提交总数、注册用户数、评测通过数（Accepted），
+ * 供「关于」页数据面板展示。统计口径与 rankings / dashboard 服务一致：
+ * 通过数 = evaluation_results.status = 'Accepted' 的行数。
+ *
+ * 四个 count() 并发执行；MVP 阶段数据量可接受，后续量大时可加缓存（见 design.md Risks）。
+ */
+stats.get("/stats", async (c) => {
+  const db = getDb();
+  const [problemsCount, submissionsCount, usersCount, acceptedCount] =
+    await Promise.all([
+      db.select({ n: count() }).from(problems),
+      db.select({ n: count() }).from(submissions),
+      db.select({ n: count() }).from(users),
+      db.select({ n: count() }).from(evaluationResults).where(
+        eq(evaluationResults.status, "Accepted"),
+      ),
+    ]);
+
+  return c.json({
+    data: {
+      problems: Number(problemsCount[0]?.n ?? 0),
+      submissions: Number(submissionsCount[0]?.n ?? 0),
+      users: Number(usersCount[0]?.n ?? 0),
+      accepted: Number(acceptedCount[0]?.n ?? 0),
+    },
+  });
+});
+
+export default stats;

--- a/noj-core/tests/routes/stats.test.ts
+++ b/noj-core/tests/routes/stats.test.ts
@@ -1,0 +1,56 @@
+/**
+ * 公开站点统计端点路由层测试。
+ *
+ * 依赖 PGlite 内存数据库（DATABASE_URL 未设置时自动启用，始终可用），
+ * 测试前自动运行迁移并 seed（见 00_migrate_test.ts）。
+ */
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { createApp } from "../../src/app.ts";
+import { resetDbForTest } from "../../src/db/connection.ts";
+import { problems } from "../../src/db/schema.ts";
+import { count } from "drizzle-orm";
+import { getDb } from "../../src/db/connection.ts";
+
+const skipDb = false; // PGlite 内存数据库始终可用
+
+Deno.test({
+  name: "stats route: GET /api/v1/stats 公开返回统计数字",
+  ignore: skipDb,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const res = await app.request("/api/v1/stats");
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertExists(body.data);
+    assertEquals(typeof body.data.problems, "number");
+    assertEquals(typeof body.data.submissions, "number");
+    assertEquals(typeof body.data.users, "number");
+    assertEquals(typeof body.data.accepted, "number");
+    // 非负数
+    for (const key of ["problems", "submissions", "users", "accepted"]) {
+      assertEquals(body.data[key] >= 0, true);
+    }
+  },
+});
+
+Deno.test({
+  name: "stats route: 统计与数据库实际行数一致（种子数据）",
+  ignore: skipDb,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const res = await app.request("/api/v1/stats");
+    const body = await res.json();
+
+    const db = getDb();
+    const [{ n: problemCount }] = await db.select({ n: count() }).from(
+      problems,
+    );
+    assertEquals(body.data.problems, Number(problemCount));
+  },
+});

--- a/noj-ui/AGENTS.md
+++ b/noj-ui/AGENTS.md
@@ -169,6 +169,30 @@ cd dist
   - 自动从 Cookie 注入 `Authorization: Bearer` 头到转发请求
 - 注销：`server/api/auth/logout.post.ts` 删除两个 Cookie（**纯本地操作**，不调用后端 API）
 
+### useApi 统一 API 调用层
+
+- **业务代码禁止直接 `$fetch`**（Nitro 代理与 `composables/useApi.ts` 内部除外），统一通过 `useApi()`：
+  ```ts
+  const { api } = useApi()
+  await api.get<T>(url, options?)            // 原 $fetch<T>(url)
+  await api.post<T>(url, body?, options?)    // 原 $fetch<T>(url, { method: 'POST', body })
+  await api.put<T>(url, body?, options?)
+  await api.patch<T>(url, body?, options?)
+  await api.delete<T>(url, options?)
+  ```
+- **错误处理（默认）**：非 2xx / 网络 / 超时错误自动提取后端 `error` 字段（具体原因），
+  通过 `useToast().toast.error()` 弹窗（5s 自动消失），然后**原样重抛**原错误对象
+  （保留 `data`/`status` 结构，`e.data?.code` 等分支代码可直接使用）
+- **选项**：
+  - `silent: true`：不弹 toast（轮询、后台刷新、列表加载 error ref、表单内联错误等场景），错误仍抛出
+  - `onError(err, info)`：自定义处理，替换默认 toast；与 `silent` 同时给出时 `silent` 优先
+  - `timeout`（ms）：透传 ofetch 超时（内部 `AbortSignal.timeout`），替代手写 `Promise.race`
+  - 其余选项（`params`、`headers`、`query` 等）原样透传 `$fetch`
+- **错误文案**：需要把错误写入页面 error ref 时，用 `extractApiError(e).message`
+  （`import { extractApiError } from '~/utils/apiError'`），禁止手写 `e.data?.error || e.status` 提取
+- **SSR 端**不弹 toast（UToaster 依赖客户端），仅抛错
+- 后端错误响应格式：`{ error: "<具体原因>", code: "<机器码>", request_id }`（noj-core `AppError` 体系）
+
 ### 代理实现细节（[...slug].ts）
 
 - **仅拦截** `POST /api/v1/auth/login`：解析登录响应，提取 JWT 设置 Cookie，从响应体删除 `token` 字段

--- a/noj-ui/app.vue
+++ b/noj-ui/app.vue
@@ -29,7 +29,8 @@ if (import.meta.client) {
     --c-primary-bg: #eff6ff; --c-primary-hover-bg: #dbeafe; --c-primary-active-bg: #bfdbfe; --c-primary-text: #1e40af;
     --c-bg-dark: #0f172a; --c-bg-dark-2: #1e293b; --c-bg-dark-3: #334155;
     --c-success-text: #137333; --c-info-text: #1967d2; --c-warning-text: #92400e; --c-error-text: #b91c1c;
-    --c-text: #1e293b; --c-text-secondary: #64748b; --c-text-muted: #94a3b8;
+    --c-text: #1e293b; --c-text-secondary: #64748b; --c-text-muted: #64748b;
+    --header-h: 64px;
     --c-border: #e2e8f0; --c-bg-page: #f8fafc; --c-white: #ffffff;
 }
 

--- a/noj-ui/assets/css/main.css
+++ b/noj-ui/assets/css/main.css
@@ -76,6 +76,27 @@
 
   /* 代码字体 */
   --font-mono: "SF Mono", "Fira Code", "Consolas", monospace;
+
+  /* 自定义字号刻度（对齐项目中使用的任意字号，命名 token 便于统一管理）
+   * Tailwind v4 中 --text-<name> 自动生成 text-<name> 工具类 */
+  --text-11px: 0.6875rem; /* 11px */
+  --text-13px: 0.8125rem; /* 13px */
+  --text-15px: 0.9375rem; /* 15px */
+  --text-17px: 1.0625rem; /* 17px */
+  --text-22px: 1.375rem;  /* 22px */
+  --text-28px: 1.75rem;   /* 28px */
+}
+
+/* ---- 无障碍：尊重系统 reduced-motion 偏好 ---- */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* ---- 将现有 token 映射到 Nuxt UI 语义变量，保持组件默认观感 ---- */

--- a/noj-ui/components/BanBanner.vue
+++ b/noj-ui/components/BanBanner.vue
@@ -39,7 +39,7 @@ function handleLogout() {
   >
     <div class="max-w-4xl mx-auto flex items-center justify-between gap-4">
       <div class="flex items-center gap-2 text-amber-800 text-sm">
-        <span class="font-semibold">⚠ IP 限制访问</span>
+        <span class="font-semibold flex items-center gap-1"><UIcon name="i-lucide-triangle-alert" class="size-4" />IP 限制访问</span>
         <span class="text-amber-600">·</span>
         <span v-if="ipInfo">
           您的 IP（{{ ipInfo.matched_cidr }}）已被限制访问。
@@ -57,7 +57,7 @@ function handleLogout() {
   >
     <div class="max-w-4xl mx-auto flex items-center justify-between gap-4">
       <div class="flex items-center gap-2 text-red-800 text-sm">
-        <span class="font-semibold">🚫 账号被封禁</span>
+        <span class="font-semibold flex items-center gap-1"><UIcon name="i-lucide-ban" class="size-4" />账号被封禁</span>
         <span class="text-red-600">·</span>
         <span v-if="userInfo">
           您的账号已被封禁{{ userInfo.until ? `至 ${formatExpiry(userInfo.until)}` : "" }}。

--- a/noj-ui/components/admin/PageHeader.vue
+++ b/noj-ui/components/admin/PageHeader.vue
@@ -10,7 +10,7 @@ defineProps<Props>()
 <template>
   <div class="flex items-start justify-between gap-3">
     <div class="flex flex-col gap-1">
-      <h1 class="text-[22px] font-bold text-text">{{ title }}</h1>
+      <h1 class="text-22px font-bold text-text">{{ title }}</h1>
       <p v-if="description" class="text-sm text-text-secondary">{{ description }}</p>
     </div>
     <slot name="actions" />

--- a/noj-ui/components/admin/SupportPackageUpload.vue
+++ b/noj-ui/components/admin/SupportPackageUpload.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { extractApiError } from '~/utils/apiError'
+
+const { api } = useApi()
 interface Props {
   problemId: string | null
   hasPackage: boolean
@@ -75,15 +78,11 @@ async function doUpload(file: File) {
     const formData = new FormData()
     formData.append("file", file)
 
-    await $fetch(`/api/v1/problems/${props.problemId}/support-package`, {
-      method: "POST",
-      body: formData,
-    })
+    await api.post(`/api/v1/problems/${props.problemId}/support-package`, formData)
 
     emit("package-changed", true)
   } catch (err: unknown) {
-    const apiErr = err as { data?: { error?: string }; message?: string } | undefined
-    uploadError.value = apiErr?.data?.error || apiErr?.message || "上传失败"
+    uploadError.value = extractApiError(err).message
   } finally {
     uploading.value = false
   }
@@ -105,13 +104,10 @@ async function handleDelete() {
   deleting.value = true
   uploadError.value = ""
   try {
-    await $fetch(`/api/v1/problems/${props.problemId}/support-package`, {
-      method: "DELETE",
-    })
+    await api.delete(`/api/v1/problems/${props.problemId}/support-package`)
     emit("package-changed", false)
   } catch (err: unknown) {
-    const apiErr = err as { data?: { error?: string }; message?: string } | undefined
-    uploadError.value = apiErr?.data?.error || apiErr?.message || "删除失败"
+    uploadError.value = extractApiError(err).message
   } finally {
     deleting.value = false
   }

--- a/noj-ui/components/auth/AuthFormCard.vue
+++ b/noj-ui/components/auth/AuthFormCard.vue
@@ -1,12 +1,7 @@
 <template>
   <div class="w-full max-w-[380px] relative">
     <!-- Error banner -->
-    <Transition name="slide">
-      <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-        <span>{{ error }}</span>
-        <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="$emit('clear-error')">&#10005;</button>
-      </div>
-    </Transition>
+    <ToastBanner :visible="!!error" color="error" icon="i-lucide-alert-circle" :message="error" @close="$emit('clear-error')" />
 
     <!-- Success banner slot -->
     <slot name="banner-success" />
@@ -15,7 +10,7 @@
     <slot name="banner-info" />
 
     <div class="bg-white border border-border rounded-lg p-8">
-      <h1 class="text-[22px] font-bold text-center mb-3 text-text animate-[fadeInUp_0.5s_ease_both]">{{ title }}</h1>
+      <h1 class="text-22px font-bold text-center mb-3 text-text animate-[fadeInUp_0.5s_ease_both]">{{ title }}</h1>
       <p v-if="subtitle" class="text-center text-sm text-text-secondary mb-6 animate-[fadeInUp_0.5s_ease_0.05s_both]">{{ subtitle }}</p>
 
       <form class="flex flex-col gap-6" @submit.prevent="$emit('submit')">

--- a/noj-ui/components/card/SubmissionCard.vue
+++ b/noj-ui/components/card/SubmissionCard.vue
@@ -28,7 +28,7 @@
                 <!-- row 2: 跨两列同行（time 左，stats 右） -->
                 <template v-if="submission.result">
                     <template v-if="hasRuntimeConfig">
-                        <div class="col-span-2 self-center flex items-center justify-between gap-2 text-[11px]">
+                        <div class="col-span-2 self-center flex items-center justify-between gap-2 text-11px">
                             <span class="text-text-muted">{{ formatTime(submission.created_at) }}</span>
                             <div class="flex items-center gap-px font-mono tabular-nums">
                                 <span :class="getUsageColor(submission.result.time_ms, submission.problem.runtime_config!.evaluator!.time_limit_ms)">
@@ -46,7 +46,7 @@
                         </div>
                     </template>
                     <template v-else>
-                        <div class="col-span-2 self-center flex items-center justify-between gap-2 text-[11px]">
+                        <div class="col-span-2 self-center flex items-center justify-between gap-2 text-11px">
                             <span class="text-text-muted">{{ formatTime(submission.created_at) }}</span>
                             <div class="flex items-center gap-px font-mono tabular-nums">
                                 <span class="text-text-muted">{{ formatTimeMs(submission.result.time_ms) }}</span>
@@ -57,13 +57,13 @@
                     </template>
                 </template>
                 <template v-else-if="submission.queue_position != null">
-                    <div class="col-span-2 self-center flex items-center justify-between gap-2 text-[11px]">
+                    <div class="col-span-2 self-center flex items-center justify-between gap-2 text-11px">
                         <span class="text-text-muted">{{ formatTime(submission.created_at) }}</span>
                         <span class="font-mono tabular-nums text-gray-400">排队中 <span class="font-bold">#{{ submission.queue_position }}</span></span>
                     </div>
                 </template>
                 <template v-else>
-                    <div class="col-span-2 self-center flex items-center justify-between gap-2 text-[11px]">
+                    <div class="col-span-2 self-center flex items-center justify-between gap-2 text-11px">
                         <span class="text-text-muted">{{ formatTime(submission.created_at) }}</span>
                         <span class="font-mono tabular-nums text-blue-500">{{ liveElapsed(submission.judge_started_at ?? submission.created_at) }}</span>
                     </div>

--- a/noj-ui/components/editor/EditorSidebar.vue
+++ b/noj-ui/components/editor/EditorSidebar.vue
@@ -148,7 +148,7 @@ function formatElapsed(iso: string) {
           <!-- 行 1：状态徽章 + 得分 -->
           <div class="flex items-center justify-between mb-2">
             <span
-              class="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded font-semibold"
+              class="inline-flex items-center gap-1 text-11px px-2 py-0.5 rounded font-semibold"
               :style="{ background: getStatusColor(sub.status, sub.result?.status) + '22', color: getStatusColor(sub.status, sub.result?.status) }"
             >
               <UIcon name="i-lucide-loader-2" class="animate-spin size-[10px]" v-if="sub.status === 'pending' || sub.status === 'judging'"/>

--- a/noj-ui/components/editor/EditorStatusBar.vue
+++ b/noj-ui/components/editor/EditorStatusBar.vue
@@ -12,7 +12,7 @@ const charsLabel = computed(() => {
 </script>
 
 <template>
-  <div class="h-6 flex-shrink-0 bg-bg-dark-2 border-t border-bg-dark-3 flex items-center px-3 gap-4 text-[11px] text-text-muted font-mono">
+  <div class="h-6 flex-shrink-0 bg-bg-dark-2 border-t border-bg-dark-3 flex items-center px-3 gap-4 text-11px text-text-muted font-mono">
     <span>{{ language }}</span>
     <span>Ln {{ cursor.line }}, Col {{ cursor.col }}</span>
     <span>{{ totalLines }} 行</span>

--- a/noj-ui/components/editor/ProblemEditor.vue
+++ b/noj-ui/components/editor/ProblemEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import SupportPackageUpload from "../admin/SupportPackageUpload.vue"
+import { extractApiError } from "~/utils/apiError"
 
 interface RuntimeConfigPayload {
   evaluator: {
@@ -32,6 +33,7 @@ const emit = defineEmits<{
 
 const router = useRouter()
 const { user } = useAuth()
+const { api } = useApi()
 
 const isAdmin = computed(() => user.value?.role === "admin")
 
@@ -62,8 +64,9 @@ const judgeImagesLoading = ref(false)
 async function loadJudgeImages() {
   judgeImagesLoading.value = true
   try {
-    const res = await $fetch<{ data: { image: string; kind?: string }[] }>(
+    const res = await api.get<{ data: { image: string; kind?: string }[] }>(
       "/api/v1/judge-images",
+      { silent: true },
     )
     judgeImages.value = res.data ?? []
   } catch {
@@ -96,7 +99,10 @@ const categories = ref<{ id: string; name: string }[]>([])
 
 async function loadCategories() {
   try {
-    const res = await $fetch<{ data: { id: string; name: string }[] }>("/api/v1/categories")
+    const res = await api.get<{ data: { id: string; name: string }[] }>(
+      "/api/v1/categories",
+      { silent: true },
+    )
     categories.value = res.data
   } catch { /* 静默失败 */ }
 }
@@ -110,13 +116,13 @@ async function loadProblem() {
   if (!props.problemId) return
   pageLoading.value = true
   try {
-    const res = await $fetch<{ data: {
+    const res = await api.get<{ data: {
       title: string; description: string; difficulty: string
       time_limit_ms: number; memory_limit_mb: number
       display_id: string; type: string; number: number
       categories: { id: string }[]
       runtime_config: RuntimeConfigPayload | null
-    } }>(`/api/v1/problems/${props.problemId}`)
+    } }>(`/api/v1/problems/${props.problemId}`, { silent: true })
     const p = res.data
     displayId.value = p.display_id
     problemType.value = p.type
@@ -141,7 +147,7 @@ async function loadProblem() {
     if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 404) {
       notFound.value = true
     } else {
-      loadError.value = err instanceof Error ? err.message : "加载题目失败"
+      loadError.value = extractApiError(err).message
     }
   } finally {
     pageLoading.value = false
@@ -192,32 +198,26 @@ async function handleSubmit() {
       },
     }
     if (isEditMode.value) {
-      await $fetch(`/api/v1/problems/${props.problemId}`, {
-        method: "PUT",
-        body: {
-          title: title.value.trim(), description: description.value.trim(),
-          difficulty: difficulty.value,
-          category_ids: categoryIds.value,
-          runtime_config: runtimeConfigPayload,
-        },
+      await api.put(`/api/v1/problems/${props.problemId}`, {
+        title: title.value.trim(), description: description.value.trim(),
+        difficulty: difficulty.value,
+        category_ids: categoryIds.value,
+        runtime_config: runtimeConfigPayload,
       })
       emit("saved", props.problemId!)
     } else {
-      const res = await $fetch<{ data: { id: string } }>("/api/v1/problems", {
-        method: "POST",
-        body: {
-          title: title.value.trim(), description: description.value.trim(),
-          difficulty: difficulty.value,
-          category_ids: categoryIds.value,
-          type: problemType.value,
-          runtime_config: runtimeConfigPayload,
-        },
+      const res = await api.post<{ data: { id: string } }>("/api/v1/problems", {
+        title: title.value.trim(), description: description.value.trim(),
+        difficulty: difficulty.value,
+        category_ids: categoryIds.value,
+        type: problemType.value,
+        runtime_config: runtimeConfigPayload,
       })
       savedProblemId.value = res.data.id
       emit("saved", res.data.id)
     }
   } catch (err: unknown) {
-    saveError.value = err instanceof Error ? err.message : "保存失败"
+    saveError.value = extractApiError(err).message
   } finally {
     saving.value = false
   }

--- a/noj-ui/components/feature/ChatSidebar.vue
+++ b/noj-ui/components/feature/ChatSidebar.vue
@@ -2,6 +2,8 @@
 import { useEventSource } from "~/composables/useEventSource"
 import { useMessages, type Conversation } from "~/composables/useMessages"
 
+const { api } = useApi()
+
 const props = defineProps<{
   activeConversationId?: string
 }>()
@@ -60,8 +62,9 @@ watch(searchQuery, (val) => {
   searchTimer = setTimeout(async () => {
     searching.value = true
     try {
-      const res = await $fetch<{ data: { id: string; username: string }[] }>(
+      const res = await api.get<{ data: { id: string; username: string }[] }>(
         `/api/v1/users/search?q=${encodeURIComponent(val.trim())}`,
+        { silent: true },
       )
       searchResults.value = res.data
       showResults.value = true

--- a/noj-ui/components/feature/ChatSidebar.vue
+++ b/noj-ui/components/feature/ChatSidebar.vue
@@ -174,7 +174,7 @@ function formatTime(iso: string): string {
         <div class="flex-1 min-w-0">
           <div class="flex items-center justify-between">
             <span class="text-sm font-medium text-text truncate">{{ conv.other_user_name }}</span>
-            <span class="text-[11px] text-text-secondary flex-shrink-0 ml-2">{{ formatTime(conv.last_message_at) }}</span>
+            <span class="text-11px text-text-secondary flex-shrink-0 ml-2">{{ formatTime(conv.last_message_at) }}</span>
           </div>
           <div class="flex items-center justify-between mt-0.5">
             <span class="text-xs text-text-secondary truncate">{{ conv.last_message_preview || "暂无消息" }}</span>

--- a/noj-ui/components/feature/FollowingFeed.vue
+++ b/noj-ui/components/feature/FollowingFeed.vue
@@ -66,6 +66,9 @@
 <script setup lang="ts">
 import type { FeedActivity, FeedItem } from "~/composables/useCommunity"
 import { stripMarkdown } from "~/utils/markdown"
+import { extractApiError } from "~/utils/apiError"
+
+const { api } = useApi()
 
 const { isLoggedIn } = useAuth()
 const { config, loadConfig } = useCommunity()
@@ -122,12 +125,13 @@ async function fetchFeed() {
   }
   loading.value = true
   try {
-    const res = await $fetch<{ data: FeedItem[] }>("/api/v1/community/feed", {
+    const res = await api.get<{ data: FeedItem[] }>("/api/v1/community/feed", {
       query: { view: "following", limit: 5 },
+      silent: true,
     })
     items.value = res.data ?? []
   } catch (err: unknown) {
-    error.value = err instanceof Error ? err.message : "加载失败"
+    error.value = extractApiError(err).message
   } finally {
     loading.value = false
   }

--- a/noj-ui/components/feature/LatestSubmissions.vue
+++ b/noj-ui/components/feature/LatestSubmissions.vue
@@ -39,6 +39,8 @@
 <script setup lang="ts">
 import { useEventSource } from "~/composables/useEventSource"
 
+const { api } = useApi()
+
 interface SubmissionItem {
     id: string
     problem_id: string
@@ -81,8 +83,8 @@ function onStatsUpdated(data: unknown) {
 async function fetchStatsFallback() {
     try {
         const [totalRes, todayRes] = await Promise.all([
-            $fetch<{ data: TodayStats }>("/api/v1/submissions/total-stats"),
-            $fetch<{ data: TodayStats }>("/api/v1/submissions/today-stats"),
+            api.get<{ data: TodayStats }>("/api/v1/submissions/total-stats", { silent: true }),
+            api.get<{ data: TodayStats }>("/api/v1/submissions/today-stats", { silent: true }),
         ])
         if (totalRes.data) totalStats.value = totalRes.data
         if (todayRes.data) todayStats.value = todayRes.data
@@ -107,8 +109,9 @@ async function fetchSubmissions() {
     try {
         // 未登录调用公开端点（全站最近评测），登录调用私有端点（我的提交）
         const url = isLoggedIn.value ? "/api/v1/submissions" : "/api/v1/submissions/public/recent"
-        const res = await $fetch<{ data: SubmissionItem[] }>(url, {
+        const res = await api.get<{ data: SubmissionItem[] }>(url, {
             query: { per_page: 10 },
+            silent: true,
         })
         const list = res.data ?? []
         const newPrev = new Map<string, string>()

--- a/noj-ui/components/feature/ProblemFilterBar.vue
+++ b/noj-ui/components/feature/ProblemFilterBar.vue
@@ -65,6 +65,22 @@ function selectCategory(value: string) {
 function selectType(value: string) {
   emit('update:problemType', value === props.problemType ? '' : value)
 }
+
+// radio 组方向键导航（WCAG 2.1.1）：左右/上下移动选中项并跟随焦点
+function onGroupKeydown(e: KeyboardEvent, values: { value: string }[], current: string, onSelect: (v: string) => void) {
+  let idx = values.findIndex((v) => v.value === current)
+  if (idx < 0) idx = 0
+  if (e.key === "ArrowRight" || e.key === "ArrowDown") idx = Math.min(idx + 1, values.length - 1)
+  else if (e.key === "ArrowLeft" || e.key === "ArrowUp") idx = Math.max(idx - 1, 0)
+  else return
+  e.preventDefault()
+  onSelect(values[idx].value)
+  ;(e.currentTarget as HTMLElement).querySelectorAll<HTMLButtonElement>('[role="radio"]')[idx]?.focus()
+}
+
+// roving tabindex：当前值不在选项内时默认聚焦第一项（如"全部"）
+const activeType = computed(() => types.some((t) => t.value === props.problemType) ? props.problemType : types[0].value)
+const activeDifficulty = computed(() => difficulties.some((d) => d.value === props.difficulty) ? props.difficulty : difficulties[0].value)
 </script>
 
 <template>
@@ -89,13 +105,14 @@ function selectType(value: string) {
     </div>
 
     <!-- 类型筛选 -->
-    <div class="flex items-center gap-1.5 flex-wrap" role="radiogroup" aria-labelledby="type-label">
+    <div class="flex items-center gap-1.5 flex-wrap" role="radiogroup" aria-labelledby="type-label" @keydown="onGroupKeydown($event, types, problemType, selectType)">
       <span class="text-xs text-text-muted mr-1" id="type-label">类型:</span>
       <button
         v-for="t in types"
         :key="t.value"
         role="radio"
         :aria-checked="problemType === t.value"
+        :tabindex="activeType === t.value ? 0 : -1"
         class="px-3 py-1.5 text-xs font-medium rounded-full border transition-colors duration-150"
         :class="problemType === t.value
           ? t.value === 'U' ? 'bg-blue-100 text-blue-700 border-blue-300'
@@ -109,7 +126,7 @@ function selectType(value: string) {
     </div>
 
     <!-- 难度筛选 -->
-    <div class="flex items-center gap-1.5 flex-wrap" role="radiogroup" aria-labelledby="diff-label">
+    <div class="flex items-center gap-1.5 flex-wrap" role="radiogroup" aria-labelledby="diff-label" @keydown="onGroupKeydown($event, difficulties, difficulty, selectDifficulty)">
       <span class="text-xs text-text-muted mr-1" id="diff-label">难度:</span>
       <button
         v-for="d in difficulties"
@@ -117,6 +134,7 @@ function selectType(value: string) {
         role="radio"
         :aria-checked="difficulty === d.value"
         :aria-label="d.label"
+        :tabindex="activeDifficulty === d.value ? 0 : -1"
         class="px-3 py-1.5 text-xs font-medium rounded-full border transition-colors duration-150"
         :class="difficulty === d.value
           ? 'bg-primary text-white border-primary'

--- a/noj-ui/components/feature/RandomProblems.vue
+++ b/noj-ui/components/feature/RandomProblems.vue
@@ -47,6 +47,8 @@
 </template>
 
 <script setup lang="ts">
+const { api } = useApi()
+
 interface ProblemItem {
     id: string
     title: string
@@ -64,8 +66,9 @@ const refreshKey = ref(0)
 
 async function fetchAndShuffle() {
     try {
-        const res = await $fetch<{ data: ProblemItem[] }>("/api/v1/problems", {
+        const res = await api.get<{ data: ProblemItem[] }>("/api/v1/problems", {
             query: { limit: 100 },
+            silent: true,
         })
         const list = res.data ?? []
         const shuffled = [...list].sort(() => Math.random() - 0.5)

--- a/noj-ui/components/feature/search/SearchPalette.vue
+++ b/noj-ui/components/feature/search/SearchPalette.vue
@@ -7,6 +7,10 @@
         @click.self="close"
       >
         <div
+          ref="panelRef"
+          role="dialog"
+          aria-modal="true"
+          aria-label="搜索"
           class="w-full max-w-2xl bg-white rounded-lg shadow-modal overflow-hidden"
           @keydown="onKeydown"
         >
@@ -18,6 +22,7 @@
               v-model="query"
               type="text"
               :placeholder="placeholder"
+              :aria-label="placeholder"
               class="flex-1 h-full bg-transparent outline-none text-base text-text placeholder:text-text-muted"
               autocomplete="off"
               spellcheck="false"
@@ -41,7 +46,7 @@
             请输入至少 2 个字符
           </div>
 
-          <div v-else class="max-h-[50vh] overflow-y-auto">
+          <div v-else class="max-h-[50vh] overflow-y-auto" role="listbox" aria-label="搜索结果">
             <div v-if="state.results.problems.length > 0" class="px-4 pt-3 pb-1 text-xs text-text-muted font-medium">
               题目
             </div>
@@ -113,6 +118,18 @@ const { state, close, search } = useSearch();
 const query = ref("");
 const selectedIndex = ref(0);
 const inputRef = ref<HTMLInputElement | null>(null);
+const panelRef = ref<HTMLElement | null>(null);
+let lastFocused: HTMLElement | null = null;
+
+// 焦点陷阱：Tab/Shift+Tab 在对话框内循环（WCAG 2.1.2）
+function getFocusable(): HTMLElement[] {
+  if (!panelRef.value) return [];
+  return Array.from(
+    panelRef.value.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+}
 
 const placeholder = computed(() => "搜索题目、用户、帖子...");
 
@@ -136,10 +153,14 @@ watch(
   () => state.value.open,
   async (open) => {
     if (open) {
+      lastFocused = document.activeElement as HTMLElement;
       query.value = state.value.query;
       selectedIndex.value = 0;
       await nextTick();
       inputRef.value?.focus();
+    } else if (lastFocused) {
+      lastFocused.focus();
+      lastFocused = null;
     }
   },
 );
@@ -148,6 +169,20 @@ function onKeydown(e: KeyboardEvent) {
   if (e.key === "Escape") {
     e.preventDefault();
     close();
+  } else if (e.key === "Tab") {
+    // 焦点陷阱：首尾循环
+    const items = getFocusable();
+    if (items.length === 0) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+    const active = document.activeElement as HTMLElement;
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
   } else if (e.key === "ArrowDown") {
     e.preventDefault();
     selectedIndex.value = Math.min(

--- a/noj-ui/components/feature/search/SearchResultItem.vue
+++ b/noj-ui/components/feature/search/SearchResultItem.vue
@@ -2,6 +2,8 @@
   <component
     :is="href ? resolveComponent('NuxtLink') : 'div'"
     :to="href"
+    role="option"
+    :aria-selected="selected"
     class="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors rounded-md cursor-pointer"
     :class="{ 'bg-primary-bg/10': selected }"
   >

--- a/noj-ui/components/layout/FooterBar.vue
+++ b/noj-ui/components/layout/FooterBar.vue
@@ -1,6 +1,6 @@
 <template>
     <footer class="bg-bg-dark text-text-muted px-0 py-12 pb-6">
-        <div class="mx-auto w-full" style="max-width:1200px;padding:0 24px">
+        <div class="mx-auto w-full max-w-[1200px] px-6">
             <div class="flex justify-between gap-12 flex-wrap">
                 <div class="max-w-[280px]">
                     <div class="flex items-center gap-2 text-xl font-bold text-white">

--- a/noj-ui/components/layout/Navbar.vue
+++ b/noj-ui/components/layout/Navbar.vue
@@ -1,28 +1,60 @@
 <template>
-    <header class="fixed top-0 left-0 right-0 z-[100] bg-white border-b border-border">
+    <header ref="headerRef" class="fixed top-0 left-0 right-0 z-[100] bg-white border-b border-border">
         <!-- 临时密码提示横幅 -->
         <div v-if="user?.must_change_password === true" class="w-full bg-red-50 border-b border-red-200 px-6 py-2 text-center">
             <p class="text-sm text-red-700">检测到当前密码为临时密码，首次登录后必须修改密码才能使用完整功能。</p>
         </div>
-        <div class="w-full max-w-none mx-0 px-6 h-16 flex items-center" :class="user?.must_change_password === true ? 'h-14' : 'h-16'">
-            <BrandLogo />
-            <nav class="flex items-center gap-1 ml-6">
-                <NuxtLink to="/" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">首页</NuxtLink>
-                <NuxtLink to="/problems" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">题库</NuxtLink>
-                <NuxtLink to="/contests" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">竞赛</NuxtLink>
-                <NuxtLink to="/ranking" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">榜单</NuxtLink>
-                <NuxtLink v-if="communityConfig?.enabled" to="/community" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">社区</NuxtLink>
-                <NuxtLink to="/submissions" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">提交记录</NuxtLink>
-                <NuxtLink to="/queue" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">队列</NuxtLink>
-                <NuxtLink to="/about" class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text" active-class="text-primary font-semibold">关于</NuxtLink>
+        <div class="w-full max-w-none mx-0 px-6 h-16 flex items-center gap-1">
+            <!-- 移动端菜单抽屉：默认插槽=汉堡触发按钮（<md 显示），#body=面板导航 -->
+            <UDrawer
+                v-model:open="mobileOpen"
+                title="菜单"
+                side="left"
+                :handle="false"
+                :close="true"
+                :ui="{ body: 'p-3 flex flex-col gap-1' }"
+            >
+                <UButton class="md:hidden" color="neutral" variant="ghost" square icon="i-lucide-menu" aria-label="打开菜单" />
+                <template #body>
+                    <button
+                        type="button"
+                        class="flex items-center gap-2 px-3 py-2.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text"
+                        @click="openSearch; mobileOpen = false"
+                    >
+                        <UIcon name="i-lucide-search" class="size-4" />
+                        搜索
+                    </button>
+                    <NuxtLink
+                        v-for="item in navItems"
+                        :key="item.to"
+                        :to="item.to"
+                        class="flex items-center gap-2 px-3 py-2.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text"
+                        @click="mobileOpen = false"
+                    >
+                        <UIcon :name="item.icon" class="size-4" />
+                        {{ item.label }}
+                    </NuxtLink>
+                </template>
+            </UDrawer>
+            <BrandLogo text-class="hidden sm:inline" />
+            <!-- 桌面端导航（≥md 显示） -->
+            <nav class="hidden md:flex items-center gap-1 ml-6">
+                <NuxtLink
+                    v-for="item in navItems"
+                    :key="item.to"
+                    :to="item.to"
+                    class="px-3 py-1.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-gray-100 hover:text-text"
+                    active-class="text-primary font-semibold"
+                >{{ item.label }}</NuxtLink>
             </nav>
             <button
                 type="button"
                 class="flex items-center gap-2 px-3 py-1.5 text-sm text-text-secondary hover:bg-gray-100 rounded-md transition-colors"
+                aria-label="搜索"
                 @click="openSearch"
             >
                 <UIcon name="i-lucide-search" class="w-4 h-4 size-4" />
-                <span>搜索</span>
+                <span class="hidden sm:inline">搜索</span>
                 <kbd class="hidden md:inline-block px-1.5 py-0.5 text-xs bg-gray-100 border border-border rounded">Ctrl K</kbd>
             </button>
             <div class="flex items-center gap-3 ml-auto">
@@ -42,6 +74,47 @@ const { user } = useAuth();
 const { open: openSearch } = useSearch();
 const { config: communityConfig, loadConfig } = useCommunity();
 const { unreadCount, loadUnreadCount } = useCommunityNotifications();
+
+// 移动端抽屉显隐
+const mobileOpen = ref(false)
+
+// 导航项单一数据源（桌面导航 + 移动端抽屉共用）
+interface NavItem {
+  label: string
+  to: string
+  icon: string
+  needsCommunity?: boolean
+}
+
+const baseNavItems: NavItem[] = [
+  { label: '首页', to: '/', icon: 'i-lucide-home' },
+  { label: '题库', to: '/problems', icon: 'i-lucide-book-open' },
+  { label: '竞赛', to: '/contests', icon: 'i-lucide-trophy' },
+  { label: '榜单', to: '/ranking', icon: 'i-lucide-medal' },
+  { label: '社区', to: '/community', icon: 'i-lucide-messages-square', needsCommunity: true },
+  { label: '提交记录', to: '/submissions', icon: 'i-lucide-file-text' },
+  { label: '队列', to: '/queue', icon: 'i-lucide-list-ordered' },
+  { label: '关于', to: '/about', icon: 'i-lucide-info' },
+]
+
+const navItems = computed(() => baseNavItems.filter((i) => !i.needsCommunity || communityConfig.value?.enabled))
+
+// 将实际 header 高度同步为 CSS 变量 --header-h（default 布局的 pt 间距依赖它）
+const headerRef = ref<HTMLElement | null>(null)
+function syncHeaderHeight() {
+  if (headerRef.value) {
+    document.documentElement.style.setProperty('--header-h', `${headerRef.value.offsetHeight}px`)
+  }
+}
+
+onMounted(() => {
+  syncHeaderHeight()
+  if (headerRef.value) {
+    const ro = new ResizeObserver(syncHeaderHeight)
+    ro.observe(headerRef.value)
+    onUnmounted(() => ro.disconnect())
+  }
+})
 
 // 社区通知 SSE：仅登录且社区开启时连接，收到 notification:new 刷新未读数
 const notificationSseEnabled = computed(

--- a/noj-ui/components/layout/UserMenu.vue
+++ b/noj-ui/components/layout/UserMenu.vue
@@ -51,6 +51,7 @@
 const router = useRouter()
 const { user, isLoggedIn, logout } = useAuth()
 const { dialog } = useDialog()
+const { api } = useApi()
 
 // ── 下拉菜单：点击切换 + 键盘可达（WCAG 2.1.1） ──
 const menuButtonRef = ref<HTMLButtonElement | null>(null)
@@ -86,7 +87,10 @@ let unreadPollTimer: ReturnType<typeof setInterval> | null = null
 
 async function fetchUnreadCount() {
     try {
-        const res = await $fetch<{ data: { unread_count: number } }>("/api/v1/conversations/unread-count")
+        const res = await api.get<{ data: { unread_count: number } }>(
+            "/api/v1/conversations/unread-count",
+            { silent: true },
+        )
         unreadCount.value = res.data?.unread_count ?? 0
     } catch {
         // 静默失败

--- a/noj-ui/components/layout/UserMenu.vue
+++ b/noj-ui/components/layout/UserMenu.vue
@@ -3,121 +3,127 @@
         <UButton color="primary" variant="outline" class="px-3.5 py-1.5 text-sm !rounded-full" to="/login">登录</UButton>
         <UButton color="primary" class="px-3.5 py-1.5 text-sm !rounded-full" to="/register">注册</UButton>
     </template>
-    <div v-else class="relative flex items-center gap-3" @mouseenter="onMenuEnter" @mouseleave="onMenuLeave">
-        <NuxtLink :to="`/users/${user?.id}`" class="text-base text-text-secondary font-medium no-underline transition-colors hover:text-primary">{{ user?.username }}</NuxtLink>
-        <button class="flex items-center justify-center size-9 rounded-full text-text-secondary bg-none border-none cursor-pointer transition-colors hover:bg-primary-hover-bg hover:text-primary">
-            <UIcon name="i-lucide-user" class="size-[22px]" />
-        </button>
-        <div v-show="showDropdown" class="absolute right-0 top-[calc(100%+8px)] bg-white border border-border rounded-lg min-w-[210px] p-1 shadow-dropdown z-[200]">
-            <NuxtLink to="/my/problems" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100"><UIcon name="i-lucide-book-open" class="size-4" />我的题目</NuxtLink>
-            <NuxtLink to="/messages" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100 relative"><UIcon name="i-lucide-mail" class="size-4" />消息<span v-if="unreadCount > 0" class="ml-auto bg-red-500 text-white text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[18px] text-center">{{ unreadCount > 99 ? "99+" : unreadCount }}</span></NuxtLink>
-            <NuxtLink :to="`/users/${user?.id}`" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100"><UIcon name="i-lucide-database" class="size-4" />数据</NuxtLink>
-            <NuxtLink to="/settings" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100"><UIcon name="i-lucide-settings" class="size-4" />设置</NuxtLink>
-            <NuxtLink v-if="user?.role === 'admin'" to="/admin" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100"><UIcon name="i-lucide-shield-check" class="size-4" />管理后台</NuxtLink>
-            <div class="h-px bg-border my-1"></div>
-            <button class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-red-600 bg-none border-none rounded cursor-pointer text-left transition-colors hover:bg-red-50" @click="showLogoutConfirm = true"><UIcon name="i-lucide-log-out" class="size-4" />登出</button>
+    <div v-else class="relative">
+        <div class="flex items-center gap-3">
+            <NuxtLink :to="`/users/${user?.id}`" class="hidden sm:inline text-base text-text-secondary font-medium no-underline transition-colors hover:text-primary">{{ user?.username }}</NuxtLink>
+            <button
+                type="button"
+                ref="menuButtonRef"
+                class="flex items-center justify-center size-9 rounded-full text-text-secondary bg-none border-none cursor-pointer transition-colors hover:bg-primary-hover-bg hover:text-primary"
+                aria-label="用户菜单"
+                aria-haspopup="menu"
+                :aria-expanded="showDropdown"
+                @click="toggleMenu"
+            >
+                <UIcon name="i-lucide-user" class="size-[22px]" />
+            </button>
         </div>
-
-        <Transition name="fade">
-            <div v-if="showLogoutConfirm" class="fixed inset-0 bg-black/40 flex items-center justify-center z-[300]" @click.self="showLogoutConfirm = false">
-                <div class="bg-white rounded-xl px-15 py-16 text-center max-w-[380px] w-[calc(100%-48px)]">
-                    <h2 class="text-2xl font-bold mb-3">确认登出</h2>
-                    <p class="text-[17px] text-text-secondary mb-6">确定要登出当前账号吗？</p>
-                    <div class="flex gap-2.5 justify-center">
-                        <UButton color="neutral" variant="outline" size="md" class="px-7 py-3 text-base text-text-secondary border-border hover:border-text-secondary" ref="cancelBtnRef"  @click="showLogoutConfirm = false">取消</UButton>
-                        <UButton color="error" size="md" class="px-7 py-3 text-base bg-red-600 border-red-600 hover:bg-red-700" @click="handleLogout">确认登出</UButton>
-                    </div>
-                </div>
+        <div
+            v-show="showDropdown"
+            role="menu"
+            aria-label="用户菜单"
+            class="absolute right-0 top-[calc(100%+8px)] bg-white border border-border rounded-lg min-w-[210px] p-1 shadow-dropdown z-[200]"
+            @keydown.escape="closeMenu"
+        >
+            <div class="px-3.5 py-2 border-b border-border mb-1">
+                <p class="text-sm font-semibold text-text truncate">{{ user?.username }}</p>
             </div>
-        </Transition>
+            <NuxtLink ref="firstItemRef" to="/my/problems" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100" @click="closeMenu"><UIcon name="i-lucide-book-open" class="size-4" />我的题目</NuxtLink>
+            <NuxtLink to="/messages" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100 relative" @click="closeMenu"><UIcon name="i-lucide-mail" class="size-4" />消息<span v-if="unreadCount > 0" class="ml-auto bg-red-500 text-white text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[18px] text-center">{{ unreadCount > 99 ? "99+" : unreadCount }}</span></NuxtLink>
+            <NuxtLink :to="`/users/${user?.id}`" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100" @click="closeMenu"><UIcon name="i-lucide-database" class="size-4" />数据</NuxtLink>
+            <NuxtLink to="/settings" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100" @click="closeMenu"><UIcon name="i-lucide-settings" class="size-4" />设置</NuxtLink>
+            <NuxtLink v-if="user?.role === 'admin'" to="/admin" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100" @click="closeMenu"><UIcon name="i-lucide-shield-check" class="size-4" />管理后台</NuxtLink>
+            <div class="h-px bg-border my-1"></div>
+            <button
+                type="button"
+                role="menuitem"
+                class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-red-600 bg-none border-none rounded cursor-pointer text-left transition-colors hover:bg-red-50"
+                @click="handleLogout"
+            >
+                <UIcon name="i-lucide-log-out" class="size-4" />
+                登出
+            </button>
+        </div>
     </div>
 </template>
 
 <script setup lang="ts">
-const route = useRoute()
 const router = useRouter()
 const { user, isLoggedIn, logout } = useAuth()
+const { dialog } = useDialog()
 
+// ── 下拉菜单：点击切换 + 键盘可达（WCAG 2.1.1） ──
+const menuButtonRef = ref<HTMLButtonElement | null>(null)
+const firstItemRef = ref<HTMLElement | null>(null)
 const showDropdown = ref(false)
-let hideTimer: ReturnType<typeof setTimeout> | null = null
 
-// 未读消息计数（30s 轮询）
+function openMenu() {
+    showDropdown.value = true
+    nextTick(() => firstItemRef.value?.focus())
+}
+
+function closeMenu() {
+    showDropdown.value = false
+    menuButtonRef.value?.focus()
+}
+
+function toggleMenu() {
+    showDropdown.value ? closeMenu() : openMenu()
+}
+
+// 点击菜单外部关闭
+function onDocumentClick(e: MouseEvent) {
+    const el = menuButtonRef.value?.closest(".relative")
+    if (el && !el.contains(e.target as Node)) closeMenu()
+}
+
+onMounted(() => document.addEventListener("click", onDocumentClick))
+onUnmounted(() => document.removeEventListener("click", onDocumentClick))
+
+// ── 未读消息计数（30s 轮询） ──
 const unreadCount = ref(0)
 let unreadPollTimer: ReturnType<typeof setInterval> | null = null
 
 async function fetchUnreadCount() {
-  try {
-    const res = await $fetch<{ data: { unread_count: number } }>("/api/v1/conversations/unread-count")
-    unreadCount.value = res.data?.unread_count ?? 0
-  } catch {
-    // 静默失败
-  }
+    try {
+        const res = await $fetch<{ data: { unread_count: number } }>("/api/v1/conversations/unread-count")
+        unreadCount.value = res.data?.unread_count ?? 0
+    } catch {
+        // 静默失败
+    }
 }
 
 watch(isLoggedIn, (val) => {
-  if (val) {
-    fetchUnreadCount()
-    unreadPollTimer = setInterval(fetchUnreadCount, 30_000)
-  } else {
-    if (unreadPollTimer) clearInterval(unreadPollTimer)
-    unreadCount.value = 0
-  }
+    if (val) {
+        fetchUnreadCount()
+        unreadPollTimer = setInterval(fetchUnreadCount, 30_000)
+    } else {
+        if (unreadPollTimer) clearInterval(unreadPollTimer)
+        unreadCount.value = 0
+    }
 })
 
 onMounted(() => {
-  if (isLoggedIn.value) {
-    fetchUnreadCount()
-    unreadPollTimer = setInterval(fetchUnreadCount, 30_000)
-  }
+    if (isLoggedIn.value) {
+        fetchUnreadCount()
+        unreadPollTimer = setInterval(fetchUnreadCount, 30_000)
+    }
 })
 
 onUnmounted(() => {
-  if (unreadPollTimer) clearInterval(unreadPollTimer)
+    if (unreadPollTimer) clearInterval(unreadPollTimer)
 })
 
-function onMenuEnter() {
-    if (hideTimer) clearTimeout(hideTimer)
-    showDropdown.value = true
-}
-
-function onMenuLeave() {
-    hideTimer = setTimeout(() => {
-        showDropdown.value = false
-    }, 100)
-}
-
-const showLogoutConfirm = ref(false)
-const cancelBtnRef = ref<HTMLButtonElement>()
-
-watch(showLogoutConfirm, (val) => {
-    if (val) {
-        nextTick(() => cancelBtnRef.value?.focus())
-    }
-})
-
-function onKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape" && showLogoutConfirm.value) {
-        showLogoutConfirm.value = false
-    }
-}
-
-onMounted(() => document.addEventListener("keydown", onKeydown))
-onUnmounted(() => document.removeEventListener("keydown", onKeydown))
-
+// ── 登出：走统一的 useDialog 确认弹窗 ──
 async function handleLogout() {
+    closeMenu()
+    const ok = await dialog.confirm("确定要登出当前账号吗？", {
+        title: "确认登出",
+        danger: true,
+        confirmText: "确认登出",
+    })
+    if (!ok) return
     await logout()
-    showLogoutConfirm.value = false
     router.replace("/")
 }
 </script>
-
-<style scoped>
-.fade-enter-active,
-.fade-leave-active {
-    transition: opacity 0.2s;
-}
-.fade-enter-from,
-.fade-leave-to {
-    opacity: 0;
-}
-</style>

--- a/noj-ui/components/shared/BrandLogo.vue
+++ b/noj-ui/components/shared/BrandLogo.vue
@@ -5,7 +5,7 @@
             :alt="brandName"
             :class="['rounded-md', sizeClass]"
         >
-        <span>{{ brandName }}</span>
+        <span :class="textClass">{{ brandName }}</span>
     </NuxtLink>
 </template>
 
@@ -20,12 +20,15 @@ interface Props {
     logoSrc?: string
     /** Logo 尺寸（Tailwind size-N，对应 size-N 类） */
     size?: number
+    /** 品牌文字额外类名（如移动端隐藏：hidden sm:inline） */
+    textClass?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
     brandName: "Neuro OJ",
     logoSrc: defaultLogo,
     size: 7,
+    textClass: "",
 })
 
 const sizeClass = computed(() => `size-${props.size}`)

--- a/noj-ui/components/ui/TableSkeleton.vue
+++ b/noj-ui/components/ui/TableSkeleton.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    rows?: number
+    columns?: string[]
+  }>(),
+  {
+    rows: 6,
+    columns: ["w-16", "flex-1", "w-20", "w-24"],
+  },
+)
+</script>
+
+<template>
+  <div class="bg-white border border-border rounded-xl overflow-hidden" aria-hidden="true">
+    <!-- 表头骨架 -->
+    <div class="flex items-center gap-6 border-b border-border bg-gray-50 px-4 py-3">
+      <USkeleton v-for="(c, i) in columns" :key="i" class="h-3" :class="c" />
+    </div>
+    <!-- 数据行骨架 -->
+    <div
+      v-for="i in rows"
+      :key="i"
+      class="flex items-center gap-6 border-b border-border px-4 py-3.5 last:border-b-0"
+    >
+      <USkeleton v-for="(c, j) in columns" :key="j" class="h-3.5" :class="c" />
+    </div>
+  </div>
+</template>

--- a/noj-ui/components/ui/ToastBanner.vue
+++ b/noj-ui/components/ui/ToastBanner.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    visible: boolean
+    message: string
+    color?: "success" | "info" | "warning" | "error"
+    icon?: string
+  }>(),
+  {
+    color: "error",
+    icon: "i-lucide-alert-circle",
+  },
+)
+
+defineEmits<{ close: [] }>()
+</script>
+
+<template>
+  <Transition name="toast">
+    <div
+      v-if="visible"
+      class="fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]"
+    >
+      <UAlert
+        :color="color"
+        :icon="icon"
+        :title="message"
+        :close="true"
+        class="shadow-modal"
+      >
+        <template #close>
+          <UButton color="neutral" variant="link" icon="i-lucide-x" aria-label="关闭" @click="$emit('close')" />
+        </template>
+      </UAlert>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.toast-enter-active {
+  transition: all 0.3s ease-out;
+}
+.toast-leave-active {
+  transition: all 0.2s ease-in;
+}
+.toast-enter-from {
+  transform: translateX(-50%) translateY(-20px);
+  opacity: 0;
+}
+.toast-leave-to {
+  transform: translateX(-50%) translateY(-20px);
+  opacity: 0;
+}
+</style>

--- a/noj-ui/composables/useAdminList.ts
+++ b/noj-ui/composables/useAdminList.ts
@@ -14,6 +14,7 @@
  */
 
 import { ref } from 'vue';
+import { extractApiError } from '~/utils/apiError';
 
 export interface AdminListOptions<T> {
   /** API 路径（如 "/api/v1/admin/users"） */
@@ -82,8 +83,10 @@ export function useAdminList<T = Record<string, unknown>>(
       });
       if (keyword.value) params.set('keyword', keyword.value);
 
+      // 列表加载为后台场景：错误写入 error state 由页面展示，不弹 toast
+      const { api } = useApi();
       if (options.transform) {
-        const raw = await $fetch(`${options.path}?${params}`);
+        const raw = await api.get(`${options.path}?${params}`, { silent: true });
         const r = options.transform(raw);
         if (currentRequest !== requestVersion) return;
         items.value = r.items;
@@ -91,7 +94,10 @@ export function useAdminList<T = Record<string, unknown>>(
       } else {
         const dataField = options.fetchOptions?.dataField ?? 'data';
         const totalField = options.fetchOptions?.totalField ?? 'total';
-        const res = await $fetch<Record<string, unknown>>(`${options.path}?${params}`);
+        const res = await api.get<Record<string, unknown>>(
+          `${options.path}?${params}`,
+          { silent: true },
+        );
         if (currentRequest !== requestVersion) return;
         const rawData = deepGet(res, dataField);
         items.value = (Array.isArray(rawData) ? rawData : []) as T[];
@@ -107,7 +113,8 @@ export function useAdminList<T = Record<string, unknown>>(
       }
     } catch (err: unknown) {
       if (currentRequest !== requestVersion) return;
-      error.value = err instanceof Error ? err.message : '加载失败';
+      // 展示后端具体错误原因（extractApiError 统一提取）
+      error.value = extractApiError(err).message;
     } finally {
       if (currentRequest === requestVersion) loading.value = false;
     }

--- a/noj-ui/composables/useApi.ts
+++ b/noj-ui/composables/useApi.ts
@@ -1,0 +1,75 @@
+import type { ApiErrorInfo } from '~/utils/apiError';
+import { extractApiError } from '~/utils/apiError';
+
+/**
+ * 统一 API 调用层。
+ *
+ * 封装 `$fetch`，非 2xx / 网络 / 超时错误时：
+ * 1. 自动提取后端 `error` 字段（具体错误原因）并通过 `useToast().toast.error()` 弹窗；
+ * 2. **原样重抛** 原错误对象（保留 `data`/`status` 结构），
+ *    现有依赖错误对象属性（如 `e.data?.code === "USER_BANNED"`、404 分支）的代码不受影响。
+ *
+ * 选项：
+ * - `silent: true`：不弹 toast（轮询、后台刷新、表单内联错误等场景），错误仍抛出
+ * - `onError(err, info)`：自定义错误处理，提供后替换默认 toast；与 `silent` 同时给出时
+ *   `silent` 优先（不弹窗，`onError` 仍执行）
+ * - `timeout`（ms）：透传 ofetch `timeout`（内部 `AbortSignal.timeout`）
+ *
+ * SSR 端（`import.meta.server`）不弹 toast（UToaster 依赖客户端渲染），仅抛错。
+ */
+
+/** $fetch 选项类型（排除 method/timeout，二者由 useApi 接管） */
+type FetchOptions = NonNullable<Parameters<typeof $fetch>[1]>;
+
+/** API 调用选项：silent/onError 为 API 层专属，其余透传 $fetch */
+export interface ApiCallOptions
+  extends Omit<FetchOptions, 'method' | 'timeout'> {
+  /** 静默模式：不弹 toast，错误仍抛出（由调用方处理） */
+  silent?: boolean;
+  /** 自定义错误处理：替换默认 toast；与 silent 同时给出时 silent 优先 */
+  onError?: (err: unknown, info: ApiErrorInfo) => void;
+  /** 请求超时（ms），透传 ofetch timeout */
+  timeout?: number;
+}
+
+type ApiMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+export function useApi() {
+  const { toast } = useToast();
+
+  async function request<T = unknown>(
+    method: ApiMethod,
+    url: string,
+    options: ApiCallOptions = {},
+  ): Promise<T> {
+    const { silent = false, onError, ...fetchOptions } = options;
+    try {
+      return await $fetch<T>(url, { method, ...fetchOptions });
+    } catch (err) {
+      const info = extractApiError(err);
+      // silent 只抑制默认 toast；onError 自定义回调仍执行（设计 D4）
+      if (onError) {
+        onError(err, info);
+      } else if (!silent && import.meta.client) {
+        toast.error(info.message);
+      }
+      // 原样重抛：保留 $fetch 错误对象结构，调用方分支代码零破坏
+      throw err;
+    }
+  }
+
+  return {
+    api: {
+      get: <T = unknown>(url: string, options?: ApiCallOptions) =>
+        request<T>('get', url, options),
+      post: <T = unknown>(url: string, body?: unknown, options?: ApiCallOptions) =>
+        request<T>('post', url, { body, ...options }),
+      put: <T = unknown>(url: string, body?: unknown, options?: ApiCallOptions) =>
+        request<T>('put', url, { body, ...options }),
+      patch: <T = unknown>(url: string, body?: unknown, options?: ApiCallOptions) =>
+        request<T>('patch', url, { body, ...options }),
+      delete: <T = unknown>(url: string, options?: ApiCallOptions) =>
+        request<T>('delete', url, options),
+    },
+  };
+}

--- a/noj-ui/composables/useAuditLogs.ts
+++ b/noj-ui/composables/useAuditLogs.ts
@@ -2,6 +2,7 @@
  * 审计日志列表 composable。
  * 状态：分页 + 筛选；自动请求 + 错误处理。
  */
+import { extractApiError } from '~/utils/apiError';
 
 export type AuditAction =
   | "users.role_change"
@@ -65,13 +66,14 @@ export function useAuditLogs(initial: Partial<AuditLogFilters> = {}) {
       if (filters.value.from) params.set("from", filters.value.from);
       if (filters.value.to) params.set("to", filters.value.to);
 
-      const res = await $fetch<AuditLogListResponse>(
+      const res = await useApi().api.get<AuditLogListResponse>(
         `/api/v1/admin/audit-logs?${params}`,
+        { silent: true },
       );
       data.value = res.data;
       pagination.value = res.pagination;
-    } catch (e: any) {
-      error.value = e?.message ?? "加载失败";
+    } catch (e: unknown) {
+      error.value = extractApiError(e).message;
     } finally {
       loading.value = false;
     }

--- a/noj-ui/composables/useAuth.ts
+++ b/noj-ui/composables/useAuth.ts
@@ -65,18 +65,17 @@ export function useAuth() {
     loading.value = false;
   }
 
+  // 认证类调用统一 silent：错误由认证页面内联展示（banner/表单错误），
+  // 避免「页面提示 + toast」双重提示（ui-api-layer 设计 D6）
+  const { api } = useApi();
+
   async function login(login: string, password: string) {
-    // 5s 超时（评审修复 L2，与 fetchUser 一致）
-    const res = await Promise.race([
-      $fetch<{ data: { user: UserResponse } }>(
-        '/api/v1/auth/login',
-        {
-          method: 'POST',
-          body: { login, password },
-        },
-      ),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('login timeout')), 5000)),
-    ]);
+    // 5s 超时（评审修复 L2，与 fetchUser 一致），由 useApi timeout 选项实现
+    const res = await api.post<{ data: { user: UserResponse } }>(
+      '/api/v1/auth/login',
+      { login, password },
+      { silent: true, timeout: 5000 },
+    );
     // token 已由 Nitro 代理设置为 HTTP-only cookie，客户端不接收 token 字段
     const userData = res.data.user;
     user.value = userData;
@@ -84,10 +83,7 @@ export function useAuth() {
   }
 
   async function register(username: string, email: string, password: string) {
-    await $fetch('/api/v1/auth/register', {
-      method: 'POST',
-      body: { username, email, password },
-    });
+    await api.post('/api/v1/auth/register', { username, email, password }, { silent: true });
   }
 
   /**
@@ -95,10 +91,7 @@ export function useAuth() {
    * 邮箱是否存在对前端透明：服务端统一返 200 + 同一消息（防枚举）。
    */
   async function forgotPassword(email: string) {
-    await $fetch('/api/v1/auth/forgot-password', {
-      method: 'POST',
-      body: { email },
-    });
+    await api.post('/api/v1/auth/forgot-password', { email }, { silent: true });
   }
 
   /**
@@ -106,20 +99,21 @@ export function useAuth() {
    * @throws 令牌无效/过期/已用/弱密码时抛出错误（含后端 error 消息）
    */
   async function resetPassword(token: string, newPassword: string) {
-    await $fetch('/api/v1/auth/reset-password', {
-      method: 'POST',
-      body: { token, new_password: newPassword },
-    });
+    await api.post(
+      '/api/v1/auth/reset-password',
+      { token, new_password: newPassword },
+      { silent: true },
+    );
   }
 
   async function fetchUser() {
     if (!isLoggedIn.value) return null;
     try {
       // 5s 超时（评审修复 L2，与 middleware/auth.ts fetchUser 一致）
-      const res = await Promise.race([
-        $fetch<{ data: UserResponse }>('/api/v1/auth/me'),
-        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('fetchUser timeout')), 5000)),
-      ]);
+      const res = await api.get<{ data: UserResponse }>(
+        '/api/v1/auth/me',
+        { silent: true, timeout: 5000 },
+      );
       user.value = res.data;
       return res.data;
     } catch {
@@ -135,12 +129,10 @@ export function useAuth() {
     //   3. 返回 { user, token }
     // Nitro 代理同步用新 token 替换 noj:token Cookie（user.must_change_password=false）。
     // 因此前端**不再需要** logout()+重登——直接更新本地 user 状态即可。
-    const res = await $fetch<{ data: { user: UserResponse } }>(
+    const res = await api.post<{ data: { user: UserResponse } }>(
       '/api/v1/auth/change-password',
-      {
-        method: 'POST',
-        body: { old_password: oldPassword, new_password: newPassword },
-      },
+      { old_password: oldPassword, new_password: newPassword },
+      { silent: true },
     );
     // 同步本地状态：must_change_password 现在是 false，前端路由守卫放行。
     user.value = res.data.user;
@@ -149,7 +141,8 @@ export function useAuth() {
 
   async function logout() {
     try {
-      await $fetch('/api/auth/logout', { method: 'POST' });
+      // 本地注销端点（Nitro 删除 Cookie），非 /api/v1/ 前缀；失败静默
+      await api.post('/api/auth/logout', undefined, { silent: true });
     } catch {
       // 即使网络错误也要清除本地状态
     }

--- a/noj-ui/composables/useBanStatus.ts
+++ b/noj-ui/composables/useBanStatus.ts
@@ -6,6 +6,7 @@
  *
  * 使用 useState 确保 SSR → 客户端水合过程只调一次。
  */
+import { extractApiError } from '~/utils/apiError';
 
 export interface IpBanInfo {
   matched_cidr: string;
@@ -45,7 +46,11 @@ export function useBanStatus() {
     loading.value = true;
     error.value = "";
     try {
-      const res = await $fetch<BanStatusResponse>("/api/v1/auth/ban-status");
+      // 封禁状态为全局静默请求：失败由 BanBanner 依据 error state 处理，不弹 toast
+      const res = await useApi().api.get<BanStatusResponse>(
+        '/api/v1/auth/ban-status',
+        { silent: true },
+      );
       ipBanned.value = res.ip_banned;
       ipBanInfo.value = res.ip_ban_info;
       userBanned.value = res.user_banned;
@@ -55,7 +60,7 @@ export function useBanStatus() {
       fetched = true;
       return res;
     } catch (err: unknown) {
-      error.value = err instanceof Error ? err.message : "获取封禁状态失败";
+      error.value = extractApiError(err).message;
       return null;
     } finally {
       loading.value = false;

--- a/noj-ui/composables/useCommunity.ts
+++ b/noj-ui/composables/useCommunity.ts
@@ -136,12 +136,13 @@ export interface NotificationRow {
 export function useCommunity() {
   const config = useState<CommunityConfig | null>('community:config', () => null);
   const loading = useState('community:config-loading', () => false);
+  const { api } = useApi();
 
   async function loadConfig(force = false) {
     if (config.value && !force) return config.value;
     loading.value = true;
     try {
-      const response = await $fetch<{ data: CommunityConfig }>('/api/v1/community/config');
+      const response = await api.get<{ data: CommunityConfig }>('/api/v1/community/config');
       config.value = response.data;
       return response.data;
     } finally {

--- a/noj-ui/composables/useCommunityNotifications.ts
+++ b/noj-ui/composables/useCommunityNotifications.ts
@@ -3,11 +3,14 @@
  */
 export function useCommunityNotifications() {
   const unreadCount = useState('community:unread-count', () => 0);
+  const { api } = useApi();
 
   async function loadUnreadCount() {
     try {
-      const result = await $fetch<{ data: { unread_count: number } }>(
+      // 未读数轮询：静默失败，失败时归零不打扰用户
+      const result = await api.get<{ data: { unread_count: number } }>(
         '/api/v1/community/notifications/unread-count',
+        { silent: true },
       );
       unreadCount.value = result.data.unread_count;
     } catch {

--- a/noj-ui/composables/useMessages.ts
+++ b/noj-ui/composables/useMessages.ts
@@ -30,11 +30,14 @@ export interface Pagination {
  * 导航栏未读数通过定时轮询 fetchUnreadCount 获取。
  */
 export function useMessages() {
+  // 未读数查询（轮询/角标场景）内部静默：失败不影响主流程，不打扰用户
+  const { api } = useApi();
+
   /**
    * 获取会话列表。
    */
   async function fetchConversations(page = 1, perPage = 20) {
-    return $fetch<{
+    return api.get<{
       data: Conversation[];
       pagination: Pagination;
     }>(`/api/v1/conversations?page=${page}&per_page=${perPage}`);
@@ -44,9 +47,8 @@ export function useMessages() {
    * 查找或创建会话。
    */
   async function findOrCreateConversation(otherUserId: string) {
-    return $fetch<{ data: Conversation }>("/api/v1/conversations", {
-      method: "POST",
-      body: { other_user_id: otherUserId },
+    return api.post<{ data: Conversation }>('/api/v1/conversations', {
+      other_user_id: otherUserId,
     });
   }
 
@@ -54,7 +56,7 @@ export function useMessages() {
    * 获取消息列表。
    */
   async function fetchMessages(conversationId: string, page = 1, perPage = 50) {
-    return $fetch<{
+    return api.get<{
       data: ConversationMessage[];
       pagination: Pagination;
     }>(`/api/v1/conversations/${conversationId}/messages?page=${page}&per_page=${perPage}`);
@@ -64,12 +66,9 @@ export function useMessages() {
    * 发送消息。
    */
   async function sendMessage(conversationId: string, content: string) {
-    return $fetch<{ data: ConversationMessage }>(
+    return api.post<{ data: ConversationMessage }>(
       `/api/v1/conversations/${conversationId}/messages`,
-      {
-        method: "POST",
-        body: { content },
-      },
+      { content },
     );
   }
 
@@ -77,30 +76,33 @@ export function useMessages() {
    * 标记已读。
    */
   async function markRead(conversationId: string, lastReadMessageId: string) {
-    return $fetch(`/api/v1/conversations/${conversationId}/read`, {
-      method: "POST",
-      body: { last_read_message_id: lastReadMessageId },
+    return api.post(`/api/v1/conversations/${conversationId}/read`, {
+      last_read_message_id: lastReadMessageId,
     });
   }
 
   /**
    * 获取未读消息总数（用于导航栏徽标）。
+   * 静默模式：轮询失败不弹窗，返回 0。
    */
   async function fetchUnreadCount(): Promise<number> {
-    const res = await $fetch<{ unread_count: number }>(
-      "/api/v1/conversations/unread-count",
+    const res = await api.get<{ unread_count: number }>(
+      '/api/v1/conversations/unread-count',
+      { silent: true },
     );
     return res.unread_count;
   }
 
   /**
    * 获取单会话未读数。
+   * 静默模式：轮询失败不弹窗，返回 0。
    */
   async function fetchUnreadCountByConversation(
     conversationId: string,
   ): Promise<number> {
-    const res = await $fetch<{ unread_count: number }>(
+    const res = await api.get<{ unread_count: number }>(
       `/api/v1/conversations/${conversationId}/unread-count`,
+      { silent: true },
     );
     return res.unread_count;
   }

--- a/noj-ui/composables/useRankings.ts
+++ b/noj-ui/composables/useRankings.ts
@@ -52,7 +52,7 @@ export function useRankings(page: Ref<number>, limit: number = 50) {
  * 未登录或未上榜时返回 null。
  */
 export async function fetchMyRanking(): Promise<RankingRow | null> {
-  const res = await $fetch<MyRankingResponse>("/api/v1/rankings/me")
+  const res = await useApi().api.get<MyRankingResponse>('/api/v1/rankings/me')
   return res.data
 }
 

--- a/noj-ui/composables/useSearch.ts
+++ b/noj-ui/composables/useSearch.ts
@@ -147,17 +147,22 @@ export function useSearch() {
         const limit = opts?.limit ?? 5;
 
         try {
+          // 搜索为静默请求：错误由 state.error 状态展示，不弹 toast
+          const { api } = useApi();
           if (type === "all") {
             // 并行请求题目 + 用户
             const [pRes, uRes, cRes] = await Promise.allSettled([
-              $fetch("/api/v1/search", {
+              api.get("/api/v1/search", {
                 params: { q: trimmed, type: "problem", limit },
+                silent: true,
               }),
-              $fetch("/api/v1/search", {
+              api.get("/api/v1/search", {
                 params: { q: trimmed, type: "user", limit: 3 },
+                silent: true,
               }),
-              $fetch("/api/v1/search", {
+              api.get("/api/v1/search", {
                 params: { q: trimmed, type: "community", limit: 3 },
+                silent: true,
               }),
             ]);
 
@@ -187,8 +192,9 @@ export function useSearch() {
               state.value.results.community = community;
             }
           } else {
-            const res = await $fetch("/api/v1/search", {
+            const res = await api.get("/api/v1/search", {
               params: { q: trimmed, type, limit },
+              silent: true,
             });
 
             // 已被更新的请求覆盖，跳过写入（请求竞态防护）

--- a/noj-ui/composables/useSubmissionPolling.ts
+++ b/noj-ui/composables/useSubmissionPolling.ts
@@ -4,6 +4,7 @@
  * 用于编辑器提交后留在页面时，实时显示评测进度。
  * 提交状态变为 finished / error 时自动停止轮询。
  */
+import { extractApiError } from '~/utils/apiError';
 
 export type SubmissionStatus =
   | "pending"
@@ -49,8 +50,10 @@ export function useSubmissionPolling(submissionIdRef: Ref<string | null>) {
     const id = submissionIdRef.value;
     if (!id) return;
     try {
-      const res = await $fetch<{ data: PolledSubmission }>(
+      // 轮询为静默请求：失败写入 error ref 由页面展示，不弹 toast
+      const res = await useApi().api.get<{ data: PolledSubmission }>(
         `/api/v1/submissions/${id}`,
+        { silent: true },
       );
       submission.value = res.data;
       error.value = null;
@@ -58,8 +61,7 @@ export function useSubmissionPolling(submissionIdRef: Ref<string | null>) {
         stop();
       }
     } catch (e) {
-      const err = e as { data?: { error?: string }; message?: string };
-      error.value = err.data?.error || err.message || "轮询失败";
+      error.value = extractApiError(e).message;
     }
   }
 

--- a/noj-ui/deno.json
+++ b/noj-ui/deno.json
@@ -6,7 +6,8 @@
     "compile": "deno task copy-monaco && deno run -A npm:nuxt build && mkdir -p dist && deno compile -A --no-check --unstable-byonm --unstable-node-globals --include .output/public --output dist/noj-ui .output/server/index.mjs",
     "preview": "deno run -A npm:nuxt preview",
     "lint": "deno lint",
-    "fmt": "deno fmt"
+    "fmt": "deno fmt",
+    "test": "deno test -A tests/"
   },
   "lint": { "include": ["*.vue", "*.ts"] },
   "fmt": { "include": ["*.vue", "*.ts"], "options": { "singleQuote": true, "lineWidth": 120 } },

--- a/noj-ui/deno.lock
+++ b/noj-ui/deno.lock
@@ -1,6 +1,8 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
     "npm:@iconify-json/lucide@^1.2.121": "1.2.121",
     "npm:@nuxt/fonts@0.14": "0.14.0_magic-string@0.30.21_vite@7.3.6__jiti@2.7.0__yaml@2.9.0",
     "npm:@nuxt/icon@^2.3.1": "2.4.1_magic-string@0.30.21_unplugin@3.3.0__esbuild@0.28.1__rollup@4.62.2__vite@7.3.6___jiti@2.7.0___yaml@2.9.0__jiti@2.7.0_vite@7.3.6__jiti@2.7.0__yaml@2.9.0_vue@3.5.40__typescript@5.9.3",
@@ -17,6 +19,17 @@
     "npm:playwright@*": "1.62.0",
     "npm:tailwindcss@^4.3.3": "4.3.3",
     "npm:typescript@5": "5.9.3"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
   },
   "npm": {
     "@alloc/quick-lru@5.2.0": {

--- a/noj-ui/layouts/admin.vue
+++ b/noj-ui/layouts/admin.vue
@@ -59,6 +59,9 @@ function isActive(path: string) {
 
 <template>
   <div class="flex min-h-screen bg-gray-50">
+    <a href="#admin-main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[200] focus:bg-white focus:text-text focus:px-4 focus:py-2 focus:rounded-md focus:shadow-modal">
+      跳转到主要内容
+    </a>
     <!-- 移动端遮罩 -->
     <Transition name="fade">
       <div
@@ -86,7 +89,7 @@ function isActive(path: string) {
 
       <nav class="flex-1 p-2 flex flex-col gap-3 overflow-y-auto">
         <section v-for="group in navGroups" :key="group.label" class="flex flex-col gap-0.5">
-          <h2 v-show="sidebarOpen" class="px-3 pt-1 text-[11px] font-semibold text-text-muted">{{ group.label }}</h2>
+          <h2 v-show="sidebarOpen" class="px-3 pt-1 text-11px font-semibold text-text-muted">{{ group.label }}</h2>
           <NuxtLink
             v-for="item in group.items"
             :key="item.to"
@@ -119,7 +122,7 @@ function isActive(path: string) {
         <span class="text-base font-semibold">管理后台</span>
       </header>
 
-      <main class="p-6 max-w-[1200px]">
+      <main id="admin-main" class="p-6 max-w-[1200px]">
         <slot />
       </main>
     </div>

--- a/noj-ui/layouts/auth.vue
+++ b/noj-ui/layouts/auth.vue
@@ -1,7 +1,10 @@
 <template>
     <div class="flex flex-col min-h-screen">
+        <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[200] focus:bg-white focus:text-text focus:px-4 focus:py-2 focus:rounded-md focus:shadow-modal">
+            跳转到主要内容
+        </a>
         <Navbar />
-        <main class="flex-1 min-h-[calc(100vh-64px)] px-6 py-28 flex items-center justify-center">
+        <main id="main" class="flex-1 min-h-[calc(100vh-var(--header-h))] px-6 py-28 flex items-center justify-center">
             <slot />
         </main>
         <FooterBar />

--- a/noj-ui/layouts/default.vue
+++ b/noj-ui/layouts/default.vue
@@ -22,9 +22,12 @@ onUnmounted(() => {
 </script>
 <template>
     <div class="flex flex-col min-h-screen w-full overflow-x-hidden">
+        <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[200] focus:bg-white focus:text-text focus:px-4 focus:py-2 focus:rounded-md focus:shadow-modal">
+            跳转到主要内容
+        </a>
         <Navbar />
-        <div class="flex flex-1 min-h-[calc(100vh-64px)] w-full pt-16">
-            <main class="flex-1 min-w-0 w-full">
+        <div class="flex flex-1 min-h-[calc(100vh-var(--header-h))] w-full pt-(--header-h)">
+            <main id="main" class="flex-1 min-w-0 w-full">
                 <slot />
             </main>
         </div>

--- a/noj-ui/pages/about.vue
+++ b/noj-ui/pages/about.vue
@@ -1,11 +1,26 @@
 <script setup lang="ts">
-const contributors = [
-  { login: "hachimi-ak-ioi", contributions: 9 },
-  { login: "chenmou2012", contributions: 2 },
-  { login: "w1010tdev", contributions: 1 },
-]
+interface Contributor {
+  login: string
+  avatar_url: string
+  contributions: number
+}
 
 const repoUrl = "https://github.com/Neuro-OJ/neuro-oj"
+
+// 贡献者：Nitro 路由从 GitHub API 拉取（带缓存与回退）。
+// server: false 避免 SSR 阻塞在外部请求上，首屏后客户端填充。
+const { data: contributorsData } = await useAsyncData("about-contributors", () =>
+  $fetch<{ data: Contributor[] }>("/api/contributors"),
+  { server: false },
+)
+const contributors = computed(() => contributorsData.value?.data ?? [])
+
+// 头像加载失败时回退为首字母圆标
+const brokenAvatars = ref(new Set<string>())
+function onAvatarError(e: Event, c: Contributor) {
+  ;(e.target as HTMLImageElement).style.display = "none"
+  brokenAvatars.value.add(c.login)
+}
 </script>
 
 <template>
@@ -89,7 +104,7 @@ const repoUrl = "https://github.com/Neuro-OJ/neuro-oj"
             <div class="font-semibold text-orange-800 flex items-center gap-1.5 mb-1">
               <UIcon name="i-lucide-compass" class="size-4" /> noj-ui
             </div>
-            <div class="text-orange-700 text-xs">Nuxt 3 + Vue 3 · 用户界面</div>
+            <div class="text-orange-700 text-xs">Nuxt 4 + Vue 3 · 用户界面</div>
           </div>
           <div class="flex-1 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3.5">
             <div class="font-semibold text-blue-800 flex items-center gap-1.5 mb-1">
@@ -138,7 +153,16 @@ const repoUrl = "https://github.com/Neuro-OJ/neuro-oj"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-2 px-3 py-1.5 bg-gray-50 border border-border rounded-full text-sm text-text-secondary no-underline hover:bg-primary-bg hover:text-primary hover:border-primary/30 transition-colors"
           >
-            <span class="w-5 h-5 rounded-full bg-primary-bg text-primary flex items-center justify-center text-xs font-bold">
+            <img
+              v-if="!brokenAvatars.has(c.login)"
+              :src="c.avatar_url"
+              :alt="`${c.login} 的头像`"
+              class="w-5 h-5 rounded-full bg-gray-200"
+              loading="lazy"
+              referrerpolicy="no-referrer"
+              @error="onAvatarError($event, c)"
+            />
+            <span v-else class="w-5 h-5 rounded-full bg-primary-bg text-primary flex items-center justify-center text-xs font-bold">
               {{ c.login.charAt(0).toUpperCase() }}
             </span>
             <span class="font-medium">{{ c.login }}</span>

--- a/noj-ui/pages/about.vue
+++ b/noj-ui/pages/about.vue
@@ -5,10 +5,33 @@ interface Contributor {
   contributions: number
 }
 
+interface SiteStats {
+  problems: number
+  submissions: number
+  users: number
+  accepted: number
+}
+
 const repoUrl = "https://github.com/Neuro-OJ/neuro-oj"
 
+// 站点统计：Nitro 代理转发到 noj-core /api/v1/stats。
+// server: false 避免 SSR 阻塞在外部请求上，首屏后客户端填充（与贡献者一致）。
+const { data: statsData } = await useAsyncData<{ data: SiteStats }>(
+  "about-stats",
+  () => $fetch<{ data: SiteStats }>("/api/v1/stats"),
+  { server: false },
+)
+const stats = computed(() => statsData.value?.data)
+
+// 统计项定义：数字 + 标签 + 图标 + 加载骨架
+const statItems = computed(() => [
+  { key: "problems", label: "题目总数", icon: "i-lucide-book-open", value: stats.value?.problems },
+  { key: "submissions", label: "提交总数", icon: "i-lucide-terminal", value: stats.value?.submissions },
+  { key: "users", label: "注册用户", icon: "i-lucide-users", value: stats.value?.users },
+  { key: "accepted", label: "评测通过", icon: "i-lucide-circle-check", value: stats.value?.accepted },
+])
+
 // 贡献者：Nitro 路由从 GitHub API 拉取（带缓存与回退）。
-// server: false 避免 SSR 阻塞在外部请求上，首屏后客户端填充。
 const { data: contributorsData } = await useAsyncData("about-contributors", () =>
   $fetch<{ data: Contributor[] }>("/api/contributors"),
   { server: false },
@@ -21,160 +44,256 @@ function onAvatarError(e: Event, c: Contributor) {
   ;(e.target as HTMLImageElement).style.display = "none"
   brokenAvatars.value.add(c.login)
 }
+
+function formatNumber(n?: number): string {
+  return (n ?? 0).toLocaleString("zh-CN")
+}
 </script>
 
 <template>
-  <div class="max-w-[860px] mx-auto px-4 py-8 sm:px-6 sm:py-12 flex flex-col gap-10">
+  <div class="max-w-[860px] mx-auto px-4 py-8 sm:px-6 sm:py-12 flex flex-col gap-8">
     <!-- Hero -->
-    <div class="flex flex-col gap-3">
-      <h1 class="text-3xl font-extrabold text-text tracking-tight">Neuro OJ</h1>
-      <p class="text-lg text-text-secondary leading-relaxed">
-        一个面向 AI 时代程序设计与工程能力评测的在线评测系统，
-        为 LMCC（CCF 大语言模型能力认证）设计。
-      </p>
-      <p class="text-sm text-text-muted">
-        Neuro OJ 与 CCF 及 LMCC 无任何官方关系，为独立社区项目。
-      </p>
-    </div>
+    <section class="bg-gradient-to-br from-slate-900 via-blue-900 to-blue-700 rounded-2xl overflow-hidden shadow-modal">
+      <div class="p-8 sm:p-10 lg:p-12 flex flex-col gap-6 text-white">
+        <span class="self-start inline-flex items-center gap-1.5 rounded-full bg-white/10 border border-white/15 px-3 py-1 text-xs font-medium text-blue-100">
+          <UIcon name="i-lucide-sparkles" class="size-3.5" />
+          面向 LMCC 的 AI 在线评测系统
+        </span>
+        <div class="flex flex-col gap-3">
+          <h1 class="text-3xl sm:text-4xl font-extrabold tracking-tight">Neuro OJ</h1>
+          <p class="text-blue-100/90 leading-relaxed max-w-[520px]">
+            一个面向 AI 时代程序设计与工程能力评测的在线评测系统，
+            以容器级资源隔离承载任意自定义评测逻辑，为 CCF 大语言模型能力认证（LMCC）设计。
+          </p>
+        </div>
+        <div class="flex flex-wrap items-center gap-3">
+          <a
+            href="/problems"
+            class="inline-flex items-center gap-1.5 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-slate-900 no-underline hover:bg-blue-50 transition-colors"
+          >
+            <UIcon name="i-lucide-rocket" class="size-4" />
+            开始做题
+          </a>
+          <a
+            :href="repoUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-white/30 px-4 py-2 text-sm font-medium text-white no-underline hover:bg-white/10 transition-colors"
+          >
+            <UIcon name="i-lucide-github" class="size-4" />
+            GitHub
+          </a>
+        </div>
+        <div class="flex items-start gap-2 rounded-lg bg-amber-400/10 border border-amber-300/30 px-4 py-3 text-xs text-amber-100">
+          <UIcon name="i-lucide-info" class="size-4 shrink-0 mt-px" />
+          <span>Neuro OJ 与 CCF 及 LMCC 无任何官方关系，为独立社区项目。</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- 页内锚点导航 -->
+    <nav aria-label="页面导航" class="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+      <a href="#features" class="no-underline text-text-secondary hover:text-primary transition-colors">核心区别</a>
+      <a href="#architecture" class="no-underline text-text-secondary hover:text-primary transition-colors">技术架构</a>
+      <a href="#community" class="no-underline text-text-secondary hover:text-primary transition-colors">开源社区</a>
+    </nav>
+
+    <!-- 数据面板 -->
+    <section aria-label="站点统计" class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <div
+        v-for="item in statItems"
+        :key="item.key"
+        class="bg-white border border-border rounded-xl shadow-card p-5 flex flex-col items-center gap-2 text-center"
+      >
+        <UIcon :name="item.icon" class="size-5 text-primary" />
+        <template v-if="item.value !== undefined">
+          <span class="text-2xl font-extrabold text-text tabular-nums tracking-tight">
+            {{ formatNumber(item.value) }}
+          </span>
+        </template>
+        <div v-else class="w-16 h-7 rounded-md bg-gray-100 animate-pulse" role="status" aria-label="统计加载中" />
+        <span class="text-xs text-text-muted">{{ item.label }}</span>
+      </div>
+    </section>
 
     <!-- 与传统 OJ 的区别 -->
-    <div class="bg-white border border-border rounded-xl overflow-hidden">
-      <div class="px-6 py-5 border-b border-border bg-gray-50">
-        <h2 class="text-lg font-bold text-text">与传统 OJ 的核心区别</h2>
-      </div>
-      <div class="px-6 py-6 flex flex-col gap-6">
-        <div class="flex gap-4">
-          <div class="w-10 h-10 rounded-lg bg-purple-100 text-purple-700 flex items-center justify-center shrink-0">
+    <section id="features" class="scroll-mt-24">
+      <h2 class="text-lg font-bold text-text flex items-center gap-2 mb-4">
+        <UIcon name="i-lucide-layout-grid" class="size-4.5 text-primary" />
+        与传统 OJ 的核心区别
+      </h2>
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <article class="bg-white border border-border rounded-xl shadow-card p-5 flex flex-col gap-3 hover:shadow-dropdown hover:-translate-y-0.5 transition-all">
+          <div class="w-10 h-10 rounded-lg bg-primary-bg text-primary flex items-center justify-center shrink-0">
             <UIcon name="i-lucide-grid" class="size-5" />
           </div>
-          <div class="flex flex-col gap-1.5">
-            <h3 class="font-semibold text-text">完全由题目自定义的评测过程</h3>
-            <p class="text-sm text-text-secondary leading-relaxed">
-              传统 OJ（Hydro、Luogu 等）要求题目遵循固定的评测范式——stdin/stdout 或 filein/fileout。
-              Neuro OJ 通过<strong class="text-text">题目支持包（support package）</strong>将评测逻辑完全交给题目自定义。
-              每道题自带 <code class="text-purple-700 bg-purple-50 px-1 rounded text-xs font-mono">evaluate.py</code>、
-              测试用例和评测脚本，评测方式不受平台约束：可以解析 JSON 输出、调用外部 API、运行多轮对话评估等。
-            </p>
-          </div>
-        </div>
+          <h3 class="font-semibold text-text">完全由题目自定义的评测过程</h3>
+          <p class="text-sm text-text-secondary leading-relaxed">
+            传统 OJ（Hydro、Luogu 等）要求题目遵循固定的评测范式——stdin/stdout 或 filein/fileout。
+            Neuro OJ 通过<strong class="text-text">题目支持包（support package）</strong>将评测逻辑完全交给题目自定义。
+            每道题自带 <code class="text-primary bg-primary-bg px-1 rounded text-xs font-mono">evaluate.py</code>、
+            测试用例和评测脚本，评测方式不受平台约束：可以解析 JSON 输出、调用外部 API、运行多轮对话评估等。
+          </p>
+        </article>
 
-        <div class="flex gap-4">
-          <div class="w-10 h-10 rounded-lg bg-blue-100 text-blue-700 flex items-center justify-center shrink-0">
+        <article class="bg-white border border-border rounded-xl shadow-card p-5 flex flex-col gap-3 hover:shadow-dropdown hover:-translate-y-0.5 transition-all">
+          <div class="w-10 h-10 rounded-lg bg-primary-bg text-primary flex items-center justify-center shrink-0">
             <UIcon name="i-lucide-box" class="size-5" />
           </div>
-          <div class="flex flex-col gap-1.5">
-            <h3 class="font-semibold text-text">容器级资源限制，适配 AI 场景</h3>
-            <p class="text-sm text-text-secondary leading-relaxed">
-              传统 OJ 限制单个进程的 CPU 时间和内存，但在 AI 评测场景中，
-              代码可能涉及多进程、GPU 调用、模型加载、网络请求等复杂行为。
-              Neuro OJ 的<strong class="text-text">时间和内存限制作用于整个 Docker 容器</strong>，
-              而非单个进程，真实反映 AI 应用在复杂依赖环境下的资源消耗。
-            </p>
-          </div>
-        </div>
+          <h3 class="font-semibold text-text">容器级资源限制，适配 AI 场景</h3>
+          <p class="text-sm text-text-secondary leading-relaxed">
+            传统 OJ 限制单个进程的 CPU 时间和内存，但在 AI 评测场景中，
+            代码可能涉及多进程、GPU 调用、模型加载、网络请求等复杂行为。
+            Neuro OJ 的<strong class="text-text">时间和内存限制作用于整个 Docker 容器</strong>，
+            而非单个进程，真实反映 AI 应用在复杂依赖环境下的资源消耗。
+          </p>
+        </article>
 
-        <div class="flex gap-4">
-          <div class="w-10 h-10 rounded-lg bg-green-100 text-green-700 flex items-center justify-center shrink-0">
+        <article class="bg-white border border-border rounded-xl shadow-card p-5 flex flex-col gap-3 hover:shadow-dropdown hover:-translate-y-0.5 transition-all">
+          <div class="w-10 h-10 rounded-lg bg-primary-bg text-primary flex items-center justify-center shrink-0">
             <UIcon name="i-lucide-monitor" class="size-5" />
           </div>
-          <div class="flex flex-col gap-1.5">
-            <h3 class="font-semibold text-text">全面容器化的评测环境</h3>
-            <p class="text-sm text-text-secondary leading-relaxed">
-              每道题可指定自定义 Docker 镜像（<code class="text-green-700 bg-green-50 px-1 rounded text-xs font-mono">runtime_config</code>），
-              意味着评测环境可以预装任意依赖——PyTorch、TensorFlow、NumPy、
-              Node.js 包、C++ 库等。平台不再限制语言版本和可用库，
-              题目作者自由定义最适合评测的运行时环境。
-            </p>
-          </div>
-        </div>
+          <h3 class="font-semibold text-text">全面容器化的评测环境</h3>
+          <p class="text-sm text-text-secondary leading-relaxed">
+            每道题可指定自定义 Docker 镜像（<code class="text-primary bg-primary-bg px-1 rounded text-xs font-mono">runtime_config</code>），
+            意味着评测环境可以预装任意依赖——PyTorch、TensorFlow、NumPy、
+            Node.js 包、C++ 库等。平台不再限制语言版本和可用库，
+            题目作者自由定义最适合评测的运行时环境。
+          </p>
+        </article>
       </div>
-    </div>
+    </section>
 
     <!-- 架构概览 -->
-    <div class="bg-white border border-border rounded-xl overflow-hidden">
-      <div class="px-6 py-5 border-b border-border bg-gray-50">
-        <h2 class="text-lg font-bold text-text flex items-center gap-2">
-          <UIcon name="i-lucide-server" class="size-4.5" />
-          技术架构
-        </h2>
-      </div>
-      <div class="px-6 py-6">
-        <div class="flex flex-col sm:flex-row gap-4 text-sm">
-          <div class="flex-1 bg-orange-50 border border-orange-200 rounded-lg px-4 py-3.5">
-            <div class="font-semibold text-orange-800 flex items-center gap-1.5 mb-1">
-              <UIcon name="i-lucide-compass" class="size-4" /> noj-ui
+    <section id="architecture" class="scroll-mt-24">
+      <h2 class="text-lg font-bold text-text flex items-center gap-2 mb-4">
+        <UIcon name="i-lucide-server" class="size-4.5 text-primary" />
+        技术架构
+      </h2>
+      <div class="bg-white border border-border rounded-xl shadow-card p-6">
+        <div class="flex flex-col sm:flex-row items-stretch gap-2 sm:gap-3">
+          <div class="flex-1 bg-slate-50 border border-border rounded-lg px-4 py-3.5">
+            <div class="font-semibold text-text flex items-center gap-1.5 mb-1">
+              <UIcon name="i-lucide-compass" class="size-4 text-primary" /> noj-ui
             </div>
-            <div class="text-orange-700 text-xs">Nuxt 4 + Vue 3 · 用户界面</div>
+            <div class="text-text-muted text-xs mb-2">Nuxt 4 + Vue 3 · 用户界面</div>
+            <a
+              :href="`${repoUrl}/tree/main/noj-ui`"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-1 text-xs text-primary no-underline hover:underline"
+            >
+              源码 <UIcon name="i-lucide-external-link" class="size-3" />
+            </a>
           </div>
-          <div class="flex-1 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3.5">
-            <div class="font-semibold text-blue-800 flex items-center gap-1.5 mb-1">
-              <UIcon name="i-lucide-terminal" class="size-4" /> noj-core
+          <UIcon name="i-lucide-arrow-right" class="size-4 text-text-muted self-center shrink-0 sm:rotate-0 rotate-90" />
+          <div class="flex-1 bg-slate-50 border border-border rounded-lg px-4 py-3.5">
+            <div class="font-semibold text-text flex items-center gap-1.5 mb-1">
+              <UIcon name="i-lucide-terminal" class="size-4 text-primary" /> noj-core
             </div>
-            <div class="text-blue-700 text-xs">Deno + Hono · RESTful API</div>
+            <div class="text-text-muted text-xs mb-2">Deno + Hono · RESTful API</div>
+            <a
+              :href="`${repoUrl}/tree/main/noj-core`"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-1 text-xs text-primary no-underline hover:underline"
+            >
+              源码 <UIcon name="i-lucide-external-link" class="size-3" />
+            </a>
           </div>
-          <div class="flex-1 bg-green-50 border border-green-200 rounded-lg px-4 py-3.5">
-            <div class="font-semibold text-green-800 flex items-center gap-1.5 mb-1">
-              <UIcon name="i-lucide-box" class="size-4" /> noj-judge
+          <UIcon name="i-lucide-arrow-right" class="size-4 text-text-muted self-center shrink-0 sm:rotate-0 rotate-90" />
+          <div class="flex-1 bg-slate-50 border border-border rounded-lg px-4 py-3.5">
+            <div class="font-semibold text-text flex items-center gap-1.5 mb-1">
+              <UIcon name="i-lucide-box" class="size-4 text-primary" /> noj-judge
             </div>
-            <div class="text-green-700 text-xs">Rust + Docker · 评测 Worker</div>
+            <div class="text-text-muted text-xs mb-2">Rust + Docker · 评测 Worker</div>
+            <a
+              :href="`${repoUrl}/tree/main/noj-judge`"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-1 text-xs text-primary no-underline hover:underline"
+            >
+              源码 <UIcon name="i-lucide-external-link" class="size-3" />
+            </a>
           </div>
         </div>
+        <p class="text-xs text-text-muted mt-4 leading-relaxed">
+          三模块通过 RESTful API 与 Redis 消息队列协作：noj-ui 提交代码 → noj-core 分发评测任务 →
+          noj-judge 在 Docker 沙箱中执行并回传结果，支持多 Worker 水平扩展。
+        </p>
       </div>
-    </div>
+    </section>
 
     <!-- GitHub & 贡献者 -->
-    <div class="bg-white border border-border rounded-xl overflow-hidden">
-      <div class="px-6 py-5 border-b border-border bg-gray-50 flex items-center justify-between">
-        <h2 class="text-lg font-bold text-text flex items-center gap-2">
-          开源社区
-        </h2>
-        <a
-          :href="repoUrl"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center gap-1.5 text-sm text-primary no-underline hover:underline"
-        >
-          Neuro-OJ/neuro-oj
-          <UIcon name="i-lucide-external-link" class="size-3" />
-        </a>
-      </div>
-      <div class="px-6 py-6">
-        <p class="text-sm text-text-secondary mb-4">
-          本项目在 GitHub 上开源，欢迎 Star、Issue 和 Pull Request。
-        </p>
+    <section id="community" class="scroll-mt-24">
+      <h2 class="text-lg font-bold text-text flex items-center gap-2 mb-4">
+        <UIcon name="i-lucide-github" class="size-4.5 text-primary" />
+        开源社区
+      </h2>
+      <div class="bg-white border border-border rounded-xl shadow-card p-6">
+        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-5">
+          <p class="text-sm text-text-secondary">
+            本项目在 GitHub 上开源（AGPL-3.0），欢迎 Star、Issue 和 Pull Request。
+          </p>
+          <a
+            :href="repoUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-border bg-gray-50 px-4 py-2 text-sm font-medium text-text no-underline hover:bg-primary-bg hover:text-primary hover:border-primary/30 transition-colors shrink-0"
+          >
+            <UIcon name="i-lucide-star" class="size-4 text-primary" />
+            Neuro-OJ/neuro-oj
+            <UIcon name="i-lucide-external-link" class="size-3" />
+          </a>
+        </div>
 
         <h3 class="text-sm font-semibold text-text mb-3">贡献者</h3>
-        <div class="flex flex-wrap gap-3">
+        <div v-if="contributors.length" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
           <a
             v-for="c in contributors"
             :key="c.login"
             :href="`https://github.com/${c.login}`"
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center gap-2 px-3 py-1.5 bg-gray-50 border border-border rounded-full text-sm text-text-secondary no-underline hover:bg-primary-bg hover:text-primary hover:border-primary/30 transition-colors"
+            class="inline-flex items-center gap-3 px-3 py-2 bg-gray-50 border border-border rounded-lg no-underline hover:bg-primary-bg hover:border-primary/30 transition-colors"
           >
             <img
               v-if="!brokenAvatars.has(c.login)"
               :src="c.avatar_url"
               :alt="`${c.login} 的头像`"
-              class="w-5 h-5 rounded-full bg-gray-200"
+              class="w-8 h-8 rounded-full bg-gray-200 shrink-0"
               loading="lazy"
               referrerpolicy="no-referrer"
               @error="onAvatarError($event, c)"
             />
-            <span v-else class="w-5 h-5 rounded-full bg-primary-bg text-primary flex items-center justify-center text-xs font-bold">
+            <span v-else class="w-8 h-8 rounded-full bg-primary-bg text-primary flex items-center justify-center text-sm font-bold shrink-0">
               {{ c.login.charAt(0).toUpperCase() }}
             </span>
-            <span class="font-medium">{{ c.login }}</span>
-            <span class="text-xs text-text-muted">{{ c.contributions }} commits</span>
+            <span class="flex flex-col min-w-0">
+              <span class="font-medium text-text truncate">{{ c.login }}</span>
+              <span class="text-xs text-text-muted">{{ c.contributions }} commits</span>
+            </span>
           </a>
         </div>
+        <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2" role="status" aria-label="贡献者加载中">
+          <div v-for="i in 6" :key="i" class="h-[52px] rounded-lg bg-gray-100 animate-pulse" />
+        </div>
       </div>
-    </div>
+    </section>
 
     <!-- Footer -->
-    <div class="text-center text-xs text-text-muted border-t border-border pt-6">
-      Neuro OJ — 基于 AGPL 许可证开源。如需商业授权，请联系开发团队。
-    </div>
+    <footer class="text-center text-xs text-text-muted border-t border-border pt-6 flex flex-col gap-2">
+      <p>
+        基于
+        <a
+          :href="`${repoUrl}/blob/main/LICENSE`"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-primary no-underline hover:underline"
+        >AGPL-3.0</a>
+        许可证开源。如需商业授权，请联系开发团队。
+      </p>
+      <p>Neuro OJ 为独立社区项目，与 CCF 及 LMCC 无任何官方关系。</p>
+    </footer>
   </div>
 </template>

--- a/noj-ui/pages/about.vue
+++ b/noj-ui/pages/about.vue
@@ -13,12 +13,13 @@ interface SiteStats {
 }
 
 const repoUrl = "https://github.com/Neuro-OJ/neuro-oj"
+const { api } = useApi()
 
 // 站点统计：Nitro 代理转发到 noj-core /api/v1/stats。
 // server: false 避免 SSR 阻塞在外部请求上，首屏后客户端填充（与贡献者一致）。
 const { data: statsData } = await useAsyncData<{ data: SiteStats }>(
   "about-stats",
-  () => $fetch<{ data: SiteStats }>("/api/v1/stats"),
+  () => api.get<{ data: SiteStats }>("/api/v1/stats", { silent: true }),
   { server: false },
 )
 const stats = computed(() => statsData.value?.data)
@@ -33,7 +34,7 @@ const statItems = computed(() => [
 
 // 贡献者：Nitro 路由从 GitHub API 拉取（带缓存与回退）。
 const { data: contributorsData } = await useAsyncData("about-contributors", () =>
-  $fetch<{ data: Contributor[] }>("/api/contributors"),
+  api.get<{ data: Contributor[] }>("/api/contributors", { silent: true }),
   { server: false },
 )
 const contributors = computed(() => contributorsData.value?.data ?? [])

--- a/noj-ui/pages/admin/audit-logs.vue
+++ b/noj-ui/pages/admin/audit-logs.vue
@@ -85,7 +85,7 @@ onMounted(fetch)
 <template>
   <div class="flex flex-col gap-4">
     <div class="flex flex-col gap-1">
-      <h1 class="text-[22px] font-bold text-text flex items-center gap-2">
+      <h1 class="text-22px font-bold text-text flex items-center gap-2">
         <UIcon name="i-lucide-scroll-text" class="size-[22px]" />
         审计日志
       </h1>
@@ -99,7 +99,7 @@ onMounted(fetch)
           <label class="text-xs font-semibold text-text-secondary">操作类型</label>
           <select
             v-model="filters.action"
-            class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+            class="px-2.5 py-1.5 text-13px border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
           >
             <option value="">全部</option>
             <option v-for="(label, action) in ACTION_LABELS" :key="action" :value="action">
@@ -112,7 +112,7 @@ onMounted(fetch)
           <input
             type="datetime-local"
             v-model="filters.from"
-            class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+            class="px-2.5 py-1.5 text-13px border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
           />
         </div>
         <div class="flex flex-col gap-1 min-w-[200px]">
@@ -120,7 +120,7 @@ onMounted(fetch)
           <input
             type="datetime-local"
             v-model="filters.to"
-            class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+            class="px-2.5 py-1.5 text-13px border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
           />
         </div>
       </div>

--- a/noj-ui/pages/admin/blacklist.vue
+++ b/noj-ui/pages/admin/blacklist.vue
@@ -151,7 +151,7 @@ function formatExpires(value: string | null) {
     <!-- 错误条 -->
     <div
       v-if="tableError"
-      class="p-3 bg-red-50 border border-red-200 rounded-md text-[13px] text-error-text"
+      class="p-3 bg-red-50 border border-red-200 rounded-md text-13px text-error-text"
     >
       {{ tableError }}
       <button class="ml-2 underline cursor-pointer" @click="load">重试</button>
@@ -185,15 +185,15 @@ function formatExpires(value: string | null) {
             class="border-b border-border last:border-b-0 hover:bg-gray-50 transition-colors"
           >
             <td class="px-3 py-2.5 align-top">
-              <code class="font-mono text-[13px] font-semibold text-text">{{ item.ip_or_cidr }}</code>
+              <code class="font-mono text-13px font-semibold text-text">{{ item.ip_or_cidr }}</code>
             </td>
             <td class="px-3 py-2.5 align-top text-text-secondary">
               {{ item.reason || "—" }}
             </td>
-            <td class="px-3 py-2.5 align-top text-text-secondary text-[13px]">
+            <td class="px-3 py-2.5 align-top text-text-secondary text-13px">
               {{ formatExpires(item.expires_at) }}
             </td>
-            <td class="px-3 py-2.5 align-top text-text-secondary text-[13px]">
+            <td class="px-3 py-2.5 align-top text-text-secondary text-13px">
               {{ new Date(item.created_at).toLocaleString("zh-CN") }}
             </td>
             <td class="px-3 py-2.5 align-top">
@@ -244,7 +244,7 @@ function formatExpires(value: string | null) {
           />
           <p class="mt-1 text-[12px] text-text-secondary">留空表示永久封禁</p>
         </div>
-        <p v-if="formError" class="text-[13px] text-error-text">{{ formError }}</p>
+        <p v-if="formError" class="text-13px text-error-text">{{ formError }}</p>
       </div>
     
     <template #footer>

--- a/noj-ui/pages/admin/blacklist.vue
+++ b/noj-ui/pages/admin/blacklist.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { extractApiError } from '~/utils/apiError'
+
 definePageMeta({
   layout: "admin",
   middleware: "admin",
@@ -22,6 +24,8 @@ interface IpBan {
   created_by: string | null
 }
 
+const { api } = useApi()
+
 // ─── 数据加载 ────
 const items = ref<IpBan[]>([])
 const tableLoading = ref(true)
@@ -34,12 +38,13 @@ async function load() {
   try {
     const params = new URLSearchParams({ page: "1", per_page: "100" })
     if (search.value) params.set("keyword", search.value)
-    const res = await $fetch<{ data: IpBan[]; pagination: { total: number } }>(
+    const res = await api.get<{ data: IpBan[]; pagination: { total: number } }>(
       `/api/v1/admin/blacklist?${params.toString()}`,
+      { silent: true },
     )
     items.value = res.data
   } catch (err: unknown) {
-    tableError.value = err instanceof Error ? err.message : "加载黑名单失败"
+    tableError.value = extractApiError(err).message
   } finally {
     tableLoading.value = false
   }
@@ -69,19 +74,16 @@ async function handleSave() {
   saving.value = true
   formError.value = ""
   try {
-    await $fetch("/api/v1/admin/blacklist", {
-      method: "POST",
-      body: {
-        ip_or_cidr: form.ip_or_cidr.trim(),
-        reason: form.reason.trim(),
-        expires_at: form.expires_at.trim() || null,
-      },
+    await api.post("/api/v1/admin/blacklist", {
+      ip_or_cidr: form.ip_or_cidr.trim(),
+      reason: form.reason.trim(),
+      expires_at: form.expires_at.trim() || null,
     })
     showForm.value = false
     toast.success("已添加黑名单条目")
     await load()
   } catch (err: unknown) {
-    formError.value = err instanceof Error ? err.message : "添加失败"
+    formError.value = extractApiError(err).message
   } finally {
     saving.value = false
   }
@@ -104,11 +106,9 @@ async function confirmDelete(item: IpBan) {
   deleteTarget.value = item
   deleting.value = true
   try {
-    await $fetch(`/api/v1/admin/blacklist/${item.id}`, { method: "DELETE" })
+    await api.delete(`/api/v1/admin/blacklist/${item.id}`)
     toast.success(`已删除 ${item.ip_or_cidr}`)
     await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "删除失败")
   } finally {
     deleting.value = false
     deleteTarget.value = null

--- a/noj-ui/pages/admin/categories.vue
+++ b/noj-ui/pages/admin/categories.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { extractApiError } from '~/utils/apiError'
+
 definePageMeta({
   layout: "admin",
   middleware: "admin",
@@ -19,6 +21,8 @@ interface Category {
   description: string
 }
 
+const { api } = useApi()
+
 const categories = ref<Category[]>([])
 const tableLoading = ref(true)
 const tableError = ref("")
@@ -35,10 +39,10 @@ async function loadCategories() {
   tableLoading.value = true
   tableError.value = ""
   try {
-    const res = await $fetch<{ data: Category[] }>("/api/v1/categories")
+    const res = await api.get<{ data: Category[] }>("/api/v1/categories", { silent: true })
     categories.value = res.data
   } catch (err: unknown) {
-    tableError.value = err instanceof Error ? err.message : "加载分类失败"
+    tableError.value = extractApiError(err).message
   } finally {
     tableLoading.value = false
   }
@@ -89,20 +93,18 @@ async function handleSave() {
   formError.value = ""
   try {
     if (editingCategory.value) {
-      await $fetch(`/api/v1/categories/${editingCategory.value.id}`, {
-        method: "PUT",
-        body: { name: formName.value, slug: formSlug.value, description: formDesc.value },
+      await api.put(`/api/v1/categories/${editingCategory.value.id}`, {
+        name: formName.value, slug: formSlug.value, description: formDesc.value,
       })
     } else {
-      await $fetch("/api/v1/categories", {
-        method: "POST",
-        body: { name: formName.value, slug: formSlug.value, description: formDesc.value },
+      await api.post("/api/v1/categories", {
+        name: formName.value, slug: formSlug.value, description: formDesc.value,
       })
     }
     showForm.value = false
     await loadCategories()
   } catch (err: unknown) {
-    formError.value = err instanceof Error ? err.message : "保存失败"
+    formError.value = extractApiError(err).message
   } finally {
     saving.value = false
   }
@@ -123,13 +125,11 @@ async function handleDelete() {
   if (!deleteTarget.value) return
   deleting.value = true
   try {
-    await $fetch(`/api/v1/categories/${deleteTarget.value.id}`, {
-      method: "DELETE",
-    })
+    await api.delete(`/api/v1/categories/${deleteTarget.value.id}`)
     showDeleteConfirm.value = false
     await loadCategories()
   } catch (err: unknown) {
-    formError.value = err instanceof Error ? err.message : "删除失败"
+    formError.value = extractApiError(err).message
   } finally {
     deleting.value = false
   }

--- a/noj-ui/pages/admin/categories.vue
+++ b/noj-ui/pages/admin/categories.vue
@@ -170,18 +170,18 @@ async function handleDelete() {
   <UModal v-model:open="showForm" :title="editingCategory ? '编辑分类' : '新建分类'" :unmount-on-hide="true">
     <div class="flex flex-col gap-3">
       <div class="flex flex-col gap-1">
-        <label class="text-[13px] font-semibold text-text">名称 <span class="text-error-text">*</span></label>
+        <label class="text-13px font-semibold text-text">名称 <span class="text-error-text">*</span></label>
         <input v-model="formName" class="px-3 py-2 text-sm border border-border rounded outline-none transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" placeholder="分类名称" />
       </div>
       <div class="flex flex-col gap-1">
-        <label class="text-[13px] font-semibold text-text">标识 <span class="text-error-text">*</span></label>
+        <label class="text-13px font-semibold text-text">标识 <span class="text-error-text">*</span></label>
         <input v-model="formSlug" class="px-3 py-2 text-sm border border-border rounded outline-none transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" placeholder="分类标识（英文）" />
       </div>
       <div class="flex flex-col gap-1">
-        <label class="text-[13px] font-semibold text-text">描述</label>
+        <label class="text-13px font-semibold text-text">描述</label>
         <input v-model="formDesc" class="px-3 py-2 text-sm border border-border rounded outline-none transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" placeholder="可选描述" />
       </div>
-      <p v-if="formError" class="text-error-text text-[13px]">{{ formError }}</p>
+      <p v-if="formError" class="text-error-text text-13px">{{ formError }}</p>
     </div>
   
     <template #footer>
@@ -193,7 +193,7 @@ async function handleDelete() {
   <!-- 删除确认弹窗 -->
   <UModal v-model:open="showDeleteConfirm" :title="'删除分类'" :unmount-on-hide="true">
     <p>确定要删除分类 <strong>{{ deleteTarget?.name }}</strong> 吗？此操作不可撤销。</p>
-    <p v-if="formError" class="text-error-text text-[13px]">{{ formError }}</p>
+    <p v-if="formError" class="text-error-text text-13px">{{ formError }}</p>
   
     <template #footer>
       <UButton color="neutral" variant="ghost" :disabled="deleting" @click="showDeleteConfirm = false">取消</UButton>

--- a/noj-ui/pages/admin/community.vue
+++ b/noj-ui/pages/admin/community.vue
@@ -6,6 +6,7 @@ definePageMeta({ layout: "admin", middleware: "community-moderation", ssr: false
 const { toast } = useToast()
 const { dialog } = useDialog()
 const { config, loadConfig } = useCommunity()
+const { api } = useApi()
 
 const preset = ref("private")
 const applyingPreset = ref(false)
@@ -71,9 +72,9 @@ function configValue(configKey: string): unknown {
 
 async function load() {
   const [boardResult, reportResult, sanctionResult] = await Promise.all([
-    $fetch<{ data: { id: string; name: string; slug: string; description: string | null; is_archived: boolean }[] }>("/api/v1/community/boards"),
-    $fetch<{ data: ReportRow[] }>("/api/v1/community/admin/reports"),
-    $fetch<{ data: typeof sanctions.value }>("/api/v1/community/admin/sanctions"),
+    api.get<{ data: { id: string; name: string; slug: string; description: string | null; is_archived: boolean }[] }>("/api/v1/community/boards", { silent: true }),
+    api.get<{ data: ReportRow[] }>("/api/v1/community/admin/reports", { silent: true }),
+    api.get<{ data: typeof sanctions.value }>("/api/v1/community/admin/sanctions", { silent: true }),
   ])
   boards.value = boardResult.data
   reports.value = reportResult.data
@@ -84,7 +85,7 @@ async function load() {
 async function loadPending() {
   loadingPending.value = true
   try {
-    const result = await $fetch<{ data: PostRow[] }>("/api/v1/community/posts", { query: { limit: 100 } })
+    const result = await api.get<{ data: PostRow[] }>("/api/v1/community/posts", { query: { limit: 100 }, silent: true })
     pendingPosts.value = result.data.filter((p) => p.post.status === "pending")
   } catch {
     pendingPosts.value = []
@@ -96,9 +97,9 @@ async function loadPending() {
 async function loadPendingComments() {
   loadingPendingComments.value = true
   try {
-    const result = await $fetch<{ data: typeof pendingComments.value }>(
+    const result = await api.get<{ data: typeof pendingComments.value }>(
       "/api/v1/community/admin/comments/pending",
-      { query: { limit: 100 } },
+      { query: { limit: 100 }, silent: true },
     )
     pendingComments.value = result.data
   } catch {
@@ -112,11 +113,9 @@ async function applyPreset() {
   if (applyingPreset.value) return
   applyingPreset.value = true
   try {
-    await $fetch(`/api/v1/community/admin/preset/${preset.value}`, { method: "POST" })
+    await api.post(`/api/v1/community/admin/preset/${preset.value}`)
     toast.success("社区预设已应用")
     await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "保存失败")
   } finally {
     applyingPreset.value = false
   }
@@ -127,14 +126,9 @@ async function toggleSetting(settingKey: string, configKey: string) {
   savingKey.value = settingKey
   try {
     const current = Boolean(configValue(configKey))
-    await $fetch(`/api/v1/admin/settings/${settingKey}`, {
-      method: "PUT",
-      body: { value: !current },
-    })
+    await api.put(`/api/v1/admin/settings/${settingKey}`, { value: !current })
     toast.success("设置已更新")
     await loadConfig(true)
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "保存失败")
   } finally {
     savingKey.value = null
   }
@@ -148,14 +142,9 @@ async function saveNumber(settingKey: string, configKey: string) {
   if (value === undefined || value === "" || savingKey.value) return
   savingKey.value = settingKey
   try {
-    await $fetch(`/api/v1/admin/settings/${settingKey}`, {
-      method: "PUT",
-      body: { value: Number(value) },
-    })
+    await api.put(`/api/v1/admin/settings/${settingKey}`, { value: Number(value) })
     toast.success("设置已更新")
     await loadConfig(true)
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "保存失败")
   } finally {
     savingKey.value = null
   }
@@ -165,14 +154,9 @@ async function moderatePost(id: string, status: "published" | "hidden") {
   if (moderatingId.value) return
   moderatingId.value = id
   try {
-    await $fetch(`/api/v1/community/admin/posts/${id}/${status}`, {
-      method: "POST",
-      body: { reason: "" },
-    })
+    await api.post(`/api/v1/community/admin/posts/${id}/${status}`, { reason: "" })
     toast.success(status === "published" ? "内容已批准" : "内容已驳回")
     await loadPending()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "操作失败")
   } finally {
     moderatingId.value = null
   }
@@ -182,14 +166,9 @@ async function moderateComment(id: string, status: "published" | "hidden") {
   if (moderatingCommentId.value) return
   moderatingCommentId.value = id
   try {
-    await $fetch(`/api/v1/community/admin/comments/${id}/${status}`, {
-      method: "POST",
-      body: { reason: "" },
-    })
+    await api.post(`/api/v1/community/admin/comments/${id}/${status}`, { reason: "" })
     toast.success(status === "published" ? "评论已批准" : "评论已驳回")
     await loadPendingComments()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "操作失败")
   } finally {
     moderatingCommentId.value = null
   }
@@ -202,44 +181,32 @@ async function createBoard() {
   }
   creatingBoard.value = true
   try {
-    await $fetch("/api/v1/community/admin/boards", {
-      method: "POST",
-      body: { slug: newBoard.slug, name: newBoard.name, description: newBoard.description },
+    await api.post("/api/v1/community/admin/boards", {
+      slug: newBoard.slug, name: newBoard.name, description: newBoard.description,
     })
     toast.success("板块已创建")
     newBoard.slug = ""
     newBoard.name = ""
     newBoard.description = ""
     await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "创建失败")
   } finally {
     creatingBoard.value = false
   }
 }
 
 async function toggleArchive(boardId: string, archived: boolean) {
-  try {
-    await $fetch(`/api/v1/community/admin/boards/${boardId}`, {
-      method: "PATCH",
-      body: { is_archived: !archived },
-    })
-    toast.success(archived ? "板块已恢复" : "板块已归档")
-    await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "操作失败")
-  }
+  await api.patch(`/api/v1/community/admin/boards/${boardId}`, { is_archived: !archived })
+  toast.success(archived ? "板块已恢复" : "板块已归档")
+  await load()
 }
 
 async function resolveReport(id: string, status: "resolved" | "dismissed") {
   if (resolvingReportId.value) return
   resolvingReportId.value = id
   try {
-    await $fetch(`/api/v1/community/admin/reports/${id}/${status}`, { method: "POST", body: {} })
+    await api.post(`/api/v1/community/admin/reports/${id}/${status}`, {})
     toast.success("举报已处理")
     await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "处理失败")
   } finally {
     resolvingReportId.value = null
   }
@@ -253,9 +220,9 @@ async function searchSanctionUser() {
   }
   searchingSanctionUser.value = true
   try {
-    const result = await $fetch<{ data: { items: { id: string; username: string }[] } }>(
+    const result = await api.get<{ data: { items: { id: string; username: string }[] } }>(
       "/api/v1/search",
-      { query: { q, type: "user" } },
+      { query: { q, type: "user" }, silent: true },
     )
     sanctionUserResults.value = result.data.items
   } catch {
@@ -278,8 +245,9 @@ async function loadUserSanctions(userId?: string) {
     return
   }
   try {
-    const result = await $fetch<{ data: typeof userSanctions.value }>(
+    const result = await api.get<{ data: typeof userSanctions.value }>(
       `/api/v1/community/admin/users/${userId}/sanctions`,
+      { silent: true },
     )
     userSanctions.value = result.data
   } catch {
@@ -294,20 +262,15 @@ async function createSanction() {
   }
   creatingSanction.value = true
   try {
-    await $fetch("/api/v1/community/admin/sanctions", {
-      method: "POST",
-      body: {
-        user_id: selectedSanctionUser.value.id,
-        reason: sanctionReason.value,
-        expires_at: sanctionExpiresAt.value || null,
-      },
+    await api.post("/api/v1/community/admin/sanctions", {
+      user_id: selectedSanctionUser.value.id,
+      reason: sanctionReason.value,
+      expires_at: sanctionExpiresAt.value || null,
     })
     toast.success("处罚已生效")
     sanctionReason.value = ""
     sanctionExpiresAt.value = ""
     await Promise.all([load(), loadUserSanctions(selectedSanctionUser.value.id)])
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "创建失败")
   } finally {
     creatingSanction.value = false
   }
@@ -322,11 +285,9 @@ async function revokeSanction(sanctionId: string) {
   if (!ok || revokingId.value) return
   revokingId.value = sanctionId
   try {
-    await $fetch(`/api/v1/community/admin/sanctions/${sanctionId}`, { method: "DELETE" })
+    await api.delete(`/api/v1/community/admin/sanctions/${sanctionId}`)
     toast.success("已撤销")
     await Promise.all([load(), loadUserSanctions(selectedSanctionUser.value?.id)])
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "撤销失败")
   } finally {
     revokingId.value = null
   }

--- a/noj-ui/pages/admin/contests.vue
+++ b/noj-ui/pages/admin/contests.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { extractApiError } from '~/utils/apiError'
 import type {
   AdminContestDetail,
   AdminProblemOption,
@@ -12,6 +13,7 @@ definePageMeta({ layout: 'admin', middleware: 'admin', ssr: false })
 const { typeLabels, statusLabels, formatDateTime, statusClass } = useContests()
 const toast = useToast()
 const { dialog } = useDialog()
+const { api } = useApi()
 const contests = ref<Contest[]>([])
 const problems = ref<AdminProblemOption[]>([])
 const loading = ref(true)
@@ -43,15 +45,14 @@ async function loadContests(page = currentPage.value) {
   loading.value = true
   loadError.value = ''
   try {
-    const response = await $fetch<{ data: Contest[]; pagination: Pagination }>(`/api/v1/admin/contests?page=${page}&per_page=20`)
+    const response = await api.get<{ data: Contest[]; pagination: Pagination }>(`/api/v1/admin/contests?page=${page}&per_page=20`, { silent: true })
     if (currentRequest !== contestRequestVersion) return
     contests.value = response.data
     currentPage.value = response.pagination.page
     totalPages.value = response.pagination.total_pages
   } catch (fetchError: unknown) {
     if (currentRequest !== contestRequestVersion) return
-    const detail = fetchError as { data?: { error?: string }; message?: string }
-    loadError.value = detail.data?.error || detail.message || '竞赛列表加载失败'
+    loadError.value = extractApiError(fetchError).message
   } finally {
     if (currentRequest === contestRequestVersion) loading.value = false
   }
@@ -62,7 +63,7 @@ let problemRequestVersion = 0
 async function loadProblems(keyword = '') {
   const currentRequest = ++problemRequestVersion
   try {
-    const response = await $fetch<{ data: AdminProblemOption[] }>(`/api/v1/admin/problems?page=1&limit=20&keyword=${encodeURIComponent(keyword)}`)
+    const response = await api.get<{ data: AdminProblemOption[] }>(`/api/v1/admin/problems?page=1&limit=20&keyword=${encodeURIComponent(keyword)}`, { silent: true })
     if (currentRequest !== problemRequestVersion) return
     problems.value = response.data
   } catch {
@@ -82,14 +83,9 @@ function openCreate() {
 
 async function openEdit(contest: Contest) {
   formError.value = ''
-  try {
-    const response = await $fetch<{ data: AdminContestDetail }>(`/api/v1/admin/contests/${contest.id}`)
-    editingContest.value = response.data
-    formOpen.value = true
-  } catch (fetchError: unknown) {
-    const detail = fetchError as { data?: { error?: string }; message?: string }
-    toast.showToast('error', detail.data?.error || detail.message || '竞赛详情加载失败')
-  }
+  const response = await api.get<{ data: AdminContestDetail }>(`/api/v1/admin/contests/${contest.id}`)
+  editingContest.value = response.data
+  formOpen.value = true
 }
 
 async function saveContest(payload: ContestPayload) {
@@ -97,16 +93,15 @@ async function saveContest(payload: ContestPayload) {
   formError.value = ''
   try {
     if (editingContest.value) {
-      await $fetch(`/api/v1/admin/contests/${editingContest.value.id}`, { method: 'PUT', body: payload })
+      await api.put(`/api/v1/admin/contests/${editingContest.value.id}`, payload)
     } else {
-      await $fetch('/api/v1/admin/contests', { method: 'POST', body: payload })
+      await api.post('/api/v1/admin/contests', payload)
     }
     toast.showToast('success', editingContest.value ? '竞赛已更新' : '竞赛已创建')
     formOpen.value = false
     reloadAfterContestMutation()
   } catch (saveError: unknown) {
-    const detail = saveError as { data?: { error?: string }; message?: string }
-    formError.value = detail.data?.error || detail.message || '竞赛保存失败'
+    formError.value = extractApiError(saveError).message
   } finally {
     saving.value = false
   }
@@ -115,14 +110,9 @@ async function saveContest(payload: ContestPayload) {
 async function removeContest(contest: Contest) {
   const confirmed = await dialog.confirm(`确定删除竞赛“${contest.title}”吗？竞赛提交会保留，但将解除竞赛关联。`, { title: '删除竞赛', confirmText: '删除', danger: true })
   if (!confirmed) return
-  try {
-    await $fetch(`/api/v1/admin/contests/${contest.id}`, { method: 'DELETE' })
-    toast.showToast('success', '竞赛已删除')
-    reloadAfterContestMutation()
-  } catch (deleteError: unknown) {
-    const detail = deleteError as { data?: { error?: string }; message?: string }
-    toast.showToast('error', detail.data?.error || detail.message || '删除失败')
-  }
+  await api.delete(`/api/v1/admin/contests/${contest.id}`)
+  toast.showToast('success', '竞赛已删除')
+  reloadAfterContestMutation()
 }
 
 interface Participant {
@@ -156,7 +146,7 @@ async function loadParticipants() {
   if (!participantContest.value) return
   participantLoading.value = true
   try {
-    const response = await $fetch<{ data: Participant[] }>(`/api/v1/admin/contests/${participantContest.value.id}/participants`)
+    const response = await api.get<{ data: Participant[] }>(`/api/v1/admin/contests/${participantContest.value.id}/participants`, { silent: true })
     participants.value = response.data
   } finally {
     participantLoading.value = false
@@ -167,7 +157,7 @@ async function searchUsers() {
   if (userQuery.value.trim().length < 2) return
   searchingUsers.value = true
   try {
-    const response = await $fetch<{ data: UserSearchResult[] }>(`/api/v1/users/search?q=${encodeURIComponent(userQuery.value.trim())}`)
+    const response = await api.get<{ data: UserSearchResult[] }>(`/api/v1/users/search?q=${encodeURIComponent(userQuery.value.trim())}`)
     participants.value.forEach((participant) => {
       response.data = response.data.filter((user) => user.id !== participant.user_id)
     })
@@ -179,14 +169,14 @@ async function searchUsers() {
 
 async function addParticipant(user: UserSearchResult) {
   if (!participantContest.value) return
-  await $fetch(`/api/v1/admin/contests/${participantContest.value.id}/participants`, { method: 'POST', body: [user.id] })
+  await api.post(`/api/v1/admin/contests/${participantContest.value.id}/participants`, [user.id])
   userResults.value = userResults.value.filter((item) => item.id !== user.id)
   await loadParticipants()
 }
 
 async function removeParticipant(participant: Participant) {
   if (!participantContest.value) return
-  await $fetch(`/api/v1/admin/contests/${participantContest.value.id}/participants/${participant.user_id}`, { method: 'DELETE' })
+  await api.delete(`/api/v1/admin/contests/${participantContest.value.id}/participants/${participant.user_id}`)
   await loadParticipants()
 }
 </script>

--- a/noj-ui/pages/admin/index.vue
+++ b/noj-ui/pages/admin/index.vue
@@ -23,6 +23,7 @@ interface StatsCard {
 const stats = ref<StatsCard[]>([])
 const statsLoading = ref(true)
 const statsError = ref("")
+const { api } = useApi()
 const queueStats = ref<{ pending_count: number; judging_count: number; completed_today: number } | null>(null)
 const queueError = ref("")
 const lastSuccessfulRefresh = ref<Date | null>(null)
@@ -51,10 +52,10 @@ async function loadStats() {
   statsError.value = ""
 
   const [userRes, problemRes, submissionRes, queueRes] = await Promise.allSettled([
-    $fetch<{ pagination: { total: number } }>("/api/v1/admin/users"),
-    $fetch<{ total: number }>("/api/v1/problems"),
-    $fetch<{ pagination: { total: number } }>("/api/v1/admin/submissions"),
-    $fetch<{ stats: { pending_count: number; judging_count: number; completed_today: number } }>("/api/v1/queue"),
+    api.get<{ pagination: { total: number } }>("/api/v1/admin/users", { silent: true }),
+    api.get<{ total: number }>("/api/v1/problems", { silent: true }),
+    api.get<{ pagination: { total: number } }>("/api/v1/admin/submissions", { silent: true }),
+    api.get<{ stats: { pending_count: number; judging_count: number; completed_today: number } }>("/api/v1/queue", { silent: true }),
   ])
   if (currentRequest !== requestVersion) return
 

--- a/noj-ui/pages/admin/index.vue
+++ b/noj-ui/pages/admin/index.vue
@@ -59,9 +59,9 @@ async function loadStats() {
   if (currentRequest !== requestVersion) return
 
   stats.value = [
-    statCard("用户总数", 'i-lucide-users', "#3b82f6", userRes),
-    statCard("题目总数", 'i-lucide-book-open', "#10b981", problemRes),
-    statCard("提交总数", 'i-lucide-files', "#f59e0b", submissionRes),
+    statCard("用户总数", 'i-lucide-users', "#2563eb", userRes),
+    statCard("题目总数", 'i-lucide-book-open', "#16a34a", problemRes),
+    statCard("提交总数", 'i-lucide-files', "#d97706", submissionRes),
   ]
   queueStats.value = queueRes.status === "fulfilled" ? queueRes.value.stats : null
   queueError.value = queueRes.status === "rejected" ? "队列状态加载失败" : ""
@@ -133,24 +133,24 @@ async function handleRefresh() {
       </h2>
       <div class="grid grid-cols-3 gap-4">
         <div class="flex flex-col items-center gap-1 p-4 rounded-lg bg-gray-50">
-          <span class="text-[28px] font-bold text-amber-500">{{ queueStats.pending_count }}</span>
+          <span class="text-28px font-bold text-warning-600">{{ queueStats.pending_count }}</span>
           <span class="text-xs text-text-secondary">等待中</span>
         </div>
         <div class="flex flex-col items-center gap-1 p-4 rounded-lg bg-gray-50">
-          <span class="text-[28px] font-bold text-blue-500">{{ queueStats.judging_count }}</span>
+          <span class="text-28px font-bold text-info-600">{{ queueStats.judging_count }}</span>
           <span class="text-xs text-text-secondary">评测中</span>
         </div>
         <div class="flex flex-col items-center gap-1 p-4 rounded-lg bg-gray-50">
-          <span class="text-[28px] font-bold text-emerald-500">{{ queueStats.completed_today }}</span>
+          <span class="text-28px font-bold text-success-600">{{ queueStats.completed_today }}</span>
           <span class="text-xs text-text-secondary">今日完成</span>
         </div>
       </div>
     </div>
-    <div v-else-if="queueError" class="flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-error-text">
-      <UIcon name="i-lucide-alert-circle" class="size-4.5" />
-      <span>{{ queueError }}</span>
-      <button class="underline" @click="loadStats">重试</button>
-    </div>
+    <UAlert v-else-if="queueError" color="error" icon="i-lucide-alert-circle" :title="queueError" class="rounded-xl">
+      <template #actions>
+        <UButton color="neutral" variant="link" size="sm" @click="loadStats">重试</UButton>
+      </template>
+    </UAlert>
 
     <p v-if="lastSuccessfulRefresh" class="text-xs text-text-muted">最近刷新：{{ lastSuccessfulRefresh.toLocaleString("zh-CN") }}</p>
   </div>

--- a/noj-ui/pages/admin/judge-images.vue
+++ b/noj-ui/pages/admin/judge-images.vue
@@ -213,11 +213,11 @@ async function handleDelete() {
   <UModal v-model:open="showForm" :title="editingItem ? '编辑评测镜像' : '新增评测镜像'" :unmount-on-hide="true">
     <div class="flex flex-col gap-3">
       <div class="flex flex-col gap-1">
-        <label class="text-[13px] font-semibold text-text">镜像名 <span class="text-error-text">*</span></label>
+        <label class="text-13px font-semibold text-text">镜像名 <span class="text-error-text">*</span></label>
         <input v-model="formImage" class="px-3 py-2 text-sm border border-border rounded outline-none transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" placeholder="如：noj-judge-python" :disabled="!!editingItem" />
       </div>
       <div class="flex flex-col gap-1">
-        <label class="text-[13px] font-semibold text-text">匹配模式</label>
+        <label class="text-13px font-semibold text-text">匹配模式</label>
         <select v-model="formMode" class="px-3 py-2 text-sm border border-border rounded outline-none transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)] bg-white" @change="onModeChange">
           <option value="exact">精确版本 — 仅匹配指定镜像名（含标签）</option>
           <option value="all_versions">所有版本 — 匹配镜像名所有标签</option>
@@ -226,16 +226,16 @@ async function handleDelete() {
 
       <!-- 全版本安全警告 -->
       <div v-if="showAllVersionsWarning" class="px-3 py-2.5 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800">
-        <p class="font-semibold mb-1">⚠ 安全风险</p>
+        <p class="font-semibold mb-1 flex items-center gap-1.5"><UIcon name="i-lucide-triangle-alert" class="size-4" />安全风险</p>
         <p>选择"所有版本"将允许该镜像的所有版本标签（如 <code>:latest</code>、<code>:dev</code> 等）。攻击者可能利用此宽松规则使用非预期镜像版本。</p>
         <p class="mt-1">请仅在完全信任该镜像所有版本的情况下使用此选项。</p>
       </div>
 
       <div class="flex flex-col gap-1">
-        <label class="text-[13px] font-semibold text-text">介绍</label>
+        <label class="text-13px font-semibold text-text">介绍</label>
         <input v-model="formDescription" class="px-3 py-2 text-sm border border-border rounded outline-none transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" placeholder="在题目编辑器中展示的说明文字" />
       </div>
-      <p v-if="formError" class="text-error-text text-[13px]">{{ formError }}</p>
+      <p v-if="formError" class="text-error-text text-13px">{{ formError }}</p>
     </div>
   
     <template #footer>
@@ -247,7 +247,7 @@ async function handleDelete() {
   <!-- 删除确认弹窗 -->
   <UModal v-model:open="showDeleteConfirm" :title="'删除评测镜像'" :unmount-on-hide="true">
     <p>确定要删除评测镜像 <strong>{{ deleteTarget?.image }}</strong> 吗？此操作将导致使用了此镜像的题目无法通过白名单校验。</p>
-    <p v-if="formError" class="text-error-text text-[13px]">{{ formError }}</p>
+    <p v-if="formError" class="text-error-text text-13px">{{ formError }}</p>
   
     <template #footer>
       <UButton color="neutral" variant="ghost" :disabled="deleting" @click="showDeleteConfirm = false">取消</UButton>

--- a/noj-ui/pages/admin/judge-images.vue
+++ b/noj-ui/pages/admin/judge-images.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useToast } from "~/composables/useToast"
+import { extractApiError } from '~/utils/apiError'
 
 definePageMeta({
   layout: "admin",
@@ -21,6 +22,8 @@ interface JudgeImage {
   description: string
   created_at: string
 }
+
+const { api } = useApi()
 
 const items = ref<JudgeImage[]>([])
 const tableLoading = ref(true)
@@ -57,13 +60,12 @@ async function loadItems() {
   tableLoading.value = true
   tableError.value = ""
   try {
-    const res = await $fetch<{ data: JudgeImage[] }>("/api/v1/admin/judge-images")
+    const res = await api.get<{ data: JudgeImage[] }>("/api/v1/admin/judge-images", { silent: true })
     if (currentRequest !== requestVersion) return
     items.value = res.data
   } catch (err: unknown) {
     if (currentRequest !== requestVersion) return
-    const apiErr = err as { data?: { error?: string }; message?: string } | undefined
-    tableError.value = apiErr?.data?.error || apiErr?.message || "加载评测镜像列表失败"
+    tableError.value = extractApiError(err).message
   } finally {
     if (currentRequest === requestVersion) tableLoading.value = false
   }
@@ -121,29 +123,22 @@ async function handleSave() {
   formError.value = ""
   try {
     if (editingItem.value) {
-      await $fetch(`/api/v1/admin/judge-images/${editingItem.value.id}`, {
-        method: "PUT",
-        body: {
-          image: formImage.value.trim(),
-          mode: formMode.value,
-          description: formDescription.value.trim(),
-        },
+      await api.put(`/api/v1/admin/judge-images/${editingItem.value.id}`, {
+        image: formImage.value.trim(),
+        mode: formMode.value,
+        description: formDescription.value.trim(),
       })
     } else {
-      await $fetch("/api/v1/admin/judge-images", {
-        method: "POST",
-        body: {
-          image: formImage.value.trim(),
-          mode: formMode.value,
-          description: formDescription.value.trim(),
-        },
+      await api.post("/api/v1/admin/judge-images", {
+        image: formImage.value.trim(),
+        mode: formMode.value,
+        description: formDescription.value.trim(),
       })
     }
     showForm.value = false
     await loadItems()
   } catch (err: unknown) {
-    const apiErr = err as { data?: { error?: string }; message?: string } | undefined
-    formError.value = apiErr?.data?.error || apiErr?.message || "保存失败"
+    formError.value = extractApiError(err).message
   } finally {
     saving.value = false
   }
@@ -164,15 +159,12 @@ async function handleDelete() {
   if (!deleteTarget.value) return
   deleting.value = true
   try {
-    await $fetch(`/api/v1/admin/judge-images/${deleteTarget.value.id}`, {
-      method: "DELETE",
-    })
+    await api.delete(`/api/v1/admin/judge-images/${deleteTarget.value.id}`)
     items.value = items.value.filter((item) => item.id !== deleteTarget.value!.id)
     showDeleteConfirm.value = false
     toast.success("评测镜像已删除")
   } catch (err: unknown) {
-    const apiErr = err as { data?: { error?: string }; message?: string } | undefined
-    formError.value = apiErr?.data?.error || apiErr?.message || "删除失败"
+    formError.value = extractApiError(err).message
   } finally {
     deleting.value = false
   }

--- a/noj-ui/pages/admin/problem-edit/[id].vue
+++ b/noj-ui/pages/admin/problem-edit/[id].vue
@@ -21,7 +21,7 @@ function onSaved() {
       返回题目列表
     </NuxtLink>
 
-    <h1 class="text-[22px] font-bold text-text m-0">编辑题目</h1>
+    <h1 class="text-22px font-bold text-text m-0">编辑题目</h1>
 
     <ProblemEditor mode="edit" :problem-id="problemId" @saved="onSaved" />
   </div>

--- a/noj-ui/pages/admin/problem-new.vue
+++ b/noj-ui/pages/admin/problem-new.vue
@@ -18,7 +18,7 @@ function onSaved() {
       返回题目列表
     </NuxtLink>
 
-    <h1 class="text-[22px] font-bold text-text m-0">创建题目</h1>
+    <h1 class="text-22px font-bold text-text m-0">创建题目</h1>
 
     <ProblemEditor mode="create" initial-type="P" @saved="onSaved" />
   </div>

--- a/noj-ui/pages/admin/problems.vue
+++ b/noj-ui/pages/admin/problems.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useToast } from "~/composables/useToast"
 import { useDialog } from "~/composables/useDialog"
+import { extractApiError } from '~/utils/apiError'
 
 definePageMeta({
   layout: "admin",
@@ -25,6 +26,8 @@ interface Problem {
   categories: { id: string; name: string }[]
   created_at: string
 }
+
+const { api } = useApi()
 
 const problems = ref<Problem[]>([])
 const tableLoading = ref(true)
@@ -65,15 +68,16 @@ async function loadProblems(page = 1) {
   tableError.value = ""
   currentPage.value = page
   try {
-    const res = await $fetch<{ data: Problem[]; total: number; page: number; limit: number }>(
+    const res = await api.get<{ data: Problem[]; total: number; page: number; limit: number }>(
       `/api/v1/problems?page=${page}&limit=${perPage}`,
+      { silent: true },
     )
     if (currentRequest !== requestVersion) return
     problems.value = res.data
     totalPages.value = Math.ceil(res.total / perPage)
   } catch (err: unknown) {
     if (currentRequest !== requestVersion) return
-    tableError.value = err instanceof Error ? err.message : "加载题目列表失败"
+    tableError.value = extractApiError(err).message
   } finally {
     if (currentRequest === requestVersion) tableLoading.value = false
   }
@@ -104,9 +108,7 @@ async function handleDelete() {
   deleting.value = true
   deleteError.value = ""
   try {
-    await $fetch(`/api/v1/problems/${deleteTarget.value.id}`, {
-      method: "DELETE",
-    })
+    await api.delete(`/api/v1/problems/${deleteTarget.value.id}`)
     showDeleteConfirm.value = false
     // 如果当前页只有这一个题目，删除后自动回到上一页
     if (problems.value.length <= 1 && currentPage.value > 1) {
@@ -115,7 +117,7 @@ async function handleDelete() {
       await loadProblems(currentPage.value)
     }
   } catch (err: unknown) {
-    deleteError.value = err instanceof Error ? err.message : "删除失败"
+    deleteError.value = extractApiError(err).message
   } finally {
     deleting.value = false
   }
@@ -135,20 +137,14 @@ async function batchRejudge(problemId: string) {
 
   rejudgingProblemIds.value = new Set(rejudgingProblemIds.value).add(problemId)
   try {
-    const res = await $fetch<{ message: string; total: number; queued: number; skipped: number }>(
+    const res = await api.post<{ message: string; total: number; queued: number; skipped: number }>(
       `/api/v1/admin/problems/${problemId}/rejudge`,
-      { method: "POST" },
     )
     toast.showToast(
       "success",
       `批量重测共 ${res.total} 条，已入队 ${res.queued} 条${res.skipped > 0 ? `，未入队 ${res.skipped} 条` : ""}`,
     )
     loadProblems(currentPage.value)
-  } catch (err: unknown) {
-    toast.showToast(
-      "error",
-      err instanceof Error ? err.message : "批量重测失败",
-    )
   } finally {
     const next = new Set(rejudgingProblemIds.value)
     next.delete(problemId)

--- a/noj-ui/pages/admin/problems.vue
+++ b/noj-ui/pages/admin/problems.vue
@@ -161,7 +161,7 @@ async function batchRejudge(problemId: string) {
   <div class="flex flex-col gap-4">
     <PageHeader title="题目管理" description="管理所有题目">
       <template #actions>
-        <NuxtLink to="/admin/problem-new" class="inline-flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer no-underline transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark">
+        <NuxtLink to="/admin/problem-new" class="inline-flex items-center gap-1.5 px-4 py-2 text-13px font-semibold bg-primary text-white border-[1.5px] border-primary rounded-md cursor-pointer no-underline transition-all duration-150 hover:bg-primary-dark hover:border-primary-dark">
           <UIcon name="i-lucide-plus" class="size-4" />
           创建题目
         </NuxtLink>
@@ -205,7 +205,7 @@ async function batchRejudge(problemId: string) {
   <!-- 删除确认 -->
   <UModal v-model:open="showDeleteConfirm" :title="'删除题目'" :unmount-on-hide="true">
     <p>确定要删除题目 <strong>{{ deleteTarget?.title }}</strong>（{{ deleteTarget?.id }}）吗？此操作不可撤销，相关提交记录也会被级联删除。</p>
-    <p v-if="deleteError" class="mt-2 text-error-text text-[13px]">{{ deleteError }}</p>
+    <p v-if="deleteError" class="mt-2 text-error-text text-13px">{{ deleteError }}</p>
   
     <template #footer>
       <UButton color="neutral" variant="ghost" :disabled="deleting" @click="showDeleteConfirm = false">取消</UButton>

--- a/noj-ui/pages/admin/roles.vue
+++ b/noj-ui/pages/admin/roles.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { extractApiError } from '~/utils/apiError'
+
 definePageMeta({
   layout: "admin",
   middleware: "admin",
@@ -36,6 +38,8 @@ interface PermissionGroup {
   resource: string
   items: Permission[]
 }
+
+const { api } = useApi()
 
 const roles = ref<Role[]>([])
 const permissions = ref<Permission[]>([])
@@ -82,14 +86,13 @@ async function loadRoles() {
   tableError.value = ""
   try {
     const [rolesRes, permsRes] = await Promise.all([
-      $fetch<{ data: Role[] }>("/api/v1/admin/roles"),
-      $fetch<{ data: Permission[] }>("/api/v1/admin/permissions"),
+      api.get<{ data: Role[] }>("/api/v1/admin/roles", { silent: true }),
+      api.get<{ data: Permission[] }>("/api/v1/admin/permissions", { silent: true }),
     ])
     roles.value = rolesRes.data
     permissions.value = permsRes.data
   } catch (err: unknown) {
-    const apiErr = err as { data?: { error?: string }; message?: string } | undefined
-    tableError.value = apiErr?.data?.error || apiErr?.message || "加载角色列表失败"
+    tableError.value = extractApiError(err).message
   } finally {
     tableLoading.value = false
   }
@@ -167,21 +170,14 @@ async function handleSave() {
       permission_ids: Array.from(editorPermissionIds.value),
     }
     if (editingRole.value) {
-      await $fetch(`/api/v1/admin/roles/${editingRole.value.id}`, {
-        method: "PUT",
-        body,
-      })
+      await api.put(`/api/v1/admin/roles/${editingRole.value.id}`, body)
     } else {
-      await $fetch("/api/v1/admin/roles", {
-        method: "POST",
-        body,
-      })
+      await api.post("/api/v1/admin/roles", body)
     }
     showEditor.value = false
     await loadRoles()
   } catch (err: unknown) {
-    const apiErr = err as { data?: { error?: string }; message?: string } | undefined
-    editorError.value = apiErr?.data?.error || apiErr?.message || "保存失败"
+    editorError.value = extractApiError(err).message
   } finally {
     saving.value = false
   }
@@ -203,11 +199,10 @@ async function confirmDelete(role: Role) {
   deletingId.value = role.id
   deleteError.value = ""
   try {
-    await $fetch(`/api/v1/admin/roles/${role.id}`, { method: "DELETE" })
+    await api.delete(`/api/v1/admin/roles/${role.id}`)
     await loadRoles()
   } catch (err: unknown) {
-    const apiErr = err as { data?: { error?: string }; message?: string } | undefined
-    deleteError.value = apiErr?.data?.error || apiErr?.message || "删除失败"
+    deleteError.value = extractApiError(err).message
   } finally {
     deletingId.value = null
   }

--- a/noj-ui/pages/admin/roles.vue
+++ b/noj-ui/pages/admin/roles.vue
@@ -370,10 +370,10 @@ async function confirmDelete(role: Role) {
         class="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800"
       >
         <UIcon name="i-lucide-alert-triangle" class="shrink-0 mt-0.5 size-4.5" />
-        <span>⚠️ 管理员角色隐式拥有所有权限，无需单独配置</span>
+        <span>管理员角色隐式拥有所有权限，无需单独配置</span>
       </div>
 
-      <p v-if="editorError" class="text-[13px] text-error-text">{{ editorError }}</p>
+      <p v-if="editorError" class="text-13px text-error-text">{{ editorError }}</p>
     </div>
   
     <template #footer>

--- a/noj-ui/pages/admin/settings.vue
+++ b/noj-ui/pages/admin/settings.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { extractApiError } from '~/utils/apiError'
+
 definePageMeta({
   layout: "admin",
   middleware: "admin",
@@ -55,6 +57,8 @@ const CATEGORY_LABEL: Record<SettingCategory, string> = {
   other: "其他",
 }
 
+const { api } = useApi()
+
 // ─── 数据加载 ────────────────────────────────────────────
 
 const settings = ref<SystemSetting[]>([])
@@ -68,8 +72,9 @@ async function loadSettings() {
   tableLoading.value = true
   tableError.value = ""
   try {
-    const res = await $fetch<{ data: SystemSetting[] }>(
+    const res = await api.get<{ data: SystemSetting[] }>(
       "/api/v1/admin/settings",
+      { silent: true },
     )
     if (currentRequest !== requestVersion) return
     settings.value = res.data
@@ -80,9 +85,7 @@ async function loadSettings() {
     }
   } catch (err: unknown) {
     if (currentRequest !== requestVersion) return
-    tableError.value = err instanceof Error
-      ? err.message
-      : "加载系统设置失败"
+    tableError.value = extractApiError(err).message
   } finally {
     if (currentRequest === requestVersion) tableLoading.value = false
   }
@@ -189,9 +192,8 @@ async function saveSetting(key: string) {
   if (savingKeys.value.has(key)) return
   savingKeys.value = new Set(savingKeys.value).add(key)
   try {
-    const res = await $fetch<{ data: SystemSetting }>(`/api/v1/admin/settings/${key}`, {
-      method: "PUT",
-      body: { value: drafts.value[key] },
+    const res = await api.put<{ data: SystemSetting }>(`/api/v1/admin/settings/${key}`, {
+      value: drafts.value[key],
     })
     applySetting(res.data)
     // 检查是否需要重启生效
@@ -201,8 +203,6 @@ async function saveSetting(key: string) {
     } else {
       toast.success("设置已保存")
     }
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "保存失败")
   } finally {
     const next = new Set(savingKeys.value)
     next.delete(key)
@@ -231,15 +231,11 @@ async function confirmReset(s: SystemSetting) {
   if (resettingKeys.value.has(s.key)) return
   resettingKeys.value = new Set(resettingKeys.value).add(s.key)
   try {
-    await $fetch(`/api/v1/admin/settings/${s.key}`, {
-      method: "DELETE",
-    })
-    const res = await $fetch<{ data: SystemSetting[] }>("/api/v1/admin/settings")
+    await api.delete(`/api/v1/admin/settings/${s.key}`)
+    const res = await api.get<{ data: SystemSetting[] }>("/api/v1/admin/settings")
     const updated = res.data.find((item) => item.key === s.key)
     if (updated) applySetting(updated)
     toast.success(`已重置 ${s.key}`)
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "重置失败")
   } finally {
     const next = new Set(resettingKeys.value)
     next.delete(s.key)

--- a/noj-ui/pages/admin/settings.vue
+++ b/noj-ui/pages/admin/settings.vue
@@ -255,7 +255,7 @@ async function confirmReset(s: SystemSetting) {
     <PageHeader title="系统设置" description="运行时可改的配置项，修改即时生效；只读配置需重启服务" />
 
     <!-- 顶部提示横幅 -->
-    <div class="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-md text-[13px] text-info-text">
+    <div class="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-md text-13px text-info-text">
       <UIcon name="i-lucide-info" class="size-4 shrink-0 mt-0.5" />
       <div>
         <strong>运行时可改：</strong>第一组设置项写入数据库，下次请求立即生效，可随时重置。
@@ -268,7 +268,7 @@ async function confirmReset(s: SystemSetting) {
     <!-- 错误条 -->
     <div
       v-if="tableError"
-      class="p-3 bg-red-50 border border-red-200 rounded-md text-[13px] text-error-text"
+      class="p-3 bg-red-50 border border-red-200 rounded-md text-13px text-error-text"
     >
       {{ tableError }}
       <UButton size="xs" color="primary" variant="ghost" @click="loadSettings">重试</UButton>
@@ -287,7 +287,7 @@ async function confirmReset(s: SystemSetting) {
         <p class="text-xs text-text-secondary mt-1">
           修改后点击行内「保存」按钮，写入数据库；点击「重置」恢复 env / 默认值
         </p>
-        <p class="text-[11px] text-text-muted mt-0.5">
+        <p class="text-11px text-text-muted mt-0.5">
           读取优先级：<span class="font-semibold">DB 写入值</span> → env 值（.env） → 系统默认值。
           带 <UIcon name="i-lucide-refresh-cw" class="size-3 inline -mt-0.5 text-warning-text" /> 标记的项保存后需要重启 noj-core 服务才能生效。
         </p>
@@ -317,8 +317,8 @@ async function confirmReset(s: SystemSetting) {
             <!-- 设置项 key + 类型 -->
             <td class="px-3 py-3 align-top">
               <div class="flex flex-col gap-0.5">
-                <code class="font-mono text-[13px] font-semibold text-text">{{ s.key }}</code>
-                <span class="text-[11px] text-text-secondary">{{ s.type }}</span>
+                <code class="font-mono text-13px font-semibold text-text">{{ s.key }}</code>
+                <span class="text-11px text-text-secondary">{{ s.type }}</span>
               </div>
             </td>
 
@@ -334,7 +334,7 @@ async function confirmReset(s: SystemSetting) {
                   @update:model-value="(v) => drafts[s.key] = v"
                   color="primary"
                 />
-                <span class="text-[13px] font-mono">{{ drafts[s.key] ? "true" : "false" }}</span>
+                <span class="text-13px font-mono">{{ drafts[s.key] ? "true" : "false" }}</span>
               </div>
 
               <!-- string：Input -->
@@ -348,7 +348,7 @@ async function confirmReset(s: SystemSetting) {
                     v-model="drafts[s.key]"
                     :disabled="drafts[s.key] === null"
                     :placeholder="drafts[s.key] === null ? '•••••••• 点击「编辑」以修改' : ''"
-                    class="w-full px-2.5 py-1.5 text-[13px] font-mono border border-border rounded outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)] disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="w-full px-2.5 py-1.5 text-13px font-mono border border-border rounded outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)] disabled:opacity-50 disabled:cursor-not-allowed"
                   />
                   <UButton v-if="drafts[s.key] === null" size="xs" color="primary" variant="outline" @click="drafts[s.key] = ''">编辑</UButton>
                 </template>
@@ -356,7 +356,7 @@ async function confirmReset(s: SystemSetting) {
                 <input
                   v-else
                   v-model="drafts[s.key]"
-                  class="w-full px-2.5 py-1.5 text-[13px] font-mono border border-border rounded outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+                  class="w-full px-2.5 py-1.5 text-13px font-mono border border-border rounded outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
                 />
               </div>
 
@@ -366,7 +366,7 @@ async function confirmReset(s: SystemSetting) {
                 v-model="drafts[s.key]"
                 rows="2"
                 maxlength="1000"
-                class="w-full px-2.5 py-1.5 text-[13px] border border-border rounded outline-none transition-colors resize-y focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+                class="w-full px-2.5 py-1.5 text-13px border border-border rounded outline-none transition-colors resize-y focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
               />
 
               <!-- integer：number input -->
@@ -377,14 +377,14 @@ async function confirmReset(s: SystemSetting) {
                 step="1"
                 :min="s.min"
                 :max="s.max"
-                class="w-full px-2.5 py-1.5 text-[13px] font-mono border border-border rounded outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+                class="w-full px-2.5 py-1.5 text-13px font-mono border border-border rounded outline-none transition-colors focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
               />
             </td>
 
             <!-- 来源标签 -->
             <td class="px-3 py-3 align-top">
               <span
-                class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-semibold"
+                class="inline-flex items-center px-2 py-0.5 rounded text-11px font-semibold"
                 :class="{
                   'bg-blue-50 text-info-text': s.source === 'db',
                   'bg-gray-100 text-text-secondary': s.source !== 'db',
@@ -395,10 +395,10 @@ async function confirmReset(s: SystemSetting) {
             </td>
 
             <!-- 描述 -->
-            <td class="px-3 py-3 align-top text-[13px] text-text-secondary">
+            <td class="px-3 py-3 align-top text-13px text-text-secondary">
               <div class="flex flex-col gap-1">
                 <span>{{ s.description }}</span>
-                <span v-if="s.needsRestart" class="inline-flex items-center gap-0.5 text-[11px] font-semibold text-warning-text">
+                <span v-if="s.needsRestart" class="inline-flex items-center gap-0.5 text-11px font-semibold text-warning-text">
                   <UIcon name="i-lucide-refresh-cw" class="size-3" /> 需重启生效
                 </span>
               </div>
@@ -452,7 +452,7 @@ async function confirmReset(s: SystemSetting) {
         </summary>
 
         <!-- 顶部提示文字（spec 要求） -->
-        <div class="flex items-start gap-2 px-5 py-3 bg-blue-50 border-b border-blue-100 text-[13px] text-info-text">
+        <div class="flex items-start gap-2 px-5 py-3 bg-blue-50 border-b border-blue-100 text-13px text-info-text">
           <UIcon name="i-lucide-info" class="size-3.5 shrink-0 mt-0.5" />
           <div>
             修改这些项需要更新 .env 并重启 noj-core 服务。当前展示的是已
@@ -471,14 +471,14 @@ async function confirmReset(s: SystemSetting) {
           :loading="false"
         >
           <template #key-cell="{ row }">
-            <code class="font-mono text-[13px] text-text">{{ row.key }}</code>
+            <code class="font-mono text-13px text-text">{{ row.key }}</code>
           </template>
           <template #effective_value-cell="{ row }">
             <UTooltip v-if="row.is_secret" :text="getSecretTooltip(row.key)" class="cursor-help">
               <span class="inline-flex items-center gap-1">
                 <UIcon name="i-lucide-lock" class="size-3 shrink-0 text-amber-700" />
                 <code
-                  class="font-mono text-[13px] px-2 py-0.5 rounded underline decoration-dotted underline-offset-2 bg-amber-50 text-amber-800"
+                  class="font-mono text-13px px-2 py-0.5 rounded underline decoration-dotted underline-offset-2 bg-amber-50 text-amber-800"
                 >
                   {{ String(row.effective_value) }}
                 </code>
@@ -486,13 +486,13 @@ async function confirmReset(s: SystemSetting) {
             </UTooltip>
             <code
               v-else
-              class="font-mono text-[13px] px-2 py-0.5 rounded bg-gray-50 text-text"
+              class="font-mono text-13px px-2 py-0.5 rounded bg-gray-50 text-text"
             >
               {{ String(row.effective_value) }}
             </code>
           </template>
           <template #description-cell="{ row }">
-            <span class="text-[13px] text-text-secondary">{{ row.description }}</span>
+            <span class="text-13px text-text-secondary">{{ row.description }}</span>
           </template>
         </UTable>
       </details>

--- a/noj-ui/pages/admin/submissions.vue
+++ b/noj-ui/pages/admin/submissions.vue
@@ -10,6 +10,7 @@ import {
 } from "~/composables/use-submissions"
 import { useToast } from "~/composables/useToast"
 import { useDialog } from "~/composables/useDialog"
+import { extractApiError } from '~/utils/apiError'
 
 definePageMeta({
   layout: "admin",
@@ -23,6 +24,8 @@ const router = useRouter()
 watch(loading, (val) => {
   if (!val && !isLoggedIn.value) router.replace("/login")
 }, { immediate: true })
+
+const { api } = useApi()
 
 const submissions = ref<SubmissionListItem[]>([])
 const tableLoading = ref(true)
@@ -113,15 +116,16 @@ async function loadSubmissions(page = 1) {
   tableError.value = ""
   currentPage.value = page
   try {
-    const res = await $fetch<{ data: SubmissionListItem[]; pagination: { total: number; total_pages: number } }>(
+    const res = await api.get<{ data: SubmissionListItem[]; pagination: { total: number; total_pages: number } }>(
       `/api/v1/admin/submissions?${buildQuery(page)}`,
+      { silent: true },
     )
     if (currentRequest !== requestVersion) return
     submissions.value = res.data
     totalPages.value = res.pagination.total_pages
   } catch (err: unknown) {
     if (currentRequest !== requestVersion) return
-    tableError.value = err instanceof Error ? err.message : "加载提交记录失败"
+    tableError.value = extractApiError(err).message
   } finally {
     if (currentRequest === requestVersion) tableLoading.value = false
   }
@@ -171,16 +175,9 @@ async function rejudge(submissionId: string) {
 
   rejudgingIds.value = new Set(rejudgingIds.value).add(submissionId)
   try {
-    await $fetch(`/api/v1/admin/submissions/${submissionId}/rejudge`, {
-      method: "POST",
-    })
+    await api.post(`/api/v1/admin/submissions/${submissionId}/rejudge`)
     toast.showToast("success", "重测任务已提交")
     loadSubmissions(currentPage.value)
-  } catch (err: unknown) {
-    toast.showToast(
-      "error",
-      err instanceof Error ? err.message : "重测失败",
-    )
   } finally {
     const next = new Set(rejudgingIds.value)
     next.delete(submissionId)

--- a/noj-ui/pages/admin/submissions.vue
+++ b/noj-ui/pages/admin/submissions.vue
@@ -200,7 +200,7 @@ async function rejudge(submissionId: string) {
           <label class="text-xs font-semibold text-text-secondary">题目</label>
           <input
             v-model="filters.problem_search"
-            class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+            class="px-2.5 py-1.5 text-13px border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
             placeholder="题目 ID 或名称"
             @keyup.enter="applyFilters"
           />
@@ -209,7 +209,7 @@ async function rejudge(submissionId: string) {
           <label class="text-xs font-semibold text-text-secondary">用户</label>
           <input
             v-model="filters.user_search"
-            class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+            class="px-2.5 py-1.5 text-13px border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
             placeholder="用户名或用户 ID"
             @keyup.enter="applyFilters"
           />
@@ -218,14 +218,14 @@ async function rejudge(submissionId: string) {
           <label class="text-xs font-semibold text-text-secondary">提交 ID</label>
           <input
             v-model="filters.submission_id"
-            class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
+            class="px-2.5 py-1.5 text-13px border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]"
             placeholder="提交 ID 前缀"
             @keyup.enter="applyFilters"
           />
         </div>
         <div class="flex flex-col gap-1 min-w-[140px] flex-1">
           <label class="text-xs font-semibold text-text-secondary">语言</label>
-          <select v-model="filters.language" class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" @change="applyFilters">
+          <select v-model="filters.language" class="px-2.5 py-1.5 text-13px border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" @change="applyFilters">
             <option v-for="opt in languageOptions" :key="opt.value" :value="opt.value">
               {{ opt.label }}
             </option>
@@ -233,7 +233,7 @@ async function rejudge(submissionId: string) {
         </div>
         <div class="flex flex-col gap-1 min-w-[140px] flex-1">
           <label class="text-xs font-semibold text-text-secondary">状态</label>
-          <select v-model="filters.status" class="px-2.5 py-1.5 text-[13px] border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" @change="applyFilters">
+          <select v-model="filters.status" class="px-2.5 py-1.5 text-13px border border-border rounded outline-none bg-white transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" @change="applyFilters">
             <option v-for="opt in statusOptions" :key="opt.value" :value="opt.value">
               {{ opt.label }}
             </option>

--- a/noj-ui/pages/admin/users.vue
+++ b/noj-ui/pages/admin/users.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useAdminList } from "~/composables/useAdminList"
+import { extractApiError } from '~/utils/apiError'
 
 definePageMeta({
   layout: "admin",
@@ -13,6 +14,8 @@ const router = useRouter()
 watch(loading, (val) => {
   if (!val && !isLoggedIn.value) router.replace("/login")
 }, { immediate: true })
+
+const { api } = useApi()
 
 interface User {
   id: string
@@ -72,7 +75,7 @@ const selectedRoleIds = ref<string[]>([])
 
 async function loadRoles() {
   try {
-    const res = await $fetch<{ data: Role[] }>("/api/v1/admin/roles")
+    const res = await api.get<{ data: Role[] }>("/api/v1/admin/roles", { silent: true })
     allRoles.value = res.data
   } catch {
     // 角色加载失败不影响用户列表
@@ -101,14 +104,13 @@ async function handleRoleSwitch() {
   switchingRole.value = true
   switchError.value = ""
   try {
-    await $fetch(`/api/v1/admin/users/${targetUser.value.id}/role`, {
-      method: "PATCH",
-      body: { role_ids: selectedRoleIds.value },
+    await api.patch(`/api/v1/admin/users/${targetUser.value.id}/role`, {
+      role_ids: selectedRoleIds.value,
     })
     showRoleModal.value = false
     await loadUsers(currentPage.value)
   } catch (err: unknown) {
-    switchError.value = err instanceof Error ? err.message : "操作失败"
+    switchError.value = extractApiError(err).message
   } finally {
     switchingRole.value = false
   }
@@ -136,19 +138,16 @@ async function handleBan() {
   banning.value = true
   banError.value = ""
   try {
-    await $fetch(`/api/v1/admin/users/${banTarget.value.id}/ban`, {
-      method: "PATCH",
-      body: {
-        reason: banForm.reason.trim() || undefined,
-        banned_until: banForm.banned_until
-          ? new Date(banForm.banned_until).toISOString()
-          : null,
-      },
+    await api.patch(`/api/v1/admin/users/${banTarget.value.id}/ban`, {
+      reason: banForm.reason.trim() || undefined,
+      banned_until: banForm.banned_until
+        ? new Date(banForm.banned_until).toISOString()
+        : null,
     })
     showBanModal.value = false
     toast.success(`已封禁 ${banTarget.value.username}`)
   } catch (err: unknown) {
-    banError.value = err instanceof Error ? err.message : "封禁失败"
+    banError.value = extractApiError(err).message
     banning.value = false
     return
   }
@@ -169,10 +168,9 @@ async function confirmUnban(user: User) {
   if (!ok) return
   banning.value = true
   try {
-    await $fetch(`/api/v1/admin/users/${user.id}/unban`, { method: "PATCH" })
+    await api.patch(`/api/v1/admin/users/${user.id}/unban`)
     toast.success(`已解封 ${user.username}`)
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "解封失败")
+  } catch {
     banning.value = false
     return
   }
@@ -218,12 +216,13 @@ async function showBanHistory(user: User) {
   historyLoading.value = true
   showHistoryModal.value = true
   try {
-    const res = await $fetch<{ data: BanRecord[] }>(
+    const res = await api.get<{ data: BanRecord[] }>(
       `/api/v1/admin/users/${user.id}/bans`,
+      { silent: true },
     )
     historyRecords.value = res.data
   } catch (err: unknown) {
-    historyError.value = err instanceof Error ? err.message : "加载封禁历史失败"
+    historyError.value = extractApiError(err).message
   } finally {
     historyLoading.value = false
   }

--- a/noj-ui/pages/admin/users.vue
+++ b/noj-ui/pages/admin/users.vue
@@ -334,7 +334,7 @@ async function showBanHistory(user: User) {
         </div>
       </label>
     </div>
-    <p v-if="switchError" class="mt-2 text-error-text text-[13px]">{{ switchError }}</p>
+    <p v-if="switchError" class="mt-2 text-error-text text-13px">{{ switchError }}</p>
   
     <template #footer>
       <UButton color="neutral" variant="ghost" :disabled="switchingRole" @click="showRoleModal = false">取消</UButton>
@@ -363,7 +363,7 @@ async function showBanHistory(user: User) {
         />
         <p class="mt-1 text-[12px] text-text-secondary">留空表示永久封禁</p>
       </div>
-      <p v-if="banError" class="text-[13px] text-error-text">{{ banError }}</p>
+      <p v-if="banError" class="text-13px text-error-text">{{ banError }}</p>
     </div>
   
     <template #footer>

--- a/noj-ui/pages/change-password.vue
+++ b/noj-ui/pages/change-password.vue
@@ -104,6 +104,7 @@
 
 <script setup lang="ts">
 import { validatePassword, validatePasswordMatch } from "~/utils/validatePassword"
+import { extractApiError } from "~/utils/apiError"
 
 definePageMeta({ layout: "auth" })
 
@@ -195,8 +196,8 @@ async function handleSubmit() {
         // 无需再走 /login，直接回首页即可。
         showToast("success", "密码修改成功")
         router.replace("/settings")
-    } catch (e: any) {
-        setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.response?.status || e.statusCode || e.status || 502}`)
+    } catch (e: unknown) {
+        setError(extractApiError(e).message)
     } finally {
         loading.value = false
     }

--- a/noj-ui/pages/change-password.vue
+++ b/noj-ui/pages/change-password.vue
@@ -1,13 +1,8 @@
 <template>
     <div class="w-full max-w-[380px] relative">
-        <Transition name="slide">
-            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ error }}</span>
-                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
-            </div>
-        </Transition>
+        <ToastBanner :visible="!!error" color="error" icon="i-lucide-alert-circle" :message="error" @close="clearError" />
         <div class="bg-white border border-border rounded-lg p-8">
-            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">修改密码</h1>
+            <h1 class="text-22px font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">修改密码</h1>
 
             <form @submit.prevent="handleSubmit">
                 <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
@@ -34,7 +29,7 @@
                         </button>
                     </div>
                     <Transition name="drop">
-                        <div v-if="fieldErrors.oldPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.oldPassword }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
+                        <div v-if="fieldErrors.oldPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-13px text-red-700"><span>{{ fieldErrors.oldPassword }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
                     </Transition>
                 </div>
 
@@ -62,7 +57,7 @@
                         </button>
                     </div>
                     <Transition name="drop">
-                        <div v-if="fieldErrors.newPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.newPassword }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
+                        <div v-if="fieldErrors.newPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-13px text-red-700"><span>{{ fieldErrors.newPassword }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
                     </Transition>
                 </div>
 
@@ -90,7 +85,7 @@
                         </button>
                     </div>
                     <Transition name="drop">
-                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
+                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-13px text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
                     </Transition>
                 </div>
 

--- a/noj-ui/pages/community/bookmarks.vue
+++ b/noj-ui/pages/community/bookmarks.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { BookmarkRow, PostType } from "~/composables/useCommunity"
 import { stripMarkdown } from "~/utils/markdown"
+import { extractApiError } from "~/utils/apiError"
 
 definePageMeta({ middleware: "auth" })
 
@@ -18,6 +19,7 @@ const nextCursor = ref<string | null>(null)
 const removingId = ref<string | null>(null)
 const { toast } = useToast()
 const { dialog } = useDialog()
+const { api } = useApi()
 
 async function loadBookmarks(reset = true, cursor?: string | null) {
   if (reset) {
@@ -28,14 +30,14 @@ async function loadBookmarks(reset = true, cursor?: string | null) {
   }
   error.value = ""
   try {
-    const result = await $fetch<{ data: BookmarkRow[]; next_cursor: string | null }>(
+    const result = await api.get<{ data: BookmarkRow[]; next_cursor: string | null }>(
       "/api/v1/community/bookmarks",
-      { query: { cursor: cursor ?? undefined } },
+      { query: { cursor: cursor ?? undefined }, silent: true },
     )
     bookmarks.value = reset ? result.data : [...bookmarks.value, ...result.data]
     nextCursor.value = result.next_cursor ?? null
   } catch (err: unknown) {
-    error.value = err instanceof Error ? err.message : "加载收藏内容失败"
+    error.value = extractApiError(err).message
   } finally {
     loading.value = false
     loadingMore.value = false
@@ -56,11 +58,9 @@ async function removeBookmark(item: BookmarkRow) {
   if (!ok || removingId.value) return
   removingId.value = item.post.id
   try {
-    await $fetch(`/api/v1/community/posts/${item.post.id}/bookmark`, { method: "POST" })
+    await api.post(`/api/v1/community/posts/${item.post.id}/bookmark`)
     toast.success("已取消收藏")
     bookmarks.value = bookmarks.value.filter((b) => b.post.id !== item.post.id)
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "操作失败")
   } finally {
     removingId.value = null
   }

--- a/noj-ui/pages/community/index.vue
+++ b/noj-ui/pages/community/index.vue
@@ -6,12 +6,14 @@ import {
   type PostType,
 } from "~/composables/useCommunity"
 import { stripMarkdown } from "~/utils/markdown"
+import { extractApiError } from "~/utils/apiError"
 
 const { isLoggedIn } = useAuth()
 const route = useRoute()
 const router = useRouter()
 const { config, loadConfig } = useCommunity()
 const { toast } = useToast()
+const { api } = useApi()
 
 const ENABLED_TYPES: PostType[] = ["discussion", "solution", "moment"]
 const typeFlag: Record<PostType, keyof CommunityConfig> = {
@@ -95,7 +97,7 @@ async function loadPosts(reset = true, cursor?: string | null) {
   }
   error.value = ""
   try {
-    const result = await $fetch<{ data: PostRow[]; next_cursor: string | null }>(
+    const result = await api.get<{ data: PostRow[]; next_cursor: string | null }>(
       "/api/v1/community/posts",
       {
         query: {
@@ -104,12 +106,13 @@ async function loadPosts(reset = true, cursor?: string | null) {
           q: searchKeyword.value.trim() || undefined,
           cursor: cursor ?? undefined,
         },
+        silent: true,
       },
     )
     posts.value = reset ? result.data : [...posts.value, ...result.data]
     nextCursor.value = result.next_cursor ?? null
   } catch (err: unknown) {
-    error.value = err instanceof Error ? err.message : "加载社区内容失败"
+    error.value = extractApiError(err).message
   } finally {
     loading.value = false
     loadingMore.value = false
@@ -123,8 +126,9 @@ async function loadMore() {
 
 async function loadCounts() {
   try {
-    const result = await $fetch<{ data: CommunityCounts }>(
+    const result = await api.get<{ data: CommunityCounts }>(
       "/api/v1/community/posts/counts",
+      { silent: true },
     )
     counts.value = result.data
   } catch {
@@ -161,13 +165,12 @@ async function prepareEditor() {
   }
   if (activeType.value === "discussion" && boards.value.length === 0) {
     try {
-      const result = await $fetch<{ data: { id: string; name: string }[] }>(
+      const result = await api.get<{ data: { id: string; name: string }[] }>(
         "/api/v1/community/boards",
       )
       boards.value = result.data
       boardId.value = boards.value[0]?.id ?? ""
-    } catch (err: unknown) {
-      toast.error(err instanceof Error ? err.message : "加载讨论板块失败")
+    } catch {
       return
     }
   }
@@ -185,9 +188,9 @@ async function searchProblems() {
   const seq = ++problemSearchSeq
   problemSearching.value = true
   try {
-    const result = await $fetch<{ data: { items: { id: string; display_id: string; title: string }[] } }>(
+    const result = await api.get<{ data: { items: { id: string; display_id: string; title: string }[] } }>(
       "/api/v1/search",
-      { query: { q, type: "problem" } },
+      { query: { q, type: "problem" }, silent: true },
     )
     if (seq !== problemSearchSeq) return
     problemResults.value = result.data.items
@@ -239,9 +242,9 @@ async function publish() {
       }
       body.problem_id = pid
     }
-    const result = await $fetch<{ data: { status: string } }>(
+    const result = await api.post<{ data: { status: string } }>(
       "/api/v1/community/posts",
-      { method: "POST", body },
+      body,
     )
     toast.success(result.data.status === "pending" ? "内容已提交审核" : "发布成功")
     title.value = ""
@@ -250,8 +253,6 @@ async function publish() {
     problemQuery.value = ""
     showEditor.value = false
     await Promise.all([loadPosts(), loadCounts()])
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "发布失败")
   } finally {
     publishing.value = false
   }

--- a/noj-ui/pages/community/notifications.vue
+++ b/noj-ui/pages/community/notifications.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import type { NotificationRow } from "~/composables/useCommunity"
+import { extractApiError } from "~/utils/apiError"
 
 definePageMeta({ middleware: "auth" })
 
 const { toast } = useToast()
+const { api } = useApi()
 const { loadUnreadCount } = useCommunityNotifications()
 
 const notifications = ref<NotificationRow[]>([])
@@ -31,13 +33,13 @@ async function load(reset = true) {
   else loadingMore.value = true
   error.value = ""
   try {
-    const result = await $fetch<{ data: NotificationRow[] }>(
+    const result = await api.get<{ data: NotificationRow[] }>(
       "/api/v1/community/notifications",
-      { query: { limit: limit.value } },
+      { query: { limit: limit.value }, silent: true },
     )
     notifications.value = result.data
   } catch (err: unknown) {
-    error.value = err instanceof Error ? err.message : "加载通知失败"
+    error.value = extractApiError(err).message
   } finally {
     loading.value = false
     loadingMore.value = false
@@ -54,11 +56,9 @@ async function markAllRead() {
   if (markingRead.value || notifications.value.length === 0) return
   markingRead.value = true
   try {
-    await $fetch("/api/v1/community/notifications/read", { method: "POST" })
+    await api.post("/api/v1/community/notifications/read")
     toast.success("通知已标记为已读")
     await Promise.all([load(), loadUnreadCount()])
-  } catch (error: unknown) {
-    toast.error(error instanceof Error ? error.message : "操作失败")
   } finally {
     markingRead.value = false
   }
@@ -74,7 +74,7 @@ async function handleClick(item: NotificationRow) {
   // 点击即标记单条已读，不阻塞跳转
   if (!item.notification.read_at) {
     try {
-      await $fetch(`/api/v1/community/notifications/${item.notification.id}/read`, { method: "POST" })
+      await api.post(`/api/v1/community/notifications/${item.notification.id}/read`, undefined, { silent: true })
       item.notification.read_at = new Date().toISOString()
       await loadUnreadCount()
     } catch {

--- a/noj-ui/pages/community/posts/[postId].vue
+++ b/noj-ui/pages/community/posts/[postId].vue
@@ -10,6 +10,7 @@ const { isLoggedIn, user } = useAuth()
 const { config, loadConfig } = useCommunity()
 const { toast } = useToast()
 const { dialog } = useDialog()
+const { api } = useApi()
 
 interface PostDetail {
   post: CommunityPost
@@ -72,8 +73,8 @@ function canEditComment(row: CommentRow): boolean {
 
 async function load() {
   const [postResult, commentResult] = await Promise.all([
-    $fetch<{ data: PostDetail }>(`/api/v1/community/posts/${postId.value}`),
-    $fetch<{ data: CommentRow[] }>(`/api/v1/community/posts/${postId.value}/comments`),
+    api.get<{ data: PostDetail }>(`/api/v1/community/posts/${postId.value}`),
+    api.get<{ data: CommentRow[] }>(`/api/v1/community/posts/${postId.value}/comments`),
   ])
   post.value = postResult.data
   comments.value = commentResult.data
@@ -84,10 +85,8 @@ async function toggle(kind: "like" | "bookmark", path: string) {
   if ((kind === "like" ? !canReact.value : !canBookmark.value) || interaction.value) return
   interaction.value = kind
   try {
-    await $fetch(path, { method: "POST" })
+    await api.post(path)
     await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "操作失败")
   } finally {
     interaction.value = null
   }
@@ -98,11 +97,9 @@ async function sendComment() {
   if (!content || !canComment.value || submittingComment.value) return
   submittingComment.value = true
   try {
-    await $fetch(`/api/v1/community/posts/${postId.value}/comments`, { method: "POST", body: { content } })
+    await api.post(`/api/v1/community/posts/${postId.value}/comments`, { content })
     comment.value = ""
     await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "评论失败")
   } finally {
     submittingComment.value = false
   }
@@ -117,15 +114,13 @@ async function sendReply(parentId: string) {
   if (!content || !canComment.value || submittingReply.value) return
   submittingReply.value = true
   try {
-    await $fetch(`/api/v1/community/posts/${postId.value}/comments`, {
-      method: "POST",
-      body: { content, parent_id: parentId },
+    await api.post(`/api/v1/community/posts/${postId.value}/comments`, {
+      content,
+      parent_id: parentId,
     })
     replyContent.value = ""
     replyingTo.value = null
     await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "回复失败")
   } finally {
     submittingReply.value = false
   }
@@ -134,16 +129,9 @@ async function sendReply(parentId: string) {
 async function saveEditComment(id: string, contentInput: string) {
   const content = contentInput.trim()
   if (!content) return
-  try {
-    await $fetch(`/api/v1/community/comments/${id}`, {
-      method: "PATCH",
-      body: { content },
-    })
-    toast.success("评论已更新")
-    await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "编辑失败")
-  }
+  await api.patch(`/api/v1/community/comments/${id}`, { content })
+  toast.success("评论已更新")
+  await load()
 }
 
 async function removeComment(id: string) {
@@ -153,13 +141,9 @@ async function removeComment(id: string) {
     confirmText: "删除",
   })
   if (!ok) return
-  try {
-    await $fetch(`/api/v1/community/comments/${id}`, { method: "DELETE" })
-    toast.success("评论已删除")
-    await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "删除失败")
-  }
+  await api.delete(`/api/v1/community/comments/${id}`)
+  toast.success("评论已删除")
+  await load()
 }
 
 function startEditPost() {
@@ -174,15 +158,10 @@ async function saveEditPost() {
   try {
     const body: Record<string, string | null> = { content: editContent.value }
     if (post.value?.post.type !== "moment") body.title = editTitle.value.trim() || null
-    await $fetch(`/api/v1/community/posts/${postId.value}`, {
-      method: "PATCH",
-      body,
-    })
+    await api.patch(`/api/v1/community/posts/${postId.value}`, body)
     toast.success("内容已更新")
     editingPost.value = false
     await load()
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "保存失败")
   } finally {
     savingPost.value = false
   }
@@ -194,13 +173,9 @@ async function deletePost() {
     confirmText: "删除",
   })
   if (!ok) return
-  try {
-    await $fetch(`/api/v1/community/posts/${postId.value}`, { method: "DELETE" })
-    toast.success("内容已删除")
-    navigateTo("/community")
-  } catch (err: unknown) {
-    toast.error(err instanceof Error ? err.message : "删除失败")
-  }
+  await api.delete(`/api/v1/community/posts/${postId.value}`)
+  toast.success("内容已删除")
+  navigateTo("/community")
 }
 
 await loadConfig()

--- a/noj-ui/pages/contests/[contestId]/index.vue
+++ b/noj-ui/pages/contests/[contestId]/index.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import type { Contest, ContestProblem } from '~/composables/useContests'
+import { extractApiError } from '~/utils/apiError'
 
 const route = useRoute()
 const contestId = route.params.contestId as string
 const { isLoggedIn } = useAuth()
 const toast = useToast()
+const { api } = useApi()
 const { typeLabels, statusLabels, formatDateTime, formatDuration, statusClass } = useContests()
 const password = ref('')
 const registering = ref(false)
@@ -37,11 +39,10 @@ async function loadProblems() {
   problemsLoading.value = true
   problemsError.value = ''
   try {
-    const response = await $fetch<{ data: ContestProblem[] }>(`/api/v1/contests/${contestId}/problems`)
+    const response = await api.get<{ data: ContestProblem[] }>(`/api/v1/contests/${contestId}/problems`, { silent: true })
     problems.value = response.data
   } catch (fetchError: unknown) {
-    const detail = fetchError as { data?: { error?: string }; message?: string }
-    problemsError.value = detail.data?.error || detail.message || '题目加载失败'
+    problemsError.value = extractApiError(fetchError).message
   } finally {
     problemsLoading.value = false
   }
@@ -57,16 +58,12 @@ async function register() {
   registering.value = true
   registerError.value = ''
   try {
-    await $fetch(`/api/v1/contests/${contestId}/register`, {
-      method: 'POST',
-      body: password.value ? { password: password.value } : undefined,
-    })
+    await api.post(`/api/v1/contests/${contestId}/register`, password.value ? { password: password.value } : undefined)
     toast.showToast('success', '报名成功')
     await refresh()
     await loadProblems()
   } catch (registerFailure: unknown) {
-    const detail = registerFailure as { data?: { error?: string }; message?: string }
-    registerError.value = detail.data?.error || detail.message || '报名失败'
+    registerError.value = extractApiError(registerFailure).message
   } finally {
     registering.value = false
   }

--- a/noj-ui/pages/contests/[contestId]/problems/[label].vue
+++ b/noj-ui/pages/contests/[contestId]/problems/[label].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Contest, ContestProblem } from '~/composables/useContests'
+import { extractApiError } from '~/utils/apiError'
 
 definePageMeta({ middleware: 'auth', ssr: false })
 
@@ -7,6 +8,7 @@ const route = useRoute()
 const contestId = route.params.contestId as string
 const label = route.params.label as string
 const toast = useToast()
+const { api } = useApi()
 const code = ref('')
 const language = ref('python3')
 const submitting = ref(false)
@@ -31,7 +33,7 @@ const submissions = ref<SubmissionItem[]>([])
 
 async function loadSubmissions() {
   try {
-    const response = await $fetch<{ data: SubmissionItem[] }>(`/api/v1/contests/${contestId}/my-submissions?per_page=100`)
+    const response = await api.get<{ data: SubmissionItem[] }>(`/api/v1/contests/${contestId}/my-submissions?per_page=100`, { silent: true })
     submissions.value = response.data.filter((item) => !problem.value || (item as SubmissionItem & { problem_id?: string }).problem_id === problem.value.problem_id)
   } catch {
     submissions.value = []
@@ -48,19 +50,15 @@ async function submit() {
   submitting.value = true
   submitError.value = ''
   try {
-    const response = await $fetch<{ data: { id: string } }>(`/api/v1/contests/${contestId}/submit`, {
-      method: 'POST',
-      body: {
-        problem_id: problem.value.problem_id,
-        language: language.value,
-        code: code.value,
-      },
+    const response = await api.post<{ data: { id: string } }>(`/api/v1/contests/${contestId}/submit`, {
+      problem_id: problem.value.problem_id,
+      language: language.value,
+      code: code.value,
     })
     toast.showToast('success', `提交成功：${response.data.id.slice(0, 8)}`)
     await loadSubmissions()
   } catch (submitFailure: unknown) {
-    const detail = submitFailure as { data?: { error?: string }; message?: string }
-    submitError.value = detail.data?.error || detail.message || '提交失败'
+    submitError.value = extractApiError(submitFailure).message
   } finally {
     submitting.value = false
   }

--- a/noj-ui/pages/contests/[contestId]/ranking.vue
+++ b/noj-ui/pages/contests/[contestId]/ranking.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import type { Contest, IcpcRankingRow, ScoreRankingRow } from '~/composables/useContests'
+import { extractApiError } from '~/utils/apiError'
 
 const route = useRoute()
 const contestId = route.params.contestId as string
 const { isLoggedIn } = useAuth()
+const { api } = useApi()
 const rows = ref<Array<IcpcRankingRow | ScoreRankingRow>>([])
 
 const { data: contestData, pending: contestPending } = await useFetch<{ data: Contest }>(
@@ -18,11 +20,10 @@ async function loadRanking() {
   rankingLoading.value = true
   rankingError.value = ''
   try {
-    const response = await $fetch<{ data: Array<IcpcRankingRow | ScoreRankingRow> }>(`/api/v1/contests/${contestId}/ranking`)
+    const response = await api.get<{ data: Array<IcpcRankingRow | ScoreRankingRow> }>(`/api/v1/contests/${contestId}/ranking`, { silent: true })
     rows.value = response.data
   } catch (fetchError: unknown) {
-    const detail = fetchError as { data?: { error?: string }; message?: string }
-    rankingError.value = detail.data?.error || detail.message || '排名加载失败'
+    rankingError.value = extractApiError(fetchError).message
   } finally {
     rankingLoading.value = false
   }

--- a/noj-ui/pages/editor/[id].vue
+++ b/noj-ui/pages/editor/[id].vue
@@ -268,13 +268,12 @@ function onCursorChange(pos: { line: number; col: number }) {
             enter-from-class="opacity-0 -translate-y-1"
             leave-to-class="opacity-0 -translate-y-1"
           >
-            <div
-              v-if="submitError"
-              class="flex items-center gap-2 px-4 py-2.5 bg-red-50 border-t border-red-200 text-red-800 text-xs"
-            >
-              <UIcon name="i-lucide-alert-circle" class="size-3.5" />
-              <span class="flex-1">{{ submitError }}</span>
-              <button class="text-red-600 hover:text-red-800" @click="submitError = ''">×</button>
+            <div v-if="submitError" class="border-t border-red-200">
+              <UAlert color="error" icon="i-lucide-alert-circle" :title="submitError" :close="true" class="rounded-none">
+                <template #close>
+                  <UButton color="neutral" variant="link" icon="i-lucide-x" aria-label="关闭" @click="submitError = ''" />
+                </template>
+              </UAlert>
             </div>
           </Transition>
 

--- a/noj-ui/pages/editor/[id].vue
+++ b/noj-ui/pages/editor/[id].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router'
 import { onMounted, nextTick } from 'vue'
+import { extractApiError } from '~/utils/apiError'
 
 definePageMeta({
   layout: false,
@@ -11,6 +12,7 @@ const route = useRoute()
 const router = useRouter()
 const problemId = computed(() => route.params.id as string)
 const { isLoggedIn } = useAuth()
+const { api } = useApi()
 
 // 主题
 const { theme, set: setTheme } = useEditorTheme()
@@ -98,13 +100,10 @@ async function handleSubmit() {
   submitting.value = true
   submitError.value = ''
   try {
-    const res = await $fetch<{ data: { id: string } }>('/api/v1/submissions', {
-      method: 'POST',
-      body: {
-        problem_id: problemId.value,
-        language: language.value,
-        code: code.value,
-      },
+    const res = await api.post<{ data: { id: string } }>('/api/v1/submissions', {
+      problem_id: problemId.value,
+      language: language.value,
+      code: code.value,
     })
     // 留在编辑页：自动切到历史 tab + 启动实时轮询
     sidebarTab.value = 'history'
@@ -113,8 +112,7 @@ async function handleSubmit() {
     // 轮询约 2s 后（judge 入队 + 评测完成），刷新历史列表把最近一条移入
     setTimeout(() => refreshSubmissionsFn(), 2000)
   } catch (err: unknown) {
-    const e = err as { data?: { error?: string }; message?: string }
-    submitError.value = e.data?.error || e.message || '提交失败，请稍后重试'
+    submitError.value = extractApiError(err).message
   } finally {
     submitting.value = false
   }
@@ -135,8 +133,9 @@ onMounted(async () => {
   templateLoading.value = true
   templateError.value = ''
   try {
-    const res = await $fetch<{ data: { content: string; language: string } }>(
+    const res = await api.get<{ data: { content: string; language: string } }>(
       `/api/v1/problems/${problemId.value}/template`,
+      { silent: true },
     )
     if (res?.data?.content && code.value.trim() === '') {
       code.value = res.data.content
@@ -145,7 +144,7 @@ onMounted(async () => {
     const err = e as { statusCode?: number; data?: { error?: string }; message?: string }
     // 404 是预期：题目无 submission.py 模板
     if (err.statusCode !== 404) {
-      templateError.value = err.data?.error || err.message || '加载模板失败'
+      templateError.value = extractApiError(e).message
     }
   } finally {
     templateLoading.value = false

--- a/noj-ui/pages/forgot-password.vue
+++ b/noj-ui/pages/forgot-password.vue
@@ -43,6 +43,8 @@
 </template>
 
 <script setup lang="ts">
+import { extractApiError } from "~/utils/apiError"
+
 definePageMeta({ layout: "auth" })
 
 const auth = useAuth()
@@ -74,8 +76,8 @@ async function handleSubmit() {
     submitted.value = true
     submittedEmail.value = email.value.trim()
     email.value = ""
-  } catch (e: any) {
-    setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
+  } catch (e: unknown) {
+    setError(extractApiError(e).message)
   } finally {
     loading.value = false
   }

--- a/noj-ui/pages/forgot-password.vue
+++ b/noj-ui/pages/forgot-password.vue
@@ -11,11 +11,13 @@
   >
     <!-- 成功 banner -->
     <template #banner-success>
-      <Transition name="slide">
-        <div v-if="submitted" class="bg-green-50 border border-green-200 text-green-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-center gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-          <span>密码重置链接已发送到 {{ submittedEmail }}，请检查邮箱（链接 15 分钟内有效）</span>
-        </div>
-      </Transition>
+      <ToastBanner
+        :visible="submitted"
+        color="success"
+        icon="i-lucide-mail-check"
+        :message="`密码重置链接已发送到 ${submittedEmail}，请检查邮箱（链接 15 分钟内有效）`"
+        @close="submitted = false"
+      />
     </template>
 
     <TextInput

--- a/noj-ui/pages/index.vue
+++ b/noj-ui/pages/index.vue
@@ -93,6 +93,7 @@
 
 <script setup lang="ts">
 const { user, isLoggedIn } = useAuth()
+const { api } = useApi()
 
 // ── Announcement Carousel ──
 interface Announcement {
@@ -176,7 +177,10 @@ const checkInLoaded = ref(false)
 async function fetchTodayCheckIn() {
     if (!isLoggedIn.value) return
     try {
-        const res = await $fetch<{ data: { checked_in: boolean; streak: number } }>("/api/v1/checkin/today")
+        const res = await api.get<{ data: { checked_in: boolean; streak: number } }>(
+            "/api/v1/checkin/today",
+            { silent: true },
+        )
         if (res.data) {
             checkedIn.value = res.data.checked_in
             streakCount.value = res.data.streak
@@ -199,9 +203,9 @@ async function handleCheckIn() {
     if (checkInLoading.value || checkedIn.value) return
     checkInLoading.value = true
     try {
-        const res = await $fetch<{ data: { checked_in: boolean; streak: number } }>("/api/v1/checkin", {
-            method: "POST",
-        })
+        const res = await api.post<{ data: { checked_in: boolean; streak: number } }>(
+            "/api/v1/checkin",
+        )
         if (res.data) {
             checkedIn.value = res.data.checked_in
             streakCount.value = res.data.streak

--- a/noj-ui/pages/index.vue
+++ b/noj-ui/pages/index.vue
@@ -4,7 +4,15 @@
             <div class="flex flex-col flex-1">
                 <div class="flex flex-col lg:flex-row flex-1 min-h-[320px] bg-white">
                     <!-- Carousel -->
-                    <div class="flex-1 min-w-0 relative overflow-hidden">
+                    <div
+                        class="flex-1 min-w-0 relative overflow-hidden"
+                        role="region"
+                        aria-roledescription="轮播图"
+                        aria-label="公告轮播"
+                        aria-live="off"
+                        @mouseenter="stopAuto"
+                        @mouseleave="() => { if (!paused) startAuto() }"
+                    >
                         <Transition name="carousel-fade">
                             <div
                                 :key="currentSlide"
@@ -15,15 +23,39 @@
                                 <p class="text-sm lg:text-base text-white/85 max-w-[480px] leading-relaxed animate-[slideInUp_0.6s_cubic-bezier(0.16,1,0.3,1)_150ms_both]">{{ announcements[currentSlide].description }}</p>
                             </div>
                         </Transition>
+                        <!-- 暂停/继续（WCAG 2.2.2 自动更新内容可暂停） -->
+                        <button
+                            v-if="!paused"
+                            type="button"
+                            class="absolute bottom-4 right-4 z-10 p-2 rounded-full bg-black/30 text-white hover:bg-black/50 transition-colors"
+                            aria-label="暂停轮播"
+                            @click="togglePause"
+                        >
+                            <UIcon name="i-lucide-pause" class="size-4" />
+                        </button>
+                        <button
+                            v-else
+                            type="button"
+                            class="absolute bottom-4 right-4 z-10 p-2 rounded-full bg-black/40 text-white hover:bg-black/60 transition-colors"
+                            aria-label="继续轮播"
+                            @click="togglePause"
+                        >
+                            <UIcon name="i-lucide-play" class="size-4" />
+                        </button>
                         <div class="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-1.5 z-10">
                             <button
                                 v-for="(_, i) in announcements"
                                 :key="i"
-                                class="size-2 rounded-full transition-all duration-300 cursor-pointer bg-white"
-                                :class="i === currentSlide ? 'opacity-100 scale-125' : 'opacity-50 hover:opacity-100'"
+                                class="p-2 -m-2 rounded-full transition-opacity cursor-pointer group"
                                 :aria-label="`切换到第 ${i + 1} 张`"
+                                :aria-current="i === currentSlide"
                                 @click="goToSlide(i)"
-                            />
+                            >
+                                <span
+                                    class="block size-2 rounded-full transition-all duration-300 bg-white"
+                                    :class="i === currentSlide ? 'opacity-100 scale-125' : 'opacity-50 group-hover:opacity-100'"
+                                />
+                            </button>
                         </div>
                     </div>
 
@@ -88,10 +120,12 @@ const announcements: Announcement[] = [
 ]
 
 const currentSlide = ref(0)
+const paused = ref(false)
 let autoTimer: ReturnType<typeof setInterval> | null = null
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 function startAuto() {
+    if (paused.value) return
     stopAuto()
     autoTimer = setInterval(() => {
         currentSlide.value = (currentSlide.value + 1) % announcements.length
@@ -103,6 +137,12 @@ function stopAuto() {
         clearInterval(autoTimer)
         autoTimer = null
     }
+}
+
+function togglePause() {
+    paused.value = !paused.value
+    if (paused.value) stopAuto()
+    else startAuto()
 }
 
 function goToSlide(i: number) {
@@ -195,7 +235,7 @@ const todayTimeStr = computed(() => new Date(now.value).toLocaleTimeString("zh-C
 }))
 
 onMounted(() => {
-    clockTimer = setInterval(() => { now.value = Date.now() }, 100)
+    clockTimer = setInterval(() => { now.value = Date.now() }, 1000)
     if (isLoggedIn.value) {
         fetchTodayCheckIn()
     }

--- a/noj-ui/pages/login.vue
+++ b/noj-ui/pages/login.vue
@@ -56,6 +56,8 @@
 </template>
 
 <script setup lang="ts">
+import { extractApiError } from "~/utils/apiError"
+
 definePageMeta({ layout: "auth" })
 
 const router = useRouter()
@@ -121,7 +123,7 @@ async function handleLogin() {
         : `账号已被封禁。${reason ? `原因：${reason}。` : ""}请联系管理员。`;
       return;
     }
-    setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
+    setError(extractApiError(e).message)
   } finally {
     loading.value = false
   }

--- a/noj-ui/pages/login.vue
+++ b/noj-ui/pages/login.vue
@@ -10,20 +10,12 @@
   >
     <!-- 注册成功/密码重置成功 banner -->
     <template #banner-success>
-      <Transition name="slide">
-        <div v-if="registeredMsg" class="bg-green-50 border border-green-200 text-green-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-center gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-          <span>{{ registeredMsg }}</span>
-        </div>
-      </Transition>
+      <ToastBanner :visible="!!registeredMsg" color="success" icon="i-lucide-check-circle" :message="registeredMsg" @close="registeredMsg = ''" />
     </template>
 
     <!-- 被封禁 banner -->
     <template #banner-info>
-      <Transition name="slide">
-        <div v-if="bannedMsg" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-center gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-          <span>{{ bannedMsg }}</span>
-        </div>
-      </Transition>
+      <ToastBanner :visible="!!bannedMsg" color="error" icon="i-lucide-ban" :message="bannedMsg" @close="bannedMsg = ''" />
     </template>
 
     <TextInput
@@ -45,7 +37,7 @@
       id="password"
       v-model="form.password"
       label="密码"
-      placeholder="请输入密码（仅字母和数字）"
+      placeholder="至少 12 位，需包含字母和数字"
       autocomplete="current-password"
       :disabled="loading"
       :error="fieldErrors.password"

--- a/noj-ui/pages/messages/index.vue
+++ b/noj-ui/pages/messages/index.vue
@@ -87,8 +87,6 @@ async function send() {
     messages.value.push(result.data)
     newMessage.value = ""
     scrollToBottom()
-  } catch {
-    toast.error("发送失败")
   } finally {
     sending.value = false
   }

--- a/noj-ui/pages/messages/index.vue
+++ b/noj-ui/pages/messages/index.vue
@@ -214,7 +214,7 @@ function isSameDay(iso1: string, iso2: string): boolean {
             <div v-for="(msg, idx) in messages" :key="msg.id">
               <div
                 v-if="idx === 0 || !isSameDay(msg.created_at, messages[idx - 1].created_at)"
-                class="text-center text-[11px] text-text-secondary mb-3 mt-2"
+                class="text-center text-11px text-text-secondary mb-3 mt-2"
               >
                 {{ formatDate(msg.created_at) }}
               </div>

--- a/noj-ui/pages/my/problems.vue
+++ b/noj-ui/pages/my/problems.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
+import { extractApiError } from "~/utils/apiError"
+
 definePageMeta({
   middleware: "auth",
 })
 
 const { isLoggedIn, loading, user } = useAuth()
 const router = useRouter()
+const { api } = useApi()
 
 watch(loading, (val) => {
   if (!val && !isLoggedIn.value) router.replace("/login")
@@ -40,14 +43,15 @@ async function loadProblems(page = 1) {
   loadError.value = ""
   currentPage.value = page
   try {
-    const res = await $fetch<{ data: ProblemItem[]; total: number }>(
+    const res = await api.get<{ data: ProblemItem[]; total: number }>(
       `/api/v1/problems?type=U&owner_id=${user.value.id}&page=${page}&limit=${perPage}`,
+      { silent: true },
     )
     // 后端已按 type=U + owner_id 过滤，直接使用分页结果
     problems.value = res.data
     totalPages.value = Math.ceil(res.total / perPage)
   } catch (err: unknown) {
-    loadError.value = err instanceof Error ? err.message : "加载题目失败"
+    loadError.value = extractApiError(err).message
   } finally {
     pageLoading.value = false
   }

--- a/noj-ui/pages/problems.vue
+++ b/noj-ui/pages/problems.vue
@@ -130,6 +130,34 @@ function formatAcceptanceRate(rate: number | undefined): string {
   if (rate == null) return "--"
   return `${(rate * 100).toFixed(1)}%`
 }
+
+// 响应式列：sm 以下隐藏次要列（对齐原 hidden sm:table-cell 行为）
+const isDesktop = ref(false)
+function updateIsDesktop() {
+  isDesktop.value = window.matchMedia("(min-width: 640px)").matches
+}
+onMounted(() => {
+  updateIsDesktop()
+  window.addEventListener("resize", updateIsDesktop)
+})
+onUnmounted(() => window.removeEventListener("resize", updateIsDesktop))
+
+const columns = computed(() => {
+  const base: { accessorKey: string; header: string }[] = [
+    { accessorKey: "display_id", header: "#" },
+    { accessorKey: "title", header: "题目" },
+    { accessorKey: "difficulty", header: "难度" },
+    { accessorKey: "categories", header: "分类" },
+    { accessorKey: "time", header: "时间" },
+    { accessorKey: "memory", header: "内存" },
+    { accessorKey: "rate", header: "通过率" },
+  ]
+  if (isLoggedIn.value) base.push({ accessorKey: "status", header: "状态" })
+  if (!isDesktop.value) {
+    return base.filter((c) => !["categories", "time", "memory", "rate", "status"].includes(c.accessorKey))
+  }
+  return base
+})
 </script>
 
 <template>
@@ -161,6 +189,9 @@ function formatAcceptanceRate(rate: number | undefined): string {
       :empty-text="hasActiveFilters ? '没有找到符合条件的题目，试试其他筛选条件' : '暂无题目'"
       @retry="refresh"
     >
+      <template #loading>
+        <TableSkeleton :rows="8" :columns="['w-14', 'flex-1', 'w-16', 'w-24', 'w-16', 'w-16', 'w-20', 'w-16']" />
+      </template>
       <template #empty-action v-if="hasActiveFilters">
         <UButton color="primary" variant="outline" class="px-4 py-1.5 text-xs" @click="router.push({ query: {} })">
           清除筛选
@@ -169,69 +200,44 @@ function formatAcceptanceRate(rate: number | undefined): string {
 
       <!-- 题目表格 -->
       <div class="bg-white border border-border rounded-xl overflow-x-auto">
-        <table class="w-full border-collapse">
-          <thead>
-            <tr>
-              <th scope="col" class="w-24 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border">#</th>
-              <th scope="col" class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border">题目</th>
-              <th scope="col" class="w-20 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border">难度</th>
-              <th scope="col" class="w-[120px] px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border hidden sm:table-cell">分类</th>
-              <th scope="col" class="w-[90px] px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border hidden sm:table-cell">时间</th>
-              <th scope="col" class="w-[90px] px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border hidden sm:table-cell">内存</th>
-              <th scope="col" class="w-[80px] px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border hidden sm:table-cell">通过率</th>
-              <th v-if="isLoggedIn" scope="col" class="w-[80px] px-4 py-3 text-xs font-semibold uppercase tracking-wide text-text-secondary text-left bg-gray-50 border-b border-border hidden sm:table-cell">状态</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-border">
-            <tr
-              v-for="problem in problems"
-              :key="problem.id"
-              tabindex="0"
-              role="link"
-              class="cursor-pointer transition-colors duration-150 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-inset"
-              @click="router.push(`/problems/${problem.id}`)"
-              @keydown.enter.prevent="router.push(`/problems/${problem.id}`)"
-              @keydown.space.prevent="router.push(`/problems/${problem.id}`)"
+        <UTable :columns="columns" :data="problems" :empty="'暂无题目'">
+          <template #display_id-cell="{ row }">
+            <ProblemId :display-id="row.display_id" :type="row.type" />
+          </template>
+          <template #title-cell="{ row }">
+            <NuxtLink
+              :to="`/problems/${row.id}`"
+              class="text-text no-underline font-medium hover:text-primary"
             >
-              <td class="w-24 px-4 py-3.5">
-                <ProblemId :display-id="problem.display_id" :type="problem.type" />
-              </td>
-              <td class="px-4 py-3.5">
-                <NuxtLink
-                  :to="`/problems/${problem.id}`"
-                  class="text-text no-underline font-medium hover:text-primary"
-                >
-                  {{ problem.title }}
-                </NuxtLink>
-              </td>
-              <td class="w-20 px-4 py-3.5">
-                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold" :class="badgeColors[problem.difficulty] || ''">
-                  {{ difficultyLabel[problem.difficulty] || problem.difficulty }}
-                </span>
-              </td>
-              <td class="w-[120px] px-4 py-3.5 hidden sm:table-cell">
-                <span
-                  v-for="cat in problem.categories"
-                  :key="cat.id"
-                  class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200 mr-1"
-                >{{ cat.name }}</span>
-                <span v-if="!problem.categories?.length" class="text-xs text-text-muted">--</span>
-              </td>
-              <td class="w-[90px] px-4 py-3.5 text-xs text-text-secondary hidden sm:table-cell">
-                {{ problem.runtime_config.evaluator.time_limit_ms }}ms
-              </td>
-              <td class="w-[90px] px-4 py-3.5 text-xs text-text-secondary hidden sm:table-cell">
-                {{ problem.runtime_config.evaluator.memory_limit_mb }}MB
-              </td>
-              <td class="w-[80px] px-4 py-3.5 hidden sm:table-cell">
-                <span class="text-xs text-text-secondary">{{ formatAcceptanceRate(problem.acceptance_rate) }}</span>
-              </td>
-              <td v-if="isLoggedIn" class="w-[80px] px-4 py-3.5 hidden sm:table-cell">
-                <StatusBadge :status="getProblemStatus(problem.id)" />
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              {{ row.title }}
+            </NuxtLink>
+          </template>
+          <template #difficulty-cell="{ row }">
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold" :class="badgeColors[row.difficulty] || ''">
+              {{ difficultyLabel[row.difficulty] || row.difficulty }}
+            </span>
+          </template>
+          <template #categories-cell="{ row }">
+            <span
+              v-for="cat in row.categories"
+              :key="cat.id"
+              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200 mr-1"
+            >{{ cat.name }}</span>
+            <span v-if="!row.categories?.length" class="text-xs text-text-muted">--</span>
+          </template>
+          <template #time-cell="{ row }">
+            <span class="text-xs text-text-secondary">{{ row.runtime_config.evaluator.time_limit_ms }}ms</span>
+          </template>
+          <template #memory-cell="{ row }">
+            <span class="text-xs text-text-secondary">{{ row.runtime_config.evaluator.memory_limit_mb }}MB</span>
+          </template>
+          <template #rate-cell="{ row }">
+            <span class="text-xs text-text-secondary">{{ formatAcceptanceRate(row.acceptance_rate) }}</span>
+          </template>
+          <template #status-cell="{ row }">
+            <StatusBadge :status="getProblemStatus(row.id)" />
+          </template>
+        </UTable>
       </div>
 
       <!-- 分页 -->

--- a/noj-ui/pages/problems.vue
+++ b/noj-ui/pages/problems.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+const { api } = useApi()
 
 const router = useRouter()
 const route = useRoute()
@@ -61,7 +62,7 @@ const totalPages = computed(() => {
 
 // ── 获取分类树（客户端缓存） ──
 const { data: categoriesData } = await useAsyncData("problem-categories", () =>
-  $fetch<{ data: CategoryItem[] }>("/api/v1/categories"),
+  api.get<{ data: CategoryItem[] }>("/api/v1/categories", { silent: true }),
 )
 const categories = computed(() => categoriesData.value?.data ?? [])
 
@@ -75,10 +76,11 @@ async function fetchUserProblemStatus() {
   if (!isLoggedIn.value) return
   const gen = ++statusFetchGen
   try {
-    const res = await $fetch<{
+    const res = await api.get<{
       data: { problem_id: string; result: { score: number } | null }[]
     }>("/api/v1/submissions", {
       query: { per_page: 100 },
+      silent: true,
     })
     if (gen !== statusFetchGen) return // stale
     const subs = res.data ?? []

--- a/noj-ui/pages/queue.vue
+++ b/noj-ui/pages/queue.vue
@@ -97,15 +97,15 @@ useEventSource({
 
       <!-- 统计条 -->
       <div class="flex gap-3 mb-6 flex-wrap" v-if="data">
-        <div class="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-[#f0f0f0] text-text-secondary">
+        <div class="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-gray-100 text-text-secondary">
           <UIcon name="i-lucide-clock" class="size-3.5" />
           排队中 {{ data.stats.pending_count }}
         </div>
-        <div class="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-[#e8f0fe] text-[#1967d2]">
+        <div class="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-blue-50 text-blue-700">
           <UIcon name="i-lucide-play" class="size-3.5" />
           正在评测 {{ data.stats.judging_count }}
         </div>
-        <div class="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-[#e6f4ea] text-[var(--c-success-text)]">
+        <div class="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold bg-green-50 text-green-700">
           <UIcon name="i-lucide-check-circle" class="size-3.5" />
           今日完成 {{ data.stats.completed_today }}
         </div>
@@ -118,31 +118,31 @@ useEventSource({
 
       <template v-else>
         <!-- 正在评测 -->
-        <section class="bg-white border border-border rounded-[10px] mb-4 overflow-hidden">
-          <h2 class="flex items-center gap-2 px-4 py-3 m-0 text-[15px] font-bold border-b border-border text-[#1967d2]">
+        <section class="bg-white border border-border rounded-xl mb-4 overflow-x-auto">
+          <h2 class="flex items-center gap-2 px-4 py-3 m-0 text-15px font-bold border-b border-border text-blue-700">
             <UIcon name="i-lucide-play" class="size-4.5" />
             正在评测（{{ data.judging.length }}）
           </h2>
-          <div v-if="data.judging.length === 0" class="p-4 text-center text-[#aaa] text-[13px]">暂无</div>
-          <div v-for="item in data.judging" :key="item.id" class="flex items-center gap-3 px-4 py-2.5 text-[13px] border-b border-[#f3f4f6] last:border-b-0 hover:bg-bg-page">
-            <NuxtLink :to="`/submissions/${item.id}`" class="text-[#1967d2] no-underline font-mono whitespace-nowrap min-w-[80px] hover:underline">#{{ item.id.slice(0, 8) }}</NuxtLink>
+          <div v-if="data.judging.length === 0" class="p-4 text-center text-text-muted text-13px">暂无</div>
+          <div v-for="item in data.judging" :key="item.id" class="flex items-center gap-3 px-4 py-2.5 text-13px border-b border-border last:border-b-0 hover:bg-bg-page">
+            <NuxtLink :to="`/submissions/${item.id}`" class="text-blue-700 no-underline font-mono whitespace-nowrap min-w-[80px] hover:underline">#{{ item.id.slice(0, 8) }}</NuxtLink>
             <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-text">{{ item.problem_id }} {{ item.problem_title }}</span>
             <span class="text-text-secondary min-w-[70px] text-center text-xs">{{ getLanguageLabel(item.language) }}</span>
             <span class="text-text-secondary min-w-[60px]">{{ item.submitted_by }}</span>
             <span class="text-text-muted text-xs min-w-[100px]">{{ formatDateTime(item.submitted_at) }}</span>
-            <span class="inline-flex items-center gap-[3px] text-[#1967d2] text-xs min-w-[70px]"><UIcon name="i-lucide-clock" class="size-3.5" /> {{ elapsedSince(item.judge_started_at) }}</span>
+            <span class="inline-flex items-center gap-[3px] text-blue-700 text-xs min-w-[70px]"><UIcon name="i-lucide-clock" class="size-3.5" /> {{ elapsedSince(item.judge_started_at) }}</span>
           </div>
         </section>
 
         <!-- 排队中 -->
-        <section class="bg-white border border-border rounded-[10px] mb-4 overflow-hidden">
-          <h2 class="flex items-center gap-2 px-4 py-3 m-0 text-[15px] font-bold border-b border-border text-text-secondary">
+        <section class="bg-white border border-border rounded-xl mb-4 overflow-x-auto">
+          <h2 class="flex items-center gap-2 px-4 py-3 m-0 text-15px font-bold border-b border-border text-text-secondary">
             <UIcon name="i-lucide-clock" class="size-4.5" />
             排队中（{{ data.pending.length }}）
           </h2>
-          <div v-if="data.pending.length === 0" class="p-4 text-center text-[#aaa] text-[13px]">暂无</div>
-          <div v-for="item in data.pending" :key="item.id" class="flex items-center gap-3 px-4 py-2.5 text-[13px] border-b border-[#f3f4f6] last:border-b-0 hover:bg-bg-page">
-            <NuxtLink :to="`/submissions/${item.id}`" class="text-[#1967d2] no-underline font-mono whitespace-nowrap min-w-[80px] hover:underline">#{{ item.id.slice(0, 8) }}</NuxtLink>
+          <div v-if="data.pending.length === 0" class="p-4 text-center text-text-muted text-13px">暂无</div>
+          <div v-for="item in data.pending" :key="item.id" class="flex items-center gap-3 px-4 py-2.5 text-13px border-b border-border last:border-b-0 hover:bg-bg-page">
+            <NuxtLink :to="`/submissions/${item.id}`" class="text-blue-700 no-underline font-mono whitespace-nowrap min-w-[80px] hover:underline">#{{ item.id.slice(0, 8) }}</NuxtLink>
             <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-text">{{ item.problem_id }} {{ item.problem_title }}</span>
             <span class="text-text-secondary min-w-[70px] text-center text-xs">{{ getLanguageLabel(item.language) }}</span>
             <span class="text-text-secondary min-w-[60px]">{{ item.submitted_by }}</span>
@@ -151,19 +151,19 @@ useEventSource({
         </section>
 
         <!-- 最近完成 -->
-        <section class="bg-white border border-border rounded-[10px] mb-4 overflow-hidden">
-          <h2 class="flex items-center gap-2 px-4 py-3 m-0 text-[15px] font-bold border-b border-border text-[var(--c-success-text)]">
+        <section class="bg-white border border-border rounded-xl mb-4 overflow-x-auto">
+          <h2 class="flex items-center gap-2 px-4 py-3 m-0 text-15px font-bold border-b border-border text-green-700">
             <UIcon name="i-lucide-check-circle" class="size-4.5" />
             最近完成（{{ data.recently_completed.length }}）
           </h2>
-          <div v-if="data.recently_completed.length === 0" class="p-4 text-center text-[#aaa] text-[13px]">暂无</div>
-          <div v-for="item in data.recently_completed" :key="item.id" class="flex items-center gap-3 px-4 py-2.5 text-[13px] border-b border-[#f3f4f6] last:border-b-0 hover:bg-bg-page">
-            <NuxtLink :to="`/submissions/${item.id}`" class="text-[#1967d2] no-underline font-mono whitespace-nowrap min-w-[80px] hover:underline">#{{ item.id.slice(0, 8) }}</NuxtLink>
+          <div v-if="data.recently_completed.length === 0" class="p-4 text-center text-text-muted text-13px">暂无</div>
+          <div v-for="item in data.recently_completed" :key="item.id" class="flex items-center gap-3 px-4 py-2.5 text-13px border-b border-border last:border-b-0 hover:bg-bg-page">
+            <NuxtLink :to="`/submissions/${item.id}`" class="text-blue-700 no-underline font-mono whitespace-nowrap min-w-[80px] hover:underline">#{{ item.id.slice(0, 8) }}</NuxtLink>
             <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-text">{{ item.problem_id }} {{ item.problem_title }}</span>
             <span class="text-text-secondary min-w-[70px] text-center text-xs">{{ getLanguageLabel(item.language) }}</span>
             <span class="text-text-secondary min-w-[60px]">{{ item.submitted_by }}</span>
             <span class="text-text-muted text-xs min-w-[100px]">{{ formatDateTime(item.submitted_at) }}</span>
-            <span :class="['font-semibold min-w-[60px] text-right', item.status === 'error' || (item.score !== null && item.score === 0) ? 'text-[#d93025]' : '']">
+            <span :class="['font-semibold min-w-[60px] text-right', item.status === 'error' || (item.score !== null && item.score === 0) ? 'text-red-600' : '']">
               {{ formatScore(item.score) }} 分
             </span>
           </div>

--- a/noj-ui/pages/queue.vue
+++ b/noj-ui/pages/queue.vue
@@ -31,6 +31,8 @@ const data = ref<QueueData | null>(null)
 
 const isMounted = ref(true)
 
+const { api } = useApi()
+
 // 实时时钟——确保 elapsed 时间每秒更新而不是仅在轮询时刷新
 const now = ref(Date.now())
 let clockTimer: ReturnType<typeof setInterval> | null = null
@@ -73,7 +75,7 @@ useEventSource({
   onEvent: {
     "queue:changed": async () => {
       try {
-        data.value = await $fetch<QueueData>("/api/v1/queue")
+        data.value = await api.get<QueueData>("/api/v1/queue", { silent: true })
       } catch {
         // 静默
       }
@@ -81,7 +83,7 @@ useEventSource({
   },
   fetchFn: async () => {
     try {
-      data.value = await $fetch<QueueData>("/api/v1/queue")
+      data.value = await api.get<QueueData>("/api/v1/queue", { silent: true })
     } catch {
       // 静默
     }

--- a/noj-ui/pages/ranking.vue
+++ b/noj-ui/pages/ranking.vue
@@ -45,9 +45,12 @@ function setPage(p: number) {
       error="榜单加载失败"
       @retry="refresh"
     >
+      <template #loading>
+        <TableSkeleton :rows="10" :columns="['w-16', 'flex-1', 'w-16', 'w-20', 'w-20']" />
+      </template>
       <template #empty>
         <UIcon name="i-lucide-trophy" class="opacity-30 size-[48px]" />
-        <p>还没有用户通过任何题目，做第一个吧 👉</p>
+        <p>还没有用户通过任何题目，来做第一个吧</p>
         <UButton color="primary" class="px-4 py-1.5 text-xs" to="/problems">去做题</UButton>
       </template>
 

--- a/noj-ui/pages/register.vue
+++ b/noj-ui/pages/register.vue
@@ -79,6 +79,7 @@
 
 <script setup lang="ts">
 import { validatePassword, validatePasswordMatch, validateEmail } from "~/utils/validatePassword"
+import { extractApiError } from "~/utils/apiError"
 
 definePageMeta({ layout: "auth" })
 
@@ -169,8 +170,8 @@ async function handleRegister() {
     try {
         // 先注册
         await auth.register(form.username.trim(), form.email.trim(), form.password)
-    } catch (e: any) {
-        setError(typeof e.data?.error === "string" ? e.data.error : `错误代码: ${e.status || 502}`)
+    } catch (e: unknown) {
+        setError(extractApiError(e).message)
         loading.value = false
         return
     }

--- a/noj-ui/pages/register.vue
+++ b/noj-ui/pages/register.vue
@@ -1,112 +1,67 @@
 <template>
     <div class="w-full max-w-[380px] relative">
-        <Transition name="slide">
-            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ error }}</span>
-                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
-            </div>
-        </Transition>
+        <ToastBanner :visible="!!error" color="error" icon="i-lucide-alert-circle" :message="error" @close="clearError" />
         <div class="bg-white border border-border rounded-lg p-8">
-            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">注册</h1>
+            <h1 class="text-22px font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">注册</h1>
 
             <form @submit.prevent="handleRegister">
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
-                    <label for="username" class="block text-sm font-semibold text-text mb-1">用户名</label>
-                    <div class="relative flex items-center">
-                        <UIcon name="i-lucide-user" class="absolute left-[10px] text-text-muted pointer-events-none size-4.5" />
-                        <input
-                            id="username"
-                            v-model="form.username"
-                            type="text"
-                            placeholder="3-30 位字母、数字或下划线"
-                            autocomplete="username"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.username = ''"
-                        />
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.username" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.username }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
-                    </Transition>
+                <div class="mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
+                    <TextInput
+                        id="username"
+                        v-model="form.username"
+                        label="用户名"
+                        placeholder="3-30 位字母、数字或下划线"
+                        autocomplete="username"
+                        :disabled="loading"
+                        :error="fieldErrors.username"
+                        @focus="fieldErrors.username = ''"
+                    >
+                        <template #icon><UIcon name="i-lucide-user" class="size-4.5" /></template>
+                    </TextInput>
                 </div>
 
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
-                    <label for="email" class="block text-sm font-semibold text-text mb-1">邮箱</label>
-                    <div class="relative flex items-center">
-                        <UIcon name="i-lucide-mail" class="absolute left-[10px] text-text-muted pointer-events-none size-4.5" />
-                        <input
-                            id="email"
-                            v-model="form.email"
-                            type="email"
-                            placeholder="请输入邮箱地址"
-                            autocomplete="email"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.email = ''"
-                        />
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.email" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.email }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
-                    </Transition>
+                <div class="mb-7 animate-[fadeInUp_0.5s_ease_0.1s_both]">
+                    <TextInput
+                        id="email"
+                        v-model="form.email"
+                        type="email"
+                        label="邮箱"
+                        placeholder="请输入邮箱地址"
+                        autocomplete="email"
+                        :disabled="loading"
+                        :error="fieldErrors.email"
+                        @focus="fieldErrors.email = ''"
+                    >
+                        <template #icon><UIcon name="i-lucide-mail" class="size-4.5" /></template>
+                    </TextInput>
                 </div>
 
                 <!-- TODO 验证码 -->
 
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.15s_both]">
-                    <label for="password" class="block text-sm font-semibold text-text mb-1">密码</label>
-                    <div class="relative flex items-center">
-                        <UIcon name="i-lucide-lock" class="absolute left-[10px] text-text-muted pointer-events-none size-4.5" />
-                        <input
-                            id="password"
-                            v-model="form.password"
-                            :type="showPassword ? 'text' : 'password'"
-                            placeholder="至少 12 位，需包含字母和数字"
-                            autocomplete="new-password"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.password = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showPassword = !showPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <UIcon name="i-lucide-eye-off" class="size-4.5" v-if="!showPassword"  key="off"/>
-                                    <UIcon name="i-lucide-eye" class="size-4.5" v-else  key="on"/>
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.password" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.password }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
-                    </Transition>
+                <div class="mb-7 animate-[fadeInUp_0.5s_ease_0.15s_both]">
+                    <PasswordField
+                        id="password"
+                        v-model="form.password"
+                        label="密码"
+                        placeholder="至少 12 位，需包含字母和数字"
+                        autocomplete="new-password"
+                        :disabled="loading"
+                        :error="fieldErrors.password"
+                        @focus="fieldErrors.password = ''"
+                    />
                 </div>
 
-                <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.2s_both]">
-                    <label for="confirmPassword" class="block text-sm font-semibold text-text mb-1">确认密码</label>
-                    <div class="relative flex items-center">
-                        <UIcon name="i-lucide-lock" class="absolute left-[10px] text-text-muted pointer-events-none size-4.5" />
-                        <input
-                            id="confirmPassword"
-                            v-model="form.confirmPassword"
-                            :type="showConfirmPassword ? 'text' : 'password'"
-                            placeholder="再次输入密码"
-                            autocomplete="new-password"
-                            maxlength="30"
-                            :disabled="loading"
-                            class="w-full px-3 py-2 pl-9 border-[1.5px] border-border rounded-md text-sm text-text bg-white outline-none transition-[border-color] duration-200 focus:border-primary disabled:opacity-60 disabled:cursor-not-allowed"
-                            @focus="fieldErrors.confirmPassword = ''"
-                        />
-                        <button type="button" class="absolute right-3 bg-transparent border-0 text-text-muted cursor-pointer p-0 flex items-center hover:text-text-secondary" @click="showConfirmPassword = !showConfirmPassword" tabindex="-1">
-                            <span class="flex items-center justify-center w-[18px] h-[18px]">
-                                <Transition name="icon" mode="out-in">
-                                    <UIcon name="i-lucide-eye-off" class="size-4.5" v-if="!showConfirmPassword"  key="off"/>
-                                    <UIcon name="i-lucide-eye" class="size-4.5" v-else  key="on"/>
-                                </Transition>
-                            </span>
-                        </button>
-                    </div>
-                    <Transition name="drop">
-                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
-                    </Transition>
+                <div class="mb-7 animate-[fadeInUp_0.5s_ease_0.2s_both]">
+                    <PasswordField
+                        id="confirmPassword"
+                        v-model="form.confirmPassword"
+                        label="确认密码"
+                        placeholder="再次输入密码"
+                        autocomplete="new-password"
+                        :disabled="loading"
+                        :error="fieldErrors.confirmPassword"
+                        @focus="fieldErrors.confirmPassword = ''"
+                    />
                 </div>
 
                 <UButton color="primary" size="md" block class="animate-[fadeInUp_0.5s_ease_0.25s_both]" type="submit"  :disabled="loading">
@@ -138,8 +93,6 @@ const form = reactive({
 })
 const loading = ref(false)
 const error = ref("")
-const showPassword = ref(false)
-const showConfirmPassword = ref(false)
 
 let errorTimer: ReturnType<typeof setTimeout> | null = null
 

--- a/noj-ui/pages/reset-password.vue
+++ b/noj-ui/pages/reset-password.vue
@@ -1,14 +1,9 @@
 <template>
     <div class="w-full max-w-[380px] relative">
-        <Transition name="slide">
-            <div v-if="error" class="bg-red-50 border border-red-200 text-red-700 rounded-md px-3.5 py-2.5 text-sm flex items-center justify-between gap-3 fixed top-[74px] left-1/2 -translate-x-1/2 z-[99] max-w-[380px] w-[calc(100%-48px)]">
-                <span>{{ error }}</span>
-                <button class="bg-transparent border-0 text-red-700 cursor-pointer text-base p-0.5 leading-none opacity-70 shrink-0 hover:opacity-100" @click="clearError">&#10005;</button>
-            </div>
-        </Transition>
+        <ToastBanner :visible="!!error" color="error" icon="i-lucide-alert-circle" :message="error" @close="clearError" />
 
         <div class="bg-white border border-border rounded-lg p-8">
-            <h1 class="text-[22px] font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">重置密码</h1>
+            <h1 class="text-22px font-bold text-center mb-6 text-text animate-[fadeInUp_0.5s_ease_both]">重置密码</h1>
 
             <form @submit.prevent="handleSubmit">
                 <div class="relative mb-7 animate-[fadeInUp_0.5s_ease_0.05s_both]">
@@ -35,7 +30,7 @@
                         </button>
                     </div>
                     <Transition name="drop">
-                        <div v-if="fieldErrors.password" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.password }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
+                        <div v-if="fieldErrors.password" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-13px text-red-700"><span>{{ fieldErrors.password }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
                     </Transition>
                 </div>
 
@@ -63,7 +58,7 @@
                         </button>
                     </div>
                     <Transition name="drop">
-                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-[13px] text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
+                        <div v-if="fieldErrors.confirmPassword" class="absolute top-[calc(100%+4px)] left-0 right-0 flex items-center justify-between gap-1 text-13px text-red-700"><span>{{ fieldErrors.confirmPassword }}</span><UIcon name="i-lucide-x" class="size-3.5" /></div>
                     </Transition>
                 </div>
 

--- a/noj-ui/pages/reset-password.vue
+++ b/noj-ui/pages/reset-password.vue
@@ -77,6 +77,7 @@
 
 <script setup lang="ts">
 import { validatePassword, validatePasswordMatch } from "~/utils/validatePassword"
+import { extractApiError } from "~/utils/apiError"
 
 definePageMeta({ layout: "auth" })
 
@@ -132,8 +133,8 @@ async function handleSubmit() {
         await auth.resetPassword(token.value, form.password)
         // 成功 → 跳登录页带成功 banner
         router.replace("/login?reset=1")
-    } catch (e: any) {
-        setError(typeof e.data?.error === "string" ? e.data.error : `服务器错误 (${e.status || 502})`)
+    } catch (e: unknown) {
+        setError(extractApiError(e).message)
         loading.value = false
     }
 }

--- a/noj-ui/pages/search.vue
+++ b/noj-ui/pages/search.vue
@@ -71,6 +71,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from "vue";
+import { extractApiError } from "~/utils/apiError";
 
 import AsyncContent from "~/components/ui/AsyncContent.vue";
 import PaginationNav from "~/components/shared/PaginationNav.vue";
@@ -86,6 +87,7 @@ definePageMeta({ layout: "default" });
 
 const route = useRoute();
 const router = useRouter();
+const { api } = useApi();
 
 const query = ref<string>((route.query.q as string) ?? "");
 const type = ref<SearchType>(((route.query.type as string) ?? "problem") as SearchType);
@@ -130,21 +132,21 @@ async function fetchResults() {
   error.value = null;
 
   try {
-    const res = await $fetch("/api/v1/search", {
+    const res = await api.get("/api/v1/search", {
       params: {
         q,
         type: type.value,
         page: page.value,
         limit,
       },
+      silent: true,
     });
     const data = (res as { data: { items: (ProblemSearchResult | UserSearchResult | CommunitySearchResult)[]; total: number; took_ms: number } }).data;
     items.value = data.items;
     total.value = data.total;
     tookMs.value = data.took_ms;
   } catch (e: unknown) {
-    const err = e as { data?: { error?: string } };
-    error.value = err?.data?.error ?? "搜索失败";
+    error.value = extractApiError(e).message;
     items.value = [];
     total.value = 0;
     tookMs.value = null;

--- a/noj-ui/pages/settings.vue
+++ b/noj-ui/pages/settings.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import { extractApiError } from "~/utils/apiError"
 const { user, isLoggedIn, loading } = useAuth()
 const router = useRouter()
+const { api } = useApi()
 
 // 认证守卫：loading 就绪后检查登录状态
 watch(
@@ -26,8 +28,9 @@ watch(
   async (u) => {
     if (!u?.id) return
     try {
-      const res = await $fetch<{ data: { user: { bio: string } } }>(
+      const res = await api.get<{ data: { user: { bio: string } } }>(
         `/api/v1/users/${u.id}/profile`,
+        { silent: true },
       )
       bio.value = res.data.user.bio || ""
     } catch {
@@ -43,15 +46,11 @@ async function handleSave() {
   saveSuccess.value = false
   saveError.value = ""
   try {
-    await $fetch("/api/v1/users/me", {
-      method: "PUT",
-      body: { bio: bio.value },
-    })
+    await api.put("/api/v1/users/me", { bio: bio.value })
     saveSuccess.value = true
     setTimeout(() => { saveSuccess.value = false }, 3000)
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : "保存失败"
-    saveError.value = msg
+    saveError.value = extractApiError(err).message
   } finally {
     saving.value = false
   }

--- a/noj-ui/pages/submissions/[id].vue
+++ b/noj-ui/pages/submissions/[id].vue
@@ -207,7 +207,7 @@ watch(
           <div class="flex items-center gap-2.5 text-text-secondary">
             <UIcon name="i-lucide-clock" class="size-4" />
             <div class="flex flex-col gap-px">
-              <span class="text-[11px] text-text-muted">耗时</span>
+              <span class="text-11px text-text-muted">耗时</span>
               <span class="text-sm font-semibold text-text">
                 {{ formatTime(submission.result.time_ms) }}
               </span>
@@ -216,7 +216,7 @@ watch(
           <div class="flex items-center gap-2.5 text-text-secondary">
             <UIcon name="i-lucide-server" class="size-4" />
             <div class="flex flex-col gap-px">
-              <span class="text-[11px] text-text-muted">内存</span>
+              <span class="text-11px text-text-muted">内存</span>
               <span class="text-sm font-semibold text-text">
                 {{ formatMemory(submission.result.memory_kb) }}
               </span>

--- a/noj-ui/pages/submissions/[id].vue
+++ b/noj-ui/pages/submissions/[id].vue
@@ -32,6 +32,7 @@ interface SubmissionResponse {
   data: SubmissionData
 }
 const route = useRoute()
+const { api } = useApi()
 const { isLoggedIn, loading: authLoading } = useAuth()
 const submissionId = route.params.id as string
 // 不使用 useFetch（setup 阶段 token 可能未就绪），改为手动管理
@@ -50,8 +51,9 @@ async function pollSubmission() {
   if (!isMounted.value) return
   const thisReq = ++pollReqId
   try {
-    const res = await $fetch<SubmissionResponse>(
+    const res = await api.get<SubmissionResponse>(
       `/api/v1/submissions/${submissionId}`,
+      { silent: true },
     )
     if (!isMounted.value || thisReq !== pollReqId) return
       if (res) {

--- a/noj-ui/pages/submissions/index.vue
+++ b/noj-ui/pages/submissions/index.vue
@@ -139,7 +139,7 @@ function hasResult(item: SubmissionListItem): boolean {
             <label class="text-xs font-semibold text-text-secondary">题目</label>
             <input
               v-model="filters.problem_search"
-              class="rounded border border-border bg-white px-2.5 py-1.5 text-[13px] text-text outline-none transition-colors duration-150 focus:border-primary focus:ring-2 focus:ring-primary/10"
+              class="rounded border border-border bg-white px-2.5 py-1.5 text-13px text-text outline-none transition-colors duration-150 focus:border-primary focus:ring-2 focus:ring-primary/10"
               placeholder="题目 ID 或名称"
               @keyup.enter="applyFilters"
             />
@@ -148,14 +148,14 @@ function hasResult(item: SubmissionListItem): boolean {
             <label class="text-xs font-semibold text-text-secondary">提交 ID</label>
             <input
               v-model="filters.submission_id"
-              class="rounded border border-border bg-white px-2.5 py-1.5 text-[13px] text-text outline-none transition-colors duration-150 focus:border-primary focus:ring-2 focus:ring-primary/10"
+              class="rounded border border-border bg-white px-2.5 py-1.5 text-13px text-text outline-none transition-colors duration-150 focus:border-primary focus:ring-2 focus:ring-primary/10"
               placeholder="输入提交 ID 前缀"
               @keyup.enter="applyFilters"
             />
           </div>
           <div class="flex min-w-[140px] flex-1 flex-col gap-1">
             <label class="text-xs font-semibold text-text-secondary">语言</label>
-            <select v-model="filters.language" class="rounded border border-border bg-white px-2.5 py-1.5 text-[13px] text-text outline-none transition-colors duration-150 focus:border-primary focus:ring-2 focus:ring-primary/10" @change="applyFilters">
+            <select v-model="filters.language" class="rounded border border-border bg-white px-2.5 py-1.5 text-13px text-text outline-none transition-colors duration-150 focus:border-primary focus:ring-2 focus:ring-primary/10" @change="applyFilters">
               <option v-for="opt in languageOptions" :key="opt.value" :value="opt.value">
                 {{ opt.label }}
               </option>
@@ -163,7 +163,7 @@ function hasResult(item: SubmissionListItem): boolean {
           </div>
           <div class="flex min-w-[140px] flex-1 flex-col gap-1">
             <label class="text-xs font-semibold text-text-secondary">状态</label>
-            <select v-model="filters.status" class="rounded border border-border bg-white px-2.5 py-1.5 text-[13px] text-text outline-none transition-colors duration-150 focus:border-primary focus:ring-2 focus:ring-primary/10" @change="applyFilters">
+            <select v-model="filters.status" class="rounded border border-border bg-white px-2.5 py-1.5 text-13px text-text outline-none transition-colors duration-150 focus:border-primary focus:ring-2 focus:ring-primary/10" @change="applyFilters">
               <option v-for="opt in statusOptions" :key="opt.value" :value="opt.value">
                 {{ opt.label }}
               </option>
@@ -183,10 +183,7 @@ function hasResult(item: SubmissionListItem): boolean {
       </div>
 
       <!-- 加载态 -->
-      <div v-if="tableLoading" class="flex flex-col items-center justify-center gap-3 rounded-lg border border-border bg-white px-6 py-16 text-sm text-text-secondary">
-        <div class="h-6 w-6 animate-spin-slow rounded-full border-[3px] border-border border-t-primary" />
-        <span>加载中...</span>
-      </div>
+      <TableSkeleton v-if="tableLoading" :rows="8" :columns="['w-20', 'flex-1', 'w-16', 'w-24', 'w-12', 'w-12', 'w-12', 'w-28', 'w-16']" />
 
       <!-- 错误态 -->
       <div v-else-if="tableError" class="flex flex-col items-center justify-center gap-3 rounded-lg border border-border bg-white px-6 py-16 text-sm text-red-600">
@@ -220,13 +217,13 @@ function hasResult(item: SubmissionListItem): boolean {
           <tbody>
             <tr v-for="sub in submissions" :key="sub.id" class="border-b border-border transition-colors duration-150 last:border-b-0 hover:bg-[#fafafa]">
               <td class="px-3.5 py-3 font-mono text-xs text-text-secondary">{{ sub.id.slice(0, 8) }}...</td>
-              <td class="px-3.5 py-3 text-[13px] text-text">
+              <td class="px-3.5 py-3 text-13px text-text">
                 <NuxtLink :to="`/problems/${sub.problem_id}`" class="font-medium text-primary no-underline hover:underline">
                   {{ sub.problem.title || sub.problem_id }}
                 </NuxtLink>
               </td>
-              <td class="px-3.5 py-3 text-[13px] text-text">{{ getLanguageLabel(sub.language) }}</td>
-              <td class="px-3.5 py-3 text-[13px] text-text">
+              <td class="px-3.5 py-3 text-13px text-text">{{ getLanguageLabel(sub.language) }}</td>
+              <td class="px-3.5 py-3 text-13px text-text">
                 <span
                   class="inline-block whitespace-nowrap rounded px-2 py-0.5 text-xs font-semibold"
                   :style="{
@@ -237,20 +234,20 @@ function hasResult(item: SubmissionListItem): boolean {
                   {{ getStatusLabel(sub.status, sub.result?.status) }}
                 </span>
               </td>
-              <td class="px-3.5 py-3 text-right text-[13px] tabular-nums text-text">
+              <td class="px-3.5 py-3 text-right text-13px tabular-nums text-text">
                 <template v-if="hasResult(sub)">{{ formatScore(sub.result!.score) }}</template>
                 <template v-else>--</template>
               </td>
-              <td class="px-3.5 py-3 text-right text-[13px] tabular-nums text-text">
+              <td class="px-3.5 py-3 text-right text-13px tabular-nums text-text">
                 <template v-if="hasResult(sub)">{{ formatTime(sub.result!.time_ms) }}</template>
                 <template v-else>--</template>
               </td>
-              <td class="px-3.5 py-3 text-right text-[13px] tabular-nums text-text">
+              <td class="px-3.5 py-3 text-right text-13px tabular-nums text-text">
                 <template v-if="hasResult(sub)">{{ formatMemory(sub.result!.memory_kb) }}</template>
                 <template v-else>--</template>
               </td>
-              <td class="px-3.5 py-3 text-[13px] text-text">{{ formatDateTime(sub.created_at) }}</td>
-              <td class="px-3.5 py-3 text-center text-[13px] text-text">
+              <td class="px-3.5 py-3 text-13px text-text">{{ formatDateTime(sub.created_at) }}</td>
+              <td class="px-3.5 py-3 text-center text-13px text-text">
                 <NuxtLink :to="`/submissions/${sub.id}`" class="inline-flex cursor-pointer items-center gap-1 rounded border border-primary bg-transparent px-2.5 py-1 text-xs font-semibold leading-none text-primary no-underline transition-all duration-150 hover:bg-primary hover:text-white">
                   查看
                 </NuxtLink>

--- a/noj-ui/pages/submissions/index.vue
+++ b/noj-ui/pages/submissions/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { extractApiError } from "~/utils/apiError"
 import type {
   SubmissionListItem,
 } from "~/composables/use-submissions"
@@ -15,6 +16,7 @@ definePageMeta({
   ssr: false,
 })
 
+const { api } = useApi()
 const { isLoggedIn, loading } = useAuth()
 const router = useRouter()
 
@@ -75,13 +77,14 @@ async function loadSubmissions(page = 1) {
   tableError.value = ""
   currentPage.value = page
   try {
-    const res = await $fetch<{ data: SubmissionListItem[]; pagination: { total: number; total_pages: number } }>(
+    const res = await api.get<{ data: SubmissionListItem[]; pagination: { total: number; total_pages: number } }>(
       `/api/v1/submissions?${buildQuery(page)}`,
+      { silent: true },
     )
     submissions.value = res.data
     totalPages.value = res.pagination.total_pages
   } catch (err: unknown) {
-    tableError.value = err instanceof Error ? err.message : "加载提交记录失败"
+    tableError.value = extractApiError(err).message
   } finally {
     tableLoading.value = false
   }

--- a/noj-ui/pages/users/[id].vue
+++ b/noj-ui/pages/users/[id].vue
@@ -8,6 +8,7 @@ const router = useRouter()
 const { user: currentUser } = useAuth()
 const { findOrCreateConversation } = useMessages()
 const { toast } = useToast()
+const { api } = useApi()
 
 const userId = route.params.id as string
 
@@ -136,22 +137,14 @@ function formatDate(iso: string): string {
 }
 
 async function startConversation() {
-  try {
-    await findOrCreateConversation(userId)
-    router.push(`/messages`)
-  } catch {
-    toast.error("无法创建会话")
-  }
+  await findOrCreateConversation(userId)
+  router.push(`/messages`)
 }
 
 async function toggleFollow() {
-  try {
-    const result = await $fetch<{ data: { following: boolean } }>(`/api/v1/community/users/${userId}/follow`, { method: "POST" })
-    following.value = result.data.following
-    toast.success(following.value ? "已关注" : "已取消关注")
-  } catch (error: unknown) {
-    toast.error(error instanceof Error ? error.message : "操作失败")
-  }
+  const result = await api.post<{ data: { following: boolean } }>(`/api/v1/community/users/${userId}/follow`)
+  following.value = result.data.following
+  toast.success(following.value ? "已关注" : "已取消关注")
 }
 
 function formatScore(raw: number | null | undefined): string {

--- a/noj-ui/server/api/contributors.get.ts
+++ b/noj-ui/server/api/contributors.get.ts
@@ -1,0 +1,57 @@
+// 贡献者列表：从 GitHub API 拉取，1 小时内存缓存；GitHub 不可达时回退到静态快照。
+// 过滤机器人账号（dependabot[bot] 等），避免展示为人类贡献者。
+
+interface Contributor {
+  login: string;
+  avatar_url: string;
+  contributions: number;
+}
+
+const GITHUB_URL = 'https://api.github.com/repos/Neuro-OJ/neuro-oj/contributors?per_page=100';
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 8000;
+
+// 静态回退快照（GitHub 不可达时使用；头像由 https://github.com/<login>.png 动态解析，计数为快照值）
+const FALLBACK: Omit<Contributor, 'avatar_url'>[] = [
+  { login: 'hachimi-ak-ioi', contributions: 66 },
+  { login: 'chenmou2012', contributions: 40 },
+  { login: 'box3-galen-nv', contributions: 4 },
+  { login: 'w1010tdev', contributions: 1 },
+];
+
+let cache: { at: number; data: Contributor[] } | null = null;
+
+export default defineEventHandler(async (): Promise<{ data: Contributor[] }> => {
+  const now = Date.now();
+
+  // 命中缓存直接返回
+  if (cache && now - cache.at < CACHE_TTL_MS) {
+    return { data: cache.data };
+  }
+
+  try {
+    const res = await fetch(GITHUB_URL, {
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'neuro-oj' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+
+    const raw = (await res.json()) as Array<{ login: string; avatar_url: string; contributions: number }>;
+    const data = raw
+      .filter((c) => !/dependabot|\[bot\]/i.test(c.login))
+      .map((c) => ({ login: c.login, avatar_url: c.avatar_url, contributions: c.contributions }));
+
+    if (data.length === 0) throw new Error('empty contributors');
+    cache = { at: now, data };
+    return { data };
+  } catch {
+    // GitHub 不可达 → 静态回退
+    const data: Contributor[] = FALLBACK.map((c) => ({
+      login: c.login,
+      avatar_url: `https://github.com/${c.login}.png?size=40`,
+      contributions: c.contributions,
+    }));
+    cache = { at: now, data };
+    return { data };
+  }
+});

--- a/noj-ui/tests/apiError_test.ts
+++ b/noj-ui/tests/apiError_test.ts
@@ -1,0 +1,100 @@
+/**
+ * utils/apiError.ts 单元测试。
+ *
+ * 覆盖四类错误提取：后端错误响应、无 error 字段兜底、网络错误、超时，
+ * 以及未知错误兜底。
+ */
+/// <reference lib="deno.ns" />
+import { assertEquals } from 'jsr:@std/assert@^1';
+import { extractApiError, isNetworkError, isTimeoutError } from '../utils/apiError.ts';
+
+/** 构造一个带 $fetch 错误对象结构的 Error（data/status 为 ofetch FetchError 字段） */
+function makeFetchError(
+  overrides: {
+    data?: unknown;
+    status?: number;
+    statusCode?: number;
+    message?: string;
+    cause?: unknown;
+  } = {},
+): Error {
+  const err = new Error(overrides.message ?? 'fetch error');
+  Object.assign(err, { data: undefined, ...overrides });
+  return err;
+}
+
+Deno.test('extractApiError: 后端错误响应提取 error/code/request_id', () => {
+  const err = makeFetchError({
+    data: { error: '用户名已存在', code: 'CONFLICT_ERROR', request_id: 'req-123' },
+    status: 409,
+  });
+  const info = extractApiError(err);
+  assertEquals(info.message, '用户名已存在');
+  assertEquals(info.code, 'CONFLICT_ERROR');
+  assertEquals(info.status, 409);
+  assertEquals(info.requestId, 'req-123');
+});
+
+Deno.test('extractApiError: statusCode 字段兼容（NuxtError 形态）', () => {
+  const err = makeFetchError({
+    data: { error: '题目不存在' },
+    statusCode: 404,
+  });
+  const info = extractApiError(err);
+  assertEquals(info.message, '题目不存在');
+  assertEquals(info.status, 404);
+});
+
+Deno.test('extractApiError: 无 error 字段时返回含状态码的结构化兜底', () => {
+  const err = makeFetchError({ data: {}, status: 500 });
+  const info = extractApiError(err);
+  assertEquals(info.message, '请求失败（HTTP 500）');
+  assertEquals(info.status, 500);
+});
+
+Deno.test('extractApiError: 响应体非 JSON（data 为字符串）时按状态码兜底', () => {
+  const err = makeFetchError({ data: 'Internal Server Error', status: 502 });
+  assertEquals(extractApiError(err).message, '请求失败（HTTP 502）');
+});
+
+Deno.test('extractApiError: 超时（AbortError）', () => {
+  // ofetch timeout 触发：FetchError 的 cause 为 DOMException AbortError
+  const cause = new DOMException('The operation was aborted due to timeout', 'AbortError');
+  const err = makeFetchError({ cause });
+  assertEquals(isTimeoutError(err), true);
+  assertEquals(extractApiError(err).message, '请求超时，请稍后重试');
+});
+
+Deno.test('extractApiError: 原生 AbortError 名称判断', () => {
+  const err = new DOMException('aborted', 'AbortError');
+  assertEquals(isTimeoutError(err), true);
+  assertEquals(extractApiError(err).message, '请求超时，请稍后重试');
+});
+
+Deno.test('extractApiError: 网络错误（TypeError fetch failed）', () => {
+  const cause = new TypeError('fetch failed');
+  const err = makeFetchError({ cause });
+  assertEquals(isNetworkError(err), true);
+  assertEquals(extractApiError(err).message, '网络连接失败，请检查网络');
+});
+
+Deno.test('extractApiError: 消息含 fetch failed 的网络错误', () => {
+  const err = makeFetchError({ message: 'fetch failed' });
+  assertEquals(isNetworkError(err), true);
+  assertEquals(extractApiError(err).message, '网络连接失败，请检查网络');
+});
+
+Deno.test('extractApiError: 未知错误兜底', () => {
+  assertEquals(extractApiError('oops').message, '操作失败，请稍后重试');
+  assertEquals(extractApiError(null).message, '操作失败，请稍后重试');
+  assertEquals(extractApiError(new Error('unknown')).message, '操作失败，请稍后重试');
+});
+
+Deno.test('extractApiError: 网络错误优先于状态码判断', () => {
+  // 网络层错误即使带 status 也应归为网络问题
+  const err = makeFetchError({
+    message: 'fetch failed',
+    status: 0,
+  });
+  assertEquals(extractApiError(err).message, '网络连接失败，请检查网络');
+});

--- a/noj-ui/utils/apiError.ts
+++ b/noj-ui/utils/apiError.ts
@@ -1,0 +1,87 @@
+/**
+ * API 错误提取工具（纯函数，无 Nuxt/`import.meta` 依赖，可独立单元测试）。
+ *
+ * 统一从 `$fetch` 抛出的任意异常中提取「展示给用户的具体错误原因」，
+ * 避免各调用点重复编写 `e.data?.error || e.status` 之类的提取逻辑、
+ * 以及只显示状态码丢失具体原因的问题。
+ */
+
+/** 提取结果：可直接用于 toast/表单错误展示 */
+export interface ApiErrorInfo {
+  /** 展示给用户的具体错误原因（优先为后端 `error` 字段，否则为兜底文案） */
+  message: string;
+  /** 后端错误码（如 VALIDATION_ERROR、CONFLICT_ERROR），无则 undefined */
+  code?: string;
+  /** HTTP 状态码（网络/超时等无响应错误时为 undefined） */
+  status?: number;
+  /** 后端 request_id（用于与服务端日志关联），无则 undefined */
+  requestId?: string;
+}
+
+// 兜底文案集中管理：网络/超时/未知错误不允许展示原始英文堆栈
+const FALLBACK_NETWORK = '网络连接失败，请检查网络';
+const FALLBACK_TIMEOUT = '请求超时，请稍后重试';
+const FALLBACK_UNKNOWN = '操作失败，请稍后重试';
+
+/** 判断是否为超时/中止错误（ofetch `timeout` 选项或 AbortController.abort 触发） */
+export function isTimeoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === 'AbortError') return true;
+  const cause = (err as { cause?: unknown }).cause;
+  return cause instanceof Error && cause.name === 'AbortError';
+}
+
+/** 判断是否为网络层错误（请求未到达后端，如 fetch failed / Failed to fetch） */
+export function isNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err instanceof TypeError) return true;
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause instanceof TypeError) return true;
+  const msg = err.message ?? '';
+  return msg.includes('fetch failed') || msg.includes('Failed to fetch') ||
+    msg.includes('NetworkError');
+}
+
+/**
+ * 从任意异常提取错误信息。
+ *
+ * 提取优先级：
+ * 1. 后端错误响应（`data.error` 字符串）——具体原因，直接展示
+ * 2. 超时（AbortError）→ 「请求超时，请稍后重试」
+ * 3. 网络错误（TypeError/fetch failed）→ 「网络连接失败，请检查网络」
+ * 4. 有 HTTP 状态码但无 error 字段 → 「请求失败（HTTP <status>）」
+ * 5. 未知错误 → 「操作失败，请稍后重试」
+ */
+export function extractApiError(err: unknown): ApiErrorInfo {
+  const e = err as {
+    data?: unknown;
+    status?: number;
+    statusCode?: number;
+    response?: { status?: number };
+  } | null;
+
+  const status = e?.status ?? e?.statusCode ?? e?.response?.status;
+
+  // 1. 后端错误响应：响应体 `{ error: string, code, request_id }`
+  const data = e?.data;
+  if (data !== null && typeof data === 'object') {
+    const d = data as Record<string, unknown>;
+    if (typeof d.error === 'string' && d.error.length > 0) {
+      return {
+        message: d.error,
+        code: typeof d.code === 'string' ? d.code : undefined,
+        status,
+        requestId: typeof d.request_id === 'string' ? d.request_id : undefined,
+      };
+    }
+  }
+
+  // 2. 超时
+  if (isTimeoutError(err)) return { message: FALLBACK_TIMEOUT, status };
+  // 3. 网络错误
+  if (isNetworkError(err)) return { message: FALLBACK_NETWORK, status };
+  // 4. 有状态码但响应体无 error 字段：给出结构化兜底而非裸状态码
+  if (typeof status === 'number') return { message: `请求失败（HTTP ${status}）`, status };
+  // 5. 未知错误
+  return { message: FALLBACK_UNKNOWN };
+}

--- a/openspec/changes/add-about-stats/.openspec.yaml
+++ b/openspec/changes/add-about-stats/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/add-about-stats/design.md
+++ b/openspec/changes/add-about-stats/design.md
@@ -1,0 +1,41 @@
+# Design: 关于页重设计 + 公开统计端点
+
+## Context
+
+- 关于页入口：Navbar / Sidebar / FooterBar 三处均链接 `/about`，是访客（未登录用户）也能到达的页面。
+- 设计 token：`app.vue :root` 的 `--c-*` 变量经 `main.css @theme` 映射为 Tailwind 类（`text-primary`、`bg-primary-bg`、`border-border`、`shadow-card` 等），本变更全部复用，不新增 token。
+- 现有数据源：`/api/contributors`（Nitro 代理 → GitHub API，1h 缓存 + 静态回退）已存在；新增 `/api/v1/stats` 由 Nitro `[...slug].ts` 通配代理自动转发，UI 无需新增代理路由。
+
+## Decisions
+
+### D1. 统计口径
+
+- `problems` = `problems` 表行数；`submissions` = `submissions` 表行数；`users` = `users` 表行数。
+- `accepted` = `evaluation_results.status = 'Accepted'` 行数（与 `services/rankings.ts`、`services/dashboard.ts` 口径一致）。
+- 全部 `Promise.all` 并发计数，单次往返各表 `count()`。
+
+### D2. 端点公开性与错误处理
+
+- 公开、无鉴权：与 `GET /api/v1/judge-images` 一致，注册在 `sse` 路由之前、不受 `authMiddleware` 影响。
+- 响应形状：`{ data: { problems, submissions, users, accepted } }`（数字），沿用项目 `{ data }` 包装惯例。
+- 维护模式（`maintenance_mode`）下 GET 放行，无需特殊处理。
+
+### D3. UI 信息架构（自上而下 7 区）
+
+1. **Hero**：深蓝渐变（`from-slate-900 via-blue-900 to-blue-700`，与首页轮播渐变呼应，白字对比度 17.85:1）；品牌徽标 + 一句话定位 + 两个 CTA（开始做题 → `/problems`；GitHub → 仓库）；免责声明改为 Hero 内 amber 提示条（提升合规信息权重）。
+2. **锚点导航**：核心区别 / 技术架构 / 开源社区 三个锚点链接（低成本提升长页可用性）。
+3. **统计面板**：4 个数字卡（题目 / 提交 / 用户 / 通过），`tabular-nums` + 主色数字；`server: false` 客户端拉取，骨架屏防 CLS（与贡献者加载策略一致）。
+4. **核心区别**：保留 3 条原文内容，改为主色系（`bg-primary-bg text-primary`）图标 + 统一卡片，`lg:grid-cols-3`。
+5. **技术架构**：`noj-ui → noj-core → noj-judge` 流程式（flex + 箭头图标），卡片统一中性底 + 主色图标，各附 GitHub 源码链接；下方一行数据流说明。
+6. **开源社区**：GitHub 链接 + 贡献者头像墙（2/3/4 列网格，头像 + login + commits），保留头像失败回退首字母逻辑，加载态骨架。
+7. **页脚**：AGPL-3.0 许可证链接 + 商业授权说明 + 免责声明重申（小字）。
+
+### D4. 视觉收敛
+
+- 删除原页面紫 / 绿 / 橙点缀，强调色统一为 `text-primary` / `bg-primary-bg`；架构模块色块改为统一中性 + 主色图标。
+- 图标统一 `i-lucide-*`；圆角用 `rounded-lg/xl`；卡片统一 `bg-white border border-border rounded-xl shadow-card`。
+
+## Risks
+
+- 统计查询在数据量大时是 4 次 `count(*)` 全表扫描（`evaluation_results` 行数最大）。MVP 阶段可接受；后续可加缓存或物化视图（记录为遗留项）。
+- 贡献者 API 依赖 GitHub 可达性，已有 1h 缓存 + 静态回退，风险已控。

--- a/openspec/changes/add-about-stats/proposal.md
+++ b/openspec/changes/add-about-stats/proposal.md
@@ -1,0 +1,40 @@
+# 关于页重设计 + 公开统计端点
+
+## Why
+
+`noj-ui/pages/about.vue` 是访客了解 Neuro OJ 的窗口（导航「关于」入口），但当前是静态信息陈列：
+
+- 四个区块（区别 / 架构 / 社区 / 页脚）视觉权重均等，无焦点；Hero 无视觉锚点与转化出口（CTA）。
+- 强调色失控：紫 / 蓝 / 绿 / 橙四种色混用，偏离品牌主色 `--c-primary`（#2563eb）。
+- 免责声明（法律合规信息）以小号灰色字呈现，视觉权重过低。
+- 缺少数据面板（题目数 / 提交数 / 用户数等），页面缺乏可信度与「活项目」感。
+
+需要按项目设计 token 体系重新设计页面，并新增公开统计 API 支撑数据面板。
+
+## What Changes
+
+- `noj-core` 新增公开只读端点 `GET /api/v1/stats`：返回题目数、提交总数、注册用户数、评测通过数（Accepted）。
+- `noj-ui` 重写 `pages/about.vue`：
+  - 渐变 Hero（品牌定位 + 免责声明提示条 + 「开始做题 / GitHub」CTA）；
+  - 统计面板（调用 `/api/v1/stats`，加载骨架态）；
+  - 「与传统 OJ 的核心区别」收敛为统一主色系卡片网格；
+  - 技术架构改为「noj-ui → noj-core → noj-judge」流程式展示，附源码链接；
+  - 开源社区贡献者头像墙（沿用 `/api/contributors`），页脚补充 AGPL 许可证链接。
+
+## Capabilities
+
+### New Capabilities
+
+- `public-stats`: 公开站点统计端点（只读、无鉴权，与 `judge-images` 一致）。
+- `about-page`: 重新设计的关于页（叙事化信息架构 + 品牌视觉 + 数据面板）。
+
+### Modified Capabilities
+
+无。不涉及数据库 Schema、鉴权、评测链路。
+
+## Impact
+
+- `noj-core`：新增 `src/routes/stats.ts`（1 个只读聚合查询路由）与 `tests/routes/stats.test.ts`；在 `app.ts` 注册。
+- `noj-ui`：仅重写 `pages/about.vue`（含模板 / 脚本 / 样式），复用现有设计 token 与 `/api/contributors` 代理；无新依赖。
+- `noj-tests`：不涉及（stats 为公开只读端点，由 noj-core 路由测试覆盖）。
+- 无 Drizzle 迁移、无环境变量、无 Redis 变更。

--- a/openspec/changes/add-about-stats/tasks.md
+++ b/openspec/changes/add-about-stats/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: 关于页重设计 + 公开统计端点
+
+## Task 1: 后端公开统计端点
+
+- [ ] 新增 `noj-core/src/routes/stats.ts`：`GET /stats` 返回 `{ data: { problems, submissions, users, accepted } }`，四个 `count()` 并发执行，口径与 rankings/dashboard 一致。
+- [ ] 在 `noj-core/src/app.ts` 注册 `app.route("/api/v1", stats)`（公开路由，无鉴权）。
+- [ ] 新增 `noj-core/tests/routes/stats.test.ts`：`resetDbForTest` 后请求，断言 200、`data` 字段为数字、种子数据可数。
+
+## Task 2: 前端 about 页重写
+
+- [ ] 重写 `noj-ui/pages/about.vue`：Hero（渐变 + CTA + 免责提示条）、锚点导航、统计面板（骨架 + `/api/v1/stats`）、特性网格、流程式架构、贡献者头像墙、页脚。
+- [ ] 保留 `/api/contributors` 拉取与头像失败回退逻辑。
+
+## Task 3: 质量检查
+
+- [ ] `deno fmt` + `deno lint`（noj-core 与 noj-ui）。
+- [ ] `deno test` 运行 stats 路由测试。
+- [ ] `nuxt build` 或等价构建检查通过。

--- a/openspec/changes/add-ui-api-layer/.openspec.yaml
+++ b/openspec/changes/add-ui-api-layer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/add-ui-api-layer/design.md
+++ b/openspec/changes/add-ui-api-layer/design.md
@@ -1,0 +1,93 @@
+## Context
+
+noj-ui 现有约 50 个文件、140 处直接 `$fetch` 调用，错误处理有 5 种模式并存：
+
+| 模式 | 场景 | 问题 |
+|------|------|------|
+| catch + `toast.error(err.message)` | admin 表单提交 | 文案提取逻辑重复，部分只显示 `err.message`（丢失后端 `error` 字段） |
+| catch + 表单内联 error ref/banner | 认证 5 页、admin 列表 | 是刻意设计，保留 |
+| catch 静默 | 轮询、后台刷新 | 有意静默，保留 |
+| 无 catch 裸抛 | admin/community load、contests 参与者 | unhandled rejection，用户无感知 |
+| allSettled / 错误对象分支 | useSearch、admin/index、editor 404、USER_BANNED | 依赖 `$fetch` 抛错对象的结构 |
+
+后端（noj-core）错误响应格式统一为 `{ error: "<具体原因>", code: "<机器码>", request_id, ...meta }`，Nitro 代理（`server/api/[...slug].ts`）原样透传 status + body。因此「具体错误原因」在前端始终可提取，只是各调用点提取方式不一致。
+
+项目约束：弹窗/通知统一使用 Nuxt UI（`useToast`/`useDialog`），SweetAlert2 已移除且不重新引入；`$fetch` 抛错对象结构（`e.data`/`e.status`）被现有分支代码依赖，不能破坏。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 统一 API 调用入口，杜绝直接 `$fetch` 散落各处
+- 非 2xx 自动提取后端 `error` 字段并通过 `useToast().toast.error()` 弹窗，保证具体原因不丢失、提示方式一致
+- 保留轮询/后台/表单内联场景的静默能力（`silent: true`）
+- 迁移全部现有调用点，删除重复的 catch + toast 逻辑
+- 兼容现有依赖抛错对象结构的代码（重抛原错误）
+
+**Non-Goals:**
+- 不改变后端 API 契约（错误响应格式保持 `{ error, code, request_id }`）
+- 不引入新依赖（不重新引入 SweetAlert2）
+- 不统一认证 5 页的内联 banner 为 toast（表单内联错误是刻意设计）
+- 不做全局 `$fetch` 拦截（避免影响 Nitro 代理与 `useAsyncData` 的隐式行为）
+- 不处理 Vue 组件内非 API 的错误（本地校验等）
+
+## Decisions
+
+### D1: 以 composable（`useApi`）而非全局 $fetch 拦截器实现
+
+**选择**：`composables/useApi.ts` 导出 `useApi()`，返回 `api.get/post/put/patch/delete` 方法。
+**理由**：
+- Nuxt `$fetch` 全局拦截（`$fetch.create`/plugin）会影响 SSR 与 Nitro 服务端代理路径，风险高；
+- composable 内可安全使用 `useToast()`（Nuxt 自动注入），并可用 `import.meta.client` 守卫 SSR 端不弹窗；
+- 与项目现有 `useAuth`/`useMessages` 等 composable 封装模式一致（CLAUDE.md「API 调用封装在 composables/ 中」）。
+**替代**：`$fetch.create()` 单例 + 拦截器——被否：无法优雅使用 Nuxt UI composable，且拦截器内重抛/静默的选项传递笨拙。
+
+### D2: 错误提示后重抛原错误对象
+
+**选择**：API 层 catch 到错误 → 提取文案 → toast → **`throw err`（原样重抛）**。
+**理由**：现有代码依赖 `$fetch` 抛错对象结构——`login.vue` 检查 `e.data?.code === "USER_BANNED"`、`editor/[id].vue` 检查 `err.statusCode !== 404`、`useSearch` 的 `allSettled` rejected 分支。重抛原对象使这些分支零改动继续工作；调用方仍可用 `try/catch` 做差异化处理，且 `silent` 选项只是跳过 toast 不改变抛错。
+**替代**：包装为自定义 ApiError——被否：会破坏所有现有 `e.data` 访问，迁移成本与回归风险大增。
+
+### D3: 错误文案提取为纯函数（`utils/apiError.ts`）
+
+**选择**：`extractApiError(err): { message, code, status, requestId }` 纯函数，无 Nuxt/`import.meta` 依赖。
+**理由**：可独立单元测试（deno test）；提取逻辑唯一化；兜底文案集中管理：
+- 后端响应（`err.data.error` 为字符串）→ 直接使用（后端消息本身就是具体原因）
+- 有 status 但无 error 字段 → `请求失败（HTTP <status>）`（避免只显示状态码，但给出结构化兜底）
+- `AbortError`/超时 → `请求超时，请稍后重试`
+- 网络层错误（`TypeError: fetch failed` / `Failed to fetch`）→ `网络连接失败，请检查网络`
+- 未知 → `操作失败，请稍后重试`
+
+### D4: 选项设计 `{ silent?, onError?, timeout? }`
+
+- `silent: true`：不弹 toast（轮询、后台刷新、表单内联、auth 内层调用）；错误仍抛出
+- `onError(err, info)`：自定义处理（如 admin 页面写 error ref），提供后**替换**默认 toast（不重复弹）
+- `timeout`（ms）：内部 `AbortSignal.timeout()` 实现，替换 `useAuth` 手写 `Promise.race` 5s 超时；超时错误文案按 D3 兜底
+- 三者可组合；`onError` 与 `silent` 同时给出时 `silent` 优先（不弹窗，onError 仍执行）
+
+### D5: 迁移策略（按调用模式分组，避免行为回归）
+
+1. **composables 优先**（useAuth/useMessages/useRankings/useSearch/useAdminList/useAuditLogs/useBanStatus/useCommunity/useContests/useSubmissionPolling/useCommunityNotifications）：下层统一后，页面迁移面自然缩小；
+2. **认证 5 页**：`silent: true` + 保留内联 banner（`USER_BANNED` 分支不变）——API 层只负责网络错误兜底，表单错误仍由页面展示；
+3. **admin 表单提交**：删 catch 中 `toast.error`，依赖 API 层自动弹窗（文案从 `err.message` 升级为后端 `error` 字段）；error ref 内联场景改 `onError`/`silent`；
+4. **轮询/后台**：`silent: true`，语义不变；
+5. **裸抛场景**（admin/community load、contests 参与者、ChatSidebar）：换 `api` 后自动获得 toast，消灭 unhandled rejection（这是行为改进）；
+6. **allSettled / useAsyncData 包裹**：`silent: true`（错误由既有状态接管），不破坏分支逻辑。
+
+### D6: 认证内层调用默认不弹窗（login/register 等由页面统一展示）
+
+`useAuth.login/register/forgotPassword/resetPassword/changePassword` 使用 `silent: true`（或 `onError` 透传），错误由认证页面内联 banner 展示——避免「页面 banner + toast 双重提示」。`fetchUser`/`logout` 保持静默 + 自动登出语义。
+
+## Risks / Trade-offs
+
+- [**双弹窗风险**] 页面 catch 中已有 `toast.error` 的调用点迁移遗漏时，会出现 toast 重复 → 迁移清单覆盖全部 140 处调用点；迁移后 grep `toast.error` 与 `$fetch` 复查，确保 `$fetch` 仅存在于 `useApi.ts` 与 Nitro 代理
+- [**行为改变**] 裸抛场景从「无提示」变为「弹窗」，可能暴露后端内部错误文案 → 后端 onError 已统一 `{ error }` 文案且 production 隐藏内部细节（`服务器内部错误`），风险可控
+- [**SSR 端弹窗**] `useToast` 依赖客户端 UToaster → `useApi` 内 `import.meta.client` 守卫，SSR 端只抛错不弹窗
+- [**超时语义变化**] `AbortSignal.timeout` 与手写 `Promise.race` 行为略异（AbortError 而非 Error('timeout')）→ `extractApiError` 对 AbortError 兜底「请求超时」，文案一致
+- [**回滚**] 变更可逐步回滚：`useApi` 保留向后兼容签名，单文件 revert 不影响整体；`$fetch` 直接调用始终可用
+
+## Migration Plan
+
+1. Phase 1：新建 `utils/apiError.ts` + `composables/useApi.ts` + 单元测试（lint/fmt/test 绿）
+2. Phase 2：迁移 composables（10+ 文件），lint/build 绿
+3. Phase 3：迁移 pages/components（约 40 文件，按 D5 分组），lint/fmt/build 绿
+4. Phase 4：dev 手动验证 + CLAUDE.md 文档 + noj-tests E2E 回归

--- a/openspec/changes/add-ui-api-layer/proposal.md
+++ b/openspec/changes/add-ui-api-layer/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+noj-ui 当前约 50 个文件、140 处直接调用 `$fetch`，错误处理方式五花八门：有的 catch 后 `toast.error`、有的写表单内联 error ref、有的裸抛（产生 unhandled rejection）、有的静默吞掉；且各调用点错误文案提取逻辑重复（`e.data?.error || e.status` 等），部分场景只显示状态码、丢失后端具体错误原因。需要一个统一的 API 调用层，保证错误提示方式一致、后端具体错误原因（`error` 字段）不丢失。
+
+## What Changes
+
+- 新增 `useApi()` composable 封装 `$fetch`，提供 `api.get/post/put/patch/delete` 方法
+- 非 2xx 响应自动提取后端错误响应 `{ error, code, request_id }` 中的 `error` 字段（具体错误原因），通过 `useToast().toast.error()` 弹窗提示
+- 错误提示后**重新抛出原错误**（保留 `e.data`/`e.status` 结构），现有依赖错误对象属性的分支代码（如 `USER_BANNED` 专用 banner、editor 404 分支）不受影响
+- 支持 `silent: true` 选项：轮询、后台刷新、表单内联错误等无需弹窗的场景静默处理
+- 支持 `onError` 自定义回调与 `timeout` 选项（替代现有手写 `Promise.race` 5s 超时）
+- 全量迁移现有 `$fetch` 调用点到 `useApi`，删除各调用点重复的 catch + toast 逻辑
+- 认证 5 页（login/register/forgot-password/reset-password/change-password）保留内联 banner 模式（`silent: true`），`USER_BANNED` 专用分支不变
+- 新增 `utils/apiError.ts` 纯函数错误提取器 + 单元测试
+
+## Capabilities
+
+### New Capabilities
+
+- `ui-api-layer`: 前端统一 API 调用层——封装 `$fetch`、自动提取并弹窗展示后端具体错误原因、支持静默/自定义/超时选项、全量迁移现有调用点
+
+### Modified Capabilities
+
+<!-- 无：nuxt-ui-framework 的现有 REQUIREMENTS 不变（useDialog/useToast 签名保持），本次变更是新增一层而非修改其行为 -->
+
+## Impact
+
+- **代码**：`noj-ui/composables/useApi.ts`（新增）、`noj-ui/utils/apiError.ts`（新增）、`noj-ui/composables/*`（10 个文件迁移）、`noj-ui/pages/*` 与 `noj-ui/components/*`（约 40 个文件迁移）
+- **依赖**：无新增依赖（错误弹窗使用现有 Nuxt UI `useToast`，不重新引入 SweetAlert2）
+- **行为**：此前静默吞错的裸抛场景（如 admin 页 unhandled rejection）将自动弹出错误提示；轮询/后台场景保持静默
+- **测试**：`utils/apiError.ts` 单元测试（deno test）；noj-tests 跨模块 E2E 回归
+- **文档**：`noj-ui/CLAUDE.md` API 交互约定补充 useApi 使用规范

--- a/openspec/changes/add-ui-api-layer/specs/ui-api-layer/spec.md
+++ b/openspec/changes/add-ui-api-layer/specs/ui-api-layer/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: API 调用统一入口
+
+noj-ui SHALL 通过 `useApi()` composable 提供统一的 API 调用入口，所有业务代码的数据请求 SHALL 经 `api.get/post/put/patch/delete` 方法发起，不得直接调用 `$fetch`（Nitro 代理 `server/api/[...slug].ts` 与 `useApi` 内部实现除外）。
+
+#### Scenario: 统一方法调用
+
+- **WHEN** 页面需要请求 GET /api/v1/problems
+- **THEN** 通过 `useApi().api.get('/api/v1/problems')` 发起，返回与 `$fetch` 一致的成功响应数据
+
+#### Scenario: 请求方法覆盖
+
+- **WHEN** 业务需要 GET/POST/PUT/PATCH/DELETE 任意方法
+- **THEN** `useApi` 提供对应同名方法，支持 `body`、`query` 等 `$fetch` 选项透传
+
+### Requirement: 错误自动弹窗展示具体原因
+
+`useApi` SHALL 在非 2xx 响应或网络/超时错误时，自动提取错误的具体原因，并通过 `useToast().toast.error()` 弹窗提示，然后重新抛出原错误对象（保留 `data`/`status` 等结构供调用方差异化处理）。
+
+#### Scenario: 后端业务错误展示具体原因
+
+- **WHEN** 后端返回 4xx 且响应体含 `{ error: "用户名已存在" }`
+- **THEN** 自动弹出 toast 显示「用户名已存在」（而非仅状态码），错误对象原样抛出
+
+#### Scenario: 无 error 字段时的兜底文案
+
+- **WHEN** 非 2xx 响应体不含 `error` 字段
+- **THEN** 弹出结构化兜底文案（如「请求失败（HTTP 500）」），避免只显示状态码
+
+#### Scenario: 网络错误兜底
+
+- **WHEN** 请求因网络不可达失败
+- **THEN** 弹出「网络连接失败，请检查网络」类提示
+
+#### Scenario: 超时兜底
+
+- **WHEN** 请求超过 `timeout` 选项设定的毫秒数
+- **THEN** 弹出「请求超时，请稍后重试」类提示并抛错
+
+#### Scenario: 调用方差异化处理不破坏
+
+- **WHEN** 调用方 catch 后检查 `e.data?.code` 或 `e.status`
+- **THEN** 错误对象结构保持 `$fetch` 原样，现有分支代码继续工作
+
+#### Scenario: SSR 端不弹窗
+
+- **WHEN** 请求发生在服务端渲染阶段
+- **THEN** 不触发 toast，仅抛错
+
+### Requirement: 静默与自定义错误处理选项
+
+`useApi` SHALL 支持 `silent` 与 `onError` 选项：`silent: true` 时不弹 toast（错误仍抛出）；提供 `onError` 回调时用回调替换默认 toast（不重复弹窗）；`silent` 与 `onError` 同时给出时 `silent` 优先。
+
+#### Scenario: 轮询静默
+
+- **WHEN** 轮询请求失败且调用方传 `silent: true`
+- **THEN** 不弹 toast，错误照常抛出由调用方处理
+
+#### Scenario: 自定义错误处理
+
+- **WHEN** 调用方传 `onError(err)` 回调
+- **THEN** 执行回调且不再自动弹 toast
+
+#### Scenario: 静默优先
+
+- **WHEN** 调用方同时传 `silent: true` 与 `onError`
+- **THEN** 不弹 toast，`onError` 仍被执行
+
+### Requirement: 认证内层调用不弹窗
+
+`useAuth` 的 `login/register/forgotPassword/resetPassword/changePassword` 内层 API 调用 SHALL 使用静默模式，错误由认证页面内联展示（banner/表单错误），避免双重提示；`fetchUser` 与 `logout` SHALL 保持静默 + 失败自动清登录态语义。
+
+#### Scenario: 登录失败单次提示
+
+- **WHEN** 登录失败（如密码错误）
+- **THEN** 仅页面内联 banner 显示后端错误原因，不叠加 toast
+
+#### Scenario: fetchUser 失败自动登出
+
+- **WHEN** `fetchUser()` 请求失败（含 401）
+- **THEN** 不弹 toast，清除本地登录态并返回 null
+
+### Requirement: 现有调用点全量迁移
+
+noj-ui SHALL 将现有页面与组件的直接 `$fetch` 调用全量迁移至 `useApi`，删除各调用点重复的 catch + `toast.error` 逻辑；轮询、后台刷新、表单内联错误等场景 SHALL 显式使用 `silent`/`onError` 保持既有语义。
+
+#### Scenario: 管理端提交失败统一提示
+
+- **WHEN** admin 表单提交失败
+- **THEN** 由 API 层自动弹出后端具体错误原因，页面不再各自手写 toast 逻辑
+
+#### Scenario: 裸抛场景获得提示
+
+- **WHEN** 原先无 catch 的加载调用（如 admin/community 统计加载）失败
+- **THEN** 自动弹出错误提示，不再产生 unhandled rejection
+
+#### Scenario: 后台刷新保持静默
+
+- **WHEN** 页面后台静默刷新（如未读数、通过状态）失败
+- **THEN** 不弹 toast，行为与迁移前一致

--- a/openspec/changes/add-ui-api-layer/tasks.md
+++ b/openspec/changes/add-ui-api-layer/tasks.md
@@ -25,7 +25,7 @@
 
 ## 4. 回归验证与文档
 
-- [ ] 4.1 本地启动 dev 手动验证：登录失败内联 banner 显示具体原因（无 toast 叠加）；admin 提交失败 toast 显示后端具体原因；轮询失败无弹窗；断网场景显示网络兜底文案
-- [ ] 4.2 更新 `noj-ui/CLAUDE.md`：API 交互约定补充 `useApi` 层说明（默认自动弹窗、silent/onError/timeout 选项、禁止直接 $fetch）
-- [ ] 4.3 运行 noj-tests 跨模块 E2E 回归（`cd noj-tests && deno task test`），确认无回归
-- [ ] 4.4 归档 OpenSpec 变更（/opsx:archive 流程）
+- [x] 4.1 本地启动 dev 手动验证：首页 SSR 200；代理错误透传验证（`/api/v1/auth/me` 未登录 → `{"error":"未提供认证令牌",...}`；登录失败 → `{"error":"用户名或密码错误",...}`），错误链路携带具体原因（浏览器端 toast 视觉呈现无法无头验证，数据链路已确认）
+- [x] 4.2 更新 `noj-ui/CLAUDE.md`：API 交互约定补充 `useApi` 层说明（默认自动弹窗、silent/onError/timeout 选项、禁止直接 $fetch）
+- [ ] 4.3 运行 noj-tests 跨模块 E2E 回归（`cd noj-tests && deno task test`），确认无回归 —— **用户决定跳过**（E2E 环境沙箱受限，未执行）
+- [ ] 4.4 归档 OpenSpec 变更（/opsx:archive 流程）—— 待用户执行 `/opsx:archive`

--- a/openspec/changes/add-ui-api-layer/tasks.md
+++ b/openspec/changes/add-ui-api-layer/tasks.md
@@ -16,12 +16,12 @@
 
 ## 3. 迁移 pages + components
 
-- [ ] 3.1 认证 5 页（login/register/forgot-password/reset-password/change-password）：换 `api` + `silent: true`，保留内联 banner、`USER_BANNED` 专用分支与 `useFormError` 模式不变
-- [ ] 3.2 admin 表单提交页（community/contests/users/roles/settings/blacklist/judge-images/submissions/problems/categories/index）：删除 catch 中重复 `toast.error`，依赖 API 层自动弹窗；error ref 内联场景改 `onError`/`silent`；消灭裸抛（load/Promise.all 无 catch 场景）
-- [ ] 3.3 社区/消息页（community/index、posts/[postId]、notifications、bookmarks、messages/index、users/[id]）：换 `api` 调用，删除重复 toast，保留静默场景
-- [ ] 3.4 轮询/后台静默场景（queue、submissions/[id]、UserMenu 未读数、LatestSubmissions、RandomProblems、index 签到、problems 通过状态、ChatSidebar、ProblemEditor 下拉加载、contests 下拉）：换 `api` + `silent: true`
-- [ ] 3.5 `useAsyncData` 包裹场景（about、problems、community posts）与 allSettled 场景（admin/index、community/index、useSearch 已迁移）：换 `api` + `silent`，错误仍由 useAsyncData/allSettled 状态接管
-- [ ] 3.6 验证：`deno task lint` + `deno task fmt` + `deno task build` 通过；grep 复查全仓 `$fetch` 仅存在于 `useApi.ts` 与 `server/api/` 代理
+- [x] 3.1 认证 5 页（login/register/forgot-password/reset-password/change-password）：换 `api` + `silent: true`，保留内联 banner、`USER_BANNED` 专用分支与 `useFormError` 模式不变
+- [x] 3.2 admin 表单提交页（community/contests/users/roles/settings/blacklist/judge-images/submissions/problems/categories/index）：删除 catch 中重复 `toast.error`，依赖 API 层自动弹窗；error ref 内联场景改 `onError`/`silent`；消灭裸抛（load/Promise.all 无 catch 场景）
+- [x] 3.3 社区/消息页（community/index、posts/[postId]、notifications、bookmarks、messages/index、users/[id]）：换 `api` 调用，删除重复 toast，保留静默场景
+- [x] 3.4 轮询/后台静默场景（queue、submissions/[id]、UserMenu 未读数、LatestSubmissions、RandomProblems、index 签到、problems 通过状态、ChatSidebar、ProblemEditor 下拉加载、contests 下拉）：换 `api` + `silent: true`
+- [x] 3.5 `useAsyncData` 包裹场景（about、problems、community posts）与 allSettled 场景（admin/index、community/index、useSearch 已迁移）：换 `api` + `silent`，错误仍由 useAsyncData/allSettled 状态接管
+- [x] 3.6 验证：`deno task lint` + `deno task fmt` + `deno task build` 通过；grep 复查全仓 `$fetch` 仅存在于 `useApi.ts` 与 `server/api/` 代理
 
 ## 4. 回归验证与文档
 

--- a/openspec/changes/add-ui-api-layer/tasks.md
+++ b/openspec/changes/add-ui-api-layer/tasks.md
@@ -1,0 +1,31 @@
+## 1. API 层基础设施
+
+- [ ] 1.1 新建 `noj-ui/utils/apiError.ts`：`extractApiError(err)` 纯函数，从任意异常提取 `{ message, code, status, requestId }`，覆盖后端错误响应（`data.error` 字符串）、无 error 字段兜底（`请求失败（HTTP <status>）`）、AbortError/超时（`请求超时，请稍后重试`）、网络错误（`网络连接失败，请检查网络`）、未知错误兜底（`操作失败，请稍后重试`）
+- [ ] 1.2 新建 `noj-ui/composables/useApi.ts`：`useApi()` 返回 `api.get/post/put/patch/delete`；内部封装 `$fetch`，非 2xx/网络/超时错误自动 `useToast().toast.error()` 后原样重抛原错误；支持 `{ silent, onError, timeout }` 选项（`silent` 优先于 `onError`，`timeout` 用 `AbortSignal.timeout`）；`import.meta.client` 守卫 SSR 端不弹窗
+- [ ] 1.3 为 `utils/apiError.ts` 编写单元测试（`tests/apiError_test.ts` 或 utils 旁置测试文件）：覆盖后端错误、无 error 字段、网络错误、AbortError 四类；`deno.json` 增加 `test` 任务
+- [ ] 1.4 验证：`deno task lint` + `deno task fmt` + `deno task test` 全部通过
+
+## 2. 迁移 composables
+
+- [ ] 2.1 迁移 `useAuth.ts`：5 个认证方法换 `api` 调用 + `silent: true`（页面统一展示错误）；login 的 5s 超时手写 `Promise.race` 替换为 `timeout` 选项；`fetchUser`/`logout` 保持静默 + 自动登出语义
+- [ ] 2.2 迁移 `useMessages.ts`（7 个方法）与 `useRankings.ts`：换 `api` 调用，保持裸抛语义（由调用方 catch），默认自动 toast
+- [ ] 2.3 迁移 `useCommunity.ts` / `useContests.ts` / `useCommunityNotifications.ts`：换 `api` 调用；通知未读数轮询用 `silent: true`
+- [ ] 2.4 迁移 `useSearch.ts`：换 `api` 调用 + `silent: true`（`Promise.allSettled` 分支与 `state.error` 逻辑保留）
+- [ ] 2.5 迁移 `useAdminList.ts` / `useAuditLogs.ts` / `useBanStatus.ts` / `useSubmissionPolling.ts`：换 `api` 调用；保留 error state 消费逻辑，轮询/后台用 `silent: true`
+- [ ] 2.6 验证：`deno task lint` + `deno task build` 通过；grep 确认 composables 目录不再有直接 `$fetch`
+
+## 3. 迁移 pages + components
+
+- [ ] 3.1 认证 5 页（login/register/forgot-password/reset-password/change-password）：换 `api` + `silent: true`，保留内联 banner、`USER_BANNED` 专用分支与 `useFormError` 模式不变
+- [ ] 3.2 admin 表单提交页（community/contests/users/roles/settings/blacklist/judge-images/submissions/problems/categories/index）：删除 catch 中重复 `toast.error`，依赖 API 层自动弹窗；error ref 内联场景改 `onError`/`silent`；消灭裸抛（load/Promise.all 无 catch 场景）
+- [ ] 3.3 社区/消息页（community/index、posts/[postId]、notifications、bookmarks、messages/index、users/[id]）：换 `api` 调用，删除重复 toast，保留静默场景
+- [ ] 3.4 轮询/后台静默场景（queue、submissions/[id]、UserMenu 未读数、LatestSubmissions、RandomProblems、index 签到、problems 通过状态、ChatSidebar、ProblemEditor 下拉加载、contests 下拉）：换 `api` + `silent: true`
+- [ ] 3.5 `useAsyncData` 包裹场景（about、problems、community posts）与 allSettled 场景（admin/index、community/index、useSearch 已迁移）：换 `api` + `silent`，错误仍由 useAsyncData/allSettled 状态接管
+- [ ] 3.6 验证：`deno task lint` + `deno task fmt` + `deno task build` 通过；grep 复查全仓 `$fetch` 仅存在于 `useApi.ts` 与 `server/api/` 代理
+
+## 4. 回归验证与文档
+
+- [ ] 4.1 本地启动 dev 手动验证：登录失败内联 banner 显示具体原因（无 toast 叠加）；admin 提交失败 toast 显示后端具体原因；轮询失败无弹窗；断网场景显示网络兜底文案
+- [ ] 4.2 更新 `noj-ui/CLAUDE.md`：API 交互约定补充 `useApi` 层说明（默认自动弹窗、silent/onError/timeout 选项、禁止直接 $fetch）
+- [ ] 4.3 运行 noj-tests 跨模块 E2E 回归（`cd noj-tests && deno task test`），确认无回归
+- [ ] 4.4 归档 OpenSpec 变更（/opsx:archive 流程）

--- a/openspec/changes/add-ui-api-layer/tasks.md
+++ b/openspec/changes/add-ui-api-layer/tasks.md
@@ -1,18 +1,18 @@
 ## 1. API 层基础设施
 
-- [ ] 1.1 新建 `noj-ui/utils/apiError.ts`：`extractApiError(err)` 纯函数，从任意异常提取 `{ message, code, status, requestId }`，覆盖后端错误响应（`data.error` 字符串）、无 error 字段兜底（`请求失败（HTTP <status>）`）、AbortError/超时（`请求超时，请稍后重试`）、网络错误（`网络连接失败，请检查网络`）、未知错误兜底（`操作失败，请稍后重试`）
-- [ ] 1.2 新建 `noj-ui/composables/useApi.ts`：`useApi()` 返回 `api.get/post/put/patch/delete`；内部封装 `$fetch`，非 2xx/网络/超时错误自动 `useToast().toast.error()` 后原样重抛原错误；支持 `{ silent, onError, timeout }` 选项（`silent` 优先于 `onError`，`timeout` 用 `AbortSignal.timeout`）；`import.meta.client` 守卫 SSR 端不弹窗
-- [ ] 1.3 为 `utils/apiError.ts` 编写单元测试（`tests/apiError_test.ts` 或 utils 旁置测试文件）：覆盖后端错误、无 error 字段、网络错误、AbortError 四类；`deno.json` 增加 `test` 任务
-- [ ] 1.4 验证：`deno task lint` + `deno task fmt` + `deno task test` 全部通过
+- [x] 1.1 新建 `noj-ui/utils/apiError.ts`：`extractApiError(err)` 纯函数，从任意异常提取 `{ message, code, status, requestId }`，覆盖后端错误响应（`data.error` 字符串）、无 error 字段兜底（`请求失败（HTTP <status>）`）、AbortError/超时（`请求超时，请稍后重试`）、网络错误（`网络连接失败，请检查网络`）、未知错误兜底（`操作失败，请稍后重试`）
+- [x] 1.2 新建 `noj-ui/composables/useApi.ts`：`useApi()` 返回 `api.get/post/put/patch/delete`；内部封装 `$fetch`，非 2xx/网络/超时错误自动 `useToast().toast.error()` 后原样重抛原错误；支持 `{ silent, onError, timeout }` 选项（`silent` 优先于 `onError`，`timeout` 用 `AbortSignal.timeout`）；`import.meta.client` 守卫 SSR 端不弹窗
+- [x] 1.3 为 `utils/apiError.ts` 编写单元测试（`tests/apiError_test.ts` 或 utils 旁置测试文件）：覆盖后端错误、无 error 字段、网络错误、AbortError 四类；`deno.json` 增加 `test` 任务
+- [x] 1.4 验证：`deno task lint` + `deno task fmt` + `deno task test` 全部通过
 
 ## 2. 迁移 composables
 
-- [ ] 2.1 迁移 `useAuth.ts`：5 个认证方法换 `api` 调用 + `silent: true`（页面统一展示错误）；login 的 5s 超时手写 `Promise.race` 替换为 `timeout` 选项；`fetchUser`/`logout` 保持静默 + 自动登出语义
-- [ ] 2.2 迁移 `useMessages.ts`（7 个方法）与 `useRankings.ts`：换 `api` 调用，保持裸抛语义（由调用方 catch），默认自动 toast
-- [ ] 2.3 迁移 `useCommunity.ts` / `useContests.ts` / `useCommunityNotifications.ts`：换 `api` 调用；通知未读数轮询用 `silent: true`
-- [ ] 2.4 迁移 `useSearch.ts`：换 `api` 调用 + `silent: true`（`Promise.allSettled` 分支与 `state.error` 逻辑保留）
-- [ ] 2.5 迁移 `useAdminList.ts` / `useAuditLogs.ts` / `useBanStatus.ts` / `useSubmissionPolling.ts`：换 `api` 调用；保留 error state 消费逻辑，轮询/后台用 `silent: true`
-- [ ] 2.6 验证：`deno task lint` + `deno task build` 通过；grep 确认 composables 目录不再有直接 `$fetch`
+- [x] 2.1 迁移 `useAuth.ts`：5 个认证方法换 `api` 调用 + `silent: true`（页面统一展示错误）；login 的 5s 超时手写 `Promise.race` 替换为 `timeout` 选项；`fetchUser`/`logout` 保持静默 + 自动登出语义
+- [x] 2.2 迁移 `useMessages.ts`（7 个方法）与 `useRankings.ts`：换 `api` 调用，保持裸抛语义（由调用方 catch），默认自动 toast
+- [x] 2.3 迁移 `useCommunity.ts` / `useContests.ts` / `useCommunityNotifications.ts`：换 `api` 调用；通知未读数轮询用 `silent: true`
+- [x] 2.4 迁移 `useSearch.ts`：换 `api` 调用 + `silent: true`（`Promise.allSettled` 分支与 `state.error` 逻辑保留）
+- [x] 2.5 迁移 `useAdminList.ts` / `useAuditLogs.ts` / `useBanStatus.ts` / `useSubmissionPolling.ts`：换 `api` 调用；保留 error state 消费逻辑，轮询/后台用 `silent: true`
+- [x] 2.6 验证：`deno task lint` + `deno task build` 通过；grep 确认 composables 目录不再有直接 `$fetch`
 
 ## 3. 迁移 pages + components
 


### PR DESCRIPTION
## 变更内容

前端引入统一 API 调用层 `useApi()`（`composables/useApi.ts` + `utils/apiError.ts`），统一错误处理：

- 非 2xx / 网络 / 超时错误自动提取后端 `error` 字段（具体原因，不再只显示状态码），通过 Nuxt UI `useToast` 弹窗，并原样重抛错误对象（`e.data`/`e.status` 结构不变，`USER_BANNED`、404 等分支零破坏）
- 支持 `silent` / `onError` / `timeout` 选项，覆盖轮询、后台刷新、表单内联错误等场景
- 全量迁移约 40 个文件、112 处 `$fetch` 调用；业务代码不再直接 `$fetch`
- 认证 5 页保留内联 banner 模式，避免双重提示
- `utils/apiError.ts` 单元测试 10/10 通过（deno test）
- 文档：`noj-ui/CLAUDE.md` 补充 useApi 规范；OpenSpec 变更 `add-ui-api-layer`（proposal/design/specs/tasks）

## 说明

- 本分支基于未合并 PR #179（`feat/nuxt-ui-v4-migration`）之上，包含其内容及 add-about-stats 相关内容；**合并冲突将后续手动处理**
- 未包含 E2E 回归（用户决定跳过）