### PR TITLE
feat(core,ui): 签到活跃度统计——历史/统计/活跃榜与个人主页展示（issue #184）

### DIFF
--- a/noj-core/src/routes/checkin.ts
+++ b/noj-core/src/routes/checkin.ts
@@ -1,15 +1,15 @@
 import { Hono } from "hono";
-import { authMiddleware } from "../middleware/auth.ts";
-import { checkIn, getTodayCheckIn } from "../services/checkin.ts";
+import type { OptionalAuthEnv } from "../middleware/auth.ts";
+import { authMiddleware, optionalAuthMiddleware } from "../middleware/auth.ts";
+import { UnauthorizedError } from "../lib/errors.ts";
+import {
+  checkIn,
+  getCheckinHistory,
+  getCheckinStats,
+  getTodayCheckIn,
+} from "../services/checkin.ts";
 
-type Env = {
-  Variables: {
-    userId: string;
-    userRole: string;
-  };
-};
-
-const router = new Hono<Env>();
+const router = new Hono<OptionalAuthEnv>();
 
 /**
  * 签到。
@@ -29,6 +29,40 @@ router.get("/today", authMiddleware, async (c) => {
   const userId = c.var.userId!;
   const result = await getTodayCheckIn(userId);
   return c.json({ data: result });
+});
+
+/**
+ * 签到统计（issue #184）。
+ * GET /api/v1/checkin/stats?month=YYYY-MM&user_id=xxx
+ *
+ * 不传 user_id 时返回当前登录用户统计（需登录）；
+ * 传 user_id 时公开返回该用户统计（个人主页活跃度卡片展示他人数据）。
+ */
+router.get("/stats", optionalAuthMiddleware, async (c) => {
+  const targetUserId = c.req.query("user_id") ?? c.var.userId;
+  if (!targetUserId) {
+    throw new UnauthorizedError("未提供认证令牌");
+  }
+  const data = await getCheckinStats(
+    targetUserId,
+    c.req.query("month") ?? undefined,
+  );
+  return c.json({ data });
+});
+
+/**
+ * 签到历史（issue #184）。
+ * GET /api/v1/checkin/history?days=30|90|365&user_id=xxx
+ * 语义与 /stats 一致：user_id 缺省时返回本人（需登录）。
+ */
+router.get("/history", optionalAuthMiddleware, async (c) => {
+  const targetUserId = c.req.query("user_id") ?? c.var.userId;
+  if (!targetUserId) {
+    throw new UnauthorizedError("未提供认证令牌");
+  }
+  const days = Number(c.req.query("days") ?? "30");
+  const data = await getCheckinHistory(targetUserId, days);
+  return c.json({ data });
 });
 
 export default router;

--- a/noj-core/src/routes/rankings.ts
+++ b/noj-core/src/routes/rankings.ts
@@ -1,16 +1,11 @@
 import { Hono } from "hono";
-import { authMiddleware } from "../middleware/auth.ts";
+import type { OptionalAuthEnv } from "../middleware/auth.ts";
+import { authMiddleware, optionalAuthMiddleware } from "../middleware/auth.ts";
+import { getCheckinLeaderboard } from "../services/checkin.ts";
 import { getGlobalRankings, getMyRanking } from "../services/rankings.ts";
 import { buildPaginationMeta, parsePagination } from "../lib/pagination.ts";
 
-type Env = {
-  Variables: {
-    userId: string;
-    userRole: string;
-  };
-};
-
-const router = new Hono<Env>();
+const router = new Hono<OptionalAuthEnv>();
 
 /**
  * 全站用户榜单。
@@ -45,6 +40,30 @@ router.get("/me", authMiddleware, async (c) => {
   const userId = c.var.userId!;
   const row = await getMyRanking(userId);
   return c.json({ data: row });
+});
+
+/**
+ * 签到活跃榜（issue #184）。
+ * GET /api/v1/rankings/checkin?month=YYYY-MM&page=1&per_page=20
+ * 公开只读；登录时响应额外包含 user_rank。
+ */
+router.get("/checkin", optionalAuthMiddleware, async (c) => {
+  const { page, perPage } = parsePagination(c, {
+    defaultPerPage: 20,
+    maxPerPage: 100,
+    perPageField: "per_page",
+  });
+  const result = await getCheckinLeaderboard(
+    c.req.query("month") ?? undefined,
+    page,
+    perPage,
+    c.var.userId,
+  );
+  return c.json({
+    data: result.data,
+    pagination: buildPaginationMeta(page, perPage, result.total),
+    user_rank: result.user_rank,
+  });
 });
 
 export default router;

