### PR TITLE
feat(devtool,core): devtool bootstrap admin 默认不强制首次改密（开发环境）

### DIFF
--- a/noj-core/.env.example
+++ b/noj-core/.env.example
@@ -29,6 +29,9 @@ PORT=8000
 ADMIN_EMAIL=
 # 管理员密码（需要与 ADMIN_EMAIL 配合使用；未设置但 ADMIN_EMAIL 对应已注册用户时仅提权）
 ADMIN_PASS=
+# 引导管理员是否强制首次改密（issue #75 守卫，默认 true）。
+# devtool.sh bootstrap admin 会自动设为 false，开发环境首次登录即可用完整功能。
+# NOJ_FORCE_PASSWORD_CHANGE=false
 
 # ── 速率限制（issue #73 登录限流）──────────────────────────
 # 总开关：true=启用 / false=禁用。NOJ_ENV=test 时强制关闭

--- a/noj-core/src/services/seed-system.ts
+++ b/noj-core/src/services/seed-system.ts
@@ -54,6 +54,16 @@ async function ensureAdminRoleAssignment(userId: string): Promise<void> {
 }
 
 /**
+ * 引导管理员是否强制首次改密（issue #75 守卫）。
+ *
+ * 默认 true（生产安全基线）；devtool 的 `bootstrap admin` 子命令会设置
+ * `NOJ_FORCE_PASSWORD_CHANGE=false`，使开发环境管理员首次登录即可使用完整功能。
+ */
+function shouldForcePasswordChange(): boolean {
+  return Deno.env.get("NOJ_FORCE_PASSWORD_CHANGE") !== "false";
+}
+
+/**
  * 初始化评测镜像白名单。
  * 仅保留双容器镜像（noj-evaluator-python / noj-solution-python）。
  * 幂等：使用固定 UUID 确保重复运行不重复插入。
@@ -188,14 +198,15 @@ export async function ensureAdminFromEnv(): Promise<void> {
       email: adminEmail,
       password_hash: await hashPassword(adminPass),
       role: "admin",
-      must_change_password: true,
+      must_change_password: shouldForcePasswordChange(),
       created_at: now,
       updated_at: now,
     });
     await ensureAdminRoleAssignment(id);
-    console.log(
-      `  已创建管理员用户: ${adminEmail} (${username})，已强制首次改密`,
-    );
+    const guard = shouldForcePasswordChange()
+      ? "已强制首次改密"
+      : "开发模式：未强制首次改密";
+    console.log(`  已创建管理员用户: ${adminEmail} (${username})，${guard}`);
     return;
   }
 
@@ -268,7 +279,7 @@ export async function ensureBootstrapAdmin(): Promise<void> {
     email,
     password_hash: await hashPassword(password),
     role: "admin",
-    must_change_password: true,
+    must_change_password: shouldForcePasswordChange(),
     created_at: now,
     updated_at: now,
   });
@@ -276,13 +287,19 @@ export async function ensureBootstrapAdmin(): Promise<void> {
 
   console.log("");
   console.log("-".repeat(72));
-  console.log("⚠ 已创建临时引导管理员（首次登录后必须修改密码）");
+  if (shouldForcePasswordChange()) {
+    console.log("⚠ 已创建临时引导管理员（首次登录后必须修改密码）");
+  } else {
+    console.log("✓ 已创建开发引导管理员（未强制首次改密，可直接使用完整功能）");
+  }
   console.log("-".repeat(72));
   console.log(`  username: ${username}`);
   console.log(`  email:    ${email}`);
   console.log(`  password: ${password}`);
   console.log("-".repeat(72));
-  console.log("⚠ 请立即记录上述密码，首次登录后系统会强制要求修改密码。");
+  if (shouldForcePasswordChange()) {
+    console.log("⚠ 请立即记录上述密码，首次登录后系统会强制要求修改密码。");
+  }
   console.log("-".repeat(72));
   console.log("");
 }

--- a/noj-core/tests/seed_bootstrap_admin_test.ts
+++ b/noj-core/tests/seed_bootstrap_admin_test.ts
@@ -13,6 +13,7 @@ import { assert, assertEquals } from "jsr:@std/assert@^1";
 import { getDb, resetDbForTest } from "../src/db/connection.ts";
 import { and, eq, not, sql } from "drizzle-orm";
 import {
+  auditLogs,
   conversationReads,
   conversations,
   evaluationResults,
@@ -85,6 +86,16 @@ async function countAdminRoleAssignments(userId: string): Promise<number> {
   return rows.length;
 }
 
+/**
+ * 清理测试创建的用户（含 audit_logs 引用与 user_roles 级联）。
+ * 每个用例自清理，避免依赖下一个用例的 cleanNonRootAdmins。
+ */
+async function cleanupUser(userId: string): Promise<void> {
+  const db = getDb();
+  await db.delete(auditLogs).where(eq(auditLogs.admin_id, userId));
+  await db.delete(users).where(eq(users.id, userId));
+}
+
 Deno.test({
   name: "seed bootstrap: 新数据库无可登录 admin",
   ignore: skip,
@@ -117,15 +128,19 @@ Deno.test({
       password: "TestPwd-2024-Xy9",
     });
 
-    // 直接提升为 admin
-    const db = getDb();
-    await db
-      .update(users)
-      .set({ role: "admin", updated_at: new Date().toISOString() })
-      .where(eq(users.id, user.id));
+    try {
+      // 直接提升为 admin
+      const db = getDb();
+      await db
+        .update(users)
+        .set({ role: "admin", updated_at: new Date().toISOString() })
+        .where(eq(users.id, user.id));
 
-    const beforeCount = await getAdminCount();
-    assertEquals(beforeCount, 1, "应有一个可登录 admin");
+      const beforeCount = await getAdminCount();
+      assertEquals(beforeCount, 1, "应有一个可登录 admin");
+    } finally {
+      await cleanupUser(user.id);
+    }
   },
 });
 
