### PR TITLE
fix(core): bootstrap:admin 写入 user_roles 修复新管理员无权限（issue #186）

### DIFF
--- a/noj-core/src/services/seed-system.ts
+++ b/noj-core/src/services/seed-system.ts
@@ -11,8 +11,47 @@
 
 import { and, eq, not, sql } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
-import { categories, judgeImages, users } from "../db/schema.ts";
+import {
+  categories,
+  judgeImages,
+  roles,
+  userRoles,
+  users,
+} from "../db/schema.ts";
 import { hashPassword } from "../lib/password.ts";
+import { ensureSystemRoles } from "./seed-rbac.ts";
+
+/**
+ * 为管理员用户写入 RBAC 关联（issue #186）。
+ *
+ * RBAC 落地后（#171）管理权限由 `roles.is_admin` + `user_roles` 关联表决定，
+ * `users.role` 仅用于展示/向前兼容。bootstrap:admin 创建用户时若只写
+ * `users.role = 'admin'`，登录返回的 `is_admin`（来自 RBAC 表）仍为 false，
+ * 管理接口实际无权限。
+ *
+ * 幂等：先确保系统角色存在（兼容 bootstrap 早于 init system 的执行顺序），
+ * 再以 ON CONFLICT DO NOTHING 写入 user_roles。
+ */
+async function ensureAdminRoleAssignment(userId: string): Promise<void> {
+  const db = getDb();
+  // 确保 admin 角色存在（独立执行 bootstrap:admin 时 roles 可能尚未 seed）
+  await ensureSystemRoles();
+
+  const [adminRole] = await db
+    .select({ id: roles.id })
+    .from(roles)
+    .where(eq(roles.name, "admin"))
+    .limit(1);
+  if (!adminRole) {
+    console.warn("  admin 角色不存在，无法写入 user_roles 关联");
+    return;
+  }
+
+  await db.insert(userRoles).values({
+    user_id: userId,
+    role_id: adminRole.id,
+  }).onConflictDoNothing();
+}
 
 /**
  * 初始化评测镜像白名单。
@@ -153,6 +192,7 @@ export async function ensureAdminFromEnv(): Promise<void> {
       created_at: now,
       updated_at: now,
     });
+    await ensureAdminRoleAssignment(id);
     console.log(
       `  已创建管理员用户: ${adminEmail} (${username})，已强制首次改密`,
     );
@@ -170,6 +210,7 @@ export async function ensureAdminFromEnv(): Promise<void> {
     .set({ role: "admin", updated_at: new Date().toISOString() })
     .where(eq(users.email, adminEmail));
 
+  await ensureAdminRoleAssignment(user.id);
   console.log(`  已提升用户 ${adminEmail} 为管理员`);
 }
 
@@ -231,6 +272,7 @@ export async function ensureBootstrapAdmin(): Promise<void> {
     created_at: now,
     updated_at: now,
   });
+  await ensureAdminRoleAssignment(id);
 
   console.log("");
   console.log("-".repeat(72));

--- a/noj-core/tests/seed_bootstrap_admin_test.ts
+++ b/noj-core/tests/seed_bootstrap_admin_test.ts
@@ -9,7 +9,7 @@
  * - 重复执行 seed 幂等
  */
 