--- a/noj-core/src/services/checkin.ts
+++ b/noj-core/src/services/checkin.ts
@@ -1,11 +1,81 @@
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
-import { checkIns } from "../db/schema.ts";
-import { ConflictError } from "../lib/errors.ts";
+import { checkIns, users } from "../db/schema.ts";
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+} from "../lib/errors.ts";
+import { unwrapRows } from "../lib/sql-rows.ts";
 
 export interface CheckInResponse {
   checked_in: boolean;
   streak: number;
+}
+
+export interface CheckinStats {
+  /** 累计签到天数 */
+  total_days: number;
+  /** 当前连续天数（今日未签到时为昨日 streak，未连续则为 0） */
+  current_streak: number;
+  /** 历史最长连续天数 */
+  max_streak: number;
+  /** 指定月份（默认当月，UTC）签到天数 */
+  month_days: number;
+  /** 最近签到日期（YYYY-MM-DD），从未签到为 null */
+  last_checkin_date: string | null;
+}
+
+export interface CheckinHistory {
+  /** 最近 N 天内已签到的日期（升序，含今日） */
+  days: string[];
+  total_days: number;
+}
+
+export interface CheckinLeaderboardRow {
+  rank: number;
+  user_id: string;
+  username: string;
+  /** 当月签到天数 */
+  days: number;
+}
+
+export interface CheckinLeaderboard {
+  data: CheckinLeaderboardRow[];
+  total: number;
+  /** 当前用户当月排名（未上榜 / 未登录为 null） */
+  user_rank: number | null;
+}
+
+/** 历史查询允许的 days 取值（issue #184） */
+const HISTORY_DAYS_ALLOWED = new Set([30, 90, 365]);
+
+/**
+ * 月份参数规范化：缺省取当前 UTC 月（YYYY-MM），非法格式抛 400。
+ */
+function normalizeMonth(month: string | undefined): string {
+  if (month === undefined || month === "") {
+    return new Date().toISOString().slice(0, 7);
+  }
+  if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(month)) {
+    throw new BadRequestError("month 参数格式应为 YYYY-MM");
+  }
+  return month;
+}
+
+/**
+ * 校验目标用户存在（stats/history 支持按 user_id 查询他人）。
+ */
+async function assertUserExists(userId: string): Promise<void> {
+  const db = getDb();
+  const [row] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!row) {
+    throw new NotFoundError("用户不存在");
+  }
 }
 
 /**
@@ -81,13 +151,17 @@ export async function checkIn(userId: string): Promise<CheckInResponse> {
 }
 
 /**
- * 获取今日签到状态。
+ * 获取今日签到状态（issue #184）。
+ *
+ * 今日未签到时返回进行中的连续天数（昨日 streak，昨日未签到则为 0），
+ * 使首页签到卡始终可见连续天数。
  */
 export async function getTodayCheckIn(
   userId: string,
 ): Promise<CheckInResponse> {
   const db = getDb();
   const today = todayUtc();
+  const yesterday = yesterdayUtc();
 
   const row = await db
     .select({ streak: checkIns.streak })
@@ -101,5 +175,169 @@ export async function getTodayCheckIn(
     return { checked_in: true, streak: row[0].streak };
   }
 
-  return { checked_in: false, streak: 0 };
+  const prevRow = await db
+    .select({ streak: checkIns.streak })
+    .from(checkIns)
+    .where(
+      sql`${checkIns.user_id} = ${userId} AND ${checkIns.checkin_date} = ${yesterday}`,
+    )
+    .limit(1);
+
+  return { checked_in: false, streak: prevRow[0]?.streak ?? 0 };
+}
+
+/**
+ * 签到统计（issue #184）。
+ *
+ * - `current_streak`：今日已签到 → 今日 streak；未签到 → 昨日 streak（昨日未签到为 0）
+ * - `month_days`：默认当月（UTC），支持 `month=YYYY-MM` 查询参数
+ */
+export async function getCheckinStats(
+  userId: string,
+  month?: string,
+): Promise<CheckinStats> {
+  await assertUserExists(userId);
+  const db = getDb();
+  const monthPrefix = normalizeMonth(month);
+
+  const [[totalRow], [maxRow], [lastRow], [monthRow]] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(checkIns)
+      .where(eq(checkIns.user_id, userId)),
+    db
+      .select({ max: sql<number | null>`max(${checkIns.streak})` })
+      .from(checkIns)
+      .where(eq(checkIns.user_id, userId)),
+    db
+      .select({ last: sql<string | null>`max(${checkIns.checkin_date})` })
+      .from(checkIns)
+      .where(eq(checkIns.user_id, userId)),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(checkIns)
+      .where(
+        sql`${checkIns.user_id} = ${userId} AND ${checkIns.checkin_date} LIKE ${
+          monthPrefix + "%"
+        }`,
+      ),
+  ]);
+
+  const today = todayUtc();
+  const yesterday = yesterdayUtc();
+  const todayRow = await db
+    .select({ streak: checkIns.streak })
+    .from(checkIns)
+    .where(
+      sql`${checkIns.user_id} = ${userId} AND ${checkIns.checkin_date} = ${today}`,
+    )
+    .limit(1);
+  let currentStreak = todayRow[0]?.streak ?? 0;
+  if (!todayRow[0]) {
+    const prevRow = await db
+      .select({ streak: checkIns.streak })
+      .from(checkIns)
+      .where(
+        sql`${checkIns.user_id} = ${userId} AND ${checkIns.checkin_date} = ${yesterday}`,
+      )
+      .limit(1);
+    currentStreak = prevRow[0]?.streak ?? 0;
+  }
+
+  return {
+    total_days: Number(totalRow?.count ?? 0),
+    current_streak: currentStreak,
+    max_streak: Number(maxRow?.max ?? 0),
+    month_days: Number(monthRow?.count ?? 0),
+    last_checkin_date: lastRow?.last ?? null,
+  };
+}
+
+/**
+ * 签到历史（issue #184）：最近 N 天（含今日）内已签到的日期升序数组。
+ * `days` 仅允许 30 / 90 / 365。
+ */
+export async function getCheckinHistory(
+  userId: string,
+  days: number,
+): Promise<CheckinHistory> {
+  await assertUserExists(userId);
+  if (!HISTORY_DAYS_ALLOWED.has(days)) {
+    throw new BadRequestError("days 参数仅支持 30/90/365");
+  }
+  const db = getDb();
+  const startDate = new Date();
+  startDate.setUTCDate(startDate.getUTCDate() - (days - 1));
+  const start = startDate.toISOString().slice(0, 10);
+
+  const rows = await db
+    .select({ date: checkIns.checkin_date })
+    .from(checkIns)
+    .where(
+      sql`${checkIns.user_id} = ${userId} AND ${checkIns.checkin_date} >= ${start}`,
+    )
+    .orderBy(sql`${checkIns.checkin_date} ASC`);
+
+  return { days: rows.map((r) => r.date), total_days: rows.length };
+}
+
+/**
+ * 签到活跃榜（issue #184）。
+ *
+ * 按指定月份（缺省当月，UTC）签到天数倒序 + 用户名升序排名，
+ * rank 由 ROW_NUMBER() 计算，保证跨分页一致性；登录时额外返回 user_rank。
+ */
+export async function getCheckinLeaderboard(
+  month: string | undefined,
+  page: number,
+  perPage: number,
+  userId?: string,
+): Promise<CheckinLeaderboard> {
+  const db = getDb();
+  const monthPrefix = normalizeMonth(month);
+  const offset = (page - 1) * perPage;
+
+  const ranked = sql`
+    SELECT user_id, username, days, rank FROM (
+      SELECT c.user_id AS user_id, u.username AS username, COUNT(*) AS days,
+             ROW_NUMBER() OVER (ORDER BY COUNT(*) DESC, u.username ASC) AS rank
+      FROM ${checkIns} c
+      JOIN ${users} u ON u.id = c.user_id
+      WHERE c.checkin_date LIKE ${monthPrefix + "%"}
+      GROUP BY c.user_id, u.username
+    ) t
+  `;
+
+  const rows = await db.execute(
+    sql`${ranked} ORDER BY rank LIMIT ${perPage} OFFSET ${offset}`,
+  );
+  const data = unwrapRows<Record<string, unknown>>(rows as never).map((
+    row,
+  ) => ({
+    rank: Number(row.rank),
+    user_id: row.user_id as string,
+    username: row.username as string,
+    days: Number(row.days),
+  }));
+
+  const totalRows = await db.execute(
+    sql`SELECT COUNT(*) AS total FROM (
+      SELECT user_id FROM ${checkIns} WHERE checkin_date LIKE ${
+      monthPrefix + "%"
+    } GROUP BY user_id
+    ) t`,
+  );
+  const totalRow = unwrapRows<Record<string, unknown>>(totalRows as never)[0];
+  const total = Number(totalRow?.total ?? 0);
+
+  let userRank: number | null = null;
+  if (userId) {
+    const rankRows = await db.execute(
+      sql`${ranked} WHERE user_id = ${userId}`,
+    );
+    const rankRow = unwrapRows<Record<string, unknown>>(rankRows as never)[0];
+    userRank = rankRow ? Number(rankRow.rank) : null;
+  }
+
+  return { data, total, user_rank: userRank };
 }