@@ -170,27 +185,31 @@ Deno.test({
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
-    await db.insert(users).values({
-      id,
-      username: "admin",
-      email: "admin@noj.local",
-      password_hash: await hashPassword(pwd),
-      role: "admin",
-      must_change_password: true,
-      created_at: now,
-      updated_at: now,
-    });
+    try {
+      await db.insert(users).values({
+        id,
+        username: "admin",
+        email: "admin@noj.local",
+        password_hash: await hashPassword(pwd),
+        role: "admin",
+        must_change_password: true,
+        created_at: now,
+        updated_at: now,
+      });
 
-    // 验证
-    const [admin] = await db
-      .select()
-      .from(users)
-      .where(eq(users.id, id))
-      .limit(1);
+      // 验证
+      const [admin] = await db
+        .select()
+        .from(users)
+        .where(eq(users.id, id))
+        .limit(1);
 
-    assertEquals(admin.must_change_password, true);
-    assertEquals(admin.role, "admin");
-    assertEquals(admin.username, "admin");
+      assertEquals(admin.must_change_password, true);
+      assertEquals(admin.role, "admin");
+      assertEquals(admin.username, "admin");
+    } finally {
+      await cleanupUser(id);
+    }
   },
 });
 
@@ -206,23 +225,26 @@ Deno.test({
     const origAdminEmail = Deno.env.get("ADMIN_EMAIL");
     if (origAdminEmail) Deno.env.delete("ADMIN_EMAIL");
 
-    // 直接调用真实 seed 函数，验证 user_roles 关联被写入
-    await ensureBootstrapAdmin();
+    try {
+      // 直接调用真实 seed 函数，验证 user_roles 关联被写入
+      await ensureBootstrapAdmin();
 
-    const db = getDb();
-    const [admin] = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(and(eq(users.role, "admin"), not(eq(users.id, "0"))))
-      .limit(1);
-    assert(admin, "应创建引导管理员");
-    assertEquals(
-      await countAdminRoleAssignments(admin.id),
-      1,
-      "引导管理员应拥有 admin 角色关联",
-    );
-
-    if (origAdminEmail) Deno.env.set("ADMIN_EMAIL", origAdminEmail);
+      const db = getDb();
+      const [admin] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(and(eq(users.role, "admin"), not(eq(users.id, "0"))))
+        .limit(1);
+      assert(admin, "应创建引导管理员");
+      assertEquals(
+        await countAdminRoleAssignments(admin.id),
+        1,
+        "引导管理员应拥有 admin 角色关联",
+      );
+      await cleanupUser(admin.id);
+    } finally {
+      if (origAdminEmail) Deno.env.set("ADMIN_EMAIL", origAdminEmail);
+    }
   },
 });
 
