### PR TITLE
chore(ui): lint/fmt 覆盖子目录并补充类型检查任务（issue #187）

### DIFF
--- a/noj-ui/composables/use-submissions.ts
+++ b/noj-ui/composables/use-submissions.ts
@@ -5,83 +5,83 @@
 
 // API 返回的提列表项类型
 export interface SubmissionListItem {
-  id: string
-  user_id: string
-  problem_id: string
-  language: string
-  file_name: string | null
-  status: string
-  created_at: string
+  id: string;
+  user_id: string;
+  problem_id: string;
+  language: string;
+  file_name: string | null;
+  status: string;
+  created_at: string;
   problem: {
-    id: string
-    title: string
-  }
+    id: string;
+    title: string;
+  };
   result: {
-    status: string
-    score: number
-    time_ms: number | null
-    memory_kb: number | null
-  } | null
+    status: string;
+    score: number;
+    time_ms: number | null;
+    memory_kb: number | null;
+  } | null;
 }
 
 /**
  * 语言标识 → 显示标签映射。
  */
 export const languageLabels: Record<string, string> = {
-  python3: "Python 3",
-  python: "Python",
-  cpp: "C++",
-  c: "C",
-  javascript: "JavaScript",
-}
+  python3: 'Python 3',
+  python: 'Python',
+  cpp: 'C++',
+  c: 'C',
+  javascript: 'JavaScript',
+};
 
 /**
  * 提交流 state 标签颜色。
  */
 export const statusColors: Record<string, string> = {
-  pending: "#9ca3af",
-  judging: "#3b82f6",
-  finished: "#10b981",
-  error: "#ef4444",
-}
+  pending: '#9ca3af',
+  judging: '#3b82f6',
+  finished: '#10b981',
+  error: '#ef4444',
+};
 
 /**
  * 提交流 state 标签文字。
  */
 export const statusLabels: Record<string, string> = {
-  pending: "等待评测",
-  judging: "评测中",
-  finished: "已完成",
-  error: "系统错误",
-}
+  pending: '等待评测',
+  judging: '评测中',
+  finished: '已完成',
+  error: '系统错误',
+};
 
 /**
  * 评测结果状态 → 显示标签。
  */
 export const resultLabels: Record<string, string> = {
-  Accepted: "答案正确",
-  WrongAnswer: "答案错误",
-  TimeLimitExceeded: "超出时间限制",
-  MemoryLimitExceeded: "超出内存限制",
-  RuntimeError: "运行时错误",
-  SystemError: "系统错误",
-  CompileError: "编译错误",
-  OutputLimitExceeded: "输出超出限制",
-}
+  Accepted: '答案正确',
+  WrongAnswer: '答案错误',
+  TimeLimitExceeded: '超出时间限制',
+  MemoryLimitExceeded: '超出内存限制',
+  RuntimeError: '运行时错误',
+  SystemError: '系统错误',
+  CompileError: '编译错误',
+  OutputLimitExceeded: '输出超出限制',
+};
 
 /**
  * 评测结果状态 → 标签颜色。
  */
 export const resultColors: Record<string, string> = {
-  Accepted: "#10b981",
-  WrongAnswer: "#ef4444",
-  TimeLimitExceeded: "#f59e0b",
-  MemoryLimitExceeded: "#f59e0b",
-  RuntimeError: "#ef4444",
-  SystemError: "#ef4444",
-  CompileError: "#a855f7",
-  OutputLimitExceeded: "#f97316",
-}
+  Accepted: '#10b981',
+  WrongAnswer: '#ef4444',
+  TimeLimitExceeded: '#f59e0b',
+  MemoryLimitExceeded: '#f59e0b',
+  RuntimeError: '#ef4444',
+  SystemError: '#ef4444',
+  CompileError: '#a855f7',
+  OutputLimitExceeded: '#f97316',
+};
 
 /**
  * 获取状态标签的颜色。
@@ -92,9 +92,9 @@ export function getStatusColor(
   resultStatus: string | undefined | null,
 ): string {
   if (resultStatus && resultColors[resultStatus]) {
-    return resultColors[resultStatus]
+    return resultColors[resultStatus];
   }
-  return statusColors[status] || "#6b7280"
+  return statusColors[status] || '#6b7280';
 }
 
 /**
@@ -106,109 +106,109 @@ export function getStatusLabel(
   resultStatus: string | undefined | null,
 ): string {
   if (resultStatus && resultLabels[resultStatus]) {
-    return resultLabels[resultStatus]
+    return resultLabels[resultStatus];
   }
-  return statusLabels[status] || status
+  return statusLabels[status] || status;
 }
 
 /**
  * 格式化得分（API 返回 ×100 的整数值）。
  */
 export function formatScore(raw: number | undefined | null): string {
-  if (raw === undefined || raw === null) return "--"
-  return (raw / 100).toFixed(1)
+  if (raw === undefined || raw === null) return '--';
+  return (raw / 100).toFixed(1);
 }
 
 /**
  * 格式化时间（毫秒 → 可读格式）。
  */
 export function formatTime(ms: number | undefined | null): string {
-  if (ms === undefined || ms === null) return "--"
-  if (ms < 1000) return `${ms}ms`
-  return `${(ms / 1000).toFixed(2)}s`
+  if (ms === undefined || ms === null) return '--';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
 }
 
 /**
  * 格式化内存（KB → 可读格式）。
  */
 export function formatMemory(kb: number | undefined | null): string {
-  if (kb === undefined || kb === null) return "--"
-  if (kb < 1024) return `${kb}KB`
-  if (kb < 1024 * 1024) return `${(kb / 1024).toFixed(1)}MB`
-  return `${(kb / 1024 / 1024).toFixed(2)}GB`
+  if (kb === undefined || kb === null) return '--';
+  if (kb < 1024) return `${kb}KB`;
+  if (kb < 1024 * 1024) return `${(kb / 1024).toFixed(1)}MB`;
+  return `${(kb / 1024 / 1024).toFixed(2)}GB`;
 }
 
 /**
  * 获取语言显示标签。
  */
 export function getLanguageLabel(lang: string): string {
-  return languageLabels[lang] || lang
+  return languageLabels[lang] || lang;
 }
 
 /**
  * 评测结果详细定义（含图标和样式类）。
  */
 export interface ResultDef {
-  label: string
-  icon: string
-  class: string
+  label: string;
+  icon: string;
+  class: string;
 }
 
 /**
  * 评测结果状态 → 详细定义映射。
  */
 export const resultDefMap: Record<string, ResultDef> = {
-  Accepted: { label: "答案正确", icon: "check", class: "accepted" },
-  WrongAnswer: { label: "答案错误", icon: "x", class: "wrong" },
-  TimeLimitExceeded: { label: "超出时间限制", icon: "alert", class: "tle" },
-  MemoryLimitExceeded: { label: "超出内存限制", icon: "alert", class: "mle" },
-  RuntimeError: { label: "运行时错误", icon: "x", class: "re" },
-  SystemError: { label: "系统错误", icon: "x", class: "se" },
-  CompileError: { label: "编译错误", icon: "x", class: "re" },
-  OutputLimitExceeded: { label: "输出超出限制", icon: "alert", class: "tle" },
-}
+  Accepted: { label: '答案正确', icon: 'check', class: 'accepted' },
+  WrongAnswer: { label: '答案错误', icon: 'x', class: 'wrong' },
+  TimeLimitExceeded: { label: '超出时间限制', icon: 'alert', class: 'tle' },
+  MemoryLimitExceeded: { label: '超出内存限制', icon: 'alert', class: 'mle' },
+  RuntimeError: { label: '运行时错误', icon: 'x', class: 're' },
+  SystemError: { label: '系统错误', icon: 'x', class: 'se' },
+  CompileError: { label: '编译错误', icon: 'x', class: 're' },
+  OutputLimitExceeded: { label: '输出超出限制', icon: 'alert', class: 'tle' },
+};
 
 /**
  * 获取评测结果详细定义。
  */
 export function getResultDef(status: string | undefined): ResultDef {
-  if (!status) return { label: status ?? "未知", icon: "x", class: "se" }
-  return resultDefMap[status] ?? { label: status, icon: "x", class: "se" }
+  if (!status) return { label: status ?? '未知', icon: 'x', class: 'se' };
+  return resultDefMap[status] ?? { label: status, icon: 'x', class: 'se' };
 }
 
 /**
  * 评测判定的 Tailwind 样式类。
  */
 export const verdictClasses: Record<string, string> = {
-  accepted: "bg-green-50 border border-green-200 text-green-700",
-  wrong: "bg-red-50 border border-red-200 text-red-800",
-  tle: "bg-orange-50 border border-orange-200 text-orange-800",
-  mle: "bg-orange-50 border border-orange-200 text-orange-800",
-  re: "bg-red-50 border border-red-200 text-red-800",
-  se: "bg-red-50 border border-red-200 text-red-800",
-}
+  accepted: 'bg-green-50 border border-green-200 text-green-700',
+  wrong: 'bg-red-50 border border-red-200 text-red-800',
+  tle: 'bg-orange-50 border border-orange-200 text-orange-800',
+  mle: 'bg-orange-50 border border-orange-200 text-orange-800',
+  re: 'bg-red-50 border border-red-200 text-red-800',
+  se: 'bg-red-50 border border-red-200 text-red-800',
+};
 
 /**
  * 提交状态徽章的 Tailwind 样式类。
  */
 export const statusBadgeColors: Record<string, string> = {
-  pending: "bg-gray-50 text-slate-500 border border-border",
-  judging: "bg-blue-50 text-blue-700 border border-blue-200",
-  error: "bg-red-50 text-red-800 border border-red-200",
-}
+  pending: 'bg-gray-50 text-slate-500 border border-border',
+  judging: 'bg-blue-50 text-blue-700 border border-blue-200',
+  error: 'bg-red-50 text-red-800 border border-red-200',
+};
 
 /**
  * 格式化 ISO 时间为中文可读格式。
  */
 export function formatDateTime(iso: string | undefined): string {
-  if (!iso) return "--"
-  const d = new Date(iso)
-  return d.toLocaleString("zh-CN", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  })
+  if (!iso) return '--';
+  const d = new Date(iso);
+  return d.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
 }