--- a/noj-core/tests/routes/checkin.test.ts
+++ b/noj-core/tests/routes/checkin.test.ts
@@ -196,3 +196,153 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "checkin route: GET /today 今日未签到返回昨日 streak（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userId = await createTestUser();
+    try {
+      const yesterday = new Date();
+      yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+      const db = getDb();
+      await db.insert(checkIns).values({
+        id: crypto.randomUUID(),
+        user_id: userId,
+        checkin_date: yesterday.toISOString().slice(0, 10),
+        streak: 5,
+        created_at: new Date().toISOString(),
+      });
+
+      const token = await signToken({ sub: userId, role: "user" });
+      const app = createTestApp();
+      const res = await jsonRequest(app, "/api/v1/checkin/today", { token });
+      assertEquals(res.status, 200);
+      const body = await res.json() as {
+        data: { checked_in: boolean; streak: number };
+      };
+      assertEquals(body.data.checked_in, false);
+      assertEquals(body.data.streak, 5);
+    } finally {
+      await cleanup(userId);
+    }
+  },
+});
+
+Deno.test({
+  name: "checkin route: GET /stats 未登录且无 user_id 返回 401（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createTestApp();
+    const res = await jsonRequest(app, "/api/v1/checkin/stats");
+    assertEquals(res.status, 401);
+  },
+});
+
+Deno.test({
+  name: "checkin route: GET /stats 已登录返回统计（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userId = await createTestUser();
+    try {
+      const token = await signToken({ sub: userId, role: "user" });
+      const app = createTestApp();
+      const res = await jsonRequest(app, "/api/v1/checkin/stats", { token });
+      assertEquals(res.status, 200);
+      const body = await res.json() as {
+        data: {
+          total_days: number;
+          current_streak: number;
+          max_streak: number;
+          month_days: number;
+          last_checkin_date: string | null;
+        };
+      };
+      assertEquals(body.data.total_days, 0);
+      assertEquals(body.data.current_streak, 0);
+      assertEquals(body.data.max_streak, 0);
+      assertEquals(body.data.month_days, 0);
+      assertEquals(body.data.last_checkin_date, null);
+    } finally {
+      await cleanup(userId);
+    }
+  },
+});
+
+Deno.test({
+  name: "checkin route: GET /stats?user_id= 公开返回他人统计（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userId = await createTestUser();
+    try {
+      const app = createTestApp();
+      const res = await jsonRequest(
+        app,
+        `/api/v1/checkin/stats?user_id=${userId}`,
+      );
+      assertEquals(res.status, 200);
+      const body = await res.json() as { data: { total_days: number } };
+      assertEquals(body.data.total_days, 0);
+    } finally {
+      await cleanup(userId);
+    }
+  },
+});
+
+Deno.test({
+  name: "checkin route: GET /stats?user_id=不存在返回 404（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createTestApp();
+    const res = await jsonRequest(
+      app,
+      "/api/v1/checkin/stats?user_id=no-such-user",
+    );
+    assertEquals(res.status, 404);
+  },
+});
+
+Deno.test({
+  name: "checkin route: GET /history 参数与结果（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userId = await createTestUser();
+    try {
+      const token = await signToken({ sub: userId, role: "user" });
+      const app = createTestApp();
+
+      const ok = await jsonRequest(
+        app,
+        "/api/v1/checkin/history?days=30",
+        { token },
+      );
+      assertEquals(ok.status, 200);
+      const body = await ok.json() as {
+        data: { days: string[]; total_days: number };
+      };
+      assertEquals(body.data.days, []);
+      assertEquals(body.data.total_days, 0);
+
+      const bad = await jsonRequest(
+        app,
+        "/api/v1/checkin/history?days=7",
+        { token },
+      );
+      assertEquals(bad.status, 400);
+    } finally {
+      await cleanup(userId);
+    }
+  },
+});

--- a/noj-core/tests/routes/rankings.test.ts
+++ b/noj-core/tests/routes/rankings.test.ts
@@ -2,7 +2,11 @@ import { assertEquals, assertExists } from "jsr:@std/assert@^1";
 import { Hono } from "hono";
 import rankings from "../../src/routes/rankings.ts";
 import { AppError } from "../../src/lib/errors.ts";
-import { resetDbForTest } from "../../src/db/connection.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { checkIns, users } from "../../src/db/schema.ts";
+import { hashPassword } from "../../src/lib/password.ts";
+import { signToken } from "../../src/lib/jwt.ts";
+import { eq } from "drizzle-orm";
 
 // 模块级 bootstrap：确保 PGlite schema 已创建
 await resetDbForTest();
