### PR TITLE
fix(devtool): wait_http/wait_port 增加 curl 超时并回收陈旧锁（issue #188）

### DIFF
--- a/scripts/dev/devtool.sh
+++ b/scripts/dev/devtool.sh
@@ -120,7 +120,8 @@ read_pid() {
 wait_http() {
   local url="$1" secs="$2" i
   for ((i=1; i<=secs; i++)); do
-    if curl -fsS -o /dev/null "$url" 2>/dev/null; then
+    # --max-time：目标端口半开（LISTEN 但不响应 HTTP）时避免无限卡死（issue #188）
+    if curl -fsS --max-time 3 -o /dev/null "$url" 2>/dev/null; then
       return 0
     fi
     sleep 1
@@ -132,8 +133,10 @@ wait_http() {
 wait_port() {
   local port="$1" secs="$2" i
   for ((i=1; i<=secs; i++)); do
-    if curl -fsS -o /dev/null "http://localhost:$port/" 2>/dev/null \
-       || (command -v nc >/dev/null 2>&1 && nc -z localhost "$port" 2>/dev/null); then
+    # --max-time / -w：端口已 LISTEN 但 HTTP 不响应（半开状态）时，
+    # 每个探测尝试限时 3s，由外层轮询计数真正控制总超时（issue #188）
+    if curl -fsS --max-time 3 -o /dev/null "http://localhost:$port/" 2>/dev/null \
+       || (command -v nc >/dev/null 2>&1 && nc -z -w 3 localhost "$port" 2>/dev/null); then
       return 0
     fi
     sleep 1
@@ -147,7 +150,18 @@ acquire_lock() {
   local target="$1"
   if ! mkdir "$LOCK_DIR/$target.lock" 2>/dev/null; then
     if [[ -d "$LOCK_DIR/$target.lock" ]]; then
-      fail "$target 正在被另一个 devtool.sh 操作占用（lock: $LOCK_DIR/$target.lock）"
+      # 陈旧锁回收（issue #188）：devtool 被强杀（SIGKILL）时 trap 不执行，
+      # 遗留的 lock 目录会让后续启动永远报"占用"；持有者 PID 已退出则回收。
+      local holder
+      holder="$(cat "$LOCK_DIR/$target.lock/pid" 2>/dev/null)"
+      if [[ -n "$holder" ]] && is_pid_alive "$holder"; then
+        fail "$target 正在被另一个 devtool.sh 操作占用（lock: $LOCK_DIR/$target.lock）"
+      fi
+      echo "  清理陈旧锁: $LOCK_DIR/$target.lock（持有者 PID ${holder:-未知} 已退出）"
+      rm -rf "$LOCK_DIR/$target.lock" 2>/dev/null || true
+      if ! mkdir "$LOCK_DIR/$target.lock" 2>/dev/null; then
+        fail "无法创建 lock: $LOCK_DIR/$target.lock"
+      fi
     else
       fail "无法创建 lock: $LOCK_DIR/$target.lock"
     fi


### PR DESCRIPTION
## 问题
`wait_http` / `wait_port` 使用裸 `curl -fsS`（无 `--max-time`），端口已 LISTEN 但 HTTP 不响应（半开状态，如 SSR 未就绪 / 外部字体拉取挂起）时 curl 无限等待，`devtool.sh start` 永久卡死，外层 SECS 形同虚设。

## 修复
- `wait_http` / `wait_port`：curl 增加 `--max-time 3`；nc 探测增加 `-w 3`，每次尝试限时 3s，由外层轮询真正控制总超时
- `acquire_lock`：增加陈旧锁回收——lock 目录持有者 PID 已退出（如 devtool 被 SIGKILL 强杀，trap 不执行）时自动清理并重新获取；持有者存活时仍正常拦截

## 验证
- 半开端口（nc 监听不响应）`wait_port 2` 次约 5s 超时返回 rc=1（修复前无限挂起）
- 陈旧锁（死 PID）自动回收并重新获取；存活 PID 锁正常报「占用」
- `bash -n` 语法检查通过；`devtool.sh status` 正常