-import { assertEquals } from "jsr:@std/assert@^1";
+import { assert, assertEquals } from "jsr:@std/assert@^1";
 import { getDb, resetDbForTest } from "../src/db/connection.ts";
 import { and, eq, not, sql } from "drizzle-orm";
 import {
@@ -18,11 +18,17 @@ import {
   evaluationResults,
   messageDeletions,
   messages,
+  roles,
   submissions,
+  userRoles,
   users,
 } from "../src/db/schema.ts";
 import { registerUser } from "../src/services/auth.ts";
 import { hashPassword } from "../src/lib/password.ts";
+import {
+  ensureAdminFromEnv,
+  ensureBootstrapAdmin,
+} from "../src/services/seed-system.ts";
 
 const hasDb = true; // PGlite 内存数据库始终可用
 const skip = !hasDb;
@@ -64,6 +70,19 @@ async function cleanNonRootAdmins(): Promise<void> {
   await db.delete(users).where(
     and(eq(users.role, "admin"), not(eq(users.id, "0"))),
   );
+}
+
+/**
+ * 统计用户是否拥有 admin 角色关联（RBAC user_roles，issue #186）。
+ */
+async function countAdminRoleAssignments(userId: string): Promise<number> {
+  const db = getDb();
+  const rows = await db
+    .select({ roleId: userRoles.role_id })
+    .from(userRoles)
+    .innerJoin(roles, eq(roles.id, userRoles.role_id))
+    .where(and(eq(userRoles.user_id, userId), eq(roles.name, "admin")));
+  return rows.length;
 }
 
 Deno.test({
@@ -172,5 +191,124 @@ Deno.test({
     assertEquals(admin.must_change_password, true);
     assertEquals(admin.role, "admin");
     assertEquals(admin.username, "admin");
+  },
+});
+
+Deno.test({
+  name:
+    "seed bootstrap: ensureBootstrapAdmin 创建的管理员写入 user_roles（issue #186）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    await cleanNonRootAdmins();
+    const origAdminEmail = Deno.env.get("ADMIN_EMAIL");
+    if (origAdminEmail) Deno.env.delete("ADMIN_EMAIL");
+
+    // 直接调用真实 seed 函数，验证 user_roles 关联被写入
+    await ensureBootstrapAdmin();
+
+    const db = getDb();
+    const [admin] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.role, "admin"), not(eq(users.id, "0"))))
+      .limit(1);
+    assert(admin, "应创建引导管理员");
+    assertEquals(
+      await countAdminRoleAssignments(admin.id),
+      1,
+      "引导管理员应拥有 admin 角色关联",
+    );
+
+    if (origAdminEmail) Deno.env.set("ADMIN_EMAIL", origAdminEmail);
+  },
+});
+
+Deno.test({
+  name:
+    "seed bootstrap: ensureAdminFromEnv 创建的管理员写入 user_roles（issue #186）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    await cleanNonRootAdmins();
+    const origAdminEmail = Deno.env.get("ADMIN_EMAIL");
+    const origAdminPass = Deno.env.get("ADMIN_PASS");
+
+    Deno.env.set("ADMIN_EMAIL", "ops-186@noj.local");
+    Deno.env.set("ADMIN_PASS", "OpsAdmin-2026-Xy9");
+    try {
+      await ensureAdminFromEnv();
+
+      const db = getDb();
+      const [admin] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.email, "ops-186@noj.local"))
+        .limit(1);
+      assert(admin, "应创建环境变量指定的管理员");
+      assertEquals(
+        await countAdminRoleAssignments(admin.id),
+        1,
+        "环境变量管理员应拥有 admin 角色关联",
+      );
+    } finally {
+      if (origAdminEmail) {
+        Deno.env.set("ADMIN_EMAIL", origAdminEmail);
+      } else {
+        Deno.env.delete("ADMIN_EMAIL");
+      }
+      if (origAdminPass) {
+        Deno.env.set("ADMIN_PASS", origAdminPass);
+      } else {
+        Deno.env.delete("ADMIN_PASS");
+      }
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "seed bootstrap: ensureAdminFromEnv 提升已有用户时写入 user_roles（issue #186）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    await cleanNonRootAdmins();
+    const origAdminEmail = Deno.env.get("ADMIN_EMAIL");
+    const origAdminPass = Deno.env.get("ADMIN_PASS");
+
+    const email = `promote-186-${Date.now()}@noj.local`;
+    const user = await registerUser({
+      username: `promote-186-${Date.now()}`,
+      email,
+      password: "TestPwd-2024-Xy9",
+    });
+
+    Deno.env.set("ADMIN_EMAIL", email);
+    try {
+      await ensureAdminFromEnv();
+
+      assertEquals(
+        await countAdminRoleAssignments(user.id),
+        1,
+        "被提升的管理员应写入 admin 角色关联",
+      );
+    } finally {
+      if (origAdminEmail) {
+        Deno.env.set("ADMIN_EMAIL", origAdminEmail);
+      } else {
+        Deno.env.delete("ADMIN_EMAIL");
+      }
+      if (origAdminPass) {
+        Deno.env.set("ADMIN_PASS", origAdminPass);
+      } else {
+        Deno.env.delete("ADMIN_PASS");
+      }
+    }
   },
 });


### PR DESCRIPTION
## 问题

RBAC（#171）落地后，`bootstrap:admin`（`ensureAdminFromEnv` / `ensureBootstrapAdmin`）创建管理员只写 `users.role='admin'`，未写入 `user_roles`，导致登录返回 `is_admin=false`，管理接口 403。

## 修复

- 新增 `ensureAdminRoleAssignment(userId)`：先 `ensureSystemRoles()` 保证角色存在（兼容 bootstrap 先于 init system 执行），再按 `roles.name='admin'` 幂等写入 `user_roles`
- 三处创建/提升路径均调用：环境变量创建、环境变量提升已有用户、引导管理员创建

## 测试

- `tests/seed_bootstrap_admin_test.ts` 新增 3 个回归用例：引导管理员 / 环境变量创建 / 提升已有用户均验证 `user_roles` 存在 admin 关联
- 全量 `seed_bootstrap_admin_test.ts` 7 passed；`rbac.test.ts` 5 passed；deno fmt + deno lint 通过