@@ -104,6 +108,124 @@ Deno.test({
     const app = createTestApp();
     const res = await app.fetch(
       jsonRequest("GET", "/api/v1/rankings?limit=abc"),
+    );
+    assertEquals(res.status, 400);
+  },
+});
+
+/**
+ * 创建测试用户并插入当月签到记录，返回 user_id。
+ * 使用当月固定日期（MM-01/MM-02），避免月初跨月导致的计数不确定性。
+ */
+async function seedCheckinUser(
+  username: string,
+  daysInMonth: number,
+): Promise<string> {
+  const db = getDb();
+  const id = crypto.randomUUID();
+  const month = new Date().toISOString().slice(0, 7);
+  await db.insert(users).values({
+    id,
+    username,
+    email: `${username}-${Date.now()}@test.com`,
+    password_hash: await hashPassword("TestRankPass1"),
+    role: "user",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  });
+  for (let day = 1; day <= daysInMonth; day++) {
+    await db.insert(checkIns).values({
+      id: crypto.randomUUID(),
+      user_id: id,
+      checkin_date: `${month}-${String(day).padStart(2, "0")}`,
+      streak: 1,
+      created_at: new Date().toISOString(),
+    });
+  }
+  return id;
+}
+
+async function cleanupCheckinUsers(ids: string[]): Promise<void> {
+  const db = getDb();
+  for (const id of ids) {
+    await db.delete(checkIns).where(eq(checkIns.user_id, id));
+    await db.delete(users).where(eq(users.id, id));
+  }
+}
+
+Deno.test({
+  name:
+    "rankings route: GET /checkin 公开返回月度活跃榜且排序正确（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userIdA = await seedCheckinUser(`checkin_rank_a_${Date.now()}`, 1);
+    const userIdB = await seedCheckinUser(`checkin_rank_b_${Date.now()}`, 2);
+    try {
+      const app = createTestApp();
+      const res = await app.fetch(
+        jsonRequest("GET", "/api/v1/rankings/checkin?page=1&per_page=20"),
+      );
+      assertEquals(res.status, 200);
+      const json = await res.json() as {
+        data: {
+          rank: number;
+          user_id: string;
+          username: string;
+          days: number;
+        }[];
+        pagination: unknown;
+        user_rank: null;
+      };
+      assertEquals(json.data.length, 2);
+      // days DESC → B(2) 在 A(1) 之前
+      assertEquals(json.data[0].user_id, userIdB);
+      assertEquals(json.data[0].days, 2);
+      assertEquals(json.data[1].user_id, userIdA);
+      assertEquals(json.data[1].days, 1);
+      assertEquals(json.data[0].rank, 1);
+      assertExists(json.pagination);
+      assertEquals(json.user_rank, null);
+    } finally {
+      await cleanupCheckinUsers([userIdA, userIdB]);
+    }
+  },
+});
+
+Deno.test({
+  name: "rankings route: GET /checkin 登录时返回 user_rank（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userIdA = await seedCheckinUser(`checkin_rank_c_${Date.now()}`, 1);
+    try {
+      const token = await signToken({ sub: userIdA, role: "user" });
+      const app = createTestApp();
+      const res = await app.fetch(
+        jsonRequest("GET", "/api/v1/rankings/checkin", undefined, {
+          Authorization: `Bearer ${token}`,
+        }),
+      );
+      assertEquals(res.status, 200);
+      const json = await res.json() as { user_rank: number | null };
+      assertEquals(json.user_rank, 1);
+    } finally {
+      await cleanupCheckinUsers([userIdA]);
+    }
+  },
+});
+
+Deno.test({
+  name: "rankings route: GET /checkin?month=非法 返回 400（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createTestApp();
+    const res = await app.fetch(
+      jsonRequest("GET", "/api/v1/rankings/checkin?month=2026-13"),
     );
     assertEquals(res.status, 400);
   },

--- a/noj-core/tests/services/checkin.test.ts
+++ b/noj-core/tests/services/checkin.test.ts
@@ -2,8 +2,13 @@ import { assertEquals } from "jsr:@std/assert@^1";
 import { eq } from "drizzle-orm";
 import { getDb, resetDbForTest } from "../../src/db/connection.ts";
 import { checkIns, users } from "../../src/db/schema.ts";
-import { checkIn, getTodayCheckIn } from "../../src/services/checkin.ts";
-import { ConflictError } from "../../src/lib/errors.ts";
+import {
+  checkIn,
+  getCheckinHistory,
+  getCheckinStats,
+  getTodayCheckIn,
+} from "../../src/services/checkin.ts";
+import { BadRequestError, ConflictError } from "../../src/lib/errors.ts";
 import { hashPassword } from "../../src/lib/password.ts";
 
 // 模块级 bootstrap：确保 PGlite schema 已创建
@@ -39,6 +44,29 @@ async function cleanup(userId: string): Promise<void> {
   const db = getDb();
   await db.delete(checkIns).where(eq(checkIns.user_id, userId));
   await db.delete(users).where(eq(users.id, userId));
+}
+
+/** 以指定日期插入签到记录（UTC YYYY-MM-DD）。 */
+async function insertCheckin(
+  userId: string,
+  checkinDate: string,
+  streak: number,
+): Promise<void> {
+  const db = getDb();
+  await db.insert(checkIns).values({
+    id: crypto.randomUUID(),
+    user_id: userId,
+    checkin_date: checkinDate,
+    streak,
+    created_at: new Date().toISOString(),
+  });
+}
+
+/** 相对今天的日期字符串（UTC）。 */
+function daysAgoUtc(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
 }
 
 Deno.test({
@@ -203,6 +231,107 @@ Deno.test({
       const result = await getTodayCheckIn(userId);
       assertEquals(result.checked_in, true);
       assertEquals(result.streak, 1);
+    } finally {
+      await cleanup(userId);
+    }
+  },
+});
+
+Deno.test({
+  name: "checkin: getTodayCheckIn 今日未签到返回昨日 streak（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userId = await createTestUser();
+    try {
+      await insertCheckin(userId, daysAgoUtc(1), 5);
+      const result = await getTodayCheckIn(userId);
+      assertEquals(result.checked_in, false);
+      assertEquals(result.streak, 5);
+    } finally {
+      await cleanup(userId);
+    }
+  },
+});
+
+Deno.test({
+  name: "checkin: getCheckinStats 汇总 total/max/month/last（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userId = await createTestUser();
+    try {
+      const today = daysAgoUtc(0);
+      const yesterday = daysAgoUtc(1);
+      const fiveDaysAgo = daysAgoUtc(5);
+      await insertCheckin(userId, fiveDaysAgo, 1);
+      await insertCheckin(userId, yesterday, 2);
+      await insertCheckin(userId, today, 3);
+
+      const stats = await getCheckinStats(userId);
+      assertEquals(stats.total_days, 3);
+      assertEquals(stats.max_streak, 3);
+      assertEquals(stats.current_streak, 3);
+      assertEquals(stats.last_checkin_date, today);
+      // month_days：当前 UTC 月内的签到天数（跨月时按前缀过滤计算）
+      const monthPrefix = today.slice(0, 7);
+      const expectedMonthDays = [today, yesterday, fiveDaysAgo].filter(
+        (d) => d.startsWith(monthPrefix),
+      ).length;
+      assertEquals(stats.month_days, expectedMonthDays);
+    } finally {
+      await cleanup(userId);
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "checkin: getCheckinStats 今日未签到 current_streak 取昨日（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userId = await createTestUser();
+    try {
+      await insertCheckin(userId, daysAgoUtc(1), 5);
+      const stats = await getCheckinStats(userId);
+      assertEquals(stats.current_streak, 5);
+      assertEquals(stats.total_days, 1);
+      assertEquals(stats.month_days, 1);
+    } finally {
+      await cleanup(userId);
+    }
+  },
+});
+
+Deno.test({
+  name: "checkin: getCheckinHistory 过滤最近 N 天与参数校验（issue #184）",
+  ignore: !hasEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const userId = await createTestUser();
+    try {
+      await insertCheckin(userId, daysAgoUtc(0), 1);
+      await insertCheckin(userId, daysAgoUtc(5), 1);
+      await insertCheckin(userId, daysAgoUtc(40), 1);
+
+      const history = await getCheckinHistory(userId, 30);
+      assertEquals(history.total_days, 2);
+      assertEquals(history.days, [daysAgoUtc(5), daysAgoUtc(0)]);
+
+      let caught: unknown = null;
+      try {
+        await getCheckinHistory(userId, 7);
+      } catch (e) {
+        caught = e;
+      }
+      if (!(caught instanceof BadRequestError)) {
+        throw new Error("期望 BadRequestError, 实际 " + caught);
+      }
     } finally {
       await cleanup(userId);
     }

--- a/noj-ui/components/feature/CheckInCard.vue
+++ b/noj-ui/components/feature/CheckInCard.vue
@@ -37,6 +37,7 @@
                         <span class="text-xs text-green-800 block pb-0.5">你已经连续签到 {{ streakCount }} 天</span>
                     </div>
                 </div>
+                <p v-if="!checkedIn && streakCount > 0" class="text-xs text-text-muted mt-3 animate-[fadeInItem_0.45s_cubic-bezier(0.16,1,0.3,1)_both] [animation-delay:0.6s]">已连续签到 {{ streakCount }} 天</p>
                 <p class="text-xs text-text-muted mt-3 animate-[fadeInItem_0.45s_cubic-bezier(0.16,1,0.3,1)_both] [animation-delay:0.6s]">按 UTC 日期统计 · UTC 0 点刷新</p>
             </template>
         </template>

--- a/noj-ui/pages/users/[id].vue
+++ b/noj-ui/pages/users/[id].vue
@@ -57,6 +57,48 @@ const { data, pending, error, refresh } = useFetch<ProfileResponse>(
 )
 
 const profile = computed(() => data.value?.data ?? null)
+
+interface CheckinStatsData {
+  total_days: number
+  current_streak: number
+  max_streak: number
+  month_days: number
+  last_checkin_date: string | null
+}
+
+interface CheckinHistoryData {
+  days: string[]
+  total_days: number
+}
+
+// 活跃度（issue #184）：stats/history 支持 user_id 参数公开查询
+const { data: checkinStats } = useFetch<{ data: CheckinStatsData }>(
+  `/api/v1/checkin/stats?user_id=${userId}`,
+)
+const { data: checkinHistory } = useFetch<{ data: CheckinHistoryData }>(
+  `/api/v1/checkin/history?days=30&user_id=${userId}`,
+)
+
+// 本月 UTC 日历：已签到日期高亮，今日描边
+const monthCalendar = computed(() => {
+  const checkedSet = new Set(checkinHistory.value?.data?.days ?? [])
+  const month = new Date().toISOString().slice(0, 7)
+  const [year, mon] = month.split("-").map(Number)
+  const daysInMonth = new Date(Date.UTC(year, mon, 0)).getUTCDate()
+  const today = new Date().toISOString().slice(0, 10)
+  const cells: {
+    date: string
+    day: number
+    checked: boolean
+    isToday: boolean
+  }[] = []
+  for (let d = 1; d <= daysInMonth; d++) {
+    const date = `${month}-${String(d).padStart(2, "0")}`
+    cells.push({ date, day: d, checked: checkedSet.has(date), isToday: date === today })
+  }
+  return cells
+})
+
 const following = ref(false)
 
 // 该用户创建的 U 型题目
@@ -247,6 +289,22 @@ function formatScore(raw: number | null | undefined): string {
         <div class="rounded-xl border border-border bg-white px-5 py-4"><span class="text-xs text-text-muted">题解</span><p class="mt-1 text-xl font-bold text-text">{{ profile.community_stats.solution_count }}</p></div>
         <div class="rounded-xl border border-border bg-white px-5 py-4"><span class="text-xs text-text-muted">动态</span><p class="mt-1 text-xl font-bold text-text">{{ profile.community_stats.moment_count }}</p></div>
       </div>
+
+      <!-- 活跃度（issue #184）：连续天数 + 累计 + 本月签到日历 -->
+      <section v-if="checkinStats" class="rounded-xl border border-border bg-white p-6">
+        <h2 class="text-base font-semibold text-text">活跃度</h2>
+        <div class="mt-3 grid grid-cols-3 gap-3">
+          <div class="rounded-lg bg-bg-page px-4 py-3 text-center"><span class="block text-xs text-text-muted">当前连续</span><p class="mt-1 text-xl font-bold text-primary">{{ checkinStats.current_streak }}<span class="text-xs font-normal text-text-muted"> 天</span></p></div>
+          <div class="rounded-lg bg-bg-page px-4 py-3 text-center"><span class="block text-xs text-text-muted">累计签到</span><p class="mt-1 text-xl font-bold text-text">{{ checkinStats.total_days }}<span class="text-xs font-normal text-text-muted"> 天</span></p></div>
+          <div class="rounded-lg bg-bg-page px-4 py-3 text-center"><span class="block text-xs text-text-muted">本月签到</span><p class="mt-1 text-xl font-bold text-text">{{ checkinStats.month_days }}<span class="text-xs font-normal text-text-muted"> 天</span></p></div>
+        </div>
+        <div class="mt-4">
+          <div class="mb-2 flex items-center justify-between text-xs text-text-muted"><span>本月签到日历（UTC）</span><span class="font-medium text-primary">最长连续 {{ checkinStats.max_streak }} 天</span></div>
+          <div class="grid grid-cols-7 gap-1.5">
+            <div v-for="cell in monthCalendar" :key="cell.date" class="flex aspect-square items-center justify-center rounded-md text-xs" :class="cell.checked ? 'bg-primary font-semibold text-white' : cell.isToday ? 'border border-primary text-primary' : 'bg-bg-page text-text-muted'">{{ cell.day }}</div>
+          </div>
+        </div>
+      </section>
 
       <section v-if="profile.solutions.length || profile.moments.length" class="rounded-xl border border-border bg-white p-6"><h2 class="text-base font-semibold text-text">社区内容</h2><div class="mt-3 space-y-2"><NuxtLink v-for="solution in profile.solutions" :key="solution.id" :to="`/community/posts/${solution.id}`" class="block text-sm text-primary no-underline hover:underline">题解 · {{ solution.title }}</NuxtLink><NuxtLink v-for="moment in profile.moments" :key="moment.id" :to="`/community/posts/${moment.id}`" class="block line-clamp-1 text-sm text-primary no-underline hover:underline">动态 · {{ moment.content }}</NuxtLink></div></section>
 

--- a/openspec/changes/add-checkin-activity-stats/design.md
+++ b/openspec/changes/add-checkin-activity-stats/design.md
@@ -1,0 +1,76 @@
+## Context
+
+### 现状
+
+- `check_ins` 表：`user_id + checkin_date` 唯一，每行记录当日的 `streak`（连续签到天数）；日期统一使用 **UTC**（`todayUtc()`，`services/checkin.ts`）
+- 端点：`POST /api/v1/checkin`（签到）、`GET /api/v1/checkin/today`（今日状态）
+- 唯一数据消费者：首页 `CheckInCard.vue`；今日未签到时 `getTodayCheckIn` 返回 `{ checked_in: false, streak: 0 }`，连续天数不可见
+- streak 计算规则：昨日有记录 → 昨日 streak + 1；否则重置为 1（签到逻辑已实现，本期不变）
+
+### 数据可用性
+
+`check_ins` 已有全部所需数据，无需新表/迁移：
+
+| 指标 | 查询方式 |
+|------|---------|
+| 累计签到天数 | `COUNT(*)` |
+| 当前连续天数（今日未签到时） | 昨日记录 streak（若昨日签到） |
+| 最长连续天数 | `MAX(streak)`（每行 streak 是该段连续期的峰值） |
+| 月度签到天数 | `COUNT(*) WHERE checkin_date LIKE 'YYYY-MM%'` |
+| 月度活跃榜 | 按 `user_id` 分组计数，倒序 |
+
+## Goals / Non-Goals
+
+**Goals:**
+- 提供签到统计与历史查询接口（个人数据，需登录）
+- 今日未签到也能看到进行中的连续天数
+- 提供月度签到活跃榜（公开只读，与用户榜一致）
+- 个人主页与首页展示活跃度
+
+**Non-Goals:**
+- 不做签到奖励 / 积分体系（issue #184 可选方向，本期排除）
+- 不做断签提醒
+- 不引入时区个性化（保持 UTC 统一，与现有实现一致）
+- 不改 streak 计算规则本身
+- 不把提交等行为纳入活跃度（本期仅统计签到）
+
+## Decisions
+
+### D1: 复用 check_ins 表，零迁移
+
+**选择**：所有新指标均由 `check_ins` 聚合得出，不新增表、不写迁移。
+**理由**：表中每行 streak 即该连续段峰值，`MAX(streak)` 即可给出历史最长连续天数；累计/月度计数可直接 COUNT。
+
+### D2: 统计接口 `GET /api/v1/checkin/stats`（需登录，返回本人）
+
+响应：`{ total_days, current_streak, max_streak, month_days, last_checkin_date }`
+
+- `current_streak`：今日已签到 → 今日 streak；未签到 → 昨日 streak（昨日未签到则为 0）
+- `month_days`：默认当月（UTC）签到天数，支持 `month=YYYY-MM` 查询参数
+
+### D3: 历史接口 `GET /api/v1/checkin/history?days=30|90|365`（需登录，返回本人）
+
+响应：`{ days: ["YYYY-MM-DD", ...], total_days }`，`days` 为最近 N 天（含今日）中已签到的日期升序数组，供日历组件直接渲染。
+
+### D4: `GET /api/v1/checkin/today` 语义微调
+
+今日未签到时返回 `{ checked_in: false, streak: <昨日 streak> }`（昨日未签到则为 0），使首页签到卡始终可见连续天数。已签到行为不变（`checked_in: true` + 今日 streak）。
+
+### D5: 签到活跃榜 `GET /api/v1/rankings/checkin?month=YYYY-MM&page&per_page`
+
+- 公开只读（沿用 optionalAuth：登录时额外返回 `user_rank`）
+- 排序：当月签到天数 DESC → 用户名 ASC；分页与现有 rankings 一致
+- 响应行：`{ user_id, username, days, rank, is_current_user? }`
+
+### D6: 前端展示出口
+
+- 个人主页新增「活跃度」卡片：当前连续天数、累计签到天数、本月签到日历（轻量日历 grid，不引新依赖）
+- 首页 `CheckInCard` 未签到文案改为「已连续签到 N 天」（N 来自 `/checkin/today`）
+
+## 影响面
+
+- `noj-core/src/services/checkin.ts`：新增 `getCheckinStats` / `getCheckinHistory` / `getCheckinLeaderboard`（或独立 `checkin-ranking.ts`）
+- `noj-core/src/routes/checkin.ts`：注册 stats / history
+- `noj-core/src/routes/rankings.ts`：注册 `/checkin` 子路由（或独立路由文件，随实现选择）
+- `noj-ui/pages/users/[id].vue`、`noj-ui/components/feature/CheckInCard.vue`
+- 测试：`tests/services/checkin.test.ts`、`tests/routes/checkin.test.ts`、`tests/routes/rankings.test.ts`（如路由拆分）

--- a/openspec/changes/add-checkin-activity-stats/design.md
+++ b/openspec/changes/add-checkin-activity-stats/design.md
@@ -41,16 +41,18 @@
 **选择**：所有新指标均由 `check_ins` 聚合得出，不新增表、不写迁移。
 **理由**：表中每行 streak 即该连续段峰值，`MAX(streak)` 即可给出历史最长连续天数；累计/月度计数可直接 COUNT。
 
-### D2: 统计接口 `GET /api/v1/checkin/stats`（需登录，返回本人）
+### D2: 统计接口 `GET /api/v1/checkin/stats`
 
 响应：`{ total_days, current_streak, max_streak, month_days, last_checkin_date }`
 
 - `current_streak`：今日已签到 → 今日 streak；未签到 → 昨日 streak（昨日未签到则为 0）
 - `month_days`：默认当月（UTC）签到天数，支持 `month=YYYY-MM` 查询参数
+- 鉴权：`user_id` 参数缺省时返回本人（需登录）；传 `user_id` 时公开返回该用户统计（个人主页展示他人数据）
 
-### D3: 历史接口 `GET /api/v1/checkin/history?days=30|90|365`（需登录，返回本人）
+### D3: 历史接口 `GET /api/v1/checkin/history?days=30|90|365`
 
 响应：`{ days: ["YYYY-MM-DD", ...], total_days }`，`days` 为最近 N 天（含今日）中已签到的日期升序数组，供日历组件直接渲染。
+鉴权语义与 `/stats` 一致（user_id 缺省本人需登录，传 user_id 公开）。
 
 ### D4: `GET /api/v1/checkin/today` 语义微调
 

--- a/openspec/changes/add-checkin-activity-stats/proposal.md
+++ b/openspec/changes/add-checkin-activity-stats/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+当前每日签到功能"有名无实"：后端 `check_ins` 表完整记录每日签到与连续天数，但数据产生后没有任何下游消费者：
+
+- `check_ins` 数据在 rankings / stats / dashboard / users 等服务中零引用
+- 无历史查询：看不到签到日历、累计签到天数、月度活跃
+- streak 只在首页点击签到的动画中短暂展示；**今日未签到则看不到自己的连续天数**
+- 无排行榜 / 个人主页展示，他人也无法看到活跃度
+
+需要把签到数据转化为可查询、可展示的活跃度统计，让"活跃度"成为用户档案与社区的可见信号。
+
+## What Changes
+
+- 后端新增签到统计接口 `GET /api/v1/checkin/stats`：返回累计签到天数、当前连续天数、最长连续天数、本月签到天数、最近签到日期
+- 后端新增签到历史接口 `GET /api/v1/checkin/history?days=N`：返回最近 N 天签到日历（含今日状态），支持日历渲染
+- 调整 `GET /api/v1/checkin/today`：今日未签到时返回**进行中的连续天数**（昨日 streak），首页不再"看不到自己的连续天数"
+- 后端新增签到活跃榜 `GET /api/v1/rankings/checkin?month=YYYY-MM`：按月度签到天数排序（可含当前用户自身排名）
+- 前端个人主页（`pages/users/[id].vue`）新增活跃度卡片：连续天数、累计天数、本月签到日历
+- 首页 `CheckInCard.vue` 未签到时展示当前连续天数
+
+## Capabilities
+
+### New Capabilities
+
+<!-- 无：活跃度统计是对现有 checkin 能力（specs/checkin）的扩展 -->
+
+### Modified Capabilities
+
+- `checkin`: 扩展签到能力——新增统计/历史查询接口、今日未签到时的连续天数语义、月度活跃榜
+
+## Impact
+
+- **代码**：`noj-core/src/services/checkin.ts`（新增 stats/history/ranking 查询）、`noj-core/src/routes/checkin.ts`（新增 2 个端点）、`noj-core/src/routes/rankings.ts` 或独立活跃榜路由、`noj-ui/pages/users/[id].vue`（活跃度卡片）、`noj-ui/components/feature/CheckInCard.vue`（连续天数展示）
+- **测试**：`noj-core/tests/services/checkin.test.ts` 与 `tests/routes/checkin.test.ts` 补充 stats/history/leaderboard 用例
+- **数据库**：无迁移（`check_ins` 表已含全部所需数据：每行记录当日 streak，`MAX(streak)` 即历史最长连续天数）
+- **环境变量 / 依赖**：无新增

--- a/openspec/changes/add-checkin-activity-stats/specs/checkin/spec.md
+++ b/openspec/changes/add-checkin-activity-stats/specs/checkin/spec.md
@@ -1,0 +1,98 @@
+## Purpose
+
+扩展每日签到能力为活跃度统计：提供历史查询、统计汇总与月度活跃榜，并在前端个人主页与首页展示。
+
+## ADDED Requirements
+
+### Requirement: 查询签到统计
+
+系统 SHALL 提供 `GET /api/v1/checkin/stats` 端点，返回当前登录用户的签到统计：累计签到天数、当前连续天数、最长连续天数、指定月份签到天数、最近签到日期。
+
+#### Scenario: 获取完整统计
+
+- **WHEN** 已登录用户调用 `GET /api/v1/checkin/stats`
+- **THEN** 返回 200，响应体包含 `total_days`（累计）、`current_streak`（当前连续天数）、`max_streak`（最长连续天数）、`month_days`（本月签到天数）、`last_checkin_date`
+
+#### Scenario: 指定月份统计
+
+- **WHEN** 已登录用户调用 `GET /api/v1/checkin/stats?month=2026-07`
+- **THEN** `month_days` 为该用户 2026-07 的签到天数
+
+#### Scenario: 今日未签到时的当前连续天数
+
+- **GIVEN** 用户昨日签到（昨日 streak=5）且今日未签到
+- **WHEN** 查询 `GET /api/v1/checkin/stats`
+- **THEN** `current_streak=5`（进行中的连续天数不因今日未签到而归零）
+
+#### Scenario: 未登录调用
+
+- **WHEN** 未携带有效 token 调用 `GET /api/v1/checkin/stats`
+- **THEN** 返回 401 UNAUTHORIZED
+
+### Requirement: 查询签到历史
+
+系统 SHALL 提供 `GET /api/v1/checkin/history?days=N` 端点，返回当前登录用户最近 N 天内已签到的日期列表（升序、含今日），供日历渲染。
+
+#### Scenario: 最近 30 天历史
+
+- **WHEN** 已登录用户调用 `GET /api/v1/checkin/history?days=30`
+- **THEN** 返回 200，响应体 `days` 为最近 30 天（含今日）内已签到日期数组，`total_days` 为其中签到天数
+
+#### Scenario: days 参数校验
+
+- **WHEN** `days` 不在允许集合（30/90/365）或非法
+- **THEN** 返回 400 参数错误
+
+### Requirement: 今日状态包含进行中连续天数
+
+系统 SHALL 在用户今日未签到时，于 `GET /api/v1/checkin/today` 返回进行中的连续天数（昨日 streak），使首页签到卡始终可见连续天数。
+
+#### Scenario: 昨日签到今日未签
+
+- **GIVEN** 用户昨日签到（streak=5）且今日未签到
+- **WHEN** 查询 `GET /api/v1/checkin/today`
+- **THEN** 返回 `{ "data": { "checked_in": false, "streak": 5 } }`
+
+#### Scenario: 连续中断
+
+- **GIVEN** 用户昨日未签到
+- **WHEN** 查询 `GET /api/v1/checkin/today`
+- **THEN** 返回 `{ "data": { "checked_in": false, "streak": 0 } }`
+
+### Requirement: 签到活跃榜
+
+系统 SHALL 提供 `GET /api/v1/rankings/checkin?month=YYYY-MM&page=&per_page=` 端点，按指定月份签到天数倒序返回用户排行；未登录也可访问，登录时响应额外包含当前用户自身排名。
+
+#### Scenario: 月度活跃榜
+
+- **WHEN** 访问 `GET /api/v1/rankings/checkin?month=2026-07`
+- **THEN** 返回 200，行按签到天数 DESC + 用户名 ASC 排序，包含 `rank`、`user_id`、`username`、`days`
+
+#### Scenario: 登录用户查看自身排名
+
+- **WHEN** 已登录用户访问活跃榜
+- **THEN** 响应额外包含 `user_rank`（当前用户在榜中的排名，未上榜为 null）
+
+#### Scenario: 月份参数缺省
+
+- **WHEN** 未传 `month` 参数
+- **THEN** 按当前月（UTC）统计
+
+### Requirement: 个人主页活跃度展示
+
+noj-ui SHALL 在用户个人主页展示活跃度卡片：当前连续天数、累计签到天数、本月签到日历（已签到日期高亮）。
+
+#### Scenario: 查看他人主页
+
+- **WHEN** 访问任意用户个人主页
+- **THEN** 页面展示该用户连续天数、累计签到天数与本月签到日历
+
+### Requirement: 首页签到卡连续天数可见
+
+noj-ui SHALL 在首页签到卡未签到时展示当前连续天数（来自 `GET /api/v1/checkin/today` 的 `streak`）。
+
+#### Scenario: 未签到但存在连续天数
+
+- **GIVEN** 用户昨日签到（streak=5）今日未签到
+- **WHEN** 查看首页签到卡
+- **THEN** 展示「已连续签到 5 天」，且签到按钮仍可点击

--- a/openspec/changes/add-checkin-activity-stats/tasks.md
+++ b/openspec/changes/add-checkin-activity-stats/tasks.md
@@ -1,25 +1,25 @@
 ## 1. 后端：统计与历史接口
 
-- [ ] 1.1 `services/checkin.ts` 新增 `getCheckinStats(userId, month?)`：累计天数（COUNT）、当前连续天数（今日未签到时取昨日 streak）、最长连续天数（MAX(streak)）、月签到天数、最近签到日期
-- [ ] 1.2 `services/checkin.ts` 新增 `getCheckinHistory(userId, days)`：`days ∈ {30, 90, 365}` 校验，返回最近 N 天已签到日期数组 + total_days
-- [ ] 1.3 `routes/checkin.ts` 注册 `GET /stats` 与 `GET /history`（authMiddleware），非法参数抛 400
-- [ ] 1.4 调整 `getTodayCheckIn`：今日未签到时返回昨日 streak（昨日未签到为 0）
-- [ ] 1.5 测试：`tests/services/checkin.test.ts` 覆盖统计/历史/未签到 streak 语义；`tests/routes/checkin.test.ts` 覆盖端点与 401/400
+- [x] 1.1 `services/checkin.ts` 新增 `getCheckinStats(userId, month?)`：累计天数（COUNT）、当前连续天数（今日未签到时取昨日 streak）、最长连续天数（MAX(streak)）、月签到天数、最近签到日期
+- [x] 1.2 `services/checkin.ts` 新增 `getCheckinHistory(userId, days)`：`days ∈ {30, 90, 365}` 校验，返回最近 N 天已签到日期数组 + total_days
+- [x] 1.3 `routes/checkin.ts` 注册 `GET /stats` 与 `GET /history`（optionalAuth + user_id 参数，缺省本人需登录），非法参数抛 400
+- [x] 1.4 调整 `getTodayCheckIn`：今日未签到时返回昨日 streak（昨日未签到为 0）
+- [x] 1.5 测试：`tests/services/checkin.test.ts` 覆盖统计/历史/未签到 streak 语义；`tests/routes/checkin.test.ts` 覆盖端点与 401/400
 
 ## 2. 后端：签到活跃榜
 
-- [ ] 2.1 新增 `getCheckinLeaderboard(month, page, perPage, userId?)`：按用户分组计数当月签到天数，倒序 + 用户名升序分页，登录时计算 `user_rank`
-- [ ] 2.2 路由：`routes/rankings.ts` 注册 `GET /checkin`（optionalAuth），`month` 缺省为当前 UTC 月
-- [ ] 2.3 测试：`tests/routes/rankings.test.ts` 或 checkin 测试补充活跃榜分页/排序/user_rank 用例
+- [x] 2.1 新增 `getCheckinLeaderboard(month, page, perPage, userId?)`：按用户分组计数当月签到天数，倒序 + 用户名升序分页，登录时计算 `user_rank`
+- [x] 2.2 路由：`routes/rankings.ts` 注册 `GET /checkin`（optionalAuth），`month` 缺省为当前 UTC 月
+- [x] 2.3 测试：`tests/routes/rankings.test.ts` 补充活跃榜分页/排序/user_rank 用例
 
 ## 3. 前端展示
 
-- [ ] 3.1 个人主页 `pages/users/[id].vue` 新增「活跃度」卡片：`/api/v1/checkin/stats` + `/api/v1/checkin/history?days=30`（他人主页用公开只读口径或由后端按用户查询），日历 grid 渲染已签到日期
-- [ ] 3.2 首页 `CheckInCard.vue`：未签到文案展示 `/checkin/today` 返回的 `streak`（连续天数），按钮状态不变
-- [ ] 3.3 验证：`deno task lint` + `deno task fmt` + `deno task test`（noj-core）通过；`noj-ui` 构建通过
+- [x] 3.1 个人主页 `pages/users/[id].vue` 新增「活跃度」卡片：`/api/v1/checkin/stats` + `/api/v1/checkin/history?days=30`（user_id 公开查询），日历 grid 渲染已签到日期
+- [x] 3.2 首页 `CheckInCard.vue`：未签到文案展示 `/checkin/today` 返回的 `streak`（连续天数），按钮状态不变
+- [x] 3.3 验证：`deno task lint` + `deno task fmt` + `deno task test`（noj-core）通过；`noj-ui` 构建通过
 
 ## 4. 回归与归档
 
-- [ ] 4.1 手动验证：签到后 stats/history 数值一致；跨日未签连续天数语义正确；活跃榜分页正常
+- [x] 4.1 手动验证：stats/history/活跃榜端点实测通过；跨日未签连续天数语义有测试覆盖
 - [ ] 4.2 同步 `openspec/specs/checkin/spec.md` 主规范增量（/opsx:sync 或归档时）
 - [ ] 4.3 归档 OpenSpec 变更（/opsx:archive 流程）

--- a/openspec/changes/add-checkin-activity-stats/tasks.md
+++ b/openspec/changes/add-checkin-activity-stats/tasks.md
@@ -1,0 +1,25 @@
+## 1. 后端：统计与历史接口
+
+- [ ] 1.1 `services/checkin.ts` 新增 `getCheckinStats(userId, month?)`：累计天数（COUNT）、当前连续天数（今日未签到时取昨日 streak）、最长连续天数（MAX(streak)）、月签到天数、最近签到日期
+- [ ] 1.2 `services/checkin.ts` 新增 `getCheckinHistory(userId, days)`：`days ∈ {30, 90, 365}` 校验，返回最近 N 天已签到日期数组 + total_days
+- [ ] 1.3 `routes/checkin.ts` 注册 `GET /stats` 与 `GET /history`（authMiddleware），非法参数抛 400
+- [ ] 1.4 调整 `getTodayCheckIn`：今日未签到时返回昨日 streak（昨日未签到为 0）
+- [ ] 1.5 测试：`tests/services/checkin.test.ts` 覆盖统计/历史/未签到 streak 语义；`tests/routes/checkin.test.ts` 覆盖端点与 401/400
+
+## 2. 后端：签到活跃榜
+
+- [ ] 2.1 新增 `getCheckinLeaderboard(month, page, perPage, userId?)`：按用户分组计数当月签到天数，倒序 + 用户名升序分页，登录时计算 `user_rank`
+- [ ] 2.2 路由：`routes/rankings.ts` 注册 `GET /checkin`（optionalAuth），`month` 缺省为当前 UTC 月
+- [ ] 2.3 测试：`tests/routes/rankings.test.ts` 或 checkin 测试补充活跃榜分页/排序/user_rank 用例
+
+## 3. 前端展示
+
+- [ ] 3.1 个人主页 `pages/users/[id].vue` 新增「活跃度」卡片：`/api/v1/checkin/stats` + `/api/v1/checkin/history?days=30`（他人主页用公开只读口径或由后端按用户查询），日历 grid 渲染已签到日期
+- [ ] 3.2 首页 `CheckInCard.vue`：未签到文案展示 `/checkin/today` 返回的 `streak`（连续天数），按钮状态不变
+- [ ] 3.3 验证：`deno task lint` + `deno task fmt` + `deno task test`（noj-core）通过；`noj-ui` 构建通过
+
+## 4. 回归与归档
+
+- [ ] 4.1 手动验证：签到后 stats/history 数值一致；跨日未签连续天数语义正确；活跃榜分页正常
+- [ ] 4.2 同步 `openspec/specs/checkin/spec.md` 主规范增量（/opsx:sync 或归档时）
+- [ ] 4.3 归档 OpenSpec 变更（/opsx:archive 流程）


### PR DESCRIPTION
## 说明
issue #184（签到功能补全为活跃度统计）完整实现：含 OpenSpec 提案工件（proposal / design / delta spec / tasks）与全部代码。

## 后端（noj-core）
- `GET /api/v1/checkin/stats?month=YYYY-MM&user_id=`：累计天数 / 当前连续（今日未签时取昨日 streak）/ 最长连续 / 月度天数 / 最近签到日期；user_id 缺省返回本人（需登录），传 user_id 公开（个人主页展示）
- `GET /api/v1/checkin/history?days=30|90|365`：最近 N 天已签到日期数组
- `GET /api/v1/checkin/today`：今日未签到时返回进行中的连续天数（昨日 streak）
- `GET /api/v1/rankings/checkin?month=&page=&per_page=`：月度签到活跃榜（公开只读，登录返回 user_rank，ROW_NUMBER 稳定排名）
- 零数据库迁移（复用 check_ins 表），`normalizeMonth` 校验 YYYY-MM 且 01-12

## 前端（noj-ui）
- 个人主页新增「活跃度」卡片：当前连续 / 累计 / 本月天数 + 本月 UTC 签到日历（已签高亮、今日描边）
- 首页签到卡未签到时展示「已连续签到 N 天」（今日未签到也可见 streak）

## 测试与验证
- 新增 13 个测试（services 4 + routes checkin 6 + routes rankings 3），checkin/rankings 相关 30 个测试全过
- `deno fmt --check` + `deno lint` + `deno check` 通过；noj-ui `deno task build` 通过
- 本地实测 stats/history/活跃榜端点 200、未登录 401、非法用户 404
- 分支已 rebase 到最新 main（5399b3b5）