@@ -238,6 +260,7 @@ Deno.test({
     const origAdminEmail = Deno.env.get("ADMIN_EMAIL");
     const origAdminPass = Deno.env.get("ADMIN_PASS");
 
+    let adminId: string | null = null;
     Deno.env.set("ADMIN_EMAIL", "ops-186@noj.local");
     Deno.env.set("ADMIN_PASS", "OpsAdmin-2026-Xy9");
     try {
@@ -255,7 +278,9 @@ Deno.test({
         1,
         "环境变量管理员应拥有 admin 角色关联",
       );
+      adminId = admin.id;
     } finally {
+      if (adminId) await cleanupUser(adminId);
       if (origAdminEmail) {
         Deno.env.set("ADMIN_EMAIL", origAdminEmail);
       } else {
@@ -302,6 +327,7 @@ Deno.test({
         "NOJ_FORCE_PASSWORD_CHANGE=false 时不应强制首次改密",
       );
       assertEquals(await countAdminRoleAssignments(admin.id), 1);
+      await cleanupUser(admin.id);
     } finally {
       if (origAdminEmail) {
         Deno.env.set("ADMIN_EMAIL", origAdminEmail);
@@ -346,6 +372,7 @@ Deno.test({
         "被提升的管理员应写入 admin 角色关联",
       );
     } finally {
+      await cleanupUser(user.id);
       if (origAdminEmail) {
         Deno.env.set("ADMIN_EMAIL", origAdminEmail);
       } else {

--- a/noj-core/tests/seed_bootstrap_admin_test.ts
+++ b/noj-core/tests/seed_bootstrap_admin_test.ts
@@ -272,6 +272,53 @@ Deno.test({
 
 Deno.test({
   name:
+    "seed bootstrap: NOJ_FORCE_PASSWORD_CHANGE=false 时引导管理员不强制改密（devtool 默认）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    await cleanNonRootAdmins();
+    const origAdminEmail = Deno.env.get("ADMIN_EMAIL");
+    const origForce = Deno.env.get("NOJ_FORCE_PASSWORD_CHANGE");
+    if (origAdminEmail) Deno.env.delete("ADMIN_EMAIL");
+    Deno.env.set("NOJ_FORCE_PASSWORD_CHANGE", "false");
+    try {
+      await ensureBootstrapAdmin();
+
+      const db = getDb();
+      const [admin] = await db
+        .select({
+          id: users.id,
+          must_change_password: users.must_change_password,
+        })
+        .from(users)
+        .where(and(eq(users.role, "admin"), not(eq(users.id, "0"))))
+        .limit(1);
+      assert(admin, "应创建引导管理员");
+      assertEquals(
+        admin.must_change_password,
+        false,
+        "NOJ_FORCE_PASSWORD_CHANGE=false 时不应强制首次改密",
+      );
+      assertEquals(await countAdminRoleAssignments(admin.id), 1);
+    } finally {
+      if (origAdminEmail) {
+        Deno.env.set("ADMIN_EMAIL", origAdminEmail);
+      } else {
+        Deno.env.delete("ADMIN_EMAIL");
+      }
+      if (origForce) {
+        Deno.env.set("NOJ_FORCE_PASSWORD_CHANGE", origForce);
+      } else {
+        Deno.env.delete("NOJ_FORCE_PASSWORD_CHANGE");
+      }
+    }
+  },
+});
+
+Deno.test({
+  name:
     "seed bootstrap: ensureAdminFromEnv 提升已有用户时写入 user_roles（issue #186）",
   ignore: skip,
   sanitizeResources: false,

--- a/scripts/dev/devtool.sh
+++ b/scripts/dev/devtool.sh
@@ -346,6 +346,36 @@ cmd_install_deps() {
 }
 
 # ══════════════════════════════════════════════════════════════════
+#  bootstrap — 创建/引导管理员（开发环境默认不强制首次改密）
+# ══════════════════════════════════════════════════════════════════
+# devtool 托管的开发流程默认 NOJ_FORCE_PASSWORD_CHANGE=false：
+# 管理员首次登录即可使用完整功能，无需强制改密（issue #75 守卫仅在生产保留）。
+cmd_bootstrap_admin() {
+  local email="" password=""
+  # 兼容 `devtool.sh bootstrap admin [--email ...]` 写法
+  if [[ "$1" == "admin" ]]; then
+    shift
+  fi
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --email) email="$2"; shift 2 ;;
+      --password) password="$2"; shift 2 ;;
+      *) fail "未知参数: $1（用法: devtool.sh bootstrap admin [--email X --password Y]）" ;;
+    esac
+  done
+
+  if [[ ! -f "$ENV_TARGET" ]]; then
+    fail "$ENV_TARGET 不存在，请先运行: devtool.sh init-env"
+  fi
+
+  echo ">>> 创建/引导管理员（开发模式：NOJ_FORCE_PASSWORD_CHANGE=false）..."
+  local args=("task" "bootstrap:admin")
+  [[ -n "$email" ]] && args+=(--email "$email")
+  [[ -n "$password" ]] && args+=(--password "$password")
+  (cd "$NOJ_CORE_DIR" && NOJ_FORCE_PASSWORD_CHANGE=false deno "${args[@]}")
+}
+
+# ══════════════════════════════════════════════════════════════════
 #  init-env — 初始化 / 合并 noj-core/.env
 # ══════════════════════════════════════════════════════════════════
 # 解析 env 文件为 KEY=VALUE 对（忽略注释 / 空行），输出到 stdout
@@ -1045,6 +1075,7 @@ devtool.sh — Neuro OJ 本地开发编排工具（Linux + macOS）
 子命令:
   install-deps [--check-only]   检测 / 安装前置依赖（zip / Deno / Rust / Docker）
   init-env     [--merge|--force] 初始化 noj-core/.env（默认拒绝覆盖）
+  bootstrap admin [--email X] [--password Y] 创建/引导管理员（开发模式不强制首次改密）
   start        [TARGET] [--build] 启动 TARGET（infra|core|ui|judge|all，默认 all）
   stop         [TARGET]          停止 TARGET（同上，按反向依赖顺序）
   status       [--json] [--watch SECS] 查看运行状态
@@ -1053,6 +1084,8 @@ devtool.sh — Neuro OJ 本地开发编排工具（Linux + macOS）
 示例:
   devtool.sh install-deps            # 首次：检测 + 安装依赖
   devtool.sh init-env                # 首次：复制 env.example → noj-core/.env
+  devtool.sh bootstrap admin --email admin@noj.local --password 'Admin-2026-Xy9!'
+                                     # 创建管理员（默认不强制首次改密）
   devtool.sh start                   # 启动全部（infra → core → ui → judge）
   devtool.sh start ui                # 只启动前端（纯前端开发）
   devtool.sh start judge --build     # 启动 judge 并强制重新编译
@@ -1080,6 +1113,7 @@ shift || true
 case "$cmd" in
   install-deps) cmd_install_deps "$@" ;;
   init-env)     cmd_init_env     "$@" ;;
+  bootstrap)    cmd_bootstrap_admin "$@" ;;
   start)        cmd_start        "$@" ;;
   stop)         cmd_stop         "$@" ;;
   status)       cmd_status       "$@" ;;

--- a/scripts/dev/env.example
+++ b/scripts/dev/env.example
@@ -47,6 +47,10 @@ JWT_SECRET=please-replace-with-at-least-32-random-characters-aaaaaa
 # ADMIN_EMAIL=admin@example.com
 # ADMIN_PASS=YourSecurePass123!
 
+# 引导管理员是否强制首次改密（issue #75 守卫，默认 true）。
+# 使用 `devtool.sh bootstrap admin` 创建管理员时自动设为 false（开发环境）。
+# NOJ_FORCE_PASSWORD_CHANGE=false
+
 # ── 社区设置(add-community-system, 可选) ────────────────────
 # 以下各项可在「管理后台 > 社区管理」运行时修改,env 值仅作启动期 fallback
 # COMMUNITY_ENABLED=true


### PR DESCRIPTION
## 需求
开发环境（devtool 启动）下引导管理员不应强制首次改密——`must_change_password=true` 会拦截除改密外的所有功能，本地开发体验差。issue #75 守卫保留给生产。

## 变更
- `scripts/dev/devtool.sh`：新增 `bootstrap admin [--email X --password Y]` 子命令，内部以 `NOJ_FORCE_PASSWORD_CHANGE=false` 调用 `deno task bootstrap:admin`，默认不强制改密；已更新 help
- `noj-core/src/services/seed-system.ts`：`ensureAdminFromEnv` / `ensureBootstrapAdmin` 按 `NOJ_FORCE_PASSWORD_CHANGE` 决定 `must_change_password`（默认 true，生产行为不变），创建日志区分两种模式
- 环境变量模板（noj-core/.env.example、scripts/dev/env.example）补充变量说明

## 测试与验证
- `seed_bootstrap_admin_test.ts` 新增用例：`NOJ_FORCE_PASSWORD_CHANGE=false` 时创建的引导管理员 `must_change_password=false` 且写入 user_roles；8 个测试全过
- devtool 实测：`devtool.sh bootstrap admin` 创建的账号登录返回 `is_admin=true, must_change_password=false`，可直接使用完整功能
- deno fmt / lint 通过；devtool.sh bash -n 通过