### PR TITLE
fix(ui): AsyncContent 过渡单元素化与 UserMenu 菜单聚焦修复

### DIFF
--- a/noj-ui/components/layout/UserMenu.vue
+++ b/noj-ui/components/layout/UserMenu.vue
@@ -20,6 +20,7 @@
         </div>
         <div
             v-show="showDropdown"
+            ref="menuRef"
             role="menu"
             aria-label="用户菜单"
             class="absolute right-0 top-[calc(100%+8px)] bg-white border border-border rounded-lg min-w-[210px] p-1 shadow-dropdown z-[200]"
@@ -28,7 +29,7 @@
             <div class="px-3.5 py-2 border-b border-border mb-1">
                 <p class="text-sm font-semibold text-text truncate">{{ user?.username }}</p>
             </div>
-            <NuxtLink ref="firstItemRef" to="/my/problems" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100" @click="closeMenu"><UIcon name="i-lucide-book-open" class="size-4" />我的题目</NuxtLink>
+            <NuxtLink to="/my/problems" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100" @click="closeMenu"><UIcon name="i-lucide-book-open" class="size-4" />我的题目</NuxtLink>
             <NuxtLink to="/messages" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100 relative" @click="closeMenu"><UIcon name="i-lucide-mail" class="size-4" />消息<span v-if="unreadCount > 0" class="ml-auto bg-red-500 text-white text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[18px] text-center">{{ unreadCount > 99 ? "99+" : unreadCount }}</span></NuxtLink>
             <NuxtLink :to="`/users/${user?.id}`" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100" @click="closeMenu"><UIcon name="i-lucide-database" class="size-4" />数据</NuxtLink>
             <NuxtLink to="/settings" role="menuitem" class="flex items-center gap-2 w-full px-3.5 py-2 text-sm text-text no-underline rounded hover:bg-gray-100" @click="closeMenu"><UIcon name="i-lucide-settings" class="size-4" />设置</NuxtLink>
@@ -55,12 +56,17 @@ const { api } = useApi()
 
 // ── 下拉菜单：点击切换 + 键盘可达（WCAG 2.1.1） ──
 const menuButtonRef = ref<HTMLButtonElement | null>(null)
-const firstItemRef = ref<HTMLElement | null>(null)
+const menuRef = ref<HTMLElement | null>(null)
 const showDropdown = ref(false)
 
 function openMenu() {
     showDropdown.value = true
-    nextTick(() => firstItemRef.value?.focus())
+    // Nuxt UI v4 下组件 ref 拿不到 DOM 元素（focus 不可用），
+    // 改为在菜单容器内查找第一个 menuitem 聚焦
+    nextTick(() => {
+        const first = menuRef.value?.querySelector<HTMLElement>('[role="menuitem"]')
+        first?.focus()
+    })
 }
 
 function closeMenu() {

--- a/noj-ui/components/ui/AsyncContent.vue
+++ b/noj-ui/components/ui/AsyncContent.vue
@@ -26,7 +26,12 @@ defineEmits<{ retry: [] }>()
         <slot name="empty-action" />
       </slot>
     </div>
-    <slot v-else-if="status === 'data'" />
+    <!-- data 分支包一层透明容器：Transition 只允许单元素，
+         调用方 data 插槽可能传多个根节点（如表格 + 分页），
+         display: contents 不改变布局语义 -->
+    <div v-else-if="status === 'data'" class="contents">
+      <slot />
+    </div>
   </Transition>
 </template>
 <style scoped>


### PR DESCRIPTION
## 问题（浏览器 console 报错）
1. `<transition> can only be used on a single element`：`AsyncContent` 的 data 分支是裸 `<slot>`，调用方（如 /problems）在 data 插槽里传了**多个根节点**（表格 + 分页），Transition 收到 fragment 触发警告，并引发 /problems 页 hydration children mismatch
2. `UserMenu.vue: firstItemRef.value?.focus is not a function`：ref 挂在 NuxtLink（组件）上，Nuxt UI v4 下拿到的是组件实例而非 DOM 元素，`.focus()` 不可用

## 修复
- `AsyncContent.vue`：data 分支包一层 `class="contents"`（display: contents）单元素容器，Transition 始终单子节点，且不改变调用方布局语义
- `UserMenu.vue`：菜单容器加 `menuRef`，聚焦改为 `querySelector('[role="menuitem"]')` 取真实 DOM 元素

## 验证
- `deno task build` 通过；/problems SSR 200（0.18s）且正常渲染题目
- deno fmt 通过