--- a/noj-ui/composables/useApi.ts
+++ b/noj-ui/composables/useApi.ts
@@ -22,8 +22,7 @@ import { extractApiError } from '~/utils/apiError';
 type FetchOptions = NonNullable<Parameters<typeof $fetch>[1]>;
 
 /** API 调用选项：silent/onError 为 API 层专属，其余透传 $fetch */
-export interface ApiCallOptions
-  extends Omit<FetchOptions, 'method' | 'timeout'> {
+export interface ApiCallOptions extends Omit<FetchOptions, 'method' | 'timeout'> {
   /** 静默模式：不弹 toast，错误仍抛出（由调用方处理） */
   silent?: boolean;
   /** 自定义错误处理：替换默认 toast；与 silent 同时给出时 silent 优先 */
@@ -60,16 +59,14 @@ export function useApi() {
 
   return {
     api: {
-      get: <T = unknown>(url: string, options?: ApiCallOptions) =>
-        request<T>('get', url, options),
+      get: <T = unknown>(url: string, options?: ApiCallOptions) => request<T>('get', url, options),
       post: <T = unknown>(url: string, body?: unknown, options?: ApiCallOptions) =>
         request<T>('post', url, { body, ...options }),
       put: <T = unknown>(url: string, body?: unknown, options?: ApiCallOptions) =>
         request<T>('put', url, { body, ...options }),
       patch: <T = unknown>(url: string, body?: unknown, options?: ApiCallOptions) =>
         request<T>('patch', url, { body, ...options }),
-      delete: <T = unknown>(url: string, options?: ApiCallOptions) =>
-        request<T>('delete', url, options),
+      delete: <T = unknown>(url: string, options?: ApiCallOptions) => request<T>('delete', url, options),
     },
   };
 }

--- a/noj-ui/composables/useAuditLogs.ts
+++ b/noj-ui/composables/useAuditLogs.ts
@@ -5,13 +5,13 @@
 import { extractApiError } from '~/utils/apiError';
 
 export type AuditAction =
-  | "users.role_change"
-  | "users.ban"
-  | "users.unban"
-  | "problems.delete"
-  | "categories.delete"
-  | "submissions.rejudge"
-  | "settings.update";
+  | 'users.role_change'
+  | 'users.ban'
+  | 'users.unban'
+  | 'problems.delete'
+  | 'categories.delete'
+  | 'submissions.rejudge'
+  | 'settings.update';
 
 export interface AuditLogEntry {
   id: string;
@@ -33,17 +33,17 @@ export interface AuditLogFilters {
   page: number;
   per_page: number;
   admin_id?: string;
-  action?: AuditAction | "";
+  action?: AuditAction | '';
   from?: string;
   to?: string;
 }
 
 export function useAuditLogs(initial: Partial<AuditLogFilters> = {}) {
-  const filters = useState("audit-logs-filters", () => ({
+  const filters = useState('audit-logs-filters', () => ({
     page: 1,
     per_page: 20,
     admin_id: undefined,
-    action: "" as AuditAction | "",
+    action: '' as AuditAction | '',
     from: undefined,
     to: undefined,
     ...initial,
@@ -59,12 +59,12 @@ export function useAuditLogs(initial: Partial<AuditLogFilters> = {}) {
     error.value = null;
     try {
       const params = new URLSearchParams();
-      params.set("page", String(filters.value.page));
-      params.set("per_page", String(filters.value.per_page));
-      if (filters.value.admin_id) params.set("admin_id", filters.value.admin_id);
-      if (filters.value.action) params.set("action", filters.value.action);
-      if (filters.value.from) params.set("from", filters.value.from);
-      if (filters.value.to) params.set("to", filters.value.to);
+      params.set('page', String(filters.value.page));
+      params.set('per_page', String(filters.value.per_page));
+      if (filters.value.admin_id) params.set('admin_id', filters.value.admin_id);
+      if (filters.value.action) params.set('action', filters.value.action);
+      if (filters.value.from) params.set('from', filters.value.from);
+      if (filters.value.to) params.set('to', filters.value.to);
 
       const res = await useApi().api.get<AuditLogListResponse>(
         `/api/v1/admin/audit-logs?${params}`,
@@ -80,7 +80,7 @@ export function useAuditLogs(initial: Partial<AuditLogFilters> = {}) {
   }
 
   function reset() {
-    filters.value = { page: 1, per_page: 20, admin_id: undefined, action: "", from: undefined, to: undefined };
+    filters.value = { page: 1, per_page: 20, admin_id: undefined, action: '', from: undefined, to: undefined };
   }
 
   return { filters, data, pagination, loading, error, fetch, reset };

--- a/noj-ui/composables/useBanStatus.ts
+++ b/noj-ui/composables/useBanStatus.ts
@@ -30,21 +30,21 @@ export interface BanStatusResponse {
 }
 
 export function useBanStatus() {
-  const ipBanned = useState<boolean>("ban:ipBanned", () => false);
-  const userBanned = useState<boolean>("ban:userBanned", () => false);
-  const ipBanInfo = useState<IpBanInfo | null>("ban:ipBanInfo", () => null);
-  const userBanInfo = useState<UserBanInfo | null>("ban:userBanInfo", () => null);
-  const authenticated = useState<boolean>("ban:authenticated", () => false);
-  const user = useState<{ id: string; role: string } | null>("ban:user", () => null);
-  const loading = useState<boolean>("ban:loading", () => true);
-  const error = useState<string>("ban:error", () => "");
+  const ipBanned = useState<boolean>('ban:ipBanned', () => false);
+  const userBanned = useState<boolean>('ban:userBanned', () => false);
+  const ipBanInfo = useState<IpBanInfo | null>('ban:ipBanInfo', () => null);
+  const userBanInfo = useState<UserBanInfo | null>('ban:userBanInfo', () => null);
+  const authenticated = useState<boolean>('ban:authenticated', () => false);
+  const user = useState<{ id: string; role: string } | null>('ban:user', () => null);
+  const loading = useState<boolean>('ban:loading', () => true);
+  const error = useState<string>('ban:error', () => '');
 
   let fetched = false;
 
   async function fetch(): Promise<BanStatusResponse | null> {
     if (fetched && import.meta.client) return null;
     loading.value = true;
-    error.value = "";
+    error.value = '';
     try {
       // 封禁状态为全局静默请求：失败由 BanBanner 依据 error state 处理，不弹 toast
       const res = await useApi().api.get<BanStatusResponse>(

--- a/noj-ui/composables/useDialog.ts
+++ b/noj-ui/composables/useDialog.ts
@@ -1,58 +1,58 @@
-import { useOverlay } from '@nuxt/ui/composables'
-import DialogModal from '~/components/ui/DialogModal.vue'
+import { useOverlay } from '@nuxt/ui/composables';
+import DialogModal from '~/components/ui/DialogModal.vue';
 
 interface DialogOptions {
-  title?: string
-  danger?: boolean
-  confirmText?: string
-  cancelText?: string
+  title?: string;
+  danger?: boolean;
+  confirmText?: string;
+  cancelText?: string;
 }
 
 interface PromptOptions {
-  title?: string
-  placeholder?: string
-  confirmText?: string
+  title?: string;
+  placeholder?: string;
+  confirmText?: string;
 }
 
 interface DialogMethods {
-  confirm(message: string, options?: DialogOptions): Promise<boolean>
-  alert(message: string, options?: { title?: string }): Promise<void>
-  prompt(message: string, options?: PromptOptions): Promise<string | null>
+  confirm(message: string, options?: DialogOptions): Promise<boolean>;
+  alert(message: string, options?: { title?: string }): Promise<void>;
+  prompt(message: string, options?: PromptOptions): Promise<string | null>;
 }
 
 // settings.vue 等调用点的对象式调用 `dialog({ title, text, danger, ... })`
 interface DialogShorthandOptions {
-  title?: string
-  text?: string
-  message?: string
-  danger?: boolean
-  confirmText?: string
-  cancelText?: string
+  title?: string;
+  text?: string;
+  message?: string;
+  danger?: boolean;
+  confirmText?: string;
+  cancelText?: string;
 }
 
-export type DialogApi = DialogMethods & ((options: DialogShorthandOptions) => Promise<boolean>)
+export type DialogApi = DialogMethods & ((options: DialogShorthandOptions) => Promise<boolean>);
 
 export function useDialog(): { dialog: DialogApi } {
-  const overlay = useOverlay()
+  const overlay = useOverlay();
 
   async function confirm(message: string, options: DialogOptions = {}): Promise<boolean> {
-    if (import.meta.server) return false
-    const instance = overlay.create(DialogModal)
-    const res = await instance.open({ mode: 'confirm', message, ...options })
-    return res === true
+    if (import.meta.server) return false;
+    const instance = overlay.create(DialogModal);
+    const res = await instance.open({ mode: 'confirm', message, ...options });
+    return res === true;
   }
 
   async function alert(message: string, options: { title?: string } = {}): Promise<void> {
-    if (import.meta.server) return
-    const instance = overlay.create(DialogModal)
-    await instance.open({ mode: 'alert', message, ...options })
+    if (import.meta.server) return;
+    const instance = overlay.create(DialogModal);
+    await instance.open({ mode: 'alert', message, ...options });
   }
 
   async function prompt(message: string, options: PromptOptions = {}): Promise<string | null> {
-    if (import.meta.server) return null
-    const instance = overlay.create(DialogModal)
-    const res = await instance.open({ mode: 'prompt', message, ...options })
-    return typeof res === 'string' ? res : null
+    if (import.meta.server) return null;
+    const instance = overlay.create(DialogModal);
+    const res = await instance.open({ mode: 'prompt', message, ...options });
+    return typeof res === 'string' ? res : null;
   }
 
   // 兼容对象式调用：`dialog({ title, text, danger, ... })` 等价于 dialog.confirm(text, options)
@@ -65,7 +65,7 @@ export function useDialog(): { dialog: DialogApi } {
         cancelText: options.cancelText,
       }),
     { confirm, alert, prompt },
-  ) as DialogApi
+  ) as DialogApi;
 
-  return { dialog }
+  return { dialog };
 }

--- a/noj-ui/composables/useDraftStorage.ts
+++ b/noj-ui/composables/useDraftStorage.ts
@@ -7,79 +7,79 @@
  * - QuotaExceeded 等写入错误转 state='error'
  */
 
-export type DraftState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error'
+export type DraftState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
 
 export interface DraftData {
-  content: string
-  updatedAt: number
+  content: string;
+  updatedAt: number;
 }
 
-const DEBOUNCE_MS = 800
+const DEBOUNCE_MS = 800;
 
 export function useDraftStorage(
   problemId: Ref<string>,
   code: Ref<string>,
   enabled: Ref<boolean>,
 ) {
-  const state = ref<DraftState>('idle')
-  const savedAt = ref<Date | null>(null)
+  const state = ref<DraftState>('idle');
+  const savedAt = ref<Date | null>(null);
 
-  const key = computed(() => `noj:draft:${problemId.value}`)
-  let timer: ReturnType<typeof setTimeout> | null = null
+  const key = computed(() => `noj:draft:${problemId.value}`);
+  let timer: ReturnType<typeof setTimeout> | null = null;
 
   // 加载（仅客户端）
   onMounted(() => {
-    if (!import.meta.client) return
+    if (!import.meta.client) return;
     try {
-      const raw = localStorage.getItem(key.value)
+      const raw = localStorage.getItem(key.value);
       if (raw) {
-        const data = JSON.parse(raw) as DraftData
+        const data = JSON.parse(raw) as DraftData;
         if (typeof data.content === 'string' && typeof data.updatedAt === 'number') {
-          code.value = data.content
-          savedAt.value = new Date(data.updatedAt)
-          state.value = 'saved'
+          code.value = data.content;
+          savedAt.value = new Date(data.updatedAt);
+          state.value = 'saved';
         }
       }
     } catch {
       // 损坏的 JSON 忽略，当作无草稿
-      state.value = 'idle'
+      state.value = 'idle';
     }
-  })
+  });
 
   // 监听变化写入（防抖）
   watch(code, (val) => {
-    if (!import.meta.client) return
-    if (!enabled.value) return
-    if (timer) clearTimeout(timer)
-    state.value = 'dirty'
+    if (!import.meta.client) return;
+    if (!enabled.value) return;
+    if (timer) clearTimeout(timer);
+    state.value = 'dirty';
     timer = setTimeout(() => {
-      state.value = 'saving'
+      state.value = 'saving';
       try {
         localStorage.setItem(
           key.value,
           JSON.stringify({ content: val, updatedAt: Date.now() } satisfies DraftData),
-        )
-        savedAt.value = new Date()
-        state.value = 'saved'
+        );
+        savedAt.value = new Date();
+        state.value = 'saved';
       } catch {
-        state.value = 'error'
+        state.value = 'error';
       }
-    }, DEBOUNCE_MS)
-  })
+    }, DEBOUNCE_MS);
+  });
 
   // 清理 timer
   onBeforeUnmount(() => {
-    if (timer) clearTimeout(timer)
-  })
+    if (timer) clearTimeout(timer);
+  });
 
   // 主动清除（设置面板"清除草稿"按钮调用）
   function clear() {
-    if (!import.meta.client) return
-    if (timer) clearTimeout(timer)
-    localStorage.removeItem(key.value)
-    savedAt.value = null
-    state.value = 'idle'
+    if (!import.meta.client) return;
+    if (timer) clearTimeout(timer);
+    localStorage.removeItem(key.value);
+    savedAt.value = null;
+    state.value = 'idle';
   }
 
-  return { state, savedAt, clear }
+  return { state, savedAt, clear };
 }

--- a/noj-ui/composables/useEditorTheme.ts
+++ b/noj-ui/composables/useEditorTheme.ts
@@ -5,33 +5,33 @@
  * - DOM 同步（外部职责）：调用方在主题根节点通过 `:class="{ 'editor-dark': ... }"` 切换
  * - Monaco 同步：调用方需在组件中 watch theme 后调 monaco.editor.setTheme()
  */
-export type EditorTheme = "light" | "dark"
+export type EditorTheme = 'light' | 'dark';
 
-const STORAGE_KEY = "noj:editor:theme"
+const STORAGE_KEY = 'noj:editor:theme';
 
 export function useEditorTheme() {
-  const theme = useState<EditorTheme>("editor:theme", () => {
+  const theme = useState<EditorTheme>('editor:theme', () => {
     if (import.meta.client) {
-      const stored = localStorage.getItem(STORAGE_KEY)
-      if (stored === "light" || stored === "dark") return stored
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored === 'light' || stored === 'dark') return stored;
     }
-    return "dark" // 默认 dark（沉浸式场景）
-  })
+    return 'dark'; // 默认 dark（沉浸式场景）
+  });
 
   function set(t: EditorTheme) {
-    theme.value = t
+    theme.value = t;
   }
 
   function toggle() {
-    theme.value = theme.value === "dark" ? "light" : "dark"
+    theme.value = theme.value === 'dark' ? 'light' : 'dark';
   }
 
   // 写入 localStorage
   if (import.meta.client) {
     watch(theme, (t) => {
-      localStorage.setItem(STORAGE_KEY, t)
-    })
+      localStorage.setItem(STORAGE_KEY, t);
+    });
   }
 
-  return { theme, set, toggle }
+  return { theme, set, toggle };
 }

--- a/noj-ui/composables/useEventSource.ts
+++ b/noj-ui/composables/useEventSource.ts
@@ -1,4 +1,4 @@
-import { ref, watch, onUnmounted, type Ref } from "vue";
+import { onUnmounted, type Ref, ref, watch } from 'vue';
 
 /**
  * EventSource 连接状态。
@@ -8,7 +8,7 @@ import { ref, watch, onUnmounted, type Ref } from "vue";
  * - `fallback`: SSE 不可用，自动降级到轮询模式
  * - `disabled`: 被禁用（enabled = false）
  */
-type EventSourceState = "connecting" | "connected" | "fallback" | "disabled";
+type EventSourceState = 'connecting' | 'connected' | 'fallback' | 'disabled';
 
 /**
  * useEventSource 选项。
@@ -52,16 +52,14 @@ export interface UseEventSourceOptions {
  * ```
  */
 export function useEventSource(options: UseEventSourceOptions) {
-  const state = ref<EventSourceState>("disabled");
+  const state = ref<EventSourceState>('disabled');
 
   let eventSource: EventSource | null = null;
   let fallbackTimer: ReturnType<typeof setInterval> | null = null;
   let connectTimeout: ReturnType<typeof setTimeout> | null = null;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const urlRef = typeof options.url === "string"
-    ? ref(options.url)
-    : options.url;
+  const urlRef = typeof options.url === 'string' ? ref(options.url) : options.url;
 
   const enabled = options.enabled ?? ref(true);
   const onEvent = options.onEvent ?? {};
@@ -111,7 +109,7 @@ export function useEventSource(options: UseEventSourceOptions) {
    */
   function startFallback() {
     stopFallback();
-    state.value = "fallback";
+    state.value = 'fallback';
 
     // 立即执行一次
     if (fetchFn) {
@@ -130,7 +128,7 @@ export function useEventSource(options: UseEventSourceOptions) {
     // 30 秒后重试 SSE 连接（仅客户端）
     if (isClient) {
       retryTimer = setTimeout(() => {
-        if (state.value === "fallback" && enabled.value) {
+        if (state.value === 'fallback' && enabled.value) {
           connect();
         }
       }, 30_000);
@@ -147,30 +145,30 @@ export function useEventSource(options: UseEventSourceOptions) {
     closeEventSource();
     stopFallback();
 
-    const url = typeof urlRef.value === "string" ? urlRef.value : "";
+    const url = typeof urlRef.value === 'string' ? urlRef.value : '';
     if (!url) return;
 
     // 检查浏览器是否支持 EventSource
-    if (typeof EventSource === "undefined") {
-      console.warn("useEventSource: 浏览器不支持 EventSource，降级到轮询");
+    if (typeof EventSource === 'undefined') {
+      console.warn('useEventSource: 浏览器不支持 EventSource，降级到轮询');
       startFallback();
       return;
     }
 
-    state.value = "connecting";
+    state.value = 'connecting';
 
     try {
       eventSource = new EventSource(url);
     } catch {
-      console.warn("useEventSource: EventSource 创建失败，降级到轮询");
+      console.warn('useEventSource: EventSource 创建失败，降级到轮询');
       startFallback();
       return;
     }
 
     // 连接超时：10 秒未收到 open 事件则降级
     connectTimeout = setTimeout(() => {
-      if (state.value === "connecting") {
-        console.warn("useEventSource: 连接超时（10s），降级到轮询");
+      if (state.value === 'connecting') {
+        console.warn('useEventSource: 连接超时（10s），降级到轮询');
         closeEventSource();
         startFallback();
       }
@@ -182,13 +180,13 @@ export function useEventSource(options: UseEventSourceOptions) {
         clearTimeout(connectTimeout);
         connectTimeout = null;
       }
-      state.value = "connected";
+      state.value = 'connected';
     };
 
     // 错误处理：降级到 fallback
     eventSource.onerror = () => {
-      if (state.value === "connected" || state.value === "connecting") {
-        console.warn("useEventSource: 连接出错，降级到轮询");
+      if (state.value === 'connected' || state.value === 'connecting') {
+        console.warn('useEventSource: 连接出错，降级到轮询');
         closeEventSource();
         startFallback();
       }
@@ -196,14 +194,17 @@ export function useEventSource(options: UseEventSourceOptions) {
 
     // 注册事件监听
     for (const [event, callback] of Object.entries(onEvent)) {
-      eventSource.addEventListener(event, ((e: MessageEvent) => {
-        try {
-          const data = JSON.parse(e.data);
-          callback(data);
-        } catch {
-          callback(e.data);
-        }
-      }) as EventListener);
+      eventSource.addEventListener(
+        event,
+        ((e: MessageEvent) => {
+          try {
+            const data = JSON.parse(e.data);
+            callback(data);
+          } catch {
+            callback(e.data);
+          }
+        }) as EventListener,
+      );
     }
 
     // 通用消息监听
@@ -211,9 +212,9 @@ export function useEventSource(options: UseEventSourceOptions) {
       eventSource.onmessage = ((e: MessageEvent) => {
         try {
           const data = JSON.parse(e.data);
-          onMessage("message", data);
+          onMessage('message', data);
         } catch {
-          onMessage("message", e.data);
+          onMessage('message', e.data);
         }
       }) as unknown as (this: EventSource, ev: MessageEvent) => void;
     }
@@ -225,7 +226,7 @@ export function useEventSource(options: UseEventSourceOptions) {
   function disconnect() {
     closeEventSource();
     stopFallback();
-    state.value = "disabled";
+    state.value = 'disabled';
   }
 
   // 监听 enabled 和 url 变化（SSR 阶段不连接，客户端水合后自动执行）

--- a/noj-ui/composables/useFormError.ts
+++ b/noj-ui/composables/useFormError.ts
@@ -3,21 +3,23 @@
  * Extracted from duplicated auth page patterns.
  */
 export function useFormError(duration = 3000) {
-  const error = ref("")
-  let errorTimer: ReturnType<typeof setTimeout> | null = null
+  const error = ref('');
+  let errorTimer: ReturnType<typeof setTimeout> | null = null;
 
   function setError(msg: string) {
-    error.value = msg
-    if (errorTimer) clearTimeout(errorTimer)
-    errorTimer = setTimeout(clearError, duration)
+    error.value = msg;
+    if (errorTimer) clearTimeout(errorTimer);
+    errorTimer = setTimeout(clearError, duration);
   }
 
   function clearError() {
-    error.value = ""
-    if (errorTimer) clearTimeout(errorTimer)
+    error.value = '';
+    if (errorTimer) clearTimeout(errorTimer);
   }
 
-  onUnmounted(() => { if (errorTimer) clearTimeout(errorTimer) })
+  onUnmounted(() => {
+    if (errorTimer) clearTimeout(errorTimer);
+  });
 
-  return { error, setError, clearError }
+  return { error, setError, clearError };
 }

--- a/noj-ui/composables/useMessages.ts
+++ b/noj-ui/composables/useMessages.ts
@@ -36,7 +36,7 @@ export function useMessages() {
   /**
    * 获取会话列表。
    */
-  async function fetchConversations(page = 1, perPage = 20) {
+  function fetchConversations(page = 1, perPage = 20) {
     return api.get<{
       data: Conversation[];
       pagination: Pagination;
@@ -46,7 +46,7 @@ export function useMessages() {
   /**
    * 查找或创建会话。
    */
-  async function findOrCreateConversation(otherUserId: string) {
+  function findOrCreateConversation(otherUserId: string) {
     return api.post<{ data: Conversation }>('/api/v1/conversations', {
       other_user_id: otherUserId,
     });
@@ -55,7 +55,7 @@ export function useMessages() {
   /**
    * 获取消息列表。
    */
-  async function fetchMessages(conversationId: string, page = 1, perPage = 50) {
+  function fetchMessages(conversationId: string, page = 1, perPage = 50) {
     return api.get<{
       data: ConversationMessage[];
       pagination: Pagination;
@@ -65,7 +65,7 @@ export function useMessages() {
   /**
    * 发送消息。
    */
-  async function sendMessage(conversationId: string, content: string) {
+  function sendMessage(conversationId: string, content: string) {
     return api.post<{ data: ConversationMessage }>(
       `/api/v1/conversations/${conversationId}/messages`,
       { content },
@@ -75,7 +75,7 @@ export function useMessages() {
   /**
    * 标记已读。
    */
-  async function markRead(conversationId: string, lastReadMessageId: string) {
+  function markRead(conversationId: string, lastReadMessageId: string) {
     return api.post(`/api/v1/conversations/${conversationId}/read`, {
       last_read_message_id: lastReadMessageId,
     });

--- a/noj-ui/composables/useProblemFilters.ts
+++ b/noj-ui/composables/useProblemFilters.ts
@@ -5,23 +5,21 @@
  * 提供统一的读写接口。筛选条件变化时自动重置页码。
  */
 export function useProblemFilters() {
-  const router = useRouter()
-  const route = useRoute()
+  const router = useRouter();
+  const route = useRoute();
 
   /** 从 URL 查询参数中读取筛选值（只读派生）。 */
-  const page = computed(() => Number(route.query.page) || 1)
-  const keyword = computed(() => (route.query.keyword as string) || "")
-  const difficulty = computed(() => (route.query.difficulty as string) || "")
-  const categoryId = computed(() => (route.query.category_id as string) || "")
+  const page = computed(() => Number(route.query.page) || 1);
+  const keyword = computed(() => (route.query.keyword as string) || '');
+  const difficulty = computed(() => (route.query.difficulty as string) || '');
+  const categoryId = computed(() => (route.query.category_id as string) || '');
   /** 题目类型筛选。空字符串 = 未选择（API 默认返回 P 型）。 */
-  const problemType = computed(() => (route.query.type as string) || "")
-  const problemNumber = computed(() => (route.query.number as string) || "")
+  const problemType = computed(() => (route.query.type as string) || '');
+  const problemNumber = computed(() => (route.query.number as string) || '');
 
-  const limit = 20
+  const limit = 20;
 
-  const hasActiveFilters = computed(() =>
-    !!keyword.value || !!difficulty.value || !!categoryId.value,
-  )
+  const hasActiveFilters = computed(() => !!keyword.value || !!difficulty.value || !!categoryId.value);
 
   /**
    * 更新单个筛选参数。
@@ -29,31 +27,31 @@ export function useProblemFilters() {
    * - 若非 page 参数变更，自动重置到第 1 页
    */
   function setFilter(key: string, value: string) {
-    const query = { ...route.query }
+    const query = { ...route.query };
     if (value) {
-      query[key] = value
+      query[key] = value;
     } else {
-      delete query[key]
+      delete query[key];
     }
-    if (key !== "page") {
-      delete query.page
+    if (key !== 'page') {
+      delete query.page;
     }
-    router.push({ query })
+    router.push({ query });
   }
 
   /** 构建给 API 的查询参数对象。 */
   const queryParams = computed(() => {
-    const params: Record<string, string> = {}
-    const p = page.value
-    if (p !== 1) params.page = String(p)
-    params.limit = String(limit)
-    if (keyword.value) params.keyword = keyword.value
-    if (difficulty.value) params.difficulty = difficulty.value
-    if (categoryId.value) params.category_id = categoryId.value
-    if (problemType.value) params.type = problemType.value
-    if (problemNumber.value) params.number = problemNumber.value
-    return params
-  })
+    const params: Record<string, string> = {};
+    const p = page.value;
+    if (p !== 1) params.page = String(p);
+    params.limit = String(limit);
+    if (keyword.value) params.keyword = keyword.value;
+    if (difficulty.value) params.difficulty = difficulty.value;
+    if (categoryId.value) params.category_id = categoryId.value;
+    if (problemType.value) params.type = problemType.value;
+    if (problemNumber.value) params.number = problemNumber.value;
+    return params;
+  });
 
   return {
     page,
@@ -66,5 +64,5 @@ export function useProblemFilters() {
     hasActiveFilters,
     setFilter,
     queryParams,
-  }
+  };
 }

--- a/noj-ui/composables/useRankings.ts
+++ b/noj-ui/composables/useRankings.ts
@@ -5,31 +5,31 @@
 
 export interface RankingRow {
   /** 1-based 全局名次 */
-  rank: number
-  user_id: string
-  username: string
+  rank: number;
+  user_id: string;
+  username: string;
   /** 独立通过的题目数 */
-  solved_count: number
+  solved_count: number;
   /** 总提交数 */
-  total_submissions: number
+  total_submissions: number;
   /** 0–1 浮点数 */
-  acceptance_rate: number
+  acceptance_rate: number;
 }
 
 export interface RankingsPagination {
-  page: number
-  per_page: number
-  total: number
-  total_pages: number
+  page: number;
+  per_page: number;
+  total: number;
+  total_pages: number;
 }
 
 export interface RankingsResponse {
-  data: RankingRow[]
-  pagination: RankingsPagination
+  data: RankingRow[];
+  pagination: RankingsPagination;
 }
 
 export interface MyRankingResponse {
-  data: RankingRow | null
+  data: RankingRow | null;
 }
 
 /**
@@ -42,9 +42,9 @@ export function useRankings(page: Ref<number>, limit: number = 50) {
     const qs = new URLSearchParams({
       page: String(page.value),
       limit: String(limit),
-    })
-    return `/api/v1/rankings?${qs.toString()}`
-  })
+    });
+    return `/api/v1/rankings?${qs.toString()}`;
+  });
 }
 
 /**
@@ -52,14 +52,14 @@ export function useRankings(page: Ref<number>, limit: number = 50) {
  * 未登录或未上榜时返回 null。
  */
 export async function fetchMyRanking(): Promise<RankingRow | null> {
-  const res = await useApi().api.get<MyRankingResponse>('/api/v1/rankings/me')
-  return res.data
+  const res = await useApi().api.get<MyRankingResponse>('/api/v1/rankings/me');
+  return res.data;
 }
 
 /**
  * 格式化通过率（0–1 → "xx.x%"）。
  */
 export function formatAcceptanceRate(rate: number | null | undefined): string {
-  if (rate == null) return "--"
-  return `${(rate * 100).toFixed(1)}%`
+  if (rate == null) return '--';
+  return `${(rate * 100).toFixed(1)}%`;
 }

--- a/noj-ui/composables/useResizableSplit.ts
+++ b/noj-ui/composables/useResizableSplit.ts
@@ -12,47 +12,47 @@ export function useResizableSplit(
   min: number,
   max: number,
 ) {
-  const width = ref(initial)
+  const width = ref(initial);
 
   // 加载持久化宽度
   onMounted(() => {
-    if (!import.meta.client) return
-    const stored = Number(localStorage.getItem(storageKey))
+    if (!import.meta.client) return;
+    const stored = Number(localStorage.getItem(storageKey));
     if (Number.isFinite(stored) && stored >= min && stored <= max) {
-      width.value = stored
+      width.value = stored;
     }
-  })
+  });
 
   function persist(v: number) {
     if (import.meta.client) {
-      localStorage.setItem(storageKey, String(v))
+      localStorage.setItem(storageKey, String(v));
     }
   }
 
   function startDrag(e: MouseEvent) {
-    if (!import.meta.client) return
-    e.preventDefault()
-    const startX = e.clientX
-    const startWidth = width.value
+    if (!import.meta.client) return;
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = width.value;
 
     function onMove(ev: MouseEvent) {
-      const dx = ev.clientX - startX
-      const next = Math.max(min, Math.min(max, startWidth + dx))
-      width.value = next
+      const dx = ev.clientX - startX;
+      const next = Math.max(min, Math.min(max, startWidth + dx));
+      width.value = next;
     }
     function onUp() {
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
-      persist(width.value)
+      globalThis.removeEventListener('mousemove', onMove);
+      globalThis.removeEventListener('mouseup', onUp);
+      persist(width.value);
     }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
+    globalThis.addEventListener('mousemove', onMove);
+    globalThis.addEventListener('mouseup', onUp);
   }
 
   function reset() {
-    width.value = Math.floor((min + max) / 2)
-    persist(width.value)
+    width.value = Math.floor((min + max) / 2);
+    persist(width.value);
   }
 
-  return { width, startDrag, reset }
+  return { width, startDrag, reset };
 }

--- a/noj-ui/composables/useSearch.ts
+++ b/noj-ui/composables/useSearch.ts
@@ -15,7 +15,7 @@
  * - 「all」模式下两个端点都失败时显式设置 error，不静默吞错。
  */
 
-export type SearchType = "all" | "problem" | "user" | "community";
+export type SearchType = 'all' | 'problem' | 'user' | 'community';
 
 export interface ProblemSearchResult {
   id: string;
@@ -39,7 +39,7 @@ export interface UserSearchResult {
 
 export interface CommunitySearchResult {
   id: string;
-  type: "solution" | "discussion";
+  type: 'solution' | 'discussion';
   title: string;
   author_id: string;
   author_username: string;
@@ -63,10 +63,10 @@ export interface SearchState {
 }
 
 export function useSearch() {
-  const state = useState<SearchState>("search:state", () => ({
+  const state = useState<SearchState>('search:state', () => ({
     open: false,
-    query: "",
-    type: "all",
+    query: '',
+    type: 'all',
     results: { problems: [], users: [], community: [] },
     loading: false,
     error: null,
@@ -108,7 +108,7 @@ export function useSearch() {
    * 防抖搜索（300ms）。
    * type="all" 时同时拉取题目 + 用户两个端点（前端合并展示）。
    */
-  const search = async (q: string, opts?: { type?: SearchType; limit?: number }) => {
+  const search = (q: string, opts?: { type?: SearchType; limit?: number }) => {
     // 1) 先取消上一次未触发的 debounce，并 resolve 旧 Promise。
     //    必须在短查询早退之前做，否则「ab → a」会让旧请求继续等待触发。
     if (debounceTimer) {
@@ -149,19 +149,19 @@ export function useSearch() {
         try {
           // 搜索为静默请求：错误由 state.error 状态展示，不弹 toast
           const { api } = useApi();
-          if (type === "all") {
+          if (type === 'all') {
             // 并行请求题目 + 用户
             const [pRes, uRes, cRes] = await Promise.allSettled([
-              api.get("/api/v1/search", {
-                params: { q: trimmed, type: "problem", limit },
+              api.get('/api/v1/search', {
+                params: { q: trimmed, type: 'problem', limit },
                 silent: true,
               }),
-              api.get("/api/v1/search", {
-                params: { q: trimmed, type: "user", limit: 3 },
+              api.get('/api/v1/search', {
+                params: { q: trimmed, type: 'user', limit: 3 },
                 silent: true,
               }),
-              api.get("/api/v1/search", {
-                params: { q: trimmed, type: "community", limit: 3 },
+              api.get('/api/v1/search', {
+                params: { q: trimmed, type: 'community', limit: 3 },
                 silent: true,
               }),
             ]);
@@ -172,19 +172,19 @@ export function useSearch() {
               return;
             }
 
-            const problems = pRes.status === "fulfilled"
+            const problems = pRes.status === 'fulfilled'
               ? (pRes.value as { data: { items: ProblemSearchResult[] } }).data.items
               : [];
-            const users = uRes.status === "fulfilled"
+            const users = uRes.status === 'fulfilled'
               ? (uRes.value as { data: { items: UserSearchResult[] } }).data.items
               : [];
-            const community = cRes.status === "fulfilled"
+            const community = cRes.status === 'fulfilled'
               ? (cRes.value as { data: { items: CommunitySearchResult[] } }).data.items
               : [];
 
             // 两个端点都失败时显式设置 error（Promise.allSettled 不抛错）
-            if (pRes.status === "rejected" && uRes.status === "rejected" && cRes.status === "rejected") {
-              state.value.error = "搜索失败";
+            if (pRes.status === 'rejected' && uRes.status === 'rejected' && cRes.status === 'rejected') {
+              state.value.error = '搜索失败';
               state.value.results = { problems: [], users: [], community: [] };
             } else {
               state.value.results.problems = problems;
@@ -192,7 +192,7 @@ export function useSearch() {
               state.value.results.community = community;
             }
           } else {
-            const res = await api.get("/api/v1/search", {
+            const res = await api.get('/api/v1/search', {
               params: { q: trimmed, type, limit },
               silent: true,
             });
@@ -203,19 +203,20 @@ export function useSearch() {
               return;
             }
 
-            const items = (res as { data: { items: ProblemSearchResult[] | UserSearchResult[] | CommunitySearchResult[] } })
-              .data.items;
+            const items =
+              (res as { data: { items: ProblemSearchResult[] | UserSearchResult[] | CommunitySearchResult[] } })
+                .data.items;
             state.value.results = {
-              problems: type === "problem" ? items as ProblemSearchResult[] : [],
-              users: type === "user" ? items as UserSearchResult[] : [],
-              community: type === "community" ? items as CommunitySearchResult[] : [],
+              problems: type === 'problem' ? items as ProblemSearchResult[] : [],
+              users: type === 'user' ? items as UserSearchResult[] : [],
+              community: type === 'community' ? items as CommunitySearchResult[] : [],
             };
           }
         } catch (e: unknown) {
           // 仅当本次请求仍是最新时才写入错误（避免覆盖更新的结果）
           if (mySeq === requestSeq) {
-            state.value.error = (e as { data?: { error?: string } })?.data?.error
-              ?? "搜索失败";
+            state.value.error = (e as { data?: { error?: string } })?.data?.error ??
+              '搜索失败';
             state.value.results = { problems: [], users: [], community: [] };
           }
         } finally {

--- a/noj-ui/composables/useSubmissionPolling.ts
+++ b/noj-ui/composables/useSubmissionPolling.ts
@@ -7,10 +7,10 @@
 import { extractApiError } from '~/utils/apiError';
 
 export type SubmissionStatus =
-  | "pending"
-  | "judging"
-  | "finished"
-  | "error";
+  | 'pending'
+  | 'judging'
+  | 'finished'
+  | 'error';
 
 export interface PolledSubmission {
   id: string;
@@ -28,7 +28,7 @@ export interface PolledSubmission {
   } | null;
 }
 
-const TERMINAL_STATUSES: SubmissionStatus[] = ["finished", "error"];
+const TERMINAL_STATUSES: SubmissionStatus[] = ['finished', 'error'];
 const POLL_INTERVAL_MS = 1500;
 
 export function useSubmissionPolling(submissionIdRef: Ref<string | null>) {

--- a/noj-ui/composables/useToast.ts
+++ b/noj-ui/composables/useToast.ts
@@ -1,4 +1,4 @@
-import { useToast as useNuxtToast } from '@nuxt/ui/composables'
+import { useToast as useNuxtToast } from '@nuxt/ui/composables';
 
 // 与现有 SweetAlert2 图标语义对齐的 lucide 图标
 const ICONS = {
@@ -6,44 +6,44 @@ const ICONS = {
   error: 'i-lucide-circle-x',
   warn: 'i-lucide-triangle-alert',
   info: 'i-lucide-info',
-} as const
+} as const;
 
 interface ToastMethods {
-  success(message: string): void
-  error(message: string): void
-  warn(message: string): void
-  info(message: string): void
+  success(message: string): void;
+  error(message: string): void;
+  warn(message: string): void;
+  info(message: string): void;
 }
 
-type ToastType = 'success' | 'error' | 'info' | 'warning'
+type ToastType = 'success' | 'error' | 'info' | 'warning';
 
 interface UseToastResult {
-  toast: ToastMethods
-  showToast(type: ToastType, message: string): void
+  toast: ToastMethods;
+  showToast(type: ToastType, message: string): void;
 }
 
 export function useToast(): UseToastResult {
-  const toastApi = useNuxtToast()
+  const toastApi = useNuxtToast();
 
   // SSR 阶段不发通知（Nuxt UI 的 toast 依赖客户端渲染的 UToaster）
   const push = (toast: Parameters<typeof toastApi.add>[0]) => {
-    if (import.meta.client) toastApi.add(toast)
-  }
+    if (import.meta.client) toastApi.add(toast);
+  };
 
   const toast: ToastMethods = {
     success: (msg) => push({ title: msg, color: 'success', icon: ICONS.success, timeout: 3000 }),
     error: (msg) => push({ title: msg, color: 'error', icon: ICONS.error, timeout: 5000 }),
     warn: (msg) => push({ title: msg, color: 'warning', icon: ICONS.warn, timeout: 3000 }),
     info: (msg) => push({ title: msg, color: 'info', icon: ICONS.info, timeout: 2000 }),
-  }
+  };
 
   function showToast(type: ToastType, message: string) {
     if (type === 'warning') {
-      toast.warn(message)
-      return
+      toast.warn(message);
+      return;
     }
-    toast[type](message)
+    toast[type](message);
   }
 
-  return { toast, showToast }
+  return { toast, showToast };
 }

--- a/noj-ui/deno.json
+++ b/noj-ui/deno.json
@@ -7,10 +7,15 @@
     "preview": "deno run -A npm:nuxt preview",
     "lint": "deno lint",
     "fmt": "deno fmt",
+    "check": "deno fmt --check && deno lint && deno task check:types",
+    "check:types": "deno check utils tests",
     "test": "deno test -A tests/"
   },
-  "lint": { "include": ["*.vue", "*.ts"] },
-  "fmt": { "include": ["*.vue", "*.ts"], "options": { "singleQuote": true, "lineWidth": 120 } },
+  "lint": {
+    "include": ["**/*.vue", "**/*.ts"],
+    "rules": { "exclude": ["no-sloppy-imports"] }
+  },
+  "fmt": { "include": ["**/*.vue", "**/*.ts"], "options": { "singleQuote": true, "lineWidth": 120 } },
   "nodeModulesDir": "auto",
   "allowScripts": [
     "npm:@parcel/watcher@2.5.6",

--- a/noj-ui/middleware/admin.ts
+++ b/noj-ui/middleware/admin.ts
@@ -32,13 +32,13 @@ export default defineNuxtRouteMiddleware(async (_to, _from) => {
 
   // 未登录 → 去登录页
   if (!isLoggedIn.value) {
-    return navigateTo("/login");
+    return navigateTo('/login');
   }
 
   // 非管理员 → 重定向首页（不给提示，静默拦截）
   // 使用 isAdmin 字段（优先），向后兼容 role 字段
-  const isAdmin = (user.value as Record<string, unknown>)?.is_admin ?? (user.value?.role === "admin");
+  const isAdmin = (user.value as Record<string, unknown>)?.is_admin ?? (user.value?.role === 'admin');
   if (!isAdmin) {
-    return navigateTo("/");
+    return navigateTo('/');
   }
 });

--- a/noj-ui/middleware/auth.ts
+++ b/noj-ui/middleware/auth.ts
@@ -3,10 +3,10 @@
  * 密码重置相关页面（forgot-password / reset-password）必须可匿名访问。
  */
 const PUBLIC_AUTH_PATHS = new Set([
-  "/login",
-  "/register",
-  "/forgot-password",
-  "/reset-password",
+  '/login',
+  '/register',
+  '/forgot-password',
+  '/reset-password',
 ]);
 
 /**
@@ -14,9 +14,9 @@ const PUBLIC_AUTH_PATHS = new Set([
  * must_change_password=true 时仅允许访问这些路径。
  */
 const PASSWORD_CHANGE_WHITELIST = new Set<string>([
-  "/change-password",
-  "/login",
-  "/logout",
+  '/change-password',
+  '/login',
+  '/logout',
 ]);
 
 /**
@@ -52,7 +52,7 @@ export default defineNuxtRouteMiddleware(async (to, _from) => {
   }
 
   if (!isLoggedIn.value) {
-    return navigateTo("/login");
+    return navigateTo('/login');
   }
 
   // ── issue #75：session cookie 启动时可能只含基础字段，必须调一次 /me 拿到完整 UserResponse ──
@@ -65,7 +65,7 @@ export default defineNuxtRouteMiddleware(async (to, _from) => {
   if (user.value?.must_change_password === true) {
     const path = to.path;
     if (!PASSWORD_CHANGE_WHITELIST.has(path)) {
-      return navigateTo("/change-password");
+      return navigateTo('/change-password');
     }
   }
 });

--- a/noj-ui/server/api/auth/logout.post.ts
+++ b/noj-ui/server/api/auth/logout.post.ts
@@ -15,26 +15,26 @@
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
   const cookies = parseCookies(event);
-  const token = cookies["noj:token"];
+  const token = cookies['noj:token'];
 
   // 1. 通知后端撤销该 token（fail-open：失败时也要清本地 Cookie）
   if (token) {
     try {
       await $fetch(`${config.apiBase}/api/v1/auth/logout`, {
-        method: "POST",
+        method: 'POST',
         headers: { authorization: `Bearer ${token}` },
       });
     } catch (err) {
-      console.warn("[logout] 后端撤销失败，继续清本地 Cookie:", err);
+      console.warn('[logout] 后端撤销失败，继续清本地 Cookie:', err);
     }
   }
 
   // 2. 清除本地 Cookie
-  deleteCookie(event, "noj:token", {
-    path: "/",
+  deleteCookie(event, 'noj:token', {
+    path: '/',
   });
-  deleteCookie(event, "noj:session", {
-    path: "/",
+  deleteCookie(event, 'noj:session', {
+    path: '/',
   });
 
   return { success: true };

--- a/noj-ui/tests/apiError_test.ts
+++ b/noj-ui/tests/apiError_test.ts
@@ -5,6 +5,7 @@
  * 以及未知错误兜底。
  */
 /// <reference lib="deno.ns" />
+// deno-lint-ignore no-import-prefix -- jsr: 前缀由 deno.lock 固定版本，与 noj-core 测试写法一致
 import { assertEquals } from 'jsr:@std/assert@^1';
 import { extractApiError, isNetworkError, isTimeoutError } from '../utils/apiError.ts';
 

--- a/noj-ui/utils/sanitize.ts
+++ b/noj-ui/utils/sanitize.ts
@@ -3,26 +3,64 @@
  * 优先使用 DOMPurify，不可用时使用标签白名单降级。
  */
 
-let purifyPromise: Promise<typeof import("dompurify").default> | null = null
+let purifyPromise: Promise<typeof import('dompurify').default> | null = null;
 
-function loadDompurify(): Promise<typeof import("dompurify").default> {
+function loadDompurify(): Promise<typeof import('dompurify').default> {
   if (!purifyPromise) {
-    purifyPromise = import("dompurify").then((mod) => mod.default)
+    purifyPromise = import('dompurify').then((mod) => mod.default);
   }
-  return purifyPromise
+  return purifyPromise;
 }
 
 // 白名单标签 —— markdown-it + KaTeX 生成的标签子集
 const SAFE_TAGS = new Set([
-  "a", "abbr", "b", "blockquote", "br", "code", "dd", "del", "div", "dl",
-  "dt", "em", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img",
-  "input", "ins", "kbd", "li", "mark", "ol", "p", "pre", "s", "small",
-  "span", "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
-  "thead", "tr", "ul",
-])
+  'a',
+  'abbr',
+  'b',
+  'blockquote',
+  'br',
+  'code',
+  'dd',
+  'del',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'i',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'li',
+  'mark',
+  'ol',
+  'p',
+  'pre',
+  's',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'tfoot',
+  'th',
+  'thead',
+  'tr',
+  'ul',
+]);
 
 // 白名单属性
-const SAFE_ATTR_RE = /^(?:href|title|alt|src|class|width|height|target|rel|style|align|start)$/i
+const SAFE_ATTR_RE = /^(?:href|title|alt|src|class|width|height|target|rel|style|align|start)$/i;
 
 /**
  * 简单标签白名单净化器 —— DOMPurify 不可用时的最后防线。
@@ -31,37 +69,40 @@ const SAFE_ATTR_RE = /^(?:href|title|alt|src|class|width|height|target|rel|style
  */
 function simpleSanitize(raw: string): string {
   // 首先移除所有 script / style 标签及内容
-  let html = raw.replace(/<script[\s\S]*?<\/script>/gi, "")
-  html = html.replace(/<style[\s\S]*?<\/style>/gi, "")
+  let html = raw.replace(/<script[\s\S]*?<\/script>/gi, '');
+  html = html.replace(/<style[\s\S]*?<\/style>/gi, '');
 
   // 过滤标签和属性
-  html = html.replace(/<(\/?)([a-zA-Z][a-zA-Z0-9]*)\b([^>]*)>/g, (_match, close: string, tag: string, attrs: string) => {
-    const tagLower = tag.toLowerCase()
-    if (!SAFE_TAGS.has(tagLower)) {
-      // 不认识的标签 → 转为纯文本显示
-      return `&lt;${close}${tag}${attrs}&gt;`
-    }
-    if (close) return `</${tagLower}>`
+  html = html.replace(
+    /<(\/?)([a-zA-Z][a-zA-Z0-9]*)\b([^>]*)>/g,
+    (_match, close: string, tag: string, attrs: string) => {
+      const tagLower = tag.toLowerCase();
+      if (!SAFE_TAGS.has(tagLower)) {
+        // 不认识的标签 → 转为纯文本显示
+        return `&lt;${close}${tag}${attrs}&gt;`;
+      }
+      if (close) return `</${tagLower}>`;
 
-    // 过滤属性 —— 只保留白名单属性，并阻止 javascript: 协议
-    const safeAttrs = attrs.replace(
-      /\s*([a-zA-Z-]+)\s*(?:=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/g,
-      (_am, attrName: string, dq: string, sq: string, nq: string) => {
-        const attrLower = attrName.toLowerCase()
-        if (!SAFE_ATTR_RE.test(attrLower)) return ""
-        const val = dq ?? sq ?? nq ?? ""
-        if ((attrLower === "href" || attrLower === "src") && /^\s*javascript:/i.test(val)) {
-          return ""
-        }
-        if (dq != null) return ` ${attrLower}="${dq.replace(/"/g, "&quot;")}"`
-        if (sq != null) return ` ${attrLower}='${sq.replace(/'/g, "&#039;")}'`
-        return val ? ` ${attrLower}="${val}"` : ` ${attrLower}`
-      },
-    )
-    return `<${tagLower}${safeAttrs}>`
-  })
+      // 过滤属性 —— 只保留白名单属性，并阻止 javascript: 协议
+      const safeAttrs = attrs.replace(
+        /\s*([a-zA-Z-]+)\s*(?:=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/g,
+        (_am, attrName: string, dq: string, sq: string, nq: string) => {
+          const attrLower = attrName.toLowerCase();
+          if (!SAFE_ATTR_RE.test(attrLower)) return '';
+          const val = dq ?? sq ?? nq ?? '';
+          if ((attrLower === 'href' || attrLower === 'src') && /^\s*javascript:/i.test(val)) {
+            return '';
+          }
+          if (dq != null) return ` ${attrLower}="${dq.replace(/"/g, '&quot;')}"`;
+          if (sq != null) return ` ${attrLower}='${sq.replace(/'/g, '&#039;')}'`;
+          return val ? ` ${attrLower}="${val}"` : ` ${attrLower}`;
+        },
+      );
+      return `<${tagLower}${safeAttrs}>`;
+    },
+  );
 
-  return html
+  return html;
 }
 
 /**
@@ -69,7 +110,7 @@ function simpleSanitize(raw: string): string {
  * 在客户端可用后由组件自行切换到 DOMPurify。
  */
 export function sanitizeHtmlSync(raw: string): string {
-  return simpleSanitize(raw)
+  return simpleSanitize(raw);
 }
 
 /**
@@ -78,10 +119,10 @@ export function sanitizeHtmlSync(raw: string): string {
  */
 export async function sanitizeHtmlAsync(raw: string): Promise<string> {
   try {
-    const purify = await loadDompurify()
-    return purify.sanitize(raw)
+    const purify = await loadDompurify();
+    return purify.sanitize(raw);
   } catch {
     // DOMPurify 加载失败 → 使用标签白名单降级
-    return simpleSanitize(raw)
+    return simpleSanitize(raw);
   }
 }

--- a/noj-ui/utils/validatePassword.ts
+++ b/noj-ui/utils/validatePassword.ts
@@ -2,27 +2,27 @@
  * Password validation rules extracted from auth pages.
  */
 export interface PasswordValidation {
-  valid: boolean
-  message: string
+  valid: boolean;
+  message: string;
 }
 
 export function validatePassword(password: string): PasswordValidation {
-  if (!password) return { valid: false, message: "请输入密码" }
-  if (password.length < 12) return { valid: false, message: "密码长度不能少于 12 位" }
-  if (!/[a-z]/.test(password)) return { valid: false, message: "密码必须包含至少一个小写字母" }
-  if (!/[A-Z]/.test(password)) return { valid: false, message: "密码必须包含至少一个大写字母" }
-  if (!/[0-9]/.test(password)) return { valid: false, message: "密码必须包含至少一个数字" }
-  return { valid: true, message: "" }
+  if (!password) return { valid: false, message: '请输入密码' };
+  if (password.length < 12) return { valid: false, message: '密码长度不能少于 12 位' };
+  if (!/[a-z]/.test(password)) return { valid: false, message: '密码必须包含至少一个小写字母' };
+  if (!/[A-Z]/.test(password)) return { valid: false, message: '密码必须包含至少一个大写字母' };
+  if (!/[0-9]/.test(password)) return { valid: false, message: '密码必须包含至少一个数字' };
+  return { valid: true, message: '' };
 }
 
 export function validatePasswordMatch(password: string, confirm: string): string | null {
-  if (!confirm) return "请确认密码"
-  if (password !== confirm) return "两次输入的密码不一致"
-  return null
+  if (!confirm) return '请确认密码';
+  if (password !== confirm) return '两次输入的密码不一致';
+  return null;
 }
 
 export function validateEmail(email: string): string | null {
-  if (!email.trim()) return "请输入邮箱地址"
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) return "邮箱格式不正确"
-  return null
+  if (!email.trim()) return '请输入邮箱地址';
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) return '邮箱格式不正确';
+  return null;
 }


### PR DESCRIPTION
## 问题
`noj-ui/deno.json` 的 lint/fmt include 为 `["*.vue", "*.ts"]`，只匹配根目录文件；pages/components/composables/server 等子目录从未被检查。

## 变更
- `deno.json`：lint/fmt include 改为 `**/*.vue` / `**/*.ts`；lint 排除 `no-sloppy-imports`（Nuxt 项目使用 npm 裸导入与 `~/` 别名）；新增 `check` / `check:types` 任务（`deno check utils tests`）
- 批量 `deno fmt` 修复 20 个从未被格式化的子目录文件（纯机械格式化）
- 修复 lint 真实问题：`useResizableSplit.ts` window→globalThis、`useMessages.ts` / `useSearch.ts` 移除无 await 的 async、测试文件 jsr: 导入加 lint-ignore

## 验证
- `deno lint`：34 个文件通过
- `deno fmt --check`：124 个文件通过
- `deno task check:types` + `deno task test`（10 个测试）通过

## 说明
- CI `ui-check` 增加 lint/fmt/typecheck 步骤的改动因当前 token 无 `workflow` scope 无法推送，需在具备 workflow 权限的 token 下另行提交
- 全量 `nuxt typecheck`（vue-tsc）在 Deno 2.9 下触发 TS 流分析栈溢出，且 scoped tsc 暴露 h3 1.x/2.0-rc 版本冲突等既有问题，暂不纳入；`check:types` 先覆盖纯 TS（utils/tests）