### PR TITLE
fix(ui): 修复 nuxt dev 配置变更重启时进程被 close 钩子杀死

### DIFF
--- a/noj-ui/nuxt.config.ts
+++ b/noj-ui/nuxt.config.ts
@@ -55,7 +55,12 @@ export default defineNuxtConfig({
   // Deno Compile 用，删了没法编译
   hooks: {
     close: () => {
-      process.exit(0);
+      // 仅在编译产物（deno compile 单二进制）中主动退出；
+      // nuxt dev 的配置变更重启也会触发 close，直接退出会杀掉整个开发服务器
+      // （管理后台创建竞赛时前端报「网络连接失败，请检查网络」的根因）。
+      if (!process.argv.includes('dev')) {
+        process.exit(0);
+      }
     },
   },
 


### PR DESCRIPTION
## 问题

管理后台创建竞赛时前端报「网络连接失败，请检查网络」。

根因：`noj-ui/nuxt.config.ts` 中的 `hooks.close → process.exit(0)` 本是为 `deno compile` 单二进制产物添加的，但 `nuxt dev` 在 nuxt.config.ts 变更触发重启时也会执行 close 钩子，导致整个开发服务器被杀死（端口 3000 关闭）。前端 `useApi` 将 fetch 层失败映射为「网络连接失败，请检查网络」，后端创建竞赛接口本身正常。

## 修复

仅在非 dev 模式下执行 `process.exit(0)`（已确认触发进程 argv 为 `nuxt.mjs dev`，可精确区分开发/编译场景）。

## 验证

- 修复前：`touch nuxt.config.ts` 触发重启 → 进程消失、端口关闭。
- 修复后：连续两次配置变更重启均存活，端口保持监听，SSR 恢复正常（二次请求 35ms）。
- `deno fmt --check` + `deno lint` 通过。