### PR TITLE
feat(core,judge,ui,docs): 评测网络能力：evaluator 可配联网与 capability 转发

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -422,9 +422,10 @@ jobs:
           # rustup 状态目录导致 "component download failed"（测试启动即死）。
           # 先单进程触发一次 sync，之后并行 cargo 不再下载。
           cargo --version >/dev/null
-          # 必须列出全部 5 个 e2e_* 测试文件（e2e_container_pool 已随容器池
-          # 移除而删除，见 remove-container-pool 变更）。
-          # 性能优化（2026-07）：5 个目标分 2 组并行——组内串行
+          # 必须列出全部 7 个 e2e_* 测试文件（e2e_container_pool 已随容器池
+          # 移除而删除；e2e_dual_container / e2e_network_capability 为后续新增，
+          # 见 dual-container-judge / capability-network 变更）。
+          # 性能优化（2026-07）：目标分 2 组并行——组内串行
           # （serial_test 保证单 binary 内串行），组间并行利用 runner 多核。
           run_group() {
             for target in "$@"; do
@@ -439,9 +440,12 @@ jobs:
           p1=$!
           run_group e2e_support_package e2e_problem_limits &
           p2=$!
+          run_group e2e_dual_container e2e_network_capability &
+          p3=$!
           fail=0
           wait "$p1" || fail=1
           wait "$p2" || fail=1
+          wait "$p3" || fail=1
           exit "$fail"
 
       # 失败时上传 Docker 沙箱产物

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ aa.txt
 
 # --- Docker buildx cache ---
 .buildx/
+
+.reasonix/

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ cd noj-judge && cargo test --lib
 
 # noj-judge Docker 沙箱 E2E（需要 Docker 与 NOJ_RUN_E2E=1，7 个独立 test binary）
 cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_docker_basic -- --ignored
-# ...（其余：e2e_resource_limits / e2e_security_isolation / e2e_support_package / e2e_container_pool / e2e_problem_limits / e2e_dual_container）
+# ...（其余：e2e_resource_limits / e2e_security_isolation / e2e_support_package / e2e_problem_limits / e2e_dual_container / e2e_network_capability）
 
 # 跨模块全链路 E2E（23 个测试文件，需先启动完整环境）
 cd noj-tests && deno task test

--- a/noj-core/src/services/problem-bundle.ts
+++ b/noj-core/src/services/problem-bundle.ts
@@ -300,6 +300,10 @@ async function createViaCrud(
     "solution",
   );
 
+  // evaluator 联网权限与题目创建权限一致：普通用户导入创建 U 型题可开网；
+  // P 型由上方类型检查保证仅 admin。安全提醒：联网 + 可控 evaluator.command
+  // = 联网容器任意命令执行，题目包 manifest.runtime_config 由上传者完全可控。
+
   const db = getDb();
   const categoryIds = await resolveCategoryIds(manifest.categories);
 

--- a/noj-core/src/services/problems-crud.ts
+++ b/noj-core/src/services/problems-crud.ts
@@ -78,6 +78,11 @@ export async function createProblem(
       logger.error("createProblem: runtime_config 镜像校验失败", { err });
       throw err;
     }
+
+    // evaluator 联网权限与题目创建权限一致：U 型任意登录用户可开启，
+    // P 型仅 admin（由下方类型权限检查保证）。
+    // 安全提醒：联网 + 可控 evaluator.command = 联网容器任意命令执行，
+    // 开启联网的题目等于把外部网络能力交给出题人（出题人可信边界）。
   } else {
     logger.error("createProblem: runtime_config 缺失", {
       input: JSON.stringify(input),
@@ -247,6 +252,9 @@ export async function updateProblem(
       input.runtime_config.solution.image,
       "solution",
     );
+
+    // evaluator 联网权限与题目编辑权限一致：U 型 owner/admin、P 型 admin
+    // （上方权限检查已保证）。
   }
 
   // 防御性忽略 type 和 number（spec 承诺这两个字段不可变更）

--- a/noj-core/src/services/problems-types.ts
+++ b/noj-core/src/services/problems-types.ts
@@ -103,6 +103,21 @@ export function validateRuntimeConfig(rc: RuntimeConfig): void {
     );
   }
 
+  // evaluator.network（可选，缺省 = 无网）
+  if (e.network !== undefined && e.network !== null) {
+    if (typeof e.network !== "object" || Array.isArray(e.network)) {
+      throw new BadRequestError(
+        "runtime_config.evaluator.network 必须是对象",
+      );
+    }
+    const n = e.network as { enabled?: unknown };
+    if (typeof n.enabled !== "boolean") {
+      throw new BadRequestError(
+        "runtime_config.evaluator.network.enabled 必须是布尔值",
+      );
+    }
+  }
+
   const s = rc.solution;
   if (typeof s.image !== "string" || !s.image.trim()) {
     throw new BadRequestError("runtime_config.solution.image 必须是非空字符串");

--- a/noj-core/src/types/index.ts
+++ b/noj-core/src/types/index.ts
@@ -10,6 +10,10 @@ export interface EvaluatorRuntime {
   time_limit_ms: number;
   /** Evaluator 容器内存上限（MB） */
   memory_limit_mb: number;
+  /** 网络配置（可选，缺省 = 无网；开启后 evaluator 以 bridge 模式联网） */
+  network?: {
+    enabled: boolean;
+  };
 }
 
 /**

--- a/noj-core/tests/routes/problem-bundle.test.ts
+++ b/noj-core/tests/routes/problem-bundle.test.ts
@@ -30,7 +30,6 @@ export function makeBundleZip(
     title: `导入测试题 ${ts}`,
     difficulty: "easy",
     type: "U",
-    ...manifestOverrides,
     runtime_config: {
       evaluator: {
         image: "noj-evaluator-python",
@@ -44,6 +43,7 @@ export function makeBundleZip(
         memory_limit_mb: 512,
       },
     },
+    ...manifestOverrides,
   };
   const enc = new TextEncoder();
   return zipSync({
@@ -485,5 +485,53 @@ Deno.test({
     } catch {
       // ignore
     }
+  },
+});
+
+Deno.test({
+  name: "import-bundle: 普通用户导入开启 evaluator 联网放行（有创建权限即可）",
+  ignore: skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    await ensureUser(OWNER_ID);
+    const app = createApp();
+    const token = await signToken({ sub: OWNER_ID, role: "user" });
+
+    // manifest.runtime_config.evaluator.network.enabled=true（上传者可控）
+    const formData = new FormData();
+    formData.append(
+      "file",
+      makeZipBlob({
+        runtime_config: {
+          evaluator: {
+            image: "noj-evaluator-python",
+            time_limit_ms: 5000,
+            memory_limit_mb: 512,
+            network: { enabled: true },
+          },
+          solution: {
+            image: "noj-solution-python",
+            entry: "submission_sample.py",
+            call_timeout_ms: 2000,
+            memory_limit_mb: 512,
+          },
+        },
+      }),
+      "u-net1.zip",
+    );
+
+    const res = await app.request("/api/v1/problems/import-bundle", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    });
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(
+      body.data.runtime_config.evaluator.network?.enabled,
+      true,
+    );
   },
 });

--- a/noj-core/tests/services/problems-types.test.ts
+++ b/noj-core/tests/services/problems-types.test.ts
@@ -1,0 +1,100 @@
+/**
+ * problems-types 服务层单元测试 —— runtime_config 结构校验。
+ *
+ * 纯函数测试，不依赖数据库（validateRuntimeConfig 为同步纯函数）。
+ */
+import { assertThrows } from "jsr:@std/assert@^1";
+import { validateRuntimeConfig } from "../../src/services/problems-types.ts";
+import type { RuntimeConfig } from "../../src/types/problems.ts";
+
+const ts = Date.now();
+
+function validRuntimeConfig(): RuntimeConfig {
+  return {
+    evaluator: {
+      image: "noj-evaluator-python",
+      command: "python3 /workspace/evaluate.py",
+      time_limit_ms: 5000,
+      memory_limit_mb: 512,
+    },
+    solution: {
+      image: "noj-solution-python",
+      entry: `solution_${ts}.py`,
+      call_timeout_ms: 2000,
+      memory_limit_mb: 256,
+    },
+  };
+}
+
+Deno.test({
+  name: "validateRuntimeConfig: network 缺省合法（向后兼容）",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: () => {
+    const rc = validRuntimeConfig();
+    validateRuntimeConfig(rc); // 不应抛错
+  },
+});
+
+Deno.test({
+  name: "validateRuntimeConfig: network.enabled=true 合法",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: () => {
+    const rc = validRuntimeConfig();
+    rc.evaluator.network = { enabled: true };
+    validateRuntimeConfig(rc); // 不应抛错
+  },
+});
+
+Deno.test({
+  name: "validateRuntimeConfig: network.enabled=false 合法",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: () => {
+    const rc = validRuntimeConfig();
+    rc.evaluator.network = { enabled: false };
+    validateRuntimeConfig(rc); // 不应抛错
+  },
+});
+
+Deno.test({
+  name: "validateRuntimeConfig: network.enabled 非布尔被拒",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: () => {
+    const rc = validRuntimeConfig();
+    rc.evaluator.network = { enabled: "true" as unknown as boolean };
+    assertThrows(
+      () => validateRuntimeConfig(rc),
+      Error,
+      "runtime_config.evaluator.network.enabled 必须是布尔值",
+    );
+  },
+});
+
+Deno.test({
+  name: "validateRuntimeConfig: network 非对象被拒",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: () => {
+    const rc = validRuntimeConfig();
+    rc.evaluator.network = "enabled" as unknown as { enabled: boolean };
+    assertThrows(
+      () => validateRuntimeConfig(rc),
+      Error,
+      "runtime_config.evaluator.network 必须是对象",
+    );
+  },
+});
+
+Deno.test({
+  name: "validateRuntimeConfig: network 为 null 视为缺省（合法）",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: () => {
+    const rc = validRuntimeConfig();
+    rc.evaluator.network = null as unknown as { enabled: boolean };
+    validateRuntimeConfig(rc); // 不应抛错
+  },
+});

--- a/noj-core/tests/services/problems.test.ts
+++ b/noj-core/tests/services/problems.test.ts
@@ -422,3 +422,97 @@ Deno.test({
     assertEquals(result.limit, 1);
   },
 });
+
+Deno.test({
+  name: "problems service: 普通用户开启 evaluator 联网放行（有创建权限即可）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    // 创建 user-1 用户（owner_id FK）
+    const db = getDb();
+    const now = new Date().toISOString();
+    await db.insert(users).values({
+      id: "user-1",
+      username: `net-user-${Date.now()}`,
+      email: `net-user-${Date.now()}@test.com`,
+      password_hash: "not-used",
+      role: "user",
+      created_at: now,
+      updated_at: now,
+    });
+    const created = await createProblem(
+      {
+        title: `普通用户联网题 ${Date.now()}`,
+        description: "普通用户可开启联网",
+        difficulty: "easy",
+        runtime_config: {
+          evaluator: {
+            image: "noj-evaluator-python",
+            command: "python3 /workspace/evaluate.py",
+            time_limit_ms: 5000,
+            memory_limit_mb: 512,
+            network: { enabled: true },
+          },
+          solution: {
+            image: "noj-solution-python",
+            entry: "submission_sample.py",
+            call_timeout_ms: 2000,
+            memory_limit_mb: 512,
+          },
+        },
+      },
+      "user-1",
+      "user",
+    );
+    assertEquals(created.runtime_config.evaluator.network?.enabled, true);
+  },
+});
+
+Deno.test({
+  name: "problems service: admin 开启 evaluator 联网放行",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    // 创建 admin-1 用户（owner_id FK）
+    const db = getDb();
+    const now = new Date().toISOString();
+    await db.insert(users).values({
+      id: "admin-1",
+      username: `net-admin-${Date.now()}`,
+      email: `net-admin-${Date.now()}@test.com`,
+      password_hash: "not-used",
+      role: "admin",
+      created_at: now,
+      updated_at: now,
+    });
+    const created = await createProblem(
+      {
+        title: `admin 联网题 ${Date.now()}`,
+        description: "admin 可开启联网",
+        difficulty: "easy",
+        runtime_config: {
+          evaluator: {
+            image: "noj-evaluator-python",
+            command: "python3 /workspace/evaluate.py",
+            time_limit_ms: 5000,
+            memory_limit_mb: 512,
+            network: { enabled: true },
+          },
+          solution: {
+            image: "noj-solution-python",
+            entry: "submission_sample.py",
+            call_timeout_ms: 2000,
+            memory_limit_mb: 512,
+          },
+        },
+      },
+      "admin-1",
+      "admin",
+    );
+    assertEquals(created.runtime_config.evaluator.network?.enabled, true);
+  },
+});

--- a/noj-docs/docs/.vitepress/config.ts
+++ b/noj-docs/docs/.vitepress/config.ts
@@ -71,6 +71,7 @@ export default withMermaid(defineConfig({
           items: [
             { text: "做题人文档", link: "/users/" },
             { text: "提交代码", link: "/users/submit" },
+            { text: "使用 capability", link: "/users/capability" },
             { text: "理解结果", link: "/users/results" },
             { text: "账号与密码", link: "/users/account" },
             { text: "排行榜与签到", link: "/users/ranking" },
@@ -110,6 +111,7 @@ export default withMermaid(defineConfig({
           items: [
             { text: "Evaluator SDK", link: "/problemsetters/evaluator-sdk" },
             { text: "Solution SDK", link: "/problemsetters/solution-sdk" },
+            { text: "如何提供受限网络能力", link: "/problemsetters/capability-networking" },
             { text: "RPC 与可传递数据", link: "/problemsetters/rpc" },
             { text: "评测镜像与运行时", link: "/problemsetters/runtimes" },
           ],

--- a/noj-docs/docs/intro/what-is-noj.md
+++ b/noj-docs/docs/intro/what-is-noj.md
@@ -62,19 +62,17 @@ Neuro OJ 提供完整的「注册 → 做题 → 提交 → 评测结果」闭�
 
 因此 **RPC 调用边界就是信任边界**：跨容器、显式序列化（NOJ codec）、只传递数据不传递引用。
 
-### 网络能力的差异（进行中）
+### 网络能力
 
 传统评测机对网络的处理通常是两个极端：要么**全部砍断**，要么**不做限制**。大模型应用可能涉及与外部网络 API 的交互，两种极端都不合适。
 
-Neuro OJ 的规划是通过双容器提供**有限的互联网能力**：
+Neuro OJ 通过双容器提供**有限的互联网能力**：
 
 - **solution 容器保持无网**——安全边界不变，用户代码无法直接发起网络请求；
-- **evaluator 容器获得联网能力**——出题人可以在评测脚本中访问外部 API；
-- **solution 通过 RPC 调用 evaluator 的转发能力**（`call_capability`）间接使用网络，调用边界仍是信任边界。
+- **evaluator 容器可按题目配置联网**——`runtime_config.evaluator.network.enabled`（默认关闭），开启后 evaluator 以 bridge 模式联网；
+- **solution 通过 RPC 调用 evaluator 注册的 capability**（`call_capability`）间接使用网络，调用边界仍是信任边界：capability 由出题人显式注册并负责参数校验，封装精确函数而非通用转发（见[出题指南](../problemsetters/capability-networking.md)）。
 
-::: warning 当前状态
-该能力**尚未实现**：当前沙箱对所有容器统一 `network_mode: none`（evaluator 同样无网），`call_capability` 仅为预留占位（调用会抛出 `UnsupportedCapability`）。实现进展见 [issue #197](https://github.com/Neuro-OJ/neuro-oj/issues/197)。
-:::
+实现由 [issue #197](https://github.com/Neuro-OJ/neuro-oj/issues/197) 落地。
 
 ### 时空限制方式
 
@@ -88,7 +86,7 @@ Neuro OJ 的规划是通过双容器提供**有限的互联网能力**：
 ### 评测运行时环境
 
 - **双容器隔离**：用户代码与出题人评测代码运行在**独立容器**中——用户代码无法直接读取 evaluator 侧的测试数据或评分逻辑。
-- **沙箱约束**：网络关闭（`network_mode none`）、无特权（`cap_drop ALL`）、进程数受限，容器资源由 Judge Worker 统一控制。
+- **沙箱约束**：solution 网络关闭（`network_mode none`，永远无网；evaluator 按题目配置可联网）、无特权（`cap_drop ALL`）、进程数受限，容器资源由 Judge Worker 统一控制。
 - **模块加载而非进程运行**：Solution Host 在容器内加载用户模块并保持存活（多次调用共享全局状态），用户函数的 `print()` 被重定向到 stderr 作为调试输出，不构成答案通道。
 - **运行时基础**：当前为 Python 3.12 精简镜像，不预装额外包；题目依赖由出题人在 evaluator 中自行管理。
 

--- a/noj-docs/docs/problemsetters/capability-networking.md
+++ b/noj-docs/docs/problemsetters/capability-networking.md
@@ -1,0 +1,98 @@
+# 如何提供受限网络能力
+
+本页面向出题人：当题目需要访问外部网络 API（LLM 接口、检索服务等）时，
+如何通过 capability 安全地把网络能力交给 solution 使用。
+
+## 三步概览
+
+1. **在题目配置中开启 evaluator 联网**：`runtime_config.evaluator.network.enabled = true`（Web 编辑器勾选「允许 Evaluator 联网」；**有题目创建权限的用户均可开启**——U 型任意注册用户，P 型仅管理员）。开启后 evaluator 容器以 Docker bridge 模式联网；solution 容器**始终无网**。
+2. **在 evaluate.py 中注册 capability**：用 `register_capability` 暴露一个**精确封装**的函数。
+3. **在题面中声明 capability**：明确写出名称、参数、返回值语义，做题人用 `call_capability` 调用。
+
+## 注册 capability
+
+```python
+from noj_evaluator_sdk import register_capability, result
+
+def request_llm_completion(prompt: str) -> str:
+    # ... 调用外部 LLM API（evaluator 已联网）
+    return completion_text
+
+register_capability("request_llm_completion", request_llm_completion)
+```
+
+- handler 是普通 Python 函数，在 evaluator 容器内执行，拥有该容器的网络能力。
+- 参数/返回值受 [RPC 类型约束](rpc.md)（`None / bool / int / float / str / bytes / list / dict`）。
+- 重复注册同名 capability 时，最近一次生效。
+- handler 抛异常时，错误帧（`code=Exception` + trace）会返回给 solution。
+
+## 核心原则：封装精确函数，而不是通用转发
+
+**这是最重要的安全边界。** capability 是 solution 调用网络**唯一**的入口，
+它的签名就是你的安全策略。请封装"业务意图"，而不是"网络能力"：
+
+::: danger 反例：通用转发（会打开 SSRF 面）
+```python
+def fetch_url(url: str) -> bytes:
+    # 任何 solution 代码都能请求任意地址：
+    # - http://169.254.169.254/... （云元数据服务，可能泄露凭据）
+    # - http://<内网>/...           （评测内网、judge 宿主机服务）
+    # - 任意公网地址（把评测服务器变成攻击跳板）
+    return urllib.request.urlopen(url).read()
+
+register_capability("fetch_url", fetch_url)
+```
+:::
+
+::: tip 推荐：封装业务意图
+```python
+def request_llm_completion(prompt: str) -> str:
+    """只允许调用固定的 LLM API，prompt 是唯一输入。"""
+    # URL 固定、方法固定、域名固定——solution 无法控制目标地址
+    payload = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": prompt}]}
+    resp = urllib.request.urlopen(
+        urllib.request.Request(
+            "https://api.example-llm.com/v1/chat/completions",
+            data=json.dumps(payload).encode(),
+            headers={"Authorization": "Bearer " + os.environ["LLM_API_KEY"]},
+        ),
+        timeout=10,
+    )
+    return json.loads(resp.read())["choices"][0]["message"]["content"]
+
+register_capability("request_llm_completion", request_llm_completion)
+```
+:::
+
+**判断标准**：solution 通过你的 capability 最多能做到什么？如果"任意目标地址、任意方法、任意头"都能被控制，就等同于给 solution 开了全量网络。目标地址应当固定或来自受控枚举，而不是由调用方自由传入。
+
+## 安全清单（出题人自查）
+
+- [ ] capability 名称与签名精确表达业务意图，**不暴露通用 HTTP 转发**
+- [ ] 目标 URL/域名固定（或来自白名单枚举），不由调用方任意指定
+- [ ] 若确需调用方传 URL，校验：仅允许 `https://`、拒绝 IP 字面量、拒绝内网/链路本地地址段（`10.x`、`172.16-31.x`、`192.168.x`、`169.254.x`、`127.x`、`0.0.0.0`、IPv6 对应段）、**跟随重定向前再校验一次目标**
+- [ ] 绝不访问云元数据服务（`169.254.169.254` / `fd00:ec2::254`）
+- [ ] 网络请求设置超时（如 `timeout=10`），不要无限阻塞
+- [ ] API 密钥放在 evaluator 镜像环境变量中，**不放进支持包或题面**
+- [ ] 题面明确声明 capability 名称、参数、返回值与限制
+
+## 常见陷阱
+
+- **handler 内嵌套双向调用会死锁**：capability 在 evaluator 的 runner reader 线程中同步执行，handler 内再调用 `runner.call()`（回调 solution）会互相等待，只能等评测总超时兜底——**不要**在 handler 里嵌套调用 solution。
+- **重定向绕过**：请求 `https://safe.example.com` 被 302 到 `http://169.254.169.254/`。跟随重定向的库默认会跳转——每跳都要重新校验目标。
+- **DNS rebinding**：域名先解析到公网 IP 通过校验，随后解析到内网 IP。固定域名 + 服务端解析并校验实际 IP 可缓解。
+- **编码/别名绕过**：`http://127.0.0.1`、`http://2130706433`（十进制 IP）、`http://[::1]` 等写法都需要覆盖。
+- **secret 泄露**：把 `Authorization` 头、API key 写进 capability 参数或题面，会被任何提交者看到。密钥必须留在 evaluator 侧。
+
+## 网络模式说明
+
+- `network.enabled = true`：evaluator 以 Docker **默认 bridge** 联网（**全量**出网，无网络层白名单）。安全依赖上述 capability 设计原则。
+- `network.enabled` 缺省 / `false`：evaluator 与 solution 均无网（默认，与旧行为一致）。
+- **横向移动面（威胁模型）**：Docker 默认 bridge 允许容器间互通（ICC），联网的 evaluator 可探测同宿主其他容器及网关（`172.17.0.1` 等）上的服务。由于 evaluator 只运行出题人编写的可信代码，此面由"不要注册通用转发 capability"约束兜底；生产加固方向（每任务独立 user-defined network + `icc=false`）已列入规划，当前版本请以 capability 封装为准。
+- **未来增强**：网络层白名单代理（egress proxy）已列入规划，届时可在网络层兜底限制域名/端口；当前版本请以 capability 封装为准。
+
+## 验证方法
+
+- 本地用 `deno task dev-setup` 环境跑一次真实提交，确认 solution 能通过 `call_capability` 拿到正确结果。
+- 提交一个恶意尝试（如调用未注册 capability、传非预期参数）确认被拒绝（`CapabilityNotFoundError` / `CapabilityRejectedError`）。
+- 如需确认 solution 确实无网，可在题面声明"不允许直接网络请求"，观察提交是否会失败。

--- a/noj-docs/docs/problemsetters/evaluator-sdk.md
+++ b/noj-docs/docs/problemsetters/evaluator-sdk.md
@@ -70,6 +70,27 @@ arg[0]: 不支持的类型 MyClass（仅 None/bool/int/float/str/bytes/list/dict
 
 出题人可以用 `try/except RejectedError` 把这类调用按失败用例处理；不捕获则 `evaluate.py` 异常退出，该次评测落为 `SystemError`。
 
+## 注册 capability（供 Solution 调用）
+
+当题目需要让 solution 使用网络等能力时，用 `register_capability` 暴露一个**精确封装**的 handler：
+
+```python
+from noj_evaluator_sdk import register_capability
+
+def request_llm_completion(prompt: str) -> str:
+    # evaluator 已联网（runtime_config.evaluator.network.enabled = true）
+    # ... 调用固定 URL 的外部 API，参数校验由 handler 负责
+    return completion_text
+
+register_capability("request_llm_completion", request_llm_completion)
+```
+
+- Solution 通过 `noj_solution_sdk.call_capability(name, *args)` 调用；请求经 judge 转发到 evaluator，在 **runner 的 reader 线程**中同步执行 handler，结果以 `result` 帧返回。
+- 返回值与 `runner.call()` 相同约束（`None / bool / int / float / str / bytes / list / dict`）；返回值类型非法或帧超限（> 1 MiB）→ `code="Rejected"`（参数类型已在 solution 侧校验，不会到达 evaluator）；handler 异常 → `code="Exception"`（含清洗后 trace），未注册 → `code="NotFound"`。
+- **不要嵌套双向调用**：capability handler 在 reader 线程中同步执行，若 handler 内再调用 `runner.call()`（回调 solution），双方会互相等待而死锁，只能等评测总超时兜底——不支持这种嵌套。
+- 重复注册同名 capability：最近一次生效。
+- **安全模型**：capability 是 solution 使用网络的唯一入口，**不要注册通用 URL 转发**（如 `fetch_url(url)`）；应封装固定目标的业务函数并做参数校验。详细指南见 [如何提供受限网络能力](capability-networking.md)。
+
 ## 输出评测结果
 
 Evaluator 使用 `result` 模块输出最终结果。

--- a/noj-docs/docs/problemsetters/solution-sdk.md
+++ b/noj-docs/docs/problemsetters/solution-sdk.md
@@ -47,14 +47,20 @@ def solve(a: int, b: int) -> int:
 
 ## `noj_solution_sdk`
 
-当前 `noj_solution_sdk` 仅提供占位能力：
+当题目声明了 capability（如外部网络 API）时，可以在注册函数内调用：
 
 ```python
 from noj_solution_sdk import call_capability
+
+def solve(prompt: str) -> str:
+    return call_capability("request_llm_completion", prompt)
 ```
 
-`call_capability()` 在第一阶段不支持 Solution 到 Evaluator 的能力调用，会抛出 `UnsupportedCapability`。普通题目不需要导入该 SDK。
+`call_capability(name, *args)` 把请求经 judge 转发到 Evaluator 执行，返回解码后的结果。能力名称、参数与返回值语义由题面声明。
 
-这也意味着当前 RPC 方向是 Evaluator 主动调用 Solution；Solution 不能主动读取 evaluator 的能力、文件或隐藏用例数据。
+- **RPC 方向**：Evaluator 主动调用 Solution（`runner.call()`）；Solution 通过 `call_capability` 反向调用 Evaluator 注册的能力（如网络请求）。Solution 不能读取 evaluator 的文件或隐藏用例数据。
+- **类型约束**：`call_capability` 的参数与返回值与 `runner.call()` **相同**：只允许 `None / bool / int / float / str / bytes / list / dict`，不可序列化的对象会被拒绝，不会进入 RPC 帧。
+- **错误**：未注册的 capability 抛 `CapabilityNotFoundError`；参数/返回值类型非法抛 `CapabilityRejectedError`；handler 异常抛 `CapabilityError`（含 `code` 与清洗后 trace）。
+- **安全**：Solution 容器始终无网；capability 由出题人显式注册并负责参数校验（见 [如何提供受限网络能力](capability-networking.md)）。
 
-即使未来实现能力转发，`call_capability` 的参数与返回值也受**与 `runner.call()` 相同的类型校验**约束：只允许 `None / bool / int / float / str / bytes / list / dict`，不可序列化的对象（自定义类实例、函数、文件句柄等）会被拒绝，不会进入 RPC 帧。
+普通不需要网络的题目无需导入该 SDK。

--- a/noj-docs/docs/reference/glossary.md
+++ b/noj-docs/docs/reference/glossary.md
@@ -208,4 +208,4 @@ Solution 容器中的协议进程，负责加载用户模块、接收 Evaluator 
 
 （capability）
 
-Neuro OJ 面向大模型能力评测（LMCC）的评测对象。当前 Python 运行时中，用户以函数形式暴露能力，由 Evaluator 调用；`noj_solution_sdk.call_capability` 为预留的占位能力（当前不支持 Solution 到 Evaluator 的能力调用）。
+Neuro OJ 面向大模型能力评测（LMCC）的评测对象。当前 Python 运行时中，用户以函数形式暴露能力，由 Evaluator 调用。此外，出题人可通过 `noj_evaluator_sdk.register_capability` 注册**网络等能力**，solution 经 `noj_solution_sdk.call_capability` 调用（由 judge 转发到 evaluator 执行）——solution 容器本身无网，capability 是它使用网络的唯一入口。见[做题指南](../users/capability.md)与[出题指南](../problemsetters/capability-networking.md)。

--- a/noj-docs/docs/users/capability.md
+++ b/noj-docs/docs/users/capability.md
@@ -1,0 +1,69 @@
+# 使用 capability
+
+某些题目（尤其是大模型应用类题目）会涉及与外部网络 API 的交互。出于安全考虑，你的代码（Solution 容器）**始终没有网络能力**——无法直接发起 `socket` / `urllib` / `requests` 等网络请求。
+
+如果题目需要网络，出题人会在评测端（Evaluator）注册**能力（capability）**，你在函数中通过 `call_capability` 调用它，由评测端代为执行。你拿到的只是返回值，网络访问始终发生在可信的评测端。
+
+## 前提
+
+- 题目说明中会声明可用哪些 capability（名称、参数、返回值）。
+- 未声明 capability 的题目调用 `call_capability` 会抛 `CapabilityNotFoundError`。
+
+## 基本用法
+
+```python
+from noj_solution_sdk import call_capability
+
+def solve(prompt: str) -> str:
+    # 调用出题人注册的 capability（参数/返回值由题面定义）
+    reply = call_capability("request_llm_completion", prompt)
+    return reply
+```
+
+`call_capability(name, *args)` 会阻塞等待评测端执行完毕，返回结果。调用必须在你的**注册函数内部**（顶层代码执行时调用也会工作，但不建议）。
+
+## 参数与返回值约束
+
+与普通函数调用相同的 [RPC 类型约束](../problemsetters/rpc.md)：
+
+- 只允许 `None` / `bool` / `int` / `float` / `str` / `bytes` / `list` / `dict`
+- `bytes` 会自动进行 base64 编码传输
+- 自定义对象、函数、文件句柄等不可序列化类型会被拒绝（抛 `CapabilityRejectedError`）
+
+## 错误处理
+
+| 异常 | 含义 |
+|------|------|
+| `CapabilityNotFoundError` | capability 未注册（题面未声明该能力） |
+| `CapabilityRejectedError` | 参数/返回值类型不允许，或单帧超过 1 MiB |
+| `CapabilityError` | 评测端执行失败（`code` 与清洗后 `trace` 可查看） |
+| `CapabilityConnectionError` | 评测端通道断开（通常意味着评测环境异常） |
+
+```python
+from noj_solution_sdk import call_capability, CapabilityNotFoundError
+
+def solve(prompt: str) -> str:
+    try:
+        return call_capability("request_llm_completion", prompt)
+    except CapabilityNotFoundError:
+        return "该能力不可用"
+```
+
+## 示例：带网络能力的题目
+
+题面声明 `request_llm_completion(prompt) -> str` 时：
+
+```python
+from noj_solution_sdk import call_capability
+
+def solve(prompt: str) -> str:
+    completion = call_capability("request_llm_completion", prompt)
+    # 基于返回结果继续处理
+    return completion.strip().upper()
+```
+
+## 注意事项
+
+- capability 调用受评测总时限约束；不要在函数内做无意义的重复调用。
+- 返回值会受同样的类型约束，超大返回（> 1 MiB）会被拒绝。
+- capability 的具体行为（如重试、超时、访问哪些域名）由出题人定义，题面会说明。

--- a/noj-judge/AGENTS.md
+++ b/noj-judge/AGENTS.md
@@ -64,6 +64,7 @@ noj-judge/
     ├── e2e_security_isolation.rs
     ├── e2e_support_package.rs
     ├── e2e_dual_container.rs  # 双容器 NDJSON 编排 E2E
+    ├── e2e_network_capability.rs  # evaluator 联网 + capability 转发 E2E
     └── e2e_problem_limits.rs  # 验证 time_limit_ms/memory_limit_mb 实际生效
 ```
 
@@ -88,6 +89,7 @@ NOJ_RUN_E2E=1 cargo test --test e2e_resource_limits -- --ignored
 NOJ_RUN_E2E=1 cargo test --test e2e_security_isolation -- --ignored
 NOJ_RUN_E2E=1 cargo test --test e2e_support_package -- --ignored
 NOJ_RUN_E2E=1 cargo test --test e2e_dual_container -- --ignored
+NOJ_RUN_E2E=1 cargo test --test e2e_network_capability -- --ignored
 NOJ_RUN_E2E=1 cargo test --test e2e_problem_limits -- --ignored
 
 # 运行指定集成测试

--- a/noj-judge/Cargo.lock
+++ b/noj-judge/Cargo.lock
@@ -136,9 +136,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -796,6 +796,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bollard",
+ "bytes",
  "filetime",
  "futures-util",
  "percent-encoding",

--- a/noj-judge/Cargo.toml
+++ b/noj-judge/Cargo.toml
@@ -27,3 +27,4 @@ filetime = "0.2"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+bytes = "1.12.1"

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/__init__.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/__init__.py
@@ -21,12 +21,14 @@ from .errors import (
 from .result import Result
 from .runner import SolutionRunner
 from .logging_config import configure_logging
+from .capability import register_capability
 
 # 公开 result 单例（`from noj_evaluator_sdk import result; result.accept(...)`）
 result = Result()
 
 __all__ = [
     "SolutionRunner",
+    "register_capability",
     "result",
     "configure_logging",
     "ConnectionError",

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/capability.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/capability.py
@@ -1,0 +1,46 @@
+"""
+noj_evaluator_sdk capability 注册表。
+
+evaluate.py 通过 `register_capability(name, handler)` 暴露可被 solution 调用的能力
+（如受限网络请求）。handler 是普通 Python 函数，参数/返回值受与 `runner.call()`
+相同的 RPC 类型契约约束（None / bool / int / float / str / bytes / list / dict）。
+
+调用方向：solution 的 `call_capability(name, *args)` → judge 转发 →
+evaluator runner reader 线程 → 查本注册表 → 同步执行 handler → 写响应帧。
+
+安全模型：capability 是 evaluator（出题人）显式注册的；handler 内应做参数校验
+（禁止通用 URL 转发等），参见出题人文档「如何提供受限网络能力」。
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable
+
+_CAPABILITIES: dict[str, Callable] = {}
+_LOCK = threading.RLock()
+
+
+def register_capability(name: str, handler: Callable) -> None:
+    """注册 capability。
+
+    重复注册同名时覆盖（最近注册生效）。
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise TypeError(f"capability 名称必须是非空字符串，实际 {type(name).__name__}")
+    if not callable(handler):
+        raise TypeError(f"handler 必须是 callable，实际 {type(handler).__name__}")
+    with _LOCK:
+        _CAPABILITIES[name] = handler
+
+
+def _get_capability(name: str) -> Callable | None:
+    """按名称取 handler（未注册返回 None）。"""
+    with _LOCK:
+        return _CAPABILITIES.get(name)
+
+
+def _reset_capabilities_for_tests() -> None:
+    """清空注册表（仅测试用）。"""
+    with _LOCK:
+        _CAPABILITIES.clear()

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
@@ -33,13 +33,21 @@ from .errors import (
     SystemError,
 )
 from .serialization import (
+    MAX_FRAME_BYTES,
     check_frame_size,
     decode_value,
     encode_value,
+    estimate_frame_size,
     validate_type,
 )
 
 _TB_FILE_RE = re.compile(r'File "([^"]+)"')
+
+# 裸绝对路径（如 /workspace/secret/credentials.py）：message 中不总是带 File "..." 包装
+_ABS_PATH_RE = re.compile(r"/(?:[\w.\-]+/)+[\w.\-]+")
+
+# 透传给 solution 的异常 message 截断上限（防止超长消息 / 内嵌堆栈泄露）
+_MAX_MESSAGE_LEN = 1024
 
 
 def _sanitize_traceback(exc: BaseException) -> str:
@@ -53,6 +61,23 @@ def _sanitize_traceback(exc: BaseException) -> str:
         for line in lines
     ]
     return "".join(cleaned)
+
+
+def _sanitize_message(msg: str) -> str:
+    """净化透传给 solution 的异常 `message`：路径只保留 basename + 截断长度。
+
+    `str(e)` 可能内嵌绝对路径（`File "..."` 或裸路径）/ 长堆栈 / 敏感值，与
+    `_sanitize_traceback` 做一致的路径清洗，并截断到上限，防止信息泄露与超大帧。
+    """
+    cleaned = _TB_FILE_RE.sub(
+        lambda m: f'File "{os.path.basename(m.group(1))}"', msg
+    )
+    cleaned = _ABS_PATH_RE.sub(
+        lambda m: f"/{os.path.basename(m.group(0))}", cleaned
+    )
+    if len(cleaned) > _MAX_MESSAGE_LEN:
+        cleaned = cleaned[:_MAX_MESSAGE_LEN] + f"...（截断，原长度 {len(msg)}）"
+    return cleaned
 
 
 class SolutionRunner:
@@ -238,6 +263,13 @@ class SolutionRunner:
             result = handler(*decoded_args)
             # 返回值类型校验（与 runner.call 相同的 RPC 类型契约）
             validate_type(result, "<capability result>")
+            # 大小预检：在 encode_value（bytes → base64 膨胀 ~1.33×）之前估算，
+            # 超大返回值直接拒绝，避免先吃完整序列化内存（防恶意输出拖垮 evaluator）
+            if estimate_frame_size(result) > MAX_FRAME_BYTES:
+                raise RejectedError(
+                    f"capability 返回值过大（估算序列化 > {MAX_FRAME_BYTES} 字节，"
+                    "单帧 1 MiB 软上限）"
+                )
             encoded = encode_value(result)
             # 帧大小校验放在 try 内：超大返回值按 Rejected 回给 solution。
             # （_write_out 内部也会校验，但那里的异常会逃逸到 reader 循环，
@@ -256,7 +288,7 @@ class SolutionRunner:
                     "type": "error",
                     "id": cap_id,
                     "code": "Exception",
-                    "message": str(e),
+                    "message": _sanitize_message(str(e)),
                     "trace": _sanitize_traceback(e),
                 }
             )

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
@@ -15,12 +15,16 @@ noj_evaluator_sdk SolutionRunner。
 from __future__ import annotations
 
 import json
+import os
+import re
 import sys
 import threading
+import traceback
 import uuid
 from queue import Empty, Queue
 from typing import Any, Optional
 
+from .capability import _get_capability
 from .errors import (
     ConnectionError,
     NotFoundError,
@@ -35,6 +39,21 @@ from .serialization import (
     validate_type,
 )
 
+_TB_FILE_RE = re.compile(r'File "([^"]+)"')
+
+
+def _sanitize_traceback(exc: BaseException) -> str:
+    """清洗 traceback：文件路径只保留 basename（与 solution 侧 sanitize_trace 对齐）。
+
+    error 帧会返回给 solution（做题人），不得泄露 evaluator 容器内部绝对路径。
+    """
+    lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    cleaned = [
+        _TB_FILE_RE.sub(lambda m: f'File "{os.path.basename(m.group(1))}"', line)
+        for line in lines
+    ]
+    return "".join(cleaned)
+
 
 class SolutionRunner:
     """阻塞式 Solution host 调用器。
@@ -46,6 +65,8 @@ class SolutionRunner:
         self._pending: dict[str, Queue] = {}
         self._lock = threading.Lock()
         self._closed = False
+        # stdout 写入锁：call 帧（主线程）与 capability 响应（reader 线程）并发写
+        self._out_lock = threading.Lock()
         self._reader_thread = threading.Thread(
             target=self._reader_loop, name="noj-evaluator-stdin-reader", daemon=True
         )
@@ -87,15 +108,12 @@ class SolutionRunner:
             self._pending[call_id] = q
 
         # 4. 写帧到 stdout
-        line = json.dumps(frame, ensure_ascii=False, separators=(",", ":"))
         try:
-            check_frame_size(line)
+            self._write_out(frame)
         except RejectedError:
             with self._lock:
                 self._pending.pop(call_id, None)
             raise
-        sys.stdout.write(line + "\n")
-        sys.stdout.flush()
 
         # 5. 阻塞等响应（超时由 judge 端 call_timeout_ms 控制，
         #    SDK 这里不设超时——避免与 judge 双重超时逻辑混淆）
@@ -137,7 +155,10 @@ class SolutionRunner:
                 frame_type = frame.get("type")
                 frame_id = frame.get("id")
 
-                if frame_type in ("result", "error"):
+                if frame_type == "capability":
+                    # solution 请求调用 capability：查注册表并同步执行（写响应帧）
+                    self._handle_capability(frame)
+                elif frame_type in ("result", "error"):
                     with self._lock:
                         q = self._pending.pop(frame_id, None)
                     if q is not None:
@@ -178,6 +199,70 @@ class SolutionRunner:
             sys.stderr.write(f"[noj_evaluator_sdk] reader_loop 异常: {e}\n")
             sys.stderr.flush()
             self._closed = True
+
+    def _write_out(self, frame: dict) -> None:
+        """线程安全写 NDJSON 帧到 stdout（受单帧 1 MiB 软上限约束）。"""
+        line = json.dumps(frame, ensure_ascii=False, separators=(",", ":"))
+        check_frame_size(line)
+        with self._out_lock:
+            sys.stdout.write(line + "\n")
+            sys.stdout.flush()
+
+    def _handle_capability(self, frame: dict) -> None:
+        """处理 solution 的 capability 调用（在 reader 线程同步执行）。
+
+        语义：
+        - 未注册 → error 帧 code=NotFound
+        - 参数/返回值类型非法 → error 帧 code=Rejected
+        - handler 异常 → error 帧 code=Exception（含 trace）
+        - 成功 → result 帧（value 经 codec 编码）
+        """
+        cap_id = frame.get("id")
+        name = frame.get("name", "")
+        args = frame.get("args", [])
+
+        handler = _get_capability(name)
+        if handler is None:
+            self._write_out(
+                {
+                    "type": "error",
+                    "id": cap_id,
+                    "code": "NotFound",
+                    "message": f"capability {name!r} not registered",
+                }
+            )
+            return
+
+        try:
+            decoded_args = [decode_value(a) for a in args]
+            result = handler(*decoded_args)
+            # 返回值类型校验（与 runner.call 相同的 RPC 类型契约）
+            validate_type(result, "<capability result>")
+            encoded = encode_value(result)
+            # 帧大小校验放在 try 内：超大返回值按 Rejected 回给 solution。
+            # （_write_out 内部也会校验，但那里的异常会逃逸到 reader 循环，
+            #   导致响应帧丢失、solution 侧挂起至评测超时）
+            result_frame = {"type": "result", "id": cap_id, "value": encoded}
+            line = json.dumps(result_frame, ensure_ascii=False, separators=(",", ":"))
+            check_frame_size(line)
+        except RejectedError as e:
+            self._write_out(
+                {"type": "error", "id": cap_id, "code": "Rejected", "message": str(e)}
+            )
+            return
+        except Exception as e:
+            self._write_out(
+                {
+                    "type": "error",
+                    "id": cap_id,
+                    "code": "Exception",
+                    "message": str(e),
+                    "trace": _sanitize_traceback(e),
+                }
+            )
+            return
+
+        self._write_out(result_frame)
 
     def _handle_response(self, frame: dict) -> Any:
         """处理 result/error 帧，抛出对应异常或返回值。"""

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/serialization.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/serialization.py
@@ -84,3 +84,48 @@ def check_frame_size(frame_str: str) -> None:
         raise RejectedError(
             f"frame size {len(encoded)} > {MAX_FRAME_BYTES}（单帧 1 MiB 软上限）"
         )
+
+
+def estimate_frame_size(value: Any) -> int:
+    """估算 value 序列化后帧字节数的上界（不复制数据，超限即短路）。
+
+    用于在 `encode_value`（bytes → base64 膨胀 ~1.33×）之前预检超大返回值，
+    避免对必然超限的大对象（如 handler 返回 1 GB dict）先吃完整序列化内存。
+    估算为宽松上界（≥ 实际序列化字节数），因此"估算 > MAX_FRAME_BYTES 即拒绝"
+    不会误伤合法值；边界附近仍由 `check_frame_size` 做最终判定。
+    """
+    total = 0
+
+    def walk(v: Any) -> None:
+        nonlocal total
+        if total > MAX_FRAME_BYTES:
+            return
+        if isinstance(v, str):
+            total += len(v.encode("utf-8")) + 2  # JSON 引号
+        elif isinstance(v, (bytes, bytearray, memoryview)):
+            # base64 编码后 ~1.33× 膨胀 + 包装 {"__bytes__": "..."}
+            total += len(bytes(v)) * 4 // 3 + 20
+        elif isinstance(v, (int, float, bool)) or v is None:
+            total += 24  # 数字/布尔/空值 JSON 字面量粗略上界
+        elif isinstance(v, list):
+            total += 2  # []
+            for item in v:
+                total += 1  # 逗号
+                walk(item)
+                if total > MAX_FRAME_BYTES:
+                    return
+        elif isinstance(v, dict):
+            total += 2  # {}
+            for k, kv in v.items():
+                if not isinstance(k, str):
+                    total += 64  # 非 str key（validate_type 前置校验已拒绝）
+                else:
+                    total += len(k.encode("utf-8")) + 4  # 引号 + 冒号
+                walk(kv)
+                if total > MAX_FRAME_BYTES:
+                    return
+        else:
+            total += 64  # 未知类型兜底
+
+    walk(value)
+    return total

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
@@ -382,6 +382,68 @@ class TestCapability(unittest.TestCase):
             h.teardown()
             _reset_capabilities_for_tests()
 
+    def test_capability_handler_exception_message_sanitized(self):
+        """F3：handler 异常 message 必须清洗——绝对路径 basename 化、超长截断。"""
+        from noj_evaluator_sdk.capability import (
+            _reset_capabilities_for_tests,
+            register_capability,
+        )
+
+        _reset_capabilities_for_tests()
+
+        def leaky():
+            raise ValueError(
+                f"failed at /workspace/secret/path/credentials.py, token=abc123"
+                + "x" * 5000  # 超长 message
+            )
+
+        register_capability("leaky", leaky)
+        h = IpcHarness()
+        try:
+            h.send_host_response(
+                {"type": "capability", "id": "cap7", "name": "leaky", "args": []}
+            )
+            frames = self._wait_for_frames(h)
+            resp = frames[-1]
+            self.assertEqual(resp["type"], "error")
+            self.assertEqual(resp["code"], "Exception")
+            # 绝对路径被 basename 化（不再泄露 evaluator 内部目录结构）
+            self.assertNotIn("/workspace/", resp["message"])
+            self.assertIn("credentials.py", resp["message"])
+            # 超长 message 被截断（上限 ~1024 字符）
+            self.assertLess(len(resp["message"]), 2048)
+            self.assertIn("截断", resp["message"])
+        finally:
+            h.teardown()
+            _reset_capabilities_for_tests()
+
+    def test_capability_oversize_bytes_rejected_before_encode(self):
+        """F2：超大 bytes 返回值在 encode_value（base64 膨胀）之前即被估算拒绝。"""
+        from noj_evaluator_sdk.capability import (
+            _reset_capabilities_for_tests,
+            register_capability,
+        )
+
+        _reset_capabilities_for_tests()
+
+        def big_bytes():
+            return b"x" * (1024 * 1024 + 4096)  # 编码后必超 1 MiB
+
+        register_capability("big_bytes", big_bytes)
+        h = IpcHarness()
+        try:
+            h.send_host_response(
+                {"type": "capability", "id": "cap8", "name": "big_bytes", "args": []}
+            )
+            frames = self._wait_for_frames(h)
+            resp = frames[-1]
+            self.assertEqual(resp["type"], "error")
+            self.assertEqual(resp["code"], "Rejected")
+            self.assertIn("返回值过大", resp["message"])
+        finally:
+            h.teardown()
+            _reset_capabilities_for_tests()
+
     def test_capability_overwrite_wins(self):
         from noj_evaluator_sdk.capability import (
             _reset_capabilities_for_tests,
@@ -451,7 +513,8 @@ class TestCapability(unittest.TestCase):
             resp = frames[-1]
             self.assertEqual(resp["type"], "error")
             self.assertEqual(resp["code"], "Rejected")
-            self.assertIn("frame size", resp["message"])
+            # 预检生效：encode 前估算拒绝，message 说明返回值过大
+            self.assertIn("返回值过大", resp["message"])
         finally:
             h.teardown()
             _reset_capabilities_for_tests()

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
@@ -293,5 +293,169 @@ class TestSolutionRunnerCall(unittest.TestCase):
             h.teardown()
 
 
+class TestCapability(unittest.TestCase):
+    """验证 capability 帧处理（register_capability → handler → 响应帧）。"""
+
+    def _wait_for_frames(self, harness, timeout=2.0):
+        """轮询 stdout，等待 reader 线程写出帧。返回所有帧列表。"""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            frames = harness.all_call_frames()
+            if frames:
+                return frames
+            time.sleep(0.02)
+        self.fail("capability 响应帧未在超时内写出")
+
+    def test_capability_round_trip(self):
+        from noj_evaluator_sdk.capability import (
+            _reset_capabilities_for_tests,
+            register_capability,
+        )
+
+        _reset_capabilities_for_tests()
+
+        def ping(msg: str) -> str:
+            return f"pong:{msg}"
+
+        register_capability("ping", ping)
+        h = IpcHarness()
+        try:
+            h.send_host_response(
+                {"type": "capability", "id": "cap1", "name": "ping", "args": ["hello"]}
+            )
+            frames = self._wait_for_frames(h)
+            resp = frames[-1]
+            self.assertEqual(resp["type"], "result")
+            self.assertEqual(resp["id"], "cap1")
+            self.assertEqual(resp["value"], "pong:hello")
+        finally:
+            h.teardown()
+            _reset_capabilities_for_tests()
+
+    def test_capability_not_found(self):
+        from noj_evaluator_sdk.capability import (
+            _reset_capabilities_for_tests,
+        )
+
+        _reset_capabilities_for_tests()
+        h = IpcHarness()
+        try:
+            h.send_host_response(
+                {"type": "capability", "id": "cap2", "name": "nope", "args": []}
+            )
+            frames = self._wait_for_frames(h)
+            resp = frames[-1]
+            self.assertEqual(resp["type"], "error")
+            self.assertEqual(resp["code"], "NotFound")
+            self.assertIn("nope", resp["message"])
+        finally:
+            h.teardown()
+            _reset_capabilities_for_tests()
+
+    def test_capability_handler_exception(self):
+        from noj_evaluator_sdk.capability import (
+            _reset_capabilities_for_tests,
+            register_capability,
+        )
+
+        _reset_capabilities_for_tests()
+
+        def boom():
+            raise ValueError("cap boom")
+
+        register_capability("boom", boom)
+        h = IpcHarness()
+        try:
+            h.send_host_response(
+                {"type": "capability", "id": "cap3", "name": "boom", "args": []}
+            )
+            frames = self._wait_for_frames(h)
+            resp = frames[-1]
+            self.assertEqual(resp["type"], "error")
+            self.assertEqual(resp["code"], "Exception")
+            self.assertIn("cap boom", resp["message"])
+            self.assertIn("ValueError", resp.get("trace", ""))
+            # trace 应已清洗：不含绝对路径（防泄露 evaluator 内部路径）
+            self.assertNotIn("/workspace/", resp.get("trace", ""))
+            self.assertNotIn("noj_evaluator_sdk", resp.get("trace", ""))
+        finally:
+            h.teardown()
+            _reset_capabilities_for_tests()
+
+    def test_capability_overwrite_wins(self):
+        from noj_evaluator_sdk.capability import (
+            _reset_capabilities_for_tests,
+            register_capability,
+        )
+
+        _reset_capabilities_for_tests()
+        register_capability("dup", lambda: "first")
+        register_capability("dup", lambda: "second")
+        h = IpcHarness()
+        try:
+            h.send_host_response(
+                {"type": "capability", "id": "cap4", "name": "dup", "args": []}
+            )
+            frames = self._wait_for_frames(h)
+            resp = frames[-1]
+            self.assertEqual(resp["type"], "result")
+            self.assertEqual(resp["value"], "second")
+        finally:
+            h.teardown()
+            _reset_capabilities_for_tests()
+
+    def test_capability_rejected_return_type(self):
+        from noj_evaluator_sdk.capability import (
+            _reset_capabilities_for_tests,
+            register_capability,
+        )
+
+        _reset_capabilities_for_tests()
+
+        def bad_return():
+            return object()  # 不可序列化
+
+        register_capability("bad", bad_return)
+        h = IpcHarness()
+        try:
+            h.send_host_response(
+                {"type": "capability", "id": "cap5", "name": "bad", "args": []}
+            )
+            frames = self._wait_for_frames(h)
+            resp = frames[-1]
+            self.assertEqual(resp["type"], "error")
+            self.assertEqual(resp["code"], "Rejected")
+        finally:
+            h.teardown()
+            _reset_capabilities_for_tests()
+
+    def test_capability_result_too_large_rejected(self):
+        """超大返回值（序列化后 > 1 MiB）：必须回 Rejected 帧，而不是丢失响应。"""
+        from noj_evaluator_sdk.capability import (
+            _reset_capabilities_for_tests,
+            register_capability,
+        )
+
+        _reset_capabilities_for_tests()
+
+        def big_return():
+            return "x" * (1024 * 1024 + 1024)  # 超过单帧 1 MiB 软上限
+
+        register_capability("big", big_return)
+        h = IpcHarness()
+        try:
+            h.send_host_response(
+                {"type": "capability", "id": "cap6", "name": "big", "args": []}
+            )
+            frames = self._wait_for_frames(h)
+            resp = frames[-1]
+            self.assertEqual(resp["type"], "error")
+            self.assertEqual(resp["code"], "Rejected")
+            self.assertIn("frame size", resp["message"])
+        finally:
+            h.teardown()
+            _reset_capabilities_for_tests()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_serialization.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_serialization.py
@@ -16,6 +16,7 @@ from noj_evaluator_sdk.serialization import (
     check_frame_size,
     decode_value,
     encode_value,
+    estimate_frame_size,
     validate_type,
 )
 
@@ -102,6 +103,45 @@ class TestFrameSizeLimit(unittest.TestCase):
         big = "x" * (MAX_FRAME_BYTES + 1)
         with self.assertRaises(RejectedError):
             check_frame_size(big)
+
+
+class TestEstimateFrameSize(unittest.TestCase):
+    """encode 前大小预算：估算为上界（≥ 实际序列化大小），超限即短路。"""
+
+    def _serialized_len(self, value) -> int:
+        """实际序列化帧长度（bytes 经 encode_value + json.dumps 后）。"""
+        return len(json.dumps(encode_value(value), ensure_ascii=False).encode("utf-8"))
+
+    def test_estimate_is_upper_bound_for_primitives(self):
+        for v in [None, True, False, 0, 42, -123456, 3.14, "hello", "中文", ""]:
+            self.assertGreaterEqual(estimate_frame_size(v), self._serialized_len(v))
+
+    def test_estimate_is_upper_bound_for_bytes(self):
+        # bytes base64 膨胀 ~1.33×，估算必须覆盖编码后大小
+        for size in [0, 1, 100, 1024, 1024 * 1024]:
+            v = b"x" * size
+            self.assertGreaterEqual(estimate_frame_size(v), self._serialized_len(v))
+
+    def test_estimate_is_upper_bound_for_nested(self):
+        v = {
+            "name": "test",
+            "data": b"\x00\x01" * 512,
+            "list": [1, 2, 3, "a" * 128],
+            "nested": {"k": [None, True, 3.14]},
+        }
+        self.assertGreaterEqual(estimate_frame_size(v), self._serialized_len(v))
+
+    def test_huge_dict_short_circuits_over_limit(self):
+        # 1 GB 级对象：估算应超限并短路（不完整遍历所有元素）
+        huge = {f"k{i}": "x" * 1024 for i in range(1024 * 1024)}  # ~1 GB str
+        self.assertGreater(estimate_frame_size(huge), MAX_FRAME_BYTES)
+
+    def test_oversize_bytes_over_limit(self):
+        big = b"x" * (MAX_FRAME_BYTES + 1)
+        self.assertGreater(estimate_frame_size(big), MAX_FRAME_BYTES)
+
+    def test_small_value_under_limit(self):
+        self.assertLessEqual(estimate_frame_size({"a": 1, "b": "hello"}), MAX_FRAME_BYTES)
 
 
 if __name__ == "__main__":

--- a/noj-judge/sdk/solution/noj_solution_sdk/__init__.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/__init__.py
@@ -3,6 +3,7 @@ noj_solution_sdk —— 不可信 Solution 端 SDK
 
 由用户提交的 solution.py 导入，提供：
 - `register(fn)` / `register(name, fn)`：把函数暴露给 Evaluator 调用
+- `call_capability(name, *args)`：调用 Evaluator 注册的能力（如受限网络请求）
 
 启动入口（host 模块）：
     python3 -m noj_solution_sdk.host --entry solution.py
@@ -16,9 +17,21 @@ from .registry import (
     get_registry,
     register,
 )
+from .capability import (
+    CapabilityConnectionError,
+    CapabilityError,
+    CapabilityNotFoundError,
+    CapabilityRejectedError,
+    call_capability,
+)
 
 __all__ = [
     "register",
+    "call_capability",
     "FunctionAlreadyRegisteredError",
     "NotRegisteredError",
+    "CapabilityNotFoundError",
+    "CapabilityRejectedError",
+    "CapabilityConnectionError",
+    "CapabilityError",
 ]

--- a/noj-judge/sdk/solution/noj_solution_sdk/capability.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/capability.py
@@ -1,0 +1,178 @@
+"""
+noj_solution_sdk capability 调用层。
+
+用户代码通过 `call_capability(name, *args)` 请求 evaluator 执行已注册的能力
+（如受限网络请求）。调用经 judge 转发到 evaluator，响应按 `id` 匹配返回。
+
+与 evaluator 侧 `runner.call()` 相同的 RPC 契约：
+- 参数/返回值仅允许 None / bool / int / float / str / bytes / list / dict
+- 单帧不超过 MAX_FRAME_BYTES（1 MiB）
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import uuid
+from queue import Empty, Queue
+from typing import Any
+
+from .serialization import (
+    MAX_FRAME_BYTES,
+    _RejectedTypeError,
+    check_frame_size,
+    decode_value,
+    encode_value,
+    validate_type,
+)
+
+
+class CapabilityNotFoundError(Exception):
+    """evaluator 未注册该 capability。"""
+
+
+class CapabilityRejectedError(Exception):
+    """参数/返回值类型不允许或帧超限。"""
+
+
+class CapabilityConnectionError(Exception):
+    """IPC 通道断开（host 进程关闭）。"""
+
+
+class CapabilityError(Exception):
+    """evaluator 侧 handler 执行异常（含清洗后 traceback）。"""
+
+    def __init__(self, message: str, code: str = "SystemError", trace: str = ""):
+        super().__init__(message)
+        self.code = code
+        self.trace = trace
+
+
+# pending 调用：call_id → Queue（线程安全）
+_PENDING: dict[str, Queue] = {}
+_PENDING_LOCK = threading.Lock()
+# stdout 写入锁（多线程下保证 NDJSON 帧原子写入）
+_STDOUT_LOCK = threading.Lock()
+
+
+def _write_frame(frame: dict) -> None:
+    """写 NDJSON 帧到 stdout（一行 + 换行），线程安全。"""
+    line = json.dumps(frame, ensure_ascii=False, separators=(",", ":"))
+    with _STDOUT_LOCK:
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+
+def _deliver_response(frame: dict) -> None:
+    """按 id 分发 result/error 帧到对应 pending 队列（由 host reader 线程调用）。"""
+    frame_id = frame.get("id")
+    if frame_id is None:
+        return
+    with _PENDING_LOCK:
+        q = _PENDING.pop(frame_id, None)
+    if q is not None:
+        q.put(frame)
+
+
+def _shutdown_pending() -> None:
+    """唤醒所有 pending 调用（连接断开/关闭时）。"""
+    with _PENDING_LOCK:
+        pending = list(_PENDING.values())
+        _PENDING.clear()
+    for q in pending:
+        try:
+            q.put_nowait({"type": "_shutdown"})
+        except Exception:
+            pass
+
+
+def call_capability(name: str, *args: Any) -> Any:
+    """调用 evaluator 注册的 capability。
+
+    阻塞等待 evaluator 响应（无单次超时；评测总超时兜底）。
+
+    抛出：
+        CapabilityNotFoundError - capability 未注册
+        CapabilityRejectedError - 参数类型不允许 / 帧超限
+        CapabilityError         - handler 执行异常（code + 清洗后 traceback）
+        CapabilityConnectionError - IPC 通道断开
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise CapabilityRejectedError(f"capability 名称必须是非空字符串，实际 {type(name).__name__}")
+
+    # 1. 参数类型校验（与 runner.call 相同的 RPC 类型契约）
+    #    内部 _RejectedTypeError 必须转换为公开的 CapabilityRejectedError，
+    #    否则用户代码收到无法 import 的私有异常（文档承诺的公共 API）
+    try:
+        for i, arg in enumerate(args):
+            validate_type(arg, f"arg[{i}]")
+    except _RejectedTypeError as e:
+        raise CapabilityRejectedError(str(e)) from e
+
+    # 2. 构造 capability 帧
+    call_id = uuid.uuid4().hex
+    frame = {
+        "type": "capability",
+        "id": call_id,
+        "name": name,
+        "args": [encode_value(a) for a in args],
+    }
+
+    # 3. 帧大小校验（对齐 MAX_FRAME_BYTES = 1 MiB）
+    try:
+        line = json.dumps(frame, ensure_ascii=False, separators=(",", ":"))
+        check_frame_size(line)
+    except _RejectedTypeError as e:
+        raise CapabilityRejectedError(str(e)) from e
+
+    # 4. 注册 pending
+    q: Queue = Queue(maxsize=1)
+    with _PENDING_LOCK:
+        _PENDING[call_id] = q
+
+    # 5. 写帧到 stdout
+    _write_frame(frame)
+
+    # 6. 阻塞等响应
+    try:
+        response = q.get()
+    except Exception as e:
+        with _PENDING_LOCK:
+            _PENDING.pop(call_id, None)
+        raise CapabilityConnectionError(f"等待响应异常: {e}") from e
+
+    # 7. 处理响应
+    with _PENDING_LOCK:
+        _PENDING.pop(call_id, None)
+    return _handle_response(response)
+
+
+def _handle_response(frame: dict) -> Any:
+    """处理 result/error 帧，返回解码值或抛对应异常。"""
+    if frame.get("type") == "_shutdown":
+        raise CapabilityConnectionError("evaluator 通道已关闭 / IPC 断开")
+
+    if frame.get("type") == "error":
+        code = frame.get("code", "SystemError")
+        message = frame.get("message", "")
+        if code == "NotFound":
+            raise CapabilityNotFoundError(message)
+        if code == "Rejected":
+            raise CapabilityRejectedError(message)
+        # Exception / SystemError 等
+        trace = frame.get("trace", "")
+        exc = CapabilityError(message, code=code, trace=trace)
+        if trace:
+            exc.trace = trace
+        raise exc
+
+    # type == 'result'
+    value = frame.get("value")
+    return decode_value(value)
+
+
+def _reset_pending_for_tests() -> None:
+    """清空 pending（仅测试用）。"""
+    with _PENDING_LOCK:
+        _PENDING.clear()

--- a/noj-judge/sdk/solution/noj_solution_sdk/host.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/host.py
@@ -7,12 +7,19 @@ noj_solution_sdk host 进程。
     处理结果通过 stdout 写回 NDJSON 帧。
 
 帧协议（详见 design.md §2）：
-    judge → host:  type=call    {id, fn, args[]}
-                  type=shutdown {}
-    host → judge:  type=ready   {}     (启动后立即发)
-                  type=result  {id, value}
-                  type=error   {id, code, message, trace?}
-                  type=log     {stream, data}
+    judge → host:  type=call            {id, fn, args[]}
+                    type=result/error   {id, ...}   （capability 调用的响应）
+                    type=shutdown       {}
+    host → judge:  type=ready           {}     (启动后立即发)
+                    type=result         {id, value}
+                    type=error          {id, code, message, trace?}
+                    type=capability     {id, name, args[]}   （call_capability 发出）
+
+线程模型：
+    - reader 线程：持续读 stdin；call 帧投递到队列；result/error 帧按 id 匹配
+      pending 的 capability 调用（capability.py）；shutdown/EOF 触发关闭。
+    - worker 线程：单线程顺序执行 call 帧（用户函数可在此内调用
+      `call_capability` 阻塞等待响应，由 reader 线程分发响应，不会死锁）。
 """
 
 from __future__ import annotations
@@ -21,6 +28,7 @@ import argparse
 import importlib.util
 import json
 import os
+import queue
 import signal
 import sys
 import threading
@@ -39,16 +47,17 @@ except (AttributeError, ValueError):
 from .registry import _REGISTRY, get_registry, NotRegisteredError
 from .sanitize import sanitize_trace
 from .serialization import decode_value, encode_value
+from .capability import _deliver_response, _shutdown_pending, _write_frame
 
 LOG_MAX_BYTES_PER_FRAME = 64 * 1024  # 64 KiB 单条 log 上限
 LOG_TOTAL_MAX_BYTES = 1 * 1024 * 1024  # 1 MiB 累计 log 上限
 
+# ── 线程模型 ───────────────────────────────────────────
 
-def _write_frame(frame: dict) -> None:
-    """写 NDJSON 帧到 stdout（一行 + 换行）。"""
-    line = json.dumps(frame, ensure_ascii=False, separators=(",", ":"))
-    sys.stdout.write(line + "\n")
-    sys.stdout.flush()
+# call 帧队列（worker 顺序执行）
+_CALL_QUEUE: "queue.Queue[object]" = queue.Queue()
+# worker 退出哨兵
+_POISON = object()
 
 
 def _validate_call_args(args: list) -> None:
@@ -105,40 +114,37 @@ def _execute_call(call_id: str, fn_name: str, args: list) -> None:
     _write_frame({"type": "result", "id": call_id, "value": encoded})
 
 
-def _handle_frame(frame: dict) -> bool:
-    """处理单帧。返回 False 表示收到 shutdown 应退出。"""
-    frame_type = frame.get("type")
+def _handle_call_frame(frame: dict) -> None:
+    """worker 处理一个 call 帧。"""
+    call_id = frame.get("id", "")
+    fn_name = frame.get("fn", "")
+    args = frame.get("args", [])
+    try:
+        _validate_call_args(args)
+    except ValueError as e:
+        _write_frame(
+            {
+                "type": "error",
+                "id": call_id,
+                "code": "Rejected",
+                "message": str(e),
+            }
+        )
+        return
+    _execute_call(call_id, fn_name, args)
 
-    if frame_type == "call":
-        call_id = frame.get("id", "")
-        fn_name = frame.get("fn", "")
-        args = frame.get("args", [])
-        try:
-            _validate_call_args(args)
-        except ValueError as e:
-            _write_frame(
-                {
-                    "type": "error",
-                    "id": call_id,
-                    "code": "Rejected",
-                    "message": str(e),
-                }
-            )
-            return True
-        _execute_call(call_id, fn_name, args)
-        return True
 
-    if frame_type == "shutdown":
-        return False
-
-    # 未知类型忽略（不退出）
-    sys.stderr.write(f"[host] unknown frame type: {frame_type!r}\n")
-    sys.stderr.flush()
-    return True
+def _shutdown_all() -> None:
+    """触发关闭：唤醒 pending capability 调用，通知 worker 退出。"""
+    _shutdown_pending()
+    try:
+        _CALL_QUEUE.put_nowait(_POISON)
+    except Exception:
+        pass
 
 
 def _reader_loop() -> None:
-    """主循环：从 stdin 读帧，处理直到 shutdown 或 EOF。"""
+    """reader 线程：从 stdin 读帧，分发到队列 / pending。"""
     for line in sys.stdin:
         line = line.strip()
         if not line:
@@ -151,15 +157,40 @@ def _reader_loop() -> None:
             continue
 
         try:
-            cont = _handle_frame(frame)
+            frame_type = frame.get("type")
+            if frame_type == "call":
+                _CALL_QUEUE.put(frame)
+            elif frame_type in ("result", "error"):
+                # capability 调用的响应：按 id 分发到 pending
+                _deliver_response(frame)
+            elif frame_type == "shutdown":
+                _shutdown_all()
+                return
+            else:
+                # 未知类型忽略（不退出）
+                sys.stderr.write(f"[host] unknown frame type: {frame_type!r}\n")
+                sys.stderr.flush()
         except Exception as e:
             # 防御性：避免 host 因单帧异常退出
             sys.stderr.write(f"[host] frame 处理异常: {e}\n{_traceback_mod.format_exc()}\n")
             sys.stderr.flush()
-            cont = True
 
-        if not cont:
+    # stdin EOF（judge 关闭通道）：触发关闭
+    _shutdown_all()
+
+
+def _worker_loop() -> None:
+    """worker 线程：顺序执行 call 帧，直到收到哨兵。"""
+    while True:
+        frame = _CALL_QUEUE.get()
+        if frame is _POISON:
             return
+        try:
+            _handle_call_frame(frame)
+        except Exception as e:
+            # 防御性：单帧异常不终止 worker
+            sys.stderr.write(f"[host] call 处理异常: {e}\n{_traceback_mod.format_exc()}\n")
+            sys.stderr.flush()
 
 
 def _install_signal_handlers() -> None:
@@ -195,10 +226,13 @@ def _load_entry(entry_path: str) -> None:
     sys.modules["user_solution"] = module
     spec.loader.exec_module(module)
 
-    # 自动注册模块中所有顶层函数，用户无需显式 @register
+    # 自动注册模块中所有顶层函数，用户无需显式 @register；
+    # 已显式 @register 的函数跳过（避免 FunctionAlreadyRegisteredError）
     import inspect
     for name, obj in inspect.getmembers(module, inspect.isfunction):
         if obj.__module__ == module.__name__:
+            if _REGISTRY.get(name) is not None:
+                continue
             _REGISTRY.register(name, obj)
             sys.stderr.write(f"[host] 已自动注册函数: {name}\n")
     sys.stderr.flush()
@@ -219,7 +253,15 @@ def main() -> None:
     #    决定：先 ready 再 load_entry，避免 entry 内耗时 import 让 judge 等不到 ready
     _write_frame({"type": "ready"})
 
-    # 2. 加载用户 entry
+    # 2. 启动 reader 线程（先于 entry 加载：模块顶层代码即可调用
+    #    call_capability，响应帧由 reader 分发；call 帧在队列中积压，
+    #    worker 启动后顺序处理，不会丢失）
+    reader = threading.Thread(
+        target=_reader_loop, name="noj-solution-reader", daemon=True
+    )
+    reader.start()
+
+    # 3. 加载用户 entry
     try:
         _load_entry(args.entry)
     except SystemExit:
@@ -234,10 +276,15 @@ def main() -> None:
                 "trace": sanitize_trace(e),
             }
         )
-        # 仍然进入 reader loop 等 shutdown；entry 加载失败不应静默退出
+        # 仍然启动线程等 shutdown；entry 加载失败不应静默退出
 
-    # 3. 主循环
-    _reader_loop()
+    # 4. 启动 worker 线程
+    #    reader 为 daemon：主线程 join worker，worker 退出后进程结束（reader 随进程退出）
+    worker = threading.Thread(target=_worker_loop, name="noj-solution-worker")
+    worker.start()
+
+    # 5. 主线程等待 worker 结束（worker 在 shutdown/EOF 后收到哨兵退出）
+    worker.join()
 
 
 if __name__ == "__main__":

--- a/noj-judge/sdk/solution/noj_solution_sdk/host.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/host.py
@@ -194,11 +194,17 @@ def _worker_loop() -> None:
 
 
 def _install_signal_handlers() -> None:
-    """SIGTERM/SIGINT 优雅退出。"""
+    """SIGTERM/SIGINT 优雅退出。
+
+    先 `_shutdown_all()` 唤醒阻塞中的 pending capability 调用并给 worker 放哨兵，
+    再退出——否则 `sys.exit(0)` 后解释器会等待非 daemon 的 worker 线程，
+    worker 阻塞在 `_CALL_QUEUE.get()` 收不到哨兵，进程挂起不退出。
+    """
 
     def _handler(signum, frame):
         sys.stderr.write(f"[host] 收到信号 {signum}，退出\n")
         sys.stderr.flush()
+        _shutdown_all()
         sys.exit(0)
 
     try:

--- a/noj-judge/sdk/solution/noj_solution_sdk/serialization.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/serialization.py
@@ -42,3 +42,41 @@ except ImportError:
         return value
 
     MAX_FRAME_BYTES = 1 * 1024 * 1024
+
+
+def validate_type(value: Any, path: str = "<root>") -> None:
+    """递归校验 value 是否仅含允许类型（None/bool/int/float/str/bytes/list/dict）。
+
+    list / dict 内部继续递归；不允许 set、tuple、自定义类、函数等。
+    与 noj_evaluator_sdk.validate_type 语义一致（RPC 类型契约）。
+    """
+    if value is None or isinstance(value, bool):
+        return
+    if isinstance(value, (int, float, str)):
+        return
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return
+    if isinstance(value, list):
+        for i, item in enumerate(value):
+            validate_type(item, f"{path}[{i}]")
+        return
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise _RejectedTypeError(
+                    f"{path}: dict key 必须是 str，实际 {type(k).__name__}"
+                )
+            validate_type(v, f"{path}.{k}")
+        return
+    raise _RejectedTypeError(
+        f"{path}: 不支持的类型 {type(value).__name__}（仅 None/bool/int/float/str/bytes/list/dict）"
+    )
+
+
+def check_frame_size(frame_str: str) -> None:
+    """校验序列化后单帧不超过 MAX_FRAME_BYTES（1 MiB 软上限）。"""
+    encoded = frame_str.encode("utf-8")
+    if len(encoded) > MAX_FRAME_BYTES:
+        raise _RejectedTypeError(
+            f"frame size {len(encoded)} > {MAX_FRAME_BYTES}（单帧 1 MiB 软上限）"
+        )

--- a/noj-judge/sdk/solution/noj_solution_sdk/tests/test_host.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/tests/test_host.py
@@ -7,6 +7,7 @@ noj_solution_sdk 单测 —— host 主循环。
 import base64
 import json
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -189,6 +190,38 @@ class TestHostProcess(unittest.TestCase):
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 self.fail("host 未在 shutdown 后退出")
+        finally:
+            self._cleanup(proc, path)
+
+    def test_sigterm_exits_host(self):
+        """SIGTERM 优雅退出：退出码 0、无 hang（即使有 pending capability 调用）。
+
+        signal handler 直接 sys.exit(0) 不清理 pending，随进程退出被 OS 强杀，
+        因此不构成阻塞问题；此测试锁定"信号 → 快速退出、无死锁"契约。
+        """
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register
+            from noj_solution_sdk import call_capability
+            import time
+
+            @register
+            def slow_call():
+                # 阻塞在 capability 调用上：等待永远不会来的响应
+                call_capability("never", 1)
+                return 0
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            self._read_frame(proc)  # ready
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "slow_call", "args": []})
+            # 等待 worker 进入 call_capability 阻塞态
+            time.sleep(0.5)
+            proc.send_signal(signal.SIGTERM)
+            try:
+                returncode = proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.fail("host 未在 SIGTERM 后退出（signal handler 挂起）")
+            self.assertEqual(returncode, 0)
         finally:
             self._cleanup(proc, path)
 

--- a/noj-judge/sdk/solution/noj_solution_sdk/tests/test_host.py
+++ b/noj-judge/sdk/solution/noj_solution_sdk/tests/test_host.py
@@ -238,6 +238,163 @@ class TestHostProcess(unittest.TestCase):
         finally:
             self._cleanup(proc, path)
 
+    # ── capability 调用 ──────────────────────────────
+
+    def test_capability_call_round_trip(self):
+        """用户函数内 call_capability：发 capability 帧，收 result 帧后返回。"""
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register, call_capability
+            @register
+            def solve():
+                return call_capability("ping", "hello")
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            ready = self._read_frame(proc)
+            self.assertEqual(ready["type"], "ready")
+
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "solve", "args": []})
+            # host 发出 capability 帧（转发请求）
+            cap = self._read_frame(proc)
+            self.assertEqual(cap["type"], "capability")
+            self.assertEqual(cap["name"], "ping")
+            self.assertEqual(cap["args"], ["hello"])
+
+            # 模拟 evaluator 返回 result
+            self._send_frame(
+                proc, {"type": "result", "id": cap["id"], "value": "pong"}
+            )
+            resp = self._read_frame(proc)
+            self.assertEqual(resp["type"], "result")
+            self.assertEqual(resp["id"], "c1")
+            self.assertEqual(resp["value"], "pong")
+        finally:
+            self._cleanup(proc, path)
+
+    def test_capability_not_found_raises_in_call(self):
+        """evaluator 回 NotFound → call_capability 抛 CapabilityNotFoundError。"""
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register, call_capability
+            @register
+            def solve():
+                return call_capability("missing")
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            self._read_frame(proc)  # ready
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "solve", "args": []})
+
+            cap = self._read_frame(proc)
+            self.assertEqual(cap["name"], "missing")
+
+            # evaluator 回 NotFound
+            self._send_frame(
+                proc,
+                {
+                    "type": "error",
+                    "id": cap["id"],
+                    "code": "NotFound",
+                    "message": "capability 'missing' not registered",
+                },
+            )
+            # 异常在用户函数内传播 → host 回 Exception 错误帧
+            resp = self._read_frame(proc)
+            self.assertEqual(resp["type"], "error")
+            self.assertEqual(resp["code"], "Exception")
+            self.assertIn("capability 'missing' not registered", resp["message"])
+        finally:
+            self._cleanup(proc, path)
+
+    def test_capability_rejected_type(self):
+        """不可序列化参数 → CapabilityRejectedError（公共 API，可被用户捕获），不发 capability 帧。"""
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register, call_capability, CapabilityRejectedError
+            class Foo:
+                pass
+            @register
+            def solve():
+                try:
+                    return call_capability("x", Foo())
+                except CapabilityRejectedError as e:
+                    return f"rejected: {e}"
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            self._read_frame(proc)  # ready
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "solve", "args": []})
+
+            # 直接收到 result（未发出 capability 帧）——用户捕获到了 CapabilityRejectedError
+            resp = self._read_frame(proc)
+            self.assertEqual(resp["type"], "result")
+            self.assertIn("不支持的类型", resp["value"])
+        finally:
+            self._cleanup(proc, path)
+
+    def test_capability_call_at_module_top_level(self):
+        """模块顶层代码 call_capability：reader 先于 entry 加载启动，等待响应后继续。"""
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register, call_capability
+            top = call_capability("ping", "top-level")
+            @register
+            def solve():
+                return top
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            ready = self._read_frame(proc)
+            self.assertEqual(ready["type"], "ready")
+
+            # 顶层调用发出 capability 帧（entry 加载期间）
+            cap = self._read_frame(proc)
+            self.assertEqual(cap["type"], "capability")
+            self.assertEqual(cap["name"], "ping")
+            self.assertEqual(cap["args"], ["top-level"])
+
+            # evaluator 返回后，entry 加载继续，函数可正常调用
+            self._send_frame(
+                proc, {"type": "result", "id": cap["id"], "value": "top-ok"}
+            )
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "solve", "args": []})
+            resp = self._read_frame(proc)
+            self.assertEqual(resp["type"], "result")
+            self.assertEqual(resp["value"], "top-ok")
+        finally:
+            self._cleanup(proc, path)
+
+    def test_capability_bytes_round_trip(self):
+        """capability 参数/返回值 bytes base64 编解码。"""
+        entry = textwrap.dedent("""
+            from noj_solution_sdk import register, call_capability
+            @register
+            def solve():
+                return call_capability("echo", b"payload")
+        """)
+        proc, path = self._start_host(entry)
+        try:
+            self._read_frame(proc)  # ready
+            self._send_frame(proc, {"type": "call", "id": "c1", "fn": "solve", "args": []})
+
+            cap = self._read_frame(proc)
+            self.assertEqual(cap["name"], "echo")
+            self.assertEqual(cap["args"], [{"__bytes__": base64.b64encode(b"payload").decode()}])
+
+            # 返回值也是 bytes（base64 结构）
+            self._send_frame(
+                proc,
+                {
+                    "type": "result",
+                    "id": cap["id"],
+                    "value": {"__bytes__": base64.b64encode(b"resp").decode()},
+                },
+            )
+            resp = self._read_frame(proc)
+            self.assertEqual(resp["type"], "result")
+            self.assertEqual(
+                resp["value"], {"__bytes__": base64.b64encode(b"resp").decode()}
+            )
+        finally:
+            self._cleanup(proc, path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/noj-judge/src/dual/container.rs
+++ b/noj-judge/src/dual/container.rs
@@ -32,11 +32,14 @@ pub struct DualContainer {
 
 impl DualContainer {
     /// 创建并启动 Evaluator 容器（带支持包挂载路径）。
+    ///
+    /// `network_enabled`：true 时以 bridge 模式联网，false 时保持无网（默认）。
     pub async fn create_evaluator(
         docker: &Docker,
         image: &str,
         memory_mb: u64,
         support_pkg_mount: Option<&str>,
+        network_enabled: bool,
     ) -> Result<Self> {
         let id = create_container_with_security(
             docker,
@@ -44,6 +47,7 @@ impl DualContainer {
             memory_mb,
             support_pkg_mount,
             "evaluator",
+            network_enabled,
         )
         .await?;
         info!("Evaluator 容器创建: {}", id);
@@ -56,8 +60,9 @@ impl DualContainer {
 
     /// 在现有 DualContainer 上追加 Solution 容器。
     pub async fn create_solution(&mut self, image: &str, memory_mb: u64) -> Result<()> {
-        let id = create_container_with_security(&self.docker, image, memory_mb, None, "solution")
-            .await?;
+        let id =
+            create_container_with_security(&self.docker, image, memory_mb, None, "solution", false)
+                .await?;
         info!("Solution 容器创建: {}", id);
         self.solution_id = Some(id);
         Ok(())
@@ -169,6 +174,7 @@ async fn create_container_with_security(
     memory_mb: u64,
     support_pkg_mount: Option<&str>,
     kind: &str,
+    network_enabled: bool,
 ) -> Result<String> {
     let mut labels = std::collections::HashMap::new();
     labels.insert(format!("com.noj.judge.dual.{}", kind), "true".to_string());
@@ -178,7 +184,9 @@ async fn create_container_with_security(
     let mut tmpfs = std::collections::HashMap::new();
     tmpfs.insert("/tmp", "size=256M");
 
-    let host_config = build_host_config(memory_bytes, tmpfs, false);
+    // solution 容器恒无网；evaluator 按配置可选 bridge 联网
+    let network_mode = if network_enabled { "bridge" } else { "none" };
+    let host_config = build_host_config(memory_bytes, tmpfs, false, network_mode);
 
     let body = ContainerCreateBody {
         image: Some(image.to_string()),

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -28,6 +28,20 @@ use crate::dual::protocol::{frame_type, EvaluatorLine, LineParser};
 use crate::sandbox::container::{parse_command, MAX_FILE_SIZE, MAX_TOTAL_SIZE, MAX_ZIP_ENTRIES};
 use crate::types::{JudgeResult, JudgeStatus, RuntimeConfig};
 
+/// 评测输出全文/错误累积上限（1 MiB）。恶意提交可无限打印，
+/// 若无限 append 会拖垮 judge 进程（容器内存限制不约束 judge）。
+pub const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
+
+/// 追加到累积缓冲：超过上限时丢弃头部、只保留尾部（诊断信息优先）。
+fn append_capped(buf: &mut String, s: &str) {
+    if buf.len() + s.len() > MAX_OUTPUT_BYTES {
+        let keep = MAX_OUTPUT_BYTES.saturating_sub(s.len());
+        let start = buf.len().saturating_sub(keep);
+        *buf = buf[start..].to_string();
+    }
+    buf.push_str(s);
+}
+
 /// 注入用户代码到指定容器的工作目录。
 ///
 /// 注入支持包（zip）到 Evaluator 容器的 /workspace 目录。
@@ -198,11 +212,18 @@ pub async fn evaluate_dual(
     let evaluator_cmd = parse_command(&runtime_config.evaluator.command);
 
     // 1. 创建 Evaluator 容器
+    let evaluator_network_enabled = runtime_config
+        .evaluator
+        .network
+        .as_ref()
+        .map(|n| n.enabled)
+        .unwrap_or(false);
     let mut dual = DualContainer::create_evaluator(
         &docker,
         &runtime_config.evaluator.image,
         runtime_config.evaluator.memory_limit_mb,
         None,
+        evaluator_network_enabled,
     )
     .await
     .context("创建 Evaluator 容器失败")?;
@@ -444,8 +465,8 @@ async fn run_dual_loop(
             let remaining = eval_parser.drain_remaining();
             for line in remaining {
                 if let EvaluatorLine::Unknown(s) = line {
-                    eval_stdout_full.push_str(&s);
-                    eval_stdout_full.push('\n');
+                    append_capped(&mut eval_stdout_full, &s);
+                    append_capped(&mut eval_stdout_full, "\n");
                 }
             }
             let full_output = crate::merge_output(&eval_stdout_full, &eval_stderr_buf);
@@ -476,7 +497,7 @@ async fn handle_eval_chunk(
 
     if is_err {
         let s = String::from_utf8_lossy(&data);
-        stderr_buf.push_str(&s);
+        append_capped(stderr_buf, &s);
         eprint!("[eval-stderr] {}", s);
         return Ok(());
     }
@@ -488,23 +509,26 @@ async fn handle_eval_chunk(
         match line {
             EvaluatorLine::ResultMarker => {
                 awaiting_result_payload = true;
-                stdout_full.push_str("---RESULT---\n");
+                append_capped(stdout_full, "---RESULT---\n");
             }
             EvaluatorLine::Frame(v) => {
-                // call 帧：转发到 solution stdin
-                if frame_type(&v) == Some("call") {
+                // 协议帧转发到 solution stdin：
+                // - call 帧：evaluator → solution 的函数调用（既有行为）
+                // - result/error 帧：capability 调用的响应（solution → evaluator 的反向结果）
+                // 其他类型（log 等）记录但不转发
+                let ft = frame_type(&v);
+                if ft == Some("call") || ft == Some("result") || ft == Some("error") {
                     forward_frame(eval_input, &v).await?;
                 }
-                // 其他类型（理论上 evaluator 不应在 stdout 写 result/error/log）
-                // 记录但不转发
+                // 记录所有帧到 stdout 全文（供结果展示）
                 let s = v.to_string();
-                stdout_full.push_str(&s);
-                stdout_full.push('\n');
+                append_capped(stdout_full, &s);
+                append_capped(stdout_full, "\n");
             }
             EvaluatorLine::Unknown(s) => {
                 // 普通 evaluate.py 输出，丢弃
-                stdout_full.push_str(&s);
-                stdout_full.push('\n');
+                append_capped(stdout_full, &s);
+                append_capped(stdout_full, "\n");
                 if awaiting_result_payload && !s.trim().is_empty() {
                     *result_payload = Some(s.trim().to_string());
                     awaiting_result_payload = false;
@@ -589,6 +613,45 @@ fn build_judge_result(
     }
 }
 
+/// 集成测试辅助（tests/ 目录 E2E 使用，复用真实转发逻辑）。
+///
+/// 封装 [`handle_eval_chunk`] / [`handle_sol_chunk`]，跳过 stdout/stderr 收集，
+/// 让 E2E 测试直接驱动 judge 转发语义。
+#[allow(dead_code)] // 仅 tests/ 集成测试引用（lib 目标下必然未使用）
+pub mod mod_test_helpers {
+    use super::*;
+
+    /// 等价 `handle_eval_chunk`，忽略 stderr/stdout 全文收集。
+    pub async fn handle_eval_chunk_probe(
+        parser: &mut LineParser,
+        eval_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+        result_payload: &mut Option<String>,
+        chunk: LogOutput,
+    ) {
+        let mut stderr_buf = String::new();
+        let mut stdout_full = String::new();
+        let _ = super::handle_eval_chunk(
+            parser,
+            &mut stderr_buf,
+            &mut stdout_full,
+            eval_input,
+            result_payload,
+            chunk,
+        )
+        .await;
+    }
+
+    /// 等价 `handle_sol_chunk`。
+    pub async fn handle_sol_chunk_probe(
+        parser: &mut LineParser,
+        eval_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+        chunk: LogOutput,
+        solution_ready: &mut bool,
+    ) {
+        let _ = super::handle_sol_chunk(parser, eval_input, chunk, solution_ready).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -635,5 +698,138 @@ mod tests {
         assert!(line.contains("\"type\":\"result\""));
         assert!(line.contains("\"value\":42"));
         // 实际写盘逻辑已通过 line_parser 单测间接覆盖（call 帧解析 → solution stdin 转发）
+    }
+
+    #[tokio::test]
+    async fn test_handle_eval_chunk_forwards_result_error_frames() {
+        // capability 响应（result/error）帧必须转发到 solution stdin；
+        // log 帧与普通文本不转发。
+        use bollard::container::LogOutput;
+        use tokio::io::AsyncReadExt;
+
+        let (sink, mut source) = tokio::io::duplex(8192);
+        let mut writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+            Box::pin(sink);
+
+        let mut parser = LineParser::new();
+        let mut stderr_buf = String::new();
+        let mut stdout_full = String::new();
+        let mut result_payload: Option<String> = None;
+
+        let chunk = LogOutput::StdOut {
+            message: bytes::Bytes::from_static(
+                b"{\"type\":\"result\",\"id\":\"abc\",\"value\":42}\n\
+                  {\"type\":\"error\",\"id\":\"def\",\"code\":\"NotFound\",\"message\":\"x\"}\n\
+                  {\"type\":\"log\",\"stream\":\"stdout\",\"data\":\"hi\"}\n",
+            ),
+        };
+
+        handle_eval_chunk(
+            &mut parser,
+            &mut stderr_buf,
+            &mut stdout_full,
+            &mut writer,
+            &mut result_payload,
+            chunk,
+        )
+        .await
+        .unwrap();
+
+        // 读取转发到 solution stdin 的内容
+        // 注意：duplex 的 read_to_end 需等写端 drop 才 EOF，这里用带超时的 read
+        let mut buf = [0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(2), source.read(&mut buf))
+            .await
+            .expect("读取转发内容超时")
+            .unwrap();
+        let text = String::from_utf8_lossy(&buf[..n]).to_string();
+
+        assert!(text.contains("\"type\":\"result\""));
+        assert!(text.contains("\"type\":\"error\""));
+        assert!(!text.contains("\"type\":\"log\""), "log 帧不应转发");
+        assert!(result_payload.is_none());
+        // 帧被记录到 stdout 全文（含未转发的 log）
+        assert!(stdout_full.contains("\"type\":\"log\""));
+    }
+
+    #[tokio::test]
+    async fn test_handle_eval_chunk_still_forwards_call_frames() {
+        // 既有行为回归：evaluator → solution 的 call 帧仍转发
+        use bollard::container::LogOutput;
+        use tokio::io::AsyncReadExt;
+
+        let (sink, mut source) = tokio::io::duplex(8192);
+        let mut writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+            Box::pin(sink);
+
+        let mut parser = LineParser::new();
+        let mut stderr_buf = String::new();
+        let mut stdout_full = String::new();
+        let mut result_payload: Option<String> = None;
+
+        let chunk = LogOutput::StdOut {
+            message: bytes::Bytes::from_static(
+                b"{\"type\":\"call\",\"id\":\"x\",\"fn\":\"solve\",\"args\":[1]}\nplain text\n",
+            ),
+        };
+
+        handle_eval_chunk(
+            &mut parser,
+            &mut stderr_buf,
+            &mut stdout_full,
+            &mut writer,
+            &mut result_payload,
+            chunk,
+        )
+        .await
+        .unwrap();
+
+        let mut buf = [0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(2), source.read(&mut buf))
+            .await
+            .expect("读取转发内容超时")
+            .unwrap();
+        let text = String::from_utf8_lossy(&buf[..n]).to_string();
+
+        assert!(text.contains("\"type\":\"call\""));
+        assert!(!text.contains("plain text"), "普通文本不应转发");
+    }
+
+    #[tokio::test]
+    async fn test_handle_eval_chunk_result_marker_sets_payload() {
+        // ---RESULT--- 标记行为回归：下一行 JSON 成为结果 payload
+        use bollard::container::LogOutput;
+
+        let (sink, _source) = tokio::io::duplex(8192);
+        let mut writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+            Box::pin(sink);
+
+        let mut parser = LineParser::new();
+        let mut stderr_buf = String::new();
+        let mut stdout_full = String::new();
+        let mut result_payload: Option<String> = None;
+
+        let chunk = LogOutput::StdOut {
+            message: bytes::Bytes::from_static(
+                b"---RESULT---\n{\"status\":\"Accepted\",\"score\":100}\n",
+            ),
+        };
+
+        handle_eval_chunk(
+            &mut parser,
+            &mut stderr_buf,
+            &mut stdout_full,
+            &mut writer,
+            &mut result_payload,
+            chunk,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result_payload.as_deref(),
+            Some("{\"status\":\"Accepted\",\"score\":100}")
+        );
+        assert!(stdout_full.contains("---RESULT---"));
     }
 }

--- a/noj-judge/src/dual/protocol.rs
+++ b/noj-judge/src/dual/protocol.rs
@@ -13,6 +13,7 @@
 //! - 帧类型常量（与 Python SDK 协议对齐）
 
 use serde_json::Value;
+use tracing::warn;
 
 /// NDJSON 帧 `type` 字段允许的值（与 Python SDK `host.py` 对齐）。
 ///
@@ -21,6 +22,8 @@ use serde_json::Value;
 pub const FRAME_READY: &str = "ready";
 #[allow(dead_code)]
 pub const FRAME_CALL: &str = "call";
+#[allow(dead_code)]
+pub const FRAME_CAPABILITY: &str = "capability";
 #[allow(dead_code)]
 pub const FRAME_RESULT: &str = "result";
 #[allow(dead_code)]
@@ -56,10 +59,17 @@ pub enum EvaluatorLine {
 /// 把字节流切分为行的解析器。
 ///
 /// docker exec 的 stdout 是字节流，帧可能跨多个 chunk，因此需要缓冲。
+///
+/// 安全上限：恶意提交可向 stdout 输出超长无换行行，若无限缓冲会拖垮 judge
+/// 进程（容器内存限制不约束 judge）。超过 [`MAX_BUFFER_BYTES`] 时丢弃头部、
+/// 保留尾部（诊断信息优先，评测继续）。
 #[derive(Debug, Default)]
 pub struct LineParser {
     buf: Vec<u8>,
 }
+
+/// 缓冲上限：4 MiB（覆盖正常协议帧 + 日志余量，远超单帧 1 MiB 软上限）。
+pub const MAX_BUFFER_BYTES: usize = 4 * 1024 * 1024;
 
 impl LineParser {
     pub fn new() -> Self {
@@ -67,7 +77,32 @@ impl LineParser {
     }
 
     /// 喂入一个 chunk，返回所有切分完成的行。
+    ///
+    /// 若缓冲将超过 [`MAX_BUFFER_BYTES`]，丢弃头部、保留尾部
+    /// （诊断信息优先；避免恶意超长输出拖垮 judge 进程）。
     pub fn feed(&mut self, chunk: &[u8]) -> Vec<EvaluatorLine> {
+        if self.buf.len() + chunk.len() > MAX_BUFFER_BYTES {
+            warn!(
+                "LineParser 缓冲超过上限 {} 字节，丢弃头部（恶意超长输出？）",
+                MAX_BUFFER_BYTES
+            );
+            // 保留尾部：buf 超过保留阈值时丢头部到只剩一半；
+            // buf 本身很小（超大 chunk 一次灌入）则清空，避免无界累积
+            let keep = MAX_BUFFER_BYTES / 2;
+            if self.buf.len() > keep {
+                let start = self.buf.len() - keep;
+                self.buf.drain(..start);
+            } else {
+                self.buf.clear();
+            }
+            // chunk 仍超剩余空间时只取尾部（诊断信息优先），截断后不解析
+            let remaining = MAX_BUFFER_BYTES - self.buf.len();
+            if chunk.len() > remaining {
+                let from = chunk.len() - remaining;
+                self.buf.extend_from_slice(&chunk[from..]);
+                return Vec::new();
+            }
+        }
         self.buf.extend_from_slice(chunk);
         let mut out = Vec::new();
         while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
@@ -259,5 +294,37 @@ mod tests {
         assert!(!p.buf.is_empty());
         p.discard();
         assert!(p.buf.is_empty());
+    }
+
+    #[test]
+    fn test_feed_buffer_limit_discards_on_overflow() {
+        // 恶意超长无换行输出：超过 MAX_BUFFER_BYTES 时丢弃头部（防 judge OOM）
+        let mut p = LineParser::new();
+        let big = vec![b'a'; MAX_BUFFER_BYTES + 1];
+        let lines = p.feed(&big);
+        assert!(lines.is_empty());
+        assert!(
+            p.buf.len() <= MAX_BUFFER_BYTES,
+            "超限后缓冲应被截断到上限内: {}",
+            p.buf.len()
+        );
+
+        // 截断后恢复正常解析（评测继续）——残留行先以换行结束，再解析合法帧
+        let lines = p.feed(b"\n{\"type\":\"call\",\"id\":\"x\"}\n");
+        assert!(
+            lines.iter().any(|l| matches!(l, EvaluatorLine::Frame(_))),
+            "超限截断后应能继续解析协议帧: {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn test_feed_just_below_limit_ok() {
+        // 恰好低于上限的缓冲不丢弃
+        let mut p = LineParser::new();
+        let chunk = vec![b'a'; MAX_BUFFER_BYTES - 1024];
+        let lines = p.feed(&chunk);
+        assert!(lines.is_empty());
+        assert_eq!(p.buf.len(), MAX_BUFFER_BYTES - 1024);
     }
 }

--- a/noj-judge/src/judge/runner.rs
+++ b/noj-judge/src/judge/runner.rs
@@ -235,6 +235,7 @@ mod tests {
                     command: "python3 /workspace/evaluate.py".to_string(),
                     time_limit_ms: 5000,
                     memory_limit_mb: 512,
+                    network: None,
                 },
                 solution: crate::types::SolutionRuntime {
                     image: "noj-solution-python".to_string(),

--- a/noj-judge/src/sandbox/host_config.rs
+++ b/noj-judge/src/sandbox/host_config.rs
@@ -7,17 +7,19 @@ use std::collections::HashMap;
 /// - `memory_bytes`: total memory limit (also applied to swap)
 /// - `tmpfs`: tmpfs mounts (e.g., `("/tmp", "size=256M")`)
 /// - `readonly_rootfs`: whether rootfs is read-only (dual evaluator/solution = false)
+/// - `network_mode`: container network mode (`"none"` = no network, `"bridge"` = default bridge)
 pub fn build_host_config(
     memory_bytes: i64,
     tmpfs: HashMap<&str, &str>,
     readonly_rootfs: bool,
+    network_mode: &str,
 ) -> HostConfig {
     HostConfig {
         cap_drop: Some(vec!["ALL".to_string()]),
         security_opt: Some(vec!["no-new-privileges:true".to_string()]),
         privileged: Some(false),
         readonly_rootfs: Some(readonly_rootfs),
-        network_mode: Some("none".to_string()),
+        network_mode: Some(network_mode.to_string()),
         ipc_mode: Some("none".to_string()),
         pids_limit: Some(256),
         tmpfs: Some(
@@ -39,7 +41,7 @@ mod tests {
 
     #[test]
     fn test_security_fields_are_set() {
-        let cfg = build_host_config(512 * 1024 * 1024, HashMap::new(), true);
+        let cfg = build_host_config(512 * 1024 * 1024, HashMap::new(), true, "none");
 
         assert_eq!(cfg.cap_drop, Some(vec!["ALL".to_string()]));
         assert_eq!(
@@ -55,7 +57,7 @@ mod tests {
     #[test]
     fn test_memory_swap_equals_memory() {
         let memory = 256 * 1024 * 1024;
-        let cfg = build_host_config(memory, HashMap::new(), true);
+        let cfg = build_host_config(memory, HashMap::new(), true, "none");
 
         assert_eq!(cfg.memory, Some(memory));
         assert_eq!(cfg.memory_swap, Some(memory));
@@ -64,10 +66,10 @@ mod tests {
 
     #[test]
     fn test_readonly_rootfs_honored() {
-        let cfg_ro = build_host_config(512 * 1024 * 1024, HashMap::new(), true);
+        let cfg_ro = build_host_config(512 * 1024 * 1024, HashMap::new(), true, "none");
         assert_eq!(cfg_ro.readonly_rootfs, Some(true));
 
-        let cfg_rw = build_host_config(512 * 1024 * 1024, HashMap::new(), false);
+        let cfg_rw = build_host_config(512 * 1024 * 1024, HashMap::new(), false, "none");
         assert_eq!(cfg_rw.readonly_rootfs, Some(false));
     }
 
@@ -77,7 +79,7 @@ mod tests {
         tmpfs.insert("/tmp", "size=256M");
         tmpfs.insert("/run", "size=64M");
 
-        let cfg = build_host_config(512 * 1024 * 1024, tmpfs, true);
+        let cfg = build_host_config(512 * 1024 * 1024, tmpfs, true, "none");
         let tmpfs_out = cfg.tmpfs.unwrap();
 
         assert_eq!(tmpfs_out.get("/tmp").unwrap(), "size=256M");
@@ -87,8 +89,17 @@ mod tests {
 
     #[test]
     fn test_empty_tmpfs() {
-        let cfg = build_host_config(512 * 1024 * 1024, HashMap::new(), true);
+        let cfg = build_host_config(512 * 1024 * 1024, HashMap::new(), true, "none");
         let tmpfs_out = cfg.tmpfs.unwrap();
         assert!(tmpfs_out.is_empty());
+    }
+
+    #[test]
+    fn test_network_mode_honored() {
+        let cfg_none = build_host_config(512 * 1024 * 1024, HashMap::new(), true, "none");
+        assert_eq!(cfg_none.network_mode, Some("none".to_string()));
+
+        let cfg_bridge = build_host_config(512 * 1024 * 1024, HashMap::new(), true, "bridge");
+        assert_eq!(cfg_bridge.network_mode, Some("bridge".to_string()));
     }
 }

--- a/noj-judge/src/types.rs
+++ b/noj-judge/src/types.rs
@@ -43,12 +43,24 @@ pub struct RuntimeConfig {
     pub solution: SolutionRuntime,
 }
 
+/// Evaluator 容器网络配置（可选，缺省 = 无网）。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluatorNetwork {
+    /// 是否启用网络（true = Docker bridge 模式联网）。
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+/// 双容器模式下的 Evaluator 运行时配置。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvaluatorRuntime {
     pub image: String,
     pub command: String,
     pub time_limit_ms: u64,
     pub memory_limit_mb: u64,
+    /// 网络配置；缺省/None = 容器保持 `network_mode: none`（与旧行为一致）。
+    #[serde(default)]
+    pub network: Option<EvaluatorNetwork>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/noj-judge/tests/e2e_dual_container.rs
+++ b/noj-judge/tests/e2e_dual_container.rs
@@ -40,6 +40,7 @@ fn dual_task() -> JudgeTask {
                 command: "python3 -c \"print(1)\"".to_string(),
                 time_limit_ms: 10_000,
                 memory_limit_mb: 256,
+                network: None,
             },
             solution: SolutionRuntime {
                 image: "noj-judge-test-runner:latest".to_string(),
@@ -623,6 +624,7 @@ async fn evaluate_dual_end_to_end() {
             command: r#"python3 -c "import sys,json; sys.stdout.write('---RESULT---\n'); sys.stdout.write(json.dumps({'status':'Accepted','score':10000,'details':{}})); sys.stdout.flush()""#.to_string(),
             time_limit_ms: 15000,
             memory_limit_mb: 256,
+            network: None,
         },
         solution: SolutionRuntime {
             image: "noj-judge-test-runner:latest".to_string(),

--- a/noj-judge/tests/e2e_network_capability.rs
+++ b/noj-judge/tests/e2e_network_capability.rs
@@ -1,0 +1,972 @@
+//! 评测网络能力（capability）E2E 集成测试。
+//!
+//! 覆盖（issue #197 / openspec capability-network）：
+//! - network_mode: evaluator bridge 联网 ↔ solution none 无网（UDP probe 对比，无需外网）
+//! - capability 协议闭环：solution → judge 转发 → evaluator（register_capability 语义）
+//!   → result 帧 → judge 转发（handle_eval_chunk 新分支）→ solution
+//!
+//! 注：使用现有 `noj-judge-test-runner` 镜像 + 容器内内联脚本，不依赖 SDK 镜像。
+
+mod common;
+
+use std::io::{Cursor, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use bollard::container::LogOutput;
+use bollard::exec::StartExecResults;
+use bollard::models::ExecConfig;
+use common::{get_docker, is_e2e_enabled};
+use futures_util::StreamExt;
+use noj_judge::dual::protocol::LineParser;
+use noj_judge::types::{EvaluatorNetwork, EvaluatorRuntime, RuntimeConfig, SolutionRuntime};
+
+/// 创建带 sleep infinity 的测试容器。
+///
+/// `network_enabled`：true → bridge（联网），false → none（无网，默认）。
+async fn create_sleep_container(
+    docker: &bollard::Docker,
+    image: &str,
+    memory_mb: u64,
+    network_enabled: bool,
+) -> Result<String> {
+    let network_mode = if network_enabled { "bridge" } else { "none" };
+    let body = bollard::models::ContainerCreateBody {
+        image: Some(image.to_string()),
+        cmd: Some(vec!["sleep".to_string(), "infinity".to_string()]),
+        host_config: Some(bollard::models::HostConfig {
+            memory: Some(memory_mb as i64 * 1024 * 1024),
+            memory_swap: Some(memory_mb as i64 * 1024 * 1024),
+            network_mode: Some(network_mode.to_string()),
+            cap_drop: Some(vec!["ALL".to_string()]),
+            security_opt: Some(vec!["no-new-privileges:true".to_string()]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let res = docker.create_container(None, body).await?;
+    docker.start_container(&res.id, None).await?;
+    Ok(res.id)
+}
+
+/// 在容器内跑一段 Python 脚本，返回 stdout。
+async fn run_python_in_container(
+    docker: &bollard::Docker,
+    container_id: &str,
+    script: &str,
+) -> Result<String> {
+    let cmd = vec!["python3".to_string(), "-c".to_string(), script.to_string()];
+
+    let exec = docker
+        .create_exec(
+            container_id,
+            ExecConfig {
+                cmd: Some(cmd),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let started = docker.start_exec(&exec.id, None).await?;
+    let mut stdout = String::new();
+    if let StartExecResults::Attached { mut output, .. } = started {
+        while let Some(chunk) = output.next().await {
+            if let Ok(LogOutput::StdOut { message }) = chunk {
+                stdout.push_str(&String::from_utf8_lossy(&message));
+            }
+        }
+    }
+    Ok(stdout)
+}
+
+async fn cleanup_container(docker: &bollard::Docker, container_id: &str) {
+    let _ = docker
+        .remove_container(
+            container_id,
+            Some(bollard::query_parameters::RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+}
+
+/// 网络探测脚本：UDP connect 拿本地地址。
+///
+/// - bridge 网络：成功返回 172.x/10.x 地址（无需真实外网，connect 不发包）
+/// - none 网络：抛 OSError（无路由）
+const NET_PROBE_SCRIPT: &str = r#"
+import socket, sys
+try:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    sys.stdout.write(f"NETWORKED:{s.getsockname()[0]}\n")
+except OSError as e:
+    sys.stdout.write(f"BLOCKED:{type(e).__name__}\n")
+sys.stdout.flush()
+"#;
+
+/// Evaluator bridge 联网 + Solution none 无网（对比断言，无需外网）。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn network_mode_evaluator_bridge_solution_none() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    let eval_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, true)
+        .await
+        .unwrap();
+    let sol_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, false)
+        .await
+        .unwrap();
+
+    let eval_out = run_python_in_container(&docker, &eval_id, NET_PROBE_SCRIPT)
+        .await
+        .unwrap();
+    let sol_out = run_python_in_container(&docker, &sol_id, NET_PROBE_SCRIPT)
+        .await
+        .unwrap();
+
+    assert!(
+        eval_out.contains("NETWORKED:"),
+        "evaluator（bridge）应有网络接口: {}",
+        eval_out
+    );
+    assert!(
+        sol_out.contains("BLOCKED:"),
+        "solution（none）不应有网络接口: {}",
+        sol_out
+    );
+
+    cleanup_container(&docker, &eval_id).await;
+    cleanup_container(&docker, &sol_id).await;
+}
+
+/// capability 协议闭环（协议级，模拟 judge 双向转发）。
+///
+/// - solution 容器写 `capability` 帧 → Rust 端 `handle_sol_chunk` 转发 → evaluator stdin
+/// - evaluator 容器（模拟 register_capability 的 handler）写 `result` 帧
+///   + `---RESULT---` → Rust 端 `handle_eval_chunk`（真实转发分支）→ solution stdin
+/// - solution 收到 result 帧后输出到 stderr（可观测），否则 raise
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn capability_round_trip_via_judge_forwarding() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    let eval_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, false)
+        .await
+        .unwrap();
+    let sol_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, false)
+        .await
+        .unwrap();
+
+    // evaluator 侧脚本：模拟 register_capability("ping", handler) ——
+    // 从 stdin 读 capability 帧，回 result 帧，然后输出 RESULT 标记结束评测。
+    let eval_script = r#"
+import sys, json
+line = sys.stdin.readline().strip()
+frame = json.loads(line)
+assert frame["type"] == "capability", frame
+name = frame["name"]
+value = f"pong:{name}"
+sys.stdout.write(json.dumps({"type":"result","id":frame["id"],"value":value}) + "\n")
+sys.stdout.write("---RESULT---\n")
+sys.stdout.write('{"status":"Accepted","score":10000,"details":{}}\n')
+sys.stdout.flush()
+"#;
+
+    // solution 侧脚本：模拟用户代码调用 call_capability("ping") ——
+    // 先发 ready 帧（judge 的 handle_sol_chunk 在 ready 前丢弃所有帧），
+    // 再写 capability 帧，阻塞读响应，校验 result 帧；失败则抛异常（exec 非零退出）。
+    let sol_script = r#"
+import sys, json
+sys.stdout.write(json.dumps({"type":"ready"}) + "\n")
+sys.stdout.write(json.dumps({"type":"capability","id":"cap-1","name":"ping","args":[]}) + "\n")
+sys.stdout.flush()
+line = sys.stdin.readline().strip()
+resp = json.loads(line)
+assert resp["type"] == "result", resp
+assert resp["id"] == "cap-1", resp
+assert resp["value"] == "pong:ping", resp
+sys.stderr.write("SOLUTION_GOT_RESULT\n")
+sys.stderr.flush()
+"#;
+
+    let eval_exec = docker
+        .create_exec(
+            &eval_id,
+            ExecConfig {
+                cmd: Some(vec![
+                    "python3".to_string(),
+                    "-c".to_string(),
+                    eval_script.to_string(),
+                ]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let sol_exec = docker
+        .create_exec(
+            &sol_id,
+            ExecConfig {
+                cmd: Some(vec![
+                    "python3".to_string(),
+                    "-c".to_string(),
+                    sol_script.to_string(),
+                ]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let eval_started = docker.start_exec(&eval_exec.id, None).await.unwrap();
+    let sol_started = docker.start_exec(&sol_exec.id, None).await.unwrap();
+
+    let (mut eval_output, eval_input_raw) = match eval_started {
+        StartExecResults::Attached { output, input } => (output, input),
+        _ => panic!("evaluator exec 应 Attached"),
+    };
+    // bollard 的 input 是 Box<dyn AsyncWrite + Send>（无 Unpin），包装为 trait object
+    let mut eval_input: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+        Box::pin(eval_input_raw);
+    let (mut sol_output, sol_input_raw) = match sol_started {
+        StartExecResults::Attached { output, input } => (output, input),
+        _ => panic!("solution exec 应 Attached"),
+    };
+    let mut sol_input: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+        Box::pin(sol_input_raw);
+
+    // ── 模拟 judge 编排循环（等价 run_dual_loop 的转发逻辑）──
+    let mut eval_parser = LineParser::new();
+    let mut sol_parser = LineParser::new();
+    let mut solution_ready = false;
+    let mut result_payload: Option<String> = None;
+
+    let deadline = tokio::time::sleep(Duration::from_secs(30));
+    tokio::pin!(deadline);
+
+    let mut sol_stderr = String::new();
+    let mut eval_stderr = String::new();
+
+    'outer: loop {
+        tokio::select! {
+            _ = &mut deadline => {
+                panic!("capability 闭环超时; sol_stderr={} eval_stderr={}", sol_stderr, eval_stderr);
+            }
+            chunk = eval_output.next() => {
+                let chunk = match chunk {
+                    Some(Ok(c)) => c,
+                    other => panic!("evaluator 流结束: {:?}", other),
+                };
+                if let LogOutput::StdErr { message } = &chunk {
+                    eval_stderr.push_str(&String::from_utf8_lossy(message));
+                }
+                // 真实 judge 转发逻辑：result/error 帧转发到 solution stdin
+                noj_judge::dual::mod_test_helpers::handle_eval_chunk_probe(
+                    &mut eval_parser,
+                    &mut sol_input,
+                    &mut result_payload,
+                    chunk,
+                )
+                .await;
+                if result_payload.is_some() {
+                    break 'outer;
+                }
+            }
+            chunk = sol_output.next() => {
+                let chunk = match chunk {
+                    Some(Ok(c)) => c,
+                    other => panic!("solution 流结束: {:?}", other),
+                };
+                if let LogOutput::StdErr { message } = &chunk {
+                    sol_stderr.push_str(&String::from_utf8_lossy(message));
+                }
+                // 真实 judge 转发逻辑：solution 帧转发到 evaluator stdin
+                noj_judge::dual::mod_test_helpers::handle_sol_chunk_probe(
+                    &mut sol_parser,
+                    &mut eval_input,
+                    chunk,
+                    &mut solution_ready,
+                )
+                .await;
+            }
+        }
+    }
+
+    // 等待 solution 侧 exec 结束，确认其校验通过（非零退出表示失败）。
+    // 注意：result_payload 就绪即 break 主循环，solution 的 stderr 可能尚未到达，
+    // 这里继续消费 sol_output 直到 exec 完成。
+    let mut sol_done = false;
+    for _ in 0..50 {
+        tokio::select! {
+            chunk = sol_output.next() => {
+                if let Some(Ok(LogOutput::StdErr { message })) = chunk {
+                    sol_stderr.push_str(&String::from_utf8_lossy(&message));
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+        let inspect = docker.inspect_exec(&sol_exec.id).await.unwrap();
+        if inspect.exit_code.is_some() {
+            sol_done = true;
+            assert_eq!(
+                inspect.exit_code,
+                Some(0),
+                "solution 侧 capability 校验失败; stderr={}",
+                sol_stderr
+            );
+            break;
+        }
+    }
+    assert!(
+        sol_done,
+        "solution exec 未在超时内结束; eval_stderr={} sol_stderr={}",
+        eval_stderr, sol_stderr
+    );
+
+    // evaluator 的 RESULT payload
+    assert_eq!(
+        result_payload.as_deref(),
+        Some("{\"status\":\"Accepted\",\"score\":10000,\"details\":{}}")
+    );
+    assert!(
+        sol_stderr.contains("SOLUTION_GOT_RESULT"),
+        "solution 应收到 result 帧: {}",
+        sol_stderr
+    );
+
+    cleanup_container(&docker, &eval_id).await;
+    cleanup_container(&docker, &sol_id).await;
+}
+
+/// capability 未注册 → NotFound 错误帧闭环（协议级）。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn capability_not_found_error_round_trip() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    let eval_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, false)
+        .await
+        .unwrap();
+    let sol_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, false)
+        .await
+        .unwrap();
+
+    // evaluator：未注册任何 capability → 对 capability 帧回 NotFound
+    let eval_script = r#"
+import sys, json
+line = sys.stdin.readline().strip()
+frame = json.loads(line)
+assert frame["type"] == "capability", frame
+sys.stdout.write(json.dumps({"type":"error","id":frame["id"],"code":"NotFound","message":"capability 'nope' not registered"}) + "\n")
+sys.stdout.write("---RESULT---\n")
+sys.stdout.write('{"status":"WrongAnswer","score":0,"details":{}}\n')
+sys.stdout.flush()
+"#;
+
+    // solution：先发 ready，再调用未注册 capability，expect error 帧 code=NotFound
+    let sol_script = r#"
+import sys, json
+sys.stdout.write(json.dumps({"type":"ready"}) + "\n")
+sys.stdout.write(json.dumps({"type":"capability","id":"cap-2","name":"nope","args":[]}) + "\n")
+sys.stdout.flush()
+line = sys.stdin.readline().strip()
+resp = json.loads(line)
+assert resp["type"] == "error", resp
+assert resp["code"] == "NotFound", resp
+sys.stderr.write("SOLUTION_GOT_NOT_FOUND\n")
+sys.stderr.flush()
+"#;
+
+    let eval_exec = docker
+        .create_exec(
+            &eval_id,
+            ExecConfig {
+                cmd: Some(vec![
+                    "python3".to_string(),
+                    "-c".to_string(),
+                    eval_script.to_string(),
+                ]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let sol_exec = docker
+        .create_exec(
+            &sol_id,
+            ExecConfig {
+                cmd: Some(vec![
+                    "python3".to_string(),
+                    "-c".to_string(),
+                    sol_script.to_string(),
+                ]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let eval_started = docker.start_exec(&eval_exec.id, None).await.unwrap();
+    let sol_started = docker.start_exec(&sol_exec.id, None).await.unwrap();
+
+    let (mut eval_output, eval_input_raw) = match eval_started {
+        StartExecResults::Attached { output, input } => (output, input),
+        _ => panic!("evaluator exec 应 Attached"),
+    };
+    let mut eval_input: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+        Box::pin(eval_input_raw);
+    let (mut sol_output, sol_input_raw) = match sol_started {
+        StartExecResults::Attached { output, input } => (output, input),
+        _ => panic!("solution exec 应 Attached"),
+    };
+    let mut sol_input: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+        Box::pin(sol_input_raw);
+
+    let mut eval_parser = LineParser::new();
+    let mut sol_parser = LineParser::new();
+    let mut solution_ready = false;
+    let mut result_payload: Option<String> = None;
+
+    let deadline = tokio::time::sleep(Duration::from_secs(30));
+    tokio::pin!(deadline);
+
+    let mut sol_stderr = String::new();
+
+    'outer: loop {
+        tokio::select! {
+            _ = &mut deadline => {
+                panic!("NotFound 闭环超时; sol_stderr={}", sol_stderr);
+            }
+            chunk = eval_output.next() => {
+                let chunk = match chunk {
+                    Some(Ok(c)) => c,
+                    other => panic!("evaluator 流结束: {:?}", other),
+                };
+                noj_judge::dual::mod_test_helpers::handle_eval_chunk_probe(
+                    &mut eval_parser,
+                    &mut sol_input,
+                    &mut result_payload,
+                    chunk,
+                )
+                .await;
+                if result_payload.is_some() {
+                    break 'outer;
+                }
+            }
+            chunk = sol_output.next() => {
+                let chunk = match chunk {
+                    Some(Ok(c)) => c,
+                    other => panic!("solution 流结束: {:?}", other),
+                };
+                if let LogOutput::StdErr { message } = &chunk {
+                    sol_stderr.push_str(&String::from_utf8_lossy(message));
+                }
+                noj_judge::dual::mod_test_helpers::handle_sol_chunk_probe(
+                    &mut sol_parser,
+                    &mut eval_input,
+                    chunk,
+                    &mut solution_ready,
+                )
+                .await;
+            }
+        }
+    }
+
+    // 等待 solution exec 结束（同时继续消费其 stderr）
+    let mut sol_done = false;
+    for _ in 0..50 {
+        tokio::select! {
+            chunk = sol_output.next() => {
+                if let Some(Ok(LogOutput::StdErr { message })) = chunk {
+                    sol_stderr.push_str(&String::from_utf8_lossy(&message));
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+        let inspect = docker.inspect_exec(&sol_exec.id).await.unwrap();
+        if inspect.exit_code.is_some() {
+            sol_done = true;
+            assert_eq!(
+                inspect.exit_code,
+                Some(0),
+                "solution 侧 NotFound 校验失败; stderr={}",
+                sol_stderr
+            );
+            break;
+        }
+    }
+    assert!(
+        sol_done,
+        "solution exec 未在超时内结束; sol_stderr={}",
+        sol_stderr
+    );
+    assert!(sol_stderr.contains("SOLUTION_GOT_NOT_FOUND"));
+
+    cleanup_container(&docker, &eval_id).await;
+    cleanup_container(&docker, &sol_id).await;
+}
+
+/// capability handler 异常 → error 帧（code=Exception，trace 已清洗）闭环。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn capability_handler_exception_error_round_trip() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    let eval_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, false)
+        .await
+        .unwrap();
+    let sol_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, false)
+        .await
+        .unwrap();
+
+    // evaluator：模拟注册的 handler 抛异常 → 回 Exception 错误帧（含清洗后 trace）
+    let eval_script = r#"
+import sys, json
+line = sys.stdin.readline().strip()
+frame = json.loads(line)
+assert frame["type"] == "capability", frame
+sys.stdout.write(json.dumps({
+    "type": "error",
+    "id": frame["id"],
+    "code": "Exception",
+    "message": "cap boom",
+    "trace": 'Traceback (most recent call last):\n  File "evaluate.py", line 10, in handler\nValueError: cap boom',
+}) + "\n")
+sys.stdout.write("---RESULT---\n")
+sys.stdout.write('{"status":"WrongAnswer","score":0,"details":{}}\n')
+sys.stdout.flush()
+"#;
+
+    // solution：expect error 帧 code=Exception，message 含 "cap boom"
+    let sol_script = r#"
+import sys, json
+sys.stdout.write(json.dumps({"type":"ready"}) + "\n")
+sys.stdout.write(json.dumps({"type":"capability","id":"cap-3","name":"boom","args":[]}) + "\n")
+sys.stdout.flush()
+line = sys.stdin.readline().strip()
+resp = json.loads(line)
+assert resp["type"] == "error", resp
+assert resp["code"] == "Exception", resp
+assert resp["message"] == "cap boom", resp
+sys.stderr.write("SOLUTION_GOT_HANDLER_ERROR\n")
+sys.stderr.flush()
+"#;
+
+    let eval_exec = docker
+        .create_exec(
+            &eval_id,
+            ExecConfig {
+                cmd: Some(vec![
+                    "python3".to_string(),
+                    "-c".to_string(),
+                    eval_script.to_string(),
+                ]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let sol_exec = docker
+        .create_exec(
+            &sol_id,
+            ExecConfig {
+                cmd: Some(vec![
+                    "python3".to_string(),
+                    "-c".to_string(),
+                    sol_script.to_string(),
+                ]),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let eval_started = docker.start_exec(&eval_exec.id, None).await.unwrap();
+    let sol_started = docker.start_exec(&sol_exec.id, None).await.unwrap();
+
+    let (mut eval_output, eval_input_raw) = match eval_started {
+        StartExecResults::Attached { output, input } => (output, input),
+        _ => panic!("evaluator exec 应 Attached"),
+    };
+    let mut eval_input: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+        Box::pin(eval_input_raw);
+    let (mut sol_output, sol_input_raw) = match sol_started {
+        StartExecResults::Attached { output, input } => (output, input),
+        _ => panic!("solution exec 应 Attached"),
+    };
+    let mut sol_input: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+        Box::pin(sol_input_raw);
+
+    let mut eval_parser = LineParser::new();
+    let mut sol_parser = LineParser::new();
+    let mut solution_ready = false;
+    let mut result_payload: Option<String> = None;
+
+    let deadline = tokio::time::sleep(Duration::from_secs(30));
+    tokio::pin!(deadline);
+
+    let mut sol_stderr = String::new();
+    let mut eval_stderr = String::new();
+
+    'outer: loop {
+        tokio::select! {
+            _ = &mut deadline => {
+                panic!("handler 异常闭环超时; sol_stderr={}", sol_stderr);
+            }
+            chunk = eval_output.next() => {
+                let chunk = match chunk {
+                    Some(Ok(c)) => c,
+                    other => panic!("evaluator 流结束: {:?}", other),
+                };
+                if let LogOutput::StdErr { message } = &chunk {
+                    eval_stderr.push_str(&String::from_utf8_lossy(message));
+                }
+                noj_judge::dual::mod_test_helpers::handle_eval_chunk_probe(
+                    &mut eval_parser,
+                    &mut sol_input,
+                    &mut result_payload,
+                    chunk,
+                )
+                .await;
+                if result_payload.is_some() {
+                    break 'outer;
+                }
+            }
+            chunk = sol_output.next() => {
+                let chunk = match chunk {
+                    Some(Ok(c)) => c,
+                    other => panic!("solution 流结束: {:?}", other),
+                };
+                if let LogOutput::StdErr { message } = &chunk {
+                    sol_stderr.push_str(&String::from_utf8_lossy(message));
+                }
+                noj_judge::dual::mod_test_helpers::handle_sol_chunk_probe(
+                    &mut sol_parser,
+                    &mut eval_input,
+                    chunk,
+                    &mut solution_ready,
+                )
+                .await;
+            }
+        }
+    }
+
+    // 等待 solution exec 结束（同时继续消费其 stderr）
+    let mut sol_done = false;
+    for _ in 0..50 {
+        tokio::select! {
+            chunk = sol_output.next() => {
+                if let Some(Ok(LogOutput::StdErr { message })) = chunk {
+                    sol_stderr.push_str(&String::from_utf8_lossy(&message));
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+        let inspect = docker.inspect_exec(&sol_exec.id).await.unwrap();
+        if inspect.exit_code.is_some() {
+            sol_done = true;
+            assert_eq!(
+                inspect.exit_code,
+                Some(0),
+                "solution 侧 handler 异常校验失败; stderr={}",
+                sol_stderr
+            );
+            break;
+        }
+    }
+    assert!(
+        sol_done,
+        "solution exec 未在超时内结束; eval_stderr={} sol_stderr={}",
+        eval_stderr, sol_stderr
+    );
+    assert!(sol_stderr.contains("SOLUTION_GOT_HANDLER_ERROR"));
+
+    cleanup_container(&docker, &eval_id).await;
+    cleanup_container(&docker, &sol_id).await;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SDK 全链路 + 真实网络连通性（增强，issue #197）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// 内存打包支持包 zip（evaluate.py 位于 zip 根，解压后挂载到 /workspace）。
+fn build_support_zip(evaluate_py: &str) -> Vec<u8> {
+    let mut buf = Cursor::new(Vec::new());
+    {
+        let mut zw = zip::ZipWriter::new(&mut buf);
+        let opts = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        zw.start_file("evaluate.py", opts).unwrap();
+        zw.write_all(evaluate_py.as_bytes()).unwrap();
+        zw.finish().unwrap();
+    }
+    buf.into_inner()
+}
+
+/// 确保带 SDK 的评测镜像存在（不存在则用仓库 Dockerfile 构建）。
+///
+/// 镜像内置 noj_evaluator_sdk / noj_solution_sdk 到 site-packages，
+/// 供真实 SDK 全链路测试使用（evaluate_dual 的 solution 启动命令
+/// 硬编码 `python3 -m noj_solution_sdk.host`，镜像必须含 SDK）。
+async fn ensure_sdk_images(docker: &bollard::Docker) -> Result<()> {
+    for (tag, dockerfile) in [
+        (
+            "noj-e2e-sdk-evaluator:latest",
+            "docker/evaluator-python/Dockerfile",
+        ),
+        (
+            "noj-e2e-sdk-solution:latest",
+            "docker/solution-python/Dockerfile",
+        ),
+    ] {
+        let images = docker
+            .list_images(None::<bollard::query_parameters::ListImagesOptions>)
+            .await?;
+        if images.iter().any(|i| i.repo_tags.iter().any(|t| t == tag)) {
+            continue;
+        }
+        println!("构建 SDK 测试镜像 {} ...", tag);
+        let status = std::process::Command::new("docker")
+            .args(["build", "-t", tag, "-f", dockerfile, "."])
+            // buildx 在部分环境写 activity 文件失败（只读 HOME），退回 legacy builder
+            .env("DOCKER_BUILDKIT", "0")
+            .current_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+            .status()
+            .context("执行 docker build 失败")?;
+        if !status.success() {
+            anyhow::bail!("docker build 失败: {}", tag);
+        }
+    }
+    Ok(())
+}
+
+/// bridge 容器真实网络探测：真实 TCP 出网（example.com:443）+ 真实 DNS 解析
+/// （getaddrinfo，线程 + 超时避免 resolver 长时间挂起）。需要宿主外网。
+///
+/// 注：不探测 docker embedded DNS 的 TCP 53——Docker 的 127.0.0.11
+/// 只监听 UDP 53，TCP 查询必然失败（已知限制），不能作为连通性探针。
+const REAL_NET_SCRIPT: &str = r#"
+import socket, threading
+try:
+    socket.create_connection(("example.com", 443), timeout=8).close()
+    print("TCP-OK")
+except OSError as e:
+    print("TCP-FAIL:" + repr(e))
+res = []
+def probe():
+    try:
+        socket.getaddrinfo("example.com", 443, type=socket.SOCK_STREAM)
+        res.append(True)
+    except OSError:
+        res.append(False)
+t = threading.Thread(target=probe, daemon=True)
+t.start()
+t.join(timeout=10)
+print("DNS-OK" if res and res[0] else "DNS-FAIL")
+"#;
+
+/// none 容器网络探测：TCP 与 DNS 均应被阻断（solution 无网安全边界）。
+const NONE_NET_SCRIPT: &str = r#"
+import socket, threading
+try:
+    socket.create_connection(("example.com", 443), timeout=4).close()
+    print("TCP-UNEXPECTED-OK")
+except OSError:
+    print("TCP-BLOCKED")
+res = []
+def probe():
+    try:
+        socket.getaddrinfo("example.com", 443, type=socket.SOCK_STREAM)
+        res.append(True)
+    except OSError:
+        res.append(False)
+t = threading.Thread(target=probe, daemon=True)
+t.start()
+t.join(timeout=8)
+print("DNS-OK" if res and res[0] else "DNS-BLOCKED")
+"#;
+
+/// 真实网络连通性（bridge）：TCP 到 docker DNS + 真实 DNS 解析必须成功；
+/// solution（none）对照：TCP/DNS 均不可达。DNS 解析需要宿主外网。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn bridge_dns_tcp_real_connectivity() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    // evaluator：bridge 联网 → TCP + DNS 真实可用
+    let eval_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, true)
+        .await
+        .unwrap();
+    let eval_out = run_python_in_container(&docker, &eval_id, REAL_NET_SCRIPT)
+        .await
+        .unwrap();
+    assert!(
+        eval_out.contains("TCP-OK"),
+        "bridge 容器 TCP 到 docker DNS 应成功: {}",
+        eval_out
+    );
+    assert!(
+        eval_out.contains("DNS-OK"),
+        "bridge 容器真实 DNS 解析应成功（需宿主外网）: {}",
+        eval_out
+    );
+    cleanup_container(&docker, &eval_id).await;
+
+    // solution：none 无网 → TCP/DNS 均被阻断
+    let sol_id = create_sleep_container(&docker, "noj-judge-test-runner:latest", 256, false)
+        .await
+        .unwrap();
+    let sol_out = run_python_in_container(&docker, &sol_id, NONE_NET_SCRIPT)
+        .await
+        .unwrap();
+    assert!(
+        sol_out.contains("TCP-BLOCKED"),
+        "none 容器 TCP 应被阻断: {}",
+        sol_out
+    );
+    assert!(
+        sol_out.contains("DNS-BLOCKED"),
+        "none 容器 DNS 应失败: {}",
+        sol_out
+    );
+    cleanup_container(&docker, &sol_id).await;
+}
+
+/// SDK 全链路（真实 SDK，非协议模拟）：evaluate.py `register_capability` →
+/// solution `call_capability` → judge 双向转发 → 评测 Accepted。
+///
+/// evaluator 以 bridge 联网（network.enabled=true）：capability handler 内
+/// TCP 探测 docker DNS（127.0.0.11:53），成功才返回 pong → Accepted；
+/// 若 evaluator 无网则返回 no-net → WrongAnswer（测试失败即暴露网络回归）。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn capability_sdk_full_chain_with_network() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+    ensure_sdk_images(&docker).await.unwrap();
+
+    let evaluate_py = r#"
+import socket
+from noj_evaluator_sdk import SolutionRunner, register_capability, result
+
+def ping(msg: str) -> str:
+    # handler 在 evaluator（bridge 联网）内执行：真实 TCP 出网探测（需外网）。
+    # evaluator 无网时返回 no-net → WrongAnswer，暴露网络回归。
+    try:
+        socket.create_connection(("example.com", 443), timeout=5).close()
+        return "pong:" + msg
+    except OSError as e:
+        return "no-net:" + str(e)
+
+register_capability("ping", ping)
+
+runner = SolutionRunner()
+try:
+    answer = runner.call("solve", "hello")
+except Exception as e:
+    result.runtime_error("call failed: " + repr(e))
+else:
+    if answer == "pong:hello":
+        result.accept(score=100)
+    else:
+        result.wrong_answer(score=0, message="unexpected: " + repr(answer))
+"#;
+    let support_zip = build_support_zip(evaluate_py);
+
+    let submission_id = format!("e2e-net-sdk-{}", uuid::Uuid::new_v4());
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: "python3 /workspace/evaluate.py".to_string(),
+            time_limit_ms: 20000,
+            memory_limit_mb: 256,
+            network: Some(EvaluatorNetwork { enabled: true }),
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 8000,
+            memory_limit_mb: 128,
+        },
+    };
+    let user_code = r#"
+from noj_solution_sdk import register, call_capability
+
+@register
+def solve(msg: str) -> str:
+    return call_capability("ping", msg)
+"#;
+
+    let result = noj_judge::dual::evaluate_dual(
+        docker,
+        &submission_id,
+        &runtime_config,
+        user_code,
+        "solution.py",
+        Some(&support_zip),
+        "/tmp/e2e-cache",
+        100,
+        64,
+        None,
+    )
+    .await
+    .expect("evaluate_dual 返回 Err");
+
+    assert_eq!(
+        result.status, "Accepted",
+        "SDK 全链路应 Accepted（evaluator 联网 + capability 转发），实际 {:?} score={}",
+        result.status, result.score
+    );
+}

--- a/noj-tests/e2e/23_network_capability.test.ts
+++ b/noj-tests/e2e/23_network_capability.test.ts
@@ -1,0 +1,351 @@
+/**
+ * 评测网络能力（evaluator 联网 + capability）跨模块 E2E。
+ *
+ * 覆盖（issue #197 / openspec network-capability）：
+ * - 普通用户创建带 network.enabled=true 的 U 型题目（权限放行，无需 admin）
+ * - 普通用户通过 import-bundle 导入带联网配置的统一题目包（导入路径同权限）
+ * - 提交 solution（call_capability）→ 评测完成且 evaluator 联网真实生效：
+ *   capability handler 内真实 TCP 出网探测（example.com:443）成功才 Accepted，
+ *   evaluator 无网则返回 no-net → WrongAnswer（测试失败即暴露网络回归）
+ *
+ * 要求：
+ *   NOJ_RUN_E2E=1 表示启用 E2E 测试套件
+ *   E2E_BASE_URL 指向运行中的 noj-core 服务
+ *   评测镜像 noj-evaluator-python / noj-solution-python 已构建并加入白名单
+ *   系统 zip 命令可用（与 24_import_bundle.test.ts 相同约定）
+ */
+
+import {
+  apiGet,
+  apiPost,
+  getAdminToken,
+  getProblemIdByNumber,
+  isE2E,
+  pollSubmission,
+  registerUser,
+  submitCode,
+  waitForServer,
+} from "./helper.ts";
+
+const skip = !isE2E;
+
+// ── 测试常量 ─────────────────────────────────────────
+
+const EVALUATOR_IMAGE = "noj-evaluator-python";
+const SOLUTION_IMAGE = "noj-solution-python";
+const TEST_TAG = `e2e-netcap-${Date.now()}`;
+
+let userToken = "";
+let problemId = ""; // API 创建的题目（用例 1）
+let bundleProblemId = ""; // import-bundle 导入的题目（用例 2）
+let judgeOk = false;
+
+/** 创建（或复用）评测镜像白名单条目 */
+async function ensureImage(
+  image: string,
+  kind: "evaluator" | "solution",
+): Promise<void> {
+  const adminToken = await getAdminToken();
+  const list = await apiGet("/api/v1/admin/judge-images", adminToken);
+  type JiEntry = { id: string; image: string; kind: string };
+  const existing = ((list.body as { data: JiEntry[] }).data ?? []).find(
+    (ji) => ji.image === image && ji.kind === kind,
+  );
+  if (existing) return;
+
+  const create = await apiPost(
+    "/api/v1/admin/judge-images",
+    { image, kind, mode: "exact", description: `e2e ${kind} image` },
+    adminToken,
+  );
+  if (create.status !== 201) {
+    throw new Error(
+      `Failed to create image ${image} (kind=${kind}): ${create.status} ${
+        JSON.stringify(create.body)
+      }`,
+    );
+  }
+}
+
+/** evaluate.py：注册 capability + evaluator 真实 TCP 出网探测（需外网） */
+function evaluatePy(): string {
+  return `
+import socket
+from noj_evaluator_sdk import SolutionRunner, register_capability, result
+
+def ping(msg: str) -> str:
+    # handler 在 evaluator（bridge 联网）内执行：真实 TCP 出网探测。
+    # evaluator 无网时返回 no-net → 评测 WrongAnswer，暴露网络回归。
+    try:
+        socket.create_connection(("example.com", 443), timeout=5).close()
+        return "pong:" + msg
+    except OSError as e:
+        return "no-net:" + str(e)
+
+register_capability("ping", ping)
+
+runner = SolutionRunner()
+try:
+    answer = runner.call("solve", "hello")
+except Exception as e:
+    result.runtime_error("call failed: " + repr(e))
+else:
+    if answer == "pong:hello":
+        result.accept(score=100)
+    else:
+        result.wrong_answer(score=0, message="unexpected: " + repr(answer))
+`;
+}
+
+/** 构造统一题目包 zip（临时目录 + 系统 zip 命令，network.enabled=true） */
+async function makeBundleZip(): Promise<Uint8Array> {
+  const dir = await Deno.makeTempDir();
+  const enc = new TextEncoder();
+  try {
+    const manifest = JSON.stringify({
+      format_version: 1,
+      title: `[${TEST_TAG}] 联网能力导入题`,
+      difficulty: "easy",
+      type: "U",
+      // 普通用户导入不带 number（number 由系统自动分配）
+      runtime_config: {
+        evaluator: {
+          image: EVALUATOR_IMAGE,
+          command: "python3 /workspace/evaluate.py",
+          time_limit_ms: 20000,
+          memory_limit_mb: 512,
+          network: { enabled: true },
+        },
+        solution: {
+          image: SOLUTION_IMAGE,
+          entry: "solution.py",
+          call_timeout_ms: 5000,
+          memory_limit_mb: 256,
+        },
+      },
+    });
+    await Deno.writeFile(`${dir}/problem.json`, enc.encode(manifest));
+    await Deno.writeFile(
+      `${dir}/statement.md`,
+      enc.encode(
+        `# 联网能力测试\n\n通过 call_capability 调用 evaluator 网络能力。\n`,
+      ),
+    );
+    await Deno.writeFile(`${dir}/evaluate.py`, enc.encode(evaluatePy()));
+
+    const zipPath = `${dir}/bundle.zip`;
+    const cmd = new Deno.Command("zip", {
+      args: ["-r", zipPath, "."],
+      cwd: dir,
+    });
+    const out = await cmd.output();
+    if (out.code !== 0) {
+      throw new Error("zip 打包失败");
+    }
+    return await Deno.readFile(zipPath);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/** 上传统一题目包（import-bundle），返回题目 id */
+async function importBundle(zip: Uint8Array): Promise<string> {
+  const formData = new FormData();
+  formData.append(
+    "file",
+    new Blob(
+      [zip.buffer.slice(
+        zip.byteOffset,
+        zip.byteOffset + zip.byteLength,
+      ) as ArrayBuffer],
+      { type: "application/zip" },
+    ),
+    "netcap-bundle.zip",
+  );
+  const baseUrl = Deno.env.get("E2E_BASE_URL") || "http://localhost:8099";
+  const res = await fetch(`${baseUrl}/api/v1/problems/import-bundle`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${userToken}` },
+    body: formData,
+  });
+  if (res.status !== 200) {
+    throw new Error(
+      `导入失败: ${res.status} ${(await res.text()).slice(0, 500)}`,
+    );
+  }
+  const body = (await res.json()) as {
+    data: {
+      id: string;
+      runtime_config: {
+        evaluator: { network?: { enabled?: boolean } };
+      };
+    };
+  };
+  if (body.data.runtime_config.evaluator.network?.enabled !== true) {
+    throw new Error(
+      "导入后 runtime_config.evaluator.network.enabled 未保留为 true",
+    );
+  }
+  return body.data.id;
+}
+
+/** 探测 judge 是否可用：提交样例题并等待评测有结果。
+ *
+ * 与 helper.isJudgeAvailable 不同：这里把 status=error 也视为可用——
+ * 提交 print(1) 对样例题必然 SystemError（用户代码无 solve 函数），
+ * 但评测链路完整跑通本身就证明 judge worker 可用。
+ */
+async function judgeAvailable(): Promise<boolean> {
+  try {
+    const ts = Date.now().toString(36);
+    const t = await registerUser(
+      "netcap_jchk_" + ts,
+      "netcap_jchk_" + ts + "@test.com",
+      "Test12345679",
+    );
+    const problemId = await getProblemIdByNumber(1001);
+    const id = await submitCode(t, problemId, "print(1)");
+    const baseUrl = Deno.env.get("E2E_BASE_URL") || "http://localhost:8099";
+    for (let i = 0; i < 10; i++) {
+      await new Promise((r) => setTimeout(r, 1000));
+      const res = await fetch(
+        `${baseUrl}/api/v1/submissions/${id}`,
+        { headers: { Authorization: "Bearer " + t } },
+      );
+      const data = await res.json();
+      const status = (data as { data?: { status?: string } })?.data?.status ||
+        "";
+      if (
+        status === "judging" || status === "finished" || status === "error"
+      ) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// ── 测试 ────────────────────────────────────────────
+
+Deno.test({
+  name: "[e2e/network-capability] Setup",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    if (!isE2E) return;
+    await waitForServer();
+    const ts = Date.now().toString(36);
+    userToken = await registerUser(
+      "netcap_" + ts,
+      "netcap_" + ts + "@test.com",
+      "Test12345679",
+    );
+    await ensureImage(EVALUATOR_IMAGE, "evaluator");
+    await ensureImage(SOLUTION_IMAGE, "solution");
+    judgeOk = await judgeAvailable();
+    if (!judgeOk) console.log("  ⚠ judge worker 不可用，评测用例将跳过");
+  },
+});
+
+Deno.test({
+  name:
+    "[e2e/network-capability] 普通用户创建联网题放行（network.enabled=true）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    if (!isE2E) return;
+    const res = await apiPost(
+      "/api/v1/problems",
+      {
+        title: `[${TEST_TAG}] 联网能力测试题`,
+        description: `# 联网能力测试题\n\n普通用户创建，evaluator 开启联网。`,
+        difficulty: "easy",
+        runtime_config: {
+          evaluator: {
+            image: EVALUATOR_IMAGE,
+            command: "python3 /workspace/evaluate.py",
+            time_limit_ms: 20000,
+            memory_limit_mb: 512,
+            network: { enabled: true },
+          },
+          solution: {
+            image: SOLUTION_IMAGE,
+            entry: "solution.py",
+            call_timeout_ms: 5000,
+            memory_limit_mb: 256,
+          },
+        },
+      },
+      userToken,
+    );
+    if (res.status !== 201) {
+      throw new Error(
+        `普通用户创建联网题应放行（201），实际 ${res.status} ${
+          JSON.stringify(res.body)
+        }`,
+      );
+    }
+    const data = (res.body as {
+      data: {
+        id: string;
+        runtime_config: {
+          evaluator: { network?: { enabled?: boolean } };
+        };
+      };
+    }).data;
+    problemId = data.id;
+    if (data.runtime_config.evaluator.network?.enabled !== true) {
+      throw new Error("runtime_config.evaluator.network.enabled 未保留为 true");
+    }
+    console.log(`  → 题目 ${problemId.slice(0, 8)} 创建成功（联网已开启）`);
+  },
+});
+
+Deno.test({
+  name: "[e2e/network-capability] 普通用户导入联网统一包（import-bundle 放行）",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    if (!isE2E) return;
+    const zip = await makeBundleZip();
+    bundleProblemId = await importBundle(zip);
+    console.log(
+      `  → 导入题目 ${bundleProblemId.slice(0, 8)} 成功（联网已开启）`,
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "[e2e/network-capability] 提交 solution（call_capability）→ 评测 Accepted",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    if (!isE2E || !judgeOk) {
+      console.log("  ⚠ judge 不可用，跳过评测断言");
+      return;
+    }
+    const code = `
+from noj_solution_sdk import register, call_capability
+
+@register
+def solve(msg: str) -> str:
+    return call_capability("ping", msg)
+`;
+    const id = await submitCode(userToken, bundleProblemId, code);
+    console.log(`  → 提交 ID: ${id.slice(0, 8)}`);
+    const result = await pollSubmission(userToken, id, 40, 3000);
+    console.log(`  → ${result.verdict} (${result.score}分)`);
+    if (result.verdict !== "Accepted") {
+      throw new Error(
+        `期望 Accepted（evaluator 联网 + capability 全链路），实际 ${result.verdict}`,
+      );
+    }
+  },
+});

--- a/noj-ui/components/editor/ProblemEditor.vue
+++ b/noj-ui/components/editor/ProblemEditor.vue
@@ -8,6 +8,7 @@ interface RuntimeConfigPayload {
     command: string
     time_limit_ms: number
     memory_limit_mb: number
+    network?: { enabled: boolean }
   }
   solution: {
     image: string
@@ -89,6 +90,7 @@ const evaluatorImage = ref("")
 const evaluatorCommand = ref("python3 /workspace/evaluate.py")
 const evaluatorTimeLimitMs = ref(5000)
 const evaluatorMemoryLimitMb = ref(512)
+const evaluatorNetworkEnabled = ref(false)
 const solutionImage = ref("")
 const solutionEntry = ref("submission_sample.py")
 const solutionCallTimeoutMs = ref(1000)
@@ -138,6 +140,7 @@ async function loadProblem() {
       evaluatorCommand.value = rc.evaluator.command
       evaluatorTimeLimitMs.value = rc.evaluator.time_limit_ms
       evaluatorMemoryLimitMb.value = rc.evaluator.memory_limit_mb
+      evaluatorNetworkEnabled.value = rc.evaluator.network?.enabled === true
       solutionImage.value = rc.solution.image
       solutionEntry.value = rc.solution.entry
       solutionCallTimeoutMs.value = rc.solution.call_timeout_ms
@@ -189,6 +192,7 @@ async function handleSubmit() {
         command: evaluatorCommand.value.trim(),
         time_limit_ms: evaluatorTimeLimitMs.value,
         memory_limit_mb: evaluatorMemoryLimitMb.value,
+        ...(evaluatorNetworkEnabled.value ? { network: { enabled: true } } : {}),
       },
       solution: {
         image: solutionImage.value.trim(),
@@ -361,6 +365,13 @@ async function handleSubmit() {
                 <input v-model.number="evaluatorMemoryLimitMb" type="number" class="px-2.5 py-1.5 text-sm border border-border rounded-md bg-white" min="32" max="8192" />
               </div>
             </div>
+            <label class="flex items-center gap-2 rounded-lg border border-border p-3 text-sm text-text">
+              <input v-model="evaluatorNetworkEnabled" type="checkbox" class="size-4 accent-primary">
+              <span>
+                允许 Evaluator 联网
+                <span class="block text-xs text-text-muted">开启后 evaluator 容器以 bridge 模式联网（solution 保持无网，仅能通过 capability 调用间接使用网络）</span>
+              </span>
+            </label>
           </div>
         </div>
 

--- a/openspec/changes/archive/2026-08-03-capability-network/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-03-capability-network/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-capability-network/design.md
+++ b/openspec/changes/archive/2026-08-03-capability-network/design.md
@@ -1,0 +1,76 @@
+# 评测网络能力（capability-network）设计
+
+## Context
+
+- 双容器评测：Evaluator（出题人编写的 `evaluate.py`）+ Solution（用户提交代码），judge 宿主机做 NDJSON 双向透明转发（`src/dual/mod.rs`）。
+- 现状：所有容器统一 `network_mode: none`（`src/sandbox/host_config.rs`）；evaluator stdout 仅转发 `call` 帧到 solution（`handle_eval_chunk`）；solution stdout 全部帧转发到 evaluator（`handle_sol_chunk`）。
+- SDK 现状：`noj_solution_sdk` 为单线程 reader loop（被动响应 call）；`noj_evaluator_sdk` 已有 pending/id 匹配的 `SolutionRunner.call()`；`call_capability` 仅存在于文档占位，代码中不存在。
+- LMCC 场景：solution 需调用外部网络 API（LLM 接口、检索服务），但安全边界要求 solution 无网。
+
+## Goals / Non-Goals
+
+**Goals:**
+- solution 容器保持无网（安全边界不变）；evaluator 按题目配置可联网（Docker bridge 全量）
+- solution 通过 `call_capability(name, *args)` 经 RPC 调用 evaluator 注册的 capability，judge 透明转发
+- 配置、SDK、协议、UI、文档全链路落地；向后兼容旧任务（network 缺省 = 无网）
+
+**Non-Goals:**
+- 网络层白名单代理 / egress 过滤（本期不做，文档中列为未来兜底选项）
+- capability 并发、嵌套双向调用（capability handler 内再调 solution 会死锁至总超时，文档明示不支持）
+- capability 鉴权/配额（信任模型：evaluator 可信，capability 参数校验由出题人负责）
+
+## Decisions
+
+### D1：网络配置形态 —— `evaluator.network.enabled: boolean`（可选，默认 false）
+
+- 结构为对象 `{ "enabled": boolean }` 而非裸布尔，为未来 `allowlist` / `mode` 扩展留位。
+- 旧任务（无 network 字段）反序列化为 `None` → 保持 `network_mode: none`，向后兼容。
+- 备选：字符串枚举 `"none" | "bridge"` —— 弃用理由：对象结构更易演进（JSONB 无迁移成本）。
+
+### D2：capability 协议 —— 新帧类型 `capability`，响应复用 `result/error`
+
+- `{"type":"capability","id":hex,"name":str,"args":[...]}`，solution → judge → evaluator；响应 `{"type":"result","id","value"}` / `{"type":"error","id","code","message"}`，按 `id` 匹配。
+- 备选：复用 `call` 帧加 `capability:` 前缀命名空间 —— 弃用理由：语义混淆（call 帧语义是 evaluator 调 solution 注册函数），judge 日志与 SDK 处理难以区分；新帧类型职责清晰。
+
+### D3：judge 转发改动最小化 —— 仅新增 evaluator stdout 的 `result/error` 帧转发
+
+- 现状 `handle_eval_chunk` 只转发 `call` 帧；capability 响应（result/error）来自 evaluator stdout，需新增转发到 solution stdin。
+- `log` 帧不转发（solution → evaluator 方向语义，evaluator 不产出）；`shutdown` 保持不发（现有行为）。
+- evaluator stdout 的普通文本与 `---RESULT---` 标记仍按现状处理，不转发。
+
+### D4：solution SDK —— `call_capability` + host.py 双线程重构
+
+- 现状 host.py 单线程：reader loop 内同步执行用户函数；若用户函数内调用 `call_capability` 阻塞等待响应，reader 无法读取响应帧 → 死锁。
+- 重构：reader 线程（持续读 stdin，`call` 帧投递到队列、`result/error` 帧按 id 匹配 pending 队列）+ 单 worker 线程（顺序执行 call，保持现有"顺序执行"语义）。`ready` 帧时序、entry 加载、错误码行为保持不变。
+- 帧大小限制对齐现有 `MAX_FRAME_BYTES = 1 MiB`（两端 `serialization.py` 均已定义该常量）：solution 发 `capability` 帧与 evaluator 回复 `result` 帧均受同限，防超大帧。
+
+### D5：evaluator SDK —— `register_capability(name, handler)` + reader 同步执行
+
+- runner 的 stdin reader 线程识别 `capability` 帧 → 查注册表 → 同步执行 handler → 写 `result/error` 帧到 stdout。
+- 同步执行理由：solution 侧同步等待，天然无并发；handler 内网络请求超时由出题人控制（SDK 提供 `urllib`/`requests` 超时建议），整体受 evaluator `time_limit_ms` 兜底。
+- 未注册的 capability → `{"type":"error","code":"NotFound","message":"capability 'x' not registered"}`。
+
+### D6：安全模型 —— 调用边界即信任边界
+
+- solution 永远无网；evaluator 默认无网，仅题目显式开启。
+- capability 只能调用 evaluator 显式注册的 handler；**出题人负责 handler 参数校验**（禁止通用 URL 转发、禁访元数据/内网、校验重定向）。
+- SSRF 缓解：最佳实践文档（封装精确函数如 `request_llm_completion(prompt)` 而非 `fetch_url(url)`）+ SDK 参考示例；网络层代理兜底列为未来选项。
+- 本设计不改变"solution 可向 evaluator 发送任意帧"的既有信任模型（评测本身即黑盒验证）。
+
+## Risks / Trade-offs
+
+- [出题人注册通用转发 capability 导致 SSRF 面全开] → 文档最佳实践 + 示例强调精确封装；默认无网降低误开概率；未来可加网络层白名单代理
+- [host.py 重构引入行为回归] → 既有 SDK 测试全量回归（ready 时序、error 码、顺序执行）；E2E 覆盖双容器全链路
+- [evaluator 全量联网影响资源/安全基线] → 仅显式开启的题目受影响；evaluator 容器其他安全项（cap_drop、no-new-privileges、pids_limit 等）不变
+- [嵌套双向调用死锁（handler 再调 solution）] → SDK 文档明示限制，总超时兜底
+
+## Migration Plan
+
+1. judge 端 `network` 字段 `#[serde(default)]` 可选 → 旧任务（无字段）自动按无网执行，无需迁移。
+2. `runtime_config` 为 JSONB 列，新字段随 API 落库，无 schema 迁移。
+3. SDK 双线程重构与协议新增向后兼容：旧 evaluate.py / solution.py 不导入新 API 则行为不变。
+4. 回滚：仅需移除 judge 侧 `network` 字段解析与转发分支（新帧被旧 judge 忽略——solution stdout 全帧转发本就存在，旧 evaluator runner 忽略未知帧类型）。
+
+## Open Questions
+
+- ~~capability 帧大小上限~~ **已解决**：对齐现有 `MAX_FRAME_BYTES = 1 MiB`（见 D4），无需 judge 侧额外限制。

--- a/openspec/changes/archive/2026-08-03-capability-network/proposal.md
+++ b/openspec/changes/archive/2026-08-03-capability-network/proposal.md
@@ -9,7 +9,7 @@ LMCC 大模型能力评测中，用户应用（solution）可能需要与外部�
 - **配置**：`runtime_config.evaluator.network` 新增可选对象字段（`enabled: boolean`，默认 `false`），开启后 evaluator 容器以 Docker `bridge` 模式联网；solution 容器保持 `network_mode: none` 不变。
 - **协议**：NDJSON 新增 `capability` 帧（`{"type":"capability","id","name","args":[...]}`），由 solution 发出、judge 转发至 evaluator；响应复用现有 `result/error` 帧按 `id` 匹配返回。judge 侧 `handle_eval_chunk` 需新增转发 evaluator stdout 的 `result/error` 帧。
 - **SDK**：`noj_solution_sdk` 新增 `call_capability(name, *args)`（替换现有文档占位，当前代码中不存在）；`noj_evaluator_sdk` 新增 `register_capability(name, handler)`。solution 侧 `host.py` 需从单线程 reader 重构为 reader 线程 + 单 worker 队列（避免用户函数内阻塞等待响应导致死锁）。
-- **UI**：admin 题目编辑表单（`ProblemEditor.vue`）新增「evaluator 联网」开关。
+- **UI**：题目编辑表单（`ProblemEditor.vue`，admin 与出题人通用）新增「evaluator 联网」开关。
 - **文档**：做题人文档新增 capability 使用说明；出题人文档新增 `register_capability` 用法与「如何提供受限网络能力」最佳实践（封装精确函数如 `request_llm_completion` 而非 `fetch_url`）；更新 `what-is-noj.md` / `glossary.md` 现状表述（移除"规划中"）。
 
 ## Capabilities

--- a/openspec/changes/archive/2026-08-03-capability-network/proposal.md
+++ b/openspec/changes/archive/2026-08-03-capability-network/proposal.md
@@ -1,0 +1,30 @@
+# 评测网络能力（capability-network）
+
+## Why
+
+LMCC 大模型能力评测中，用户应用（solution）可能需要与外部网络 API 交互（如 LLM 接口、检索服务）。当前评测沙箱对所有容器统一 `network_mode: none`，无法支持此类题目。需要一种**安全受控**的方式：solution 保持无网，由 evaluator 提供经注册的 capability，solution 通过 RPC 转发调用。
+
+## What Changes
+
+- **配置**：`runtime_config.evaluator.network` 新增可选对象字段（`enabled: boolean`，默认 `false`），开启后 evaluator 容器以 Docker `bridge` 模式联网；solution 容器保持 `network_mode: none` 不变。
+- **协议**：NDJSON 新增 `capability` 帧（`{"type":"capability","id","name","args":[...]}`），由 solution 发出、judge 转发至 evaluator；响应复用现有 `result/error` 帧按 `id` 匹配返回。judge 侧 `handle_eval_chunk` 需新增转发 evaluator stdout 的 `result/error` 帧。
+- **SDK**：`noj_solution_sdk` 新增 `call_capability(name, *args)`（替换现有文档占位，当前代码中不存在）；`noj_evaluator_sdk` 新增 `register_capability(name, handler)`。solution 侧 `host.py` 需从单线程 reader 重构为 reader 线程 + 单 worker 队列（避免用户函数内阻塞等待响应导致死锁）。
+- **UI**：admin 题目编辑表单（`ProblemEditor.vue`）新增「evaluator 联网」开关。
+- **文档**：做题人文档新增 capability 使用说明；出题人文档新增 `register_capability` 用法与「如何提供受限网络能力」最佳实践（封装精确函数如 `request_llm_completion` 而非 `fetch_url`）；更新 `what-is-noj.md` / `glossary.md` 现状表述（移除"规划中"）。
+
+## Capabilities
+
+### New Capabilities
+- `network-capability`: solution → evaluator 的 capability 调用协议、SDK API 与安全模型（solution 无网、evaluator 显式注册、调用边界即信任边界）
+
+### Modified Capabilities
+- `problem-runtime-config`: `runtime_config.evaluator` 增加可选 `network` 字段及其校验规则
+- `docker-sandbox`: evaluator 容器网络模式由固定 `none` 变为按配置可选 `bridge`；solution 保持 `none`
+
+## Impact
+
+- **noj-judge**：`src/types.rs`（`EvaluatorRuntime.network`）、`src/sandbox/host_config.rs`（network_mode 参数化）、`src/dual/container.rs`、`src/dual/mod.rs`（帧转发）、`src/dual/protocol.rs`（`FRAME_CAPABILITY`）、SDK 两端（`noj_solution_sdk` / `noj_evaluator_sdk`）、新 E2E binary `e2e_network_capability`。
+- **noj-core**：`src/types/index.ts`（类型）、`src/services/problems-types.ts`（`validateRuntimeConfig` 校验）。
+- **noj-ui**：`components/editor/ProblemEditor.vue`。
+- **noj-docs**：`users/`（新 capability 页面）、`problemsetters/`（solution-sdk.md / evaluator-sdk.md / 新增受限网络能力指南）、`intro/what-is-noj.md`、`reference/glossary.md`、`.vitepress/config`（侧栏注册）。
+- **安全影响**：solution 借 evaluator 网络逃逸（SSRF）风险——由「capability 显式注册 + 出题人参数校验」承担；网络层白名单代理列为文档中的未来兜底选项，本期不实现。

--- a/openspec/changes/archive/2026-08-03-capability-network/specs/docker-sandbox/spec.md
+++ b/openspec/changes/archive/2026-08-03-capability-network/specs/docker-sandbox/spec.md
@@ -1,8 +1,5 @@
-## Purpose
+## MODIFIED Requirements
 
-定义 Neuro OJ 评测沙箱的基础设施规范。no-judge 使用 Docker
-容器为每道题目创建隔离的评测环境，限制资源访问并防止恶意代码逃逸。
-## Requirements
 ### Requirement: 容器创建与配置
 
 系统 SHALL 使用 bollard 创建 Docker 容器。容器不再有池预创建：每次评测任务即时创建
@@ -53,83 +50,6 @@
 - **THEN** 返回 SystemError
 - **THEN** 错误信息包含镜像名和构建提示
 
-### Requirement: 容器执行与输出捕获
-
-系统 SHALL 通过 docker exec 在容器中执行评测命令（而非 create → start →
-run），捕获 stdout/stderr，并在超时时有序终止。
-
-#### Scenario: 正常执行
-
-- **WHEN** 文件已通过 docker exec `tar xf - -C /workspace` 注入到容器 `/workspace`
-- **WHEN** 系统通过 docker exec 执行评测命令
-- **THEN** 系统流式捕获 stdout/stderr
-- **THEN** `tokio::select!` 竞速 exec stream 与超时定时器
-
-#### Scenario: 执行超时
-
-- **WHEN** 容器内 exec 运行时间超过 `time_limit_ms + 5s`
-- **THEN** 系统先调用 `docker stop -t 2`（SIGTERM + 2s 等待）
-- **THEN** 若仍运行则 `docker kill`（SIGKILL）
-- **THEN** 捕获剩余日志输出
-
-#### Scenario: 正常退出
-
-- **WHEN** exec 内命令正常执行完毕
-- **THEN** 系统返回 stdout、stderr 和退出码
-
-#### Scenario: 非零退出
-
-- **WHEN** exec 内进程以非零退出码退出
-- **THEN** 系统保留 stdout/stderr 并标记 RuntimeError 等（由退出码映射）
-
-#### Scenario: 容器清理
-
-- **WHEN** 评测执行完毕（正常或异常）
-- **THEN** 容器按 RAII 顺序（Solution → Evaluator）被 `docker rm -f` 移除
-- **THEN** 工作目录被 `fs::remove_dir_all` 删除
-- **THEN** 无容器回补步骤（容器池已移除）
-
-### Requirement: 用户代码注入
-
-系统 SHALL 将 task.code 以 task.file_name
-为文件名写入临时目录，若文件已存在则覆盖。
-
-#### Scenario: 写入用户代码
-
-- **WHEN** 支持包已解压到临时目录
-- **THEN** 系统将 task.code 写入 `{work_dir}/{task.file_name}`
-
-#### Scenario: 覆盖已有文件
-
-- **WHEN** 支持包中包含同名的模板/示例文件
-- **THEN** 用户代码覆盖该文件
-
-### Requirement: 资源测量
-
-系统 SHALL 在评测容器执行完毕后，测量并返回执行时间和内存峰值。
-
-#### Scenario: 时间测量
-
-- **WHEN** 评测编排层执行评测命令
-- **THEN** 系统在 exec 启动前和返回后分别记录 `Instant::now()`，计算差值作为
-  `time_ms`
-- **THEN** `time_ms` 精度为毫秒（纳秒计时器读取），反映 wall-clock 时间
-
-#### Scenario: 内存峰值测量
-
-- **WHEN** exec 执行完毕
-- **THEN** 系统在容器内执行
-  `cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes`（cgroup v1）或
-  `cat /sys/fs/cgroup/memory.peak`（cgroup v2）
-- **THEN** 解析输出字节数，转换为 KB 作为 `memory_kb`
-- **WHEN** cgroup 文件不存在或读取失败
-- **THEN** `memory_kb` 设为 0，不阻塞评测结果
-
-#### Scenario: 容器未运行或已删除
-
-- **WHEN** 容器已删除导致内存读取失败
-- **THEN** `memory_kb` 设为 0，错误记录日志
-
 ### Requirement: 安全隔离
 
 系统 SHALL 确保用户代码在隔离环境中执行：
@@ -166,4 +86,3 @@ run），捕获 stdout/stderr，并在超时时有序终止。
 
 - **WHEN** 用户代码分配内存超过 memory_limit_mb
 - **THEN** Docker OOM killer 终止进程，容器退出码 137
-

--- a/openspec/changes/archive/2026-08-03-capability-network/specs/network-capability/spec.md
+++ b/openspec/changes/archive/2026-08-03-capability-network/specs/network-capability/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: capability 调用协议
+
+系统 SHALL 支持 solution 经 judge 转发调用 evaluator 注册的 capability，协议基于既有 NDJSON 帧通道。
+
+#### Scenario: solution 发起 capability 调用
+
+- **WHEN** solution 代码调用 `call_capability("http_fetch", ...)`
+- **THEN** solution 进程向 stdout 输出 `{"type":"capability","id":"<hex>","name":"<capability名>","args":[...]}` 帧
+- **THEN** judge 将帧原样转发到 evaluator stdin
+
+#### Scenario: evaluator 返回 capability 结果
+
+- **WHEN** evaluator 执行 capability handler 成功
+- **THEN** evaluator 向 stdout 输出 `{"type":"result","id":"<与请求相同的id>","value":<编码值>}` 帧
+- **THEN** judge 将 result 帧转发回 solution stdin
+- **THEN** solution 的 `call_capability` 返回解码后的值
+
+#### Scenario: capability 执行失败返回 error 帧
+
+- **WHEN** evaluator 的 capability handler 抛出异常或拒绝参数
+- **THEN** evaluator 输出 `{"type":"error","id":"<与请求相同的id>","code":"Exception"|"Rejected","message":"..."}` 帧
+- **THEN** judge 转发回 solution，`call_capability` 抛出对应异常
+
+#### Scenario: 未注册的 capability
+
+- **WHEN** solution 调用未注册的 capability 名称
+- **THEN** evaluator 输出 `{"type":"error","id":...,"code":"NotFound","message":"capability 'x' not registered"}`
+- **THEN** judge 转发回 solution，`call_capability` 抛出 `CapabilityNotFoundError`
+
+#### Scenario: judge 转发 evaluator 的 result/error 帧
+
+- **WHEN** evaluator stdout 出现 `type=result` 或 `type=error` 的协议帧
+- **THEN** judge 将其转发到 solution stdin
+- **WHEN** evaluator stdout 出现普通文本或 `---RESULT---` 标记
+- **THEN** 不转发（保持既有行为）
+
+### Requirement: solution SDK call_capability API
+
+系统 SHALL 在 `noj_solution_sdk` 提供 `call_capability(name, *args)`，供用户代码在注册函数内调用。
+
+#### Scenario: 基本调用
+
+- **WHEN** 用户代码调用 `from noj_solution_sdk import call_capability; call_capability("request_llm_completion", prompt)`
+- **THEN** 函数阻塞等待 evaluator 响应，返回解码后的结果
+
+#### Scenario: 参数类型校验
+
+- **WHEN** `args` 含不可序列化类型（自定义对象、函数等）
+- **THEN** 抛出 `RejectedError`，不发帧
+
+#### Scenario: solution 无网络能力
+
+- **WHEN** 评测沙箱中 solution 容器被配置为 `network_mode: none`
+- **THEN** solution 内任何直接网络请求（socket/urllib 等）失败
+- **THEN** solution 仅能通过 `call_capability` 间接使用网络
+
+### Requirement: evaluator SDK register_capability API
+
+系统 SHALL 在 `noj_evaluator_sdk` 提供 `register_capability(name, handler)`，供 evaluate.py 注册可被 solution 调用的能力。
+
+#### Scenario: 注册并处理调用
+
+- **WHEN** evaluate.py 调用 `register_capability("request_llm_completion", handler)`
+- **THEN** solution 的 `call_capability("request_llm_completion", ...)` 被转发到该 handler 执行
+- **THEN** handler 返回值经 codec 编码后作为 result 帧返回
+
+#### Scenario: 重复注册同名 capability
+
+- **WHEN** evaluate.py 对同一名称注册两次
+- **THEN** 第二次注册覆盖第一次（最近注册生效）
+
+#### Scenario: handler 抛异常
+
+- **WHEN** handler 执行时抛出异常
+- **THEN** evaluator 返回 error 帧（code=Exception，含截断 traceback）
+- **THEN** solution 侧抛出对应异常，评测流程不中断（evaluator 可捕获后继续）

--- a/openspec/changes/archive/2026-08-03-capability-network/specs/problem-runtime-config/spec.md
+++ b/openspec/changes/archive/2026-08-03-capability-network/specs/problem-runtime-config/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: 题目运行时配置（runtime_config）
+
+系统 SHALL 在 `problems` 表中存储 JSONB 格式的 `runtime_config`，用于描述双容器评测模式下的 Evaluator 与 Solution 各自运行时参数。
+
+#### Scenario: problems 表 runtime_config 列
+
+- **WHEN** 检查 `problems` 表结构
+- **THEN** `runtime_config` 为 JSONB NOT NULL 列（统一双容器模式，无单容器回退）
+
+#### Scenario: RuntimeConfig 结构
+
+- **WHEN** admin 设置 `runtime_config` 字段
+- **THEN** 必填结构：
+  - `evaluator.image: string`（必填，Docker 镜像名）
+  - `evaluator.command: string`（可选，缺省注入默认值 `python3 /workspace/evaluate.py`）
+  - `evaluator.time_limit_ms: number`（必填，> 0）
+  - `evaluator.memory_limit_mb: number`（必填，> 0）
+  - `evaluator.network: object`（可选，缺省视为 `{"enabled": false}`）
+  - `solution.image: string`（必填）
+  - `solution.entry: string`（必填，如 `solution.py`）
+  - `solution.call_timeout_ms: number`（必填，> 0）
+  - `solution.memory_limit_mb: number`（必填，> 0）
+
+#### Scenario: evaluator.command 缺省注入默认值
+
+- **WHEN** 导入统一题目包时 `runtime_config.evaluator.command` 缺省
+- **THEN** 系统在落库前注入默认值 `python3 /workspace/evaluate.py`
+- **THEN** 落库后的 `runtime_config.evaluator.command` 为非空字符串，结构与既有题目一致
+
+#### Scenario: API 创建/更新路径 command 必填
+
+- **WHEN** 通过题目 CRUD API 创建/更新题目且 `runtime_config.evaluator.command` 缺省
+- **THEN** 系统返回 HTTP 400（command 为必填字段；默认值注入仅限统一题目包导入路径）
+
+#### Scenario: 显式提供 command
+
+- **WHEN** `runtime_config.evaluator.command` 显式提供（如 `python3 /workspace/evaluator/main.py`）
+- **THEN** 系统保留显式值，不做默认注入
+
+## ADDED Requirements
+
+### Requirement: evaluator 网络配置
+
+系统 SHALL 支持按题目配置 evaluator 容器联网开关 `runtime_config.evaluator.network`，缺省关闭（与现状一致）。
+
+#### Scenario: network 字段缺省
+
+- **WHEN** `runtime_config.evaluator.network` 缺省或为 `null`
+- **THEN** 系统视为 `{"enabled": false}`（evaluator 无网，向后兼容）
+
+#### Scenario: network.enabled 为布尔
+
+- **WHEN** admin 设置 `runtime_config.evaluator.network`
+- **THEN** 系统校验 `enabled` 必须为布尔值
+- **WHEN** `enabled` 非布尔（字符串/数字等）
+- **THEN** 返回 HTTP 400 + 明确错误信息（如 `runtime_config.evaluator.network 必须是对象` / `runtime_config.evaluator.network.enabled 必须是布尔值`）
+
+#### Scenario: network.enabled=true 生效
+
+- **WHEN** `runtime_config.evaluator.network.enabled = true` 且提交评测
+- **THEN** judge 以 bridge 网络模式创建 evaluator 容器
+- **THEN** solution 容器仍为 `network_mode: none`

--- a/openspec/changes/archive/2026-08-03-capability-network/specs/problem-runtime-config/spec.md
+++ b/openspec/changes/archive/2026-08-03-capability-network/specs/problem-runtime-config/spec.md
@@ -11,7 +11,7 @@
 
 #### Scenario: RuntimeConfig 结构
 
-- **WHEN** admin 设置 `runtime_config` 字段
+- **WHEN** 用户设置 `runtime_config` 字段
 - **THEN** 必填结构：
   - `evaluator.image: string`（必填，Docker 镜像名）
   - `evaluator.command: string`（可选，缺省注入默认值 `python3 /workspace/evaluate.py`）
@@ -52,7 +52,7 @@
 
 #### Scenario: network.enabled 为布尔
 
-- **WHEN** admin 设置 `runtime_config.evaluator.network`
+- **WHEN** 用户设置 `runtime_config.evaluator.network`
 - **THEN** 系统校验 `enabled` 必须为布尔值
 - **WHEN** `enabled` 非布尔（字符串/数字等）
 - **THEN** 返回 HTTP 400 + 明确错误信息（如 `runtime_config.evaluator.network 必须是对象` / `runtime_config.evaluator.network.enabled 必须是布尔值`）

--- a/openspec/changes/archive/2026-08-03-capability-network/tasks.md
+++ b/openspec/changes/archive/2026-08-03-capability-network/tasks.md
@@ -1,0 +1,54 @@
+# capability-network 实施任务
+
+## 1. noj-judge 网络层与帧转发
+
+- [x] 1.1 `src/types.rs`：`EvaluatorRuntime` 增加 `network: Option<EvaluatorNetwork>`（`#[serde(default)]`，`EvaluatorNetwork { enabled: bool }`，缺省 `None` = 无网）
+- [x] 1.2 `src/sandbox/host_config.rs`：`build_host_config` 增加 `network_mode: &str` 参数（`"none"` / `"bridge"`），更新全部调用方与单元测试
+- [x] 1.3 `src/dual/container.rs`：`create_evaluator` 接收 `network_enabled: bool` 并传入 host_config（solution 恒 `none`）
+- [x] 1.4 `src/dual/protocol.rs`：增加 `FRAME_CAPABILITY: &str = "capability"` 常量
+- [x] 1.5 `src/dual/mod.rs`：`handle_eval_chunk` 新增转发 evaluator stdout 的 `result` / `error` 帧到 solution stdin（capability 响应）；保持 `call` 帧转发与 `---RESULT---` 行为不变
+- [x] 1.6 单元测试：host_config 网络参数、handle_eval_chunk 新转发分支（result/error 转发、普通文本不转发）；`cargo fmt` + `cargo clippy` 通过
+
+## 2. SDK：solution 侧
+
+- [x] 2.1 `sdk/solution/noj_solution_sdk/capability.py`（新增）：`call_capability(name, *args)` —— 帧大小校验、发 `capability` 帧、按 id 匹配 result/error、异常映射（`CapabilityNotFoundError` 等）
+- [x] 2.2 `sdk/solution/noj_solution_sdk/host.py`：重构为 reader 线程 + 单 worker 队列（call 帧投递队列顺序执行；result/error 帧按 id 匹配 pending；ready 时序、entry 加载、error 码行为不变）
+- [x] 2.3 `sdk/solution/noj_solution_sdk/__init__.py`：导出 `call_capability` 与新增错误类
+- [x] 2.4 SDK 测试：`test_host.py` 增补 call_capability 用例（成功/NotFound/参数拒绝）+ 既有行为回归
+
+## 3. SDK：evaluator 侧
+
+- [x] 3.1 `sdk/evaluator/noj_evaluator_sdk/capability.py`（新增）：`register_capability(name, handler)` + 注册表（重复注册覆盖）
+- [x] 3.2 `sdk/evaluator/noj_evaluator_sdk/runner.py`：reader 线程识别 `capability` 帧 → 查注册表 → 同步执行 handler → 写 result/error 帧（未注册 → `NotFound`）
+- [x] 3.3 `sdk/evaluator/noj_evaluator_sdk/__init__.py`：导出 `register_capability`
+- [x] 3.4 SDK 测试：`test_runner.py` 增补 register_capability 用例（成功/异常/NotFound/重复注册）
+
+## 4. noj-core 类型与校验
+
+- [x] 4.1 `src/types/index.ts`：`EvaluatorRuntime` 增加可选 `network?: { enabled: boolean }`
+- [x] 4.2 `src/services/problems-types.ts`：`validateRuntimeConfig` 校验 network（可选对象、`enabled` 必须为布尔；非法返回 `invalid_structure` 400）
+- [x] 4.3 noj-core 测试：network 缺省 / 合法 / 非法值校验用例
+
+## 5. noj-ui 题目编辑表单
+
+- [x] 5.1 `noj-ui/components/editor/ProblemEditor.vue`：新增「evaluator 联网」开关（默认关），payload 组装 `evaluator.network` 与编辑回显
+- [x] 5.2 `deno fmt` + `deno lint` 通过
+
+## 6. E2E 测试
+
+- [x] 6.1 judge E2E 新 binary `tests/e2e_network_capability.rs`（`#[ignore]` + `NOJ_RUN_E2E=1` + `#[serial_test::serial]`）：evaluator 开启联网后容器内 DNS/TCP 连通；solution 无网断言
+- [x] 6.2 同 binary：call_capability 全链路（注册 handler 返回正确值；未注册 → NotFound；handler 异常 → error 帧）
+- [x] 6.3 注册到 `Cargo.toml`（[[test]] 条目）并本地跑通
+
+## 7. 文档（noj-docs）
+
+- [x] 7.1 做题人：`docs/users/` 新增「使用 capability」页面（`call_capability` 用法、类型约束、错误语义、示例），注册到 `.vitepress` 侧栏
+- [x] 7.2 出题人：`docs/problemsetters/solution-sdk.md` 以正式 API 替换 call_capability 占位表述
+- [x] 7.3 出题人：`docs/problemsetters/evaluator-sdk.md` 增补 `register_capability` 用法
+- [x] 7.4 出题人：新增「如何提供受限网络能力」最佳实践（封装精确函数如 `request_llm_completion(prompt)` 而非 `fetch_url(url)`；参数校验、禁通用转发、禁访元数据/内网、重定向陷阱、参考示例、未来代理兜底）
+- [x] 7.5 `docs/intro/what-is-noj.md` / `docs/reference/glossary.md` 更新（移除"规划中"占位）
+
+## 8. 回归与归档
+
+- [x] 8.1 全量回归：`cargo test`（judge 单元）、SDK 测试、`deno task test`（core）、judge E2E、`deno fmt`/`deno lint`/`cargo clippy`
+- [x] 8.2 `/opsx:sync` 同步 delta specs 到主规范；`/opsx:archive` 归档（`YYYY-MM-DD-capability-network`）

--- a/openspec/specs/network-capability/spec.md
+++ b/openspec/specs/network-capability/spec.md
@@ -66,6 +66,8 @@
 
 系统 SHALL 允许具有题目创建权限的用户在题目 `runtime_config.evaluator.network` 中启用联网（`enabled=true`），不要求 admin 角色；联网权限与题目创建/编辑权限一致，不单独设限。
 
+> **设计决策**：任何人无需 admin 权限即可在自己有权限的题目内开启 evaluator 联网。开启联网等于把外部网络能力交给出题人（出题人可信边界，与可控 `evaluator.command` 同级的既有信任模型）；网络层白名单代理 / egress 过滤不在本期范围，横向移动面（ICC 互通、SSRF）由出题人文档与威胁模型显式声明。
+
 #### Scenario: 普通用户创建 U 型题目开启联网
 
 - **WHEN** 任意登录用户创建 U 型题目且 `runtime_config.evaluator.network.enabled = true`

--- a/openspec/specs/network-capability/spec.md
+++ b/openspec/specs/network-capability/spec.md
@@ -1,0 +1,113 @@
+# network-capability Specification
+
+## Purpose
+
+定义 solution → evaluator 的 capability 调用能力：protocol（capability 帧 + result/error 响应按 id 匹配）、
+`noj_solution_sdk.call_capability` / `noj_evaluator_sdk.register_capability` API 与安全模型
+（solution 容器恒无网、capability 由 evaluator 显式注册、调用边界即信任边界）。
+## Requirements
+### Requirement: capability 调用协议
+
+系统 SHALL 支持 solution 经 judge 转发调用 evaluator 注册的 capability，协议基于既有 NDJSON 帧通道。
+
+#### Scenario: solution 发起 capability 调用
+
+- **WHEN** solution 代码调用 `call_capability("http_fetch", ...)`
+- **THEN** solution 进程向 stdout 输出 `{"type":"capability","id":"<hex>","name":"<capability名>","args":[...]}` 帧
+- **THEN** judge 将帧原样转发到 evaluator stdin
+
+#### Scenario: evaluator 返回 capability 结果
+
+- **WHEN** evaluator 执行 capability handler 成功
+- **THEN** evaluator 向 stdout 输出 `{"type":"result","id":"<与请求相同的id>","value":<编码值>}` 帧
+- **THEN** judge 将 result 帧转发回 solution stdin
+- **THEN** solution 的 `call_capability` 返回解码后的值
+
+#### Scenario: capability 执行失败返回 error 帧
+
+- **WHEN** evaluator 的 capability handler 抛出异常或拒绝参数
+- **THEN** evaluator 输出 `{"type":"error","id":"<与请求相同的id>","code":"Exception"|"Rejected","message":"..."}` 帧
+- **THEN** judge 转发回 solution，`call_capability` 抛出对应异常
+
+#### Scenario: 未注册的 capability
+
+- **WHEN** solution 调用未注册的 capability 名称
+- **THEN** evaluator 输出 `{"type":"error","id":...,"code":"NotFound","message":"capability 'x' not registered"}`
+- **THEN** judge 转发回 solution，`call_capability` 抛出 `CapabilityNotFoundError`
+
+#### Scenario: judge 转发 evaluator 的 result/error 帧
+
+- **WHEN** evaluator stdout 出现 `type=result` 或 `type=error` 的协议帧
+- **THEN** judge 将其转发到 solution stdin
+- **WHEN** evaluator stdout 出现普通文本或 `---RESULT---` 标记
+- **THEN** 不转发（保持既有行为）
+
+### Requirement: solution SDK call_capability API
+
+系统 SHALL 在 `noj_solution_sdk` 提供 `call_capability(name, *args)`，供用户代码在注册函数内调用。
+
+#### Scenario: 基本调用
+
+- **WHEN** 用户代码调用 `from noj_solution_sdk import call_capability; call_capability("request_llm_completion", prompt)`
+- **THEN** 函数阻塞等待 evaluator 响应，返回解码后的结果
+
+#### Scenario: 参数类型校验
+
+- **WHEN** `args` 含不可序列化类型（自定义对象、函数等）
+- **THEN** 抛出 `CapabilityRejectedError`（公共 API，可被用户捕获），不发帧
+
+#### Scenario: solution 无网络能力
+
+- **WHEN** 评测沙箱中 solution 容器被配置为 `network_mode: none`
+- **THEN** solution 内任何直接网络请求（socket/urllib 等）失败
+- **THEN** solution 仅能通过 `call_capability` 间接使用网络
+
+### Requirement: evaluator 联网启用权限
+
+系统 SHALL 允许具有题目创建权限的用户在题目 `runtime_config.evaluator.network` 中启用联网（`enabled=true`），不要求 admin 角色；联网权限与题目创建/编辑权限一致，不单独设限。
+
+#### Scenario: 普通用户创建 U 型题目开启联网
+
+- **WHEN** 任意登录用户创建 U 型题目且 `runtime_config.evaluator.network.enabled = true`
+- **THEN** 题目创建成功，评测时 evaluator 容器以 bridge 模式联网（solution 容器仍为 `network_mode: none`）
+
+#### Scenario: 管理员创建 P 型题目开启联网
+
+- **WHEN** admin 创建 P 型题目且 `runtime_config.evaluator.network.enabled = true`
+- **THEN** 题目创建成功
+
+#### Scenario: 普通用户创建 P 型题目开启联网
+
+- **WHEN** 非 admin 创建 P 型题目（即使带联网配置）
+- **THEN** 创建被拒绝（沿用 P 型仅 admin 的创建权限，与联网配置无关）
+
+#### Scenario: 编辑既有题目开启/关闭联网
+
+- **WHEN** 用户编辑题目并在 `runtime_config` 中变更 `evaluator.network.enabled`
+- **THEN** 仅当该用户对题目有编辑权限时生效（U 型 owner/admin、P 型 admin），否则拒绝
+
+#### Scenario: 题目包导入开启联网
+
+- **WHEN** 用户通过题目包导入创建题目且 `manifest.runtime_config.evaluator.network.enabled = true`
+- **THEN** 与直接创建同权限语义：普通用户导入创建 U 型题可开启，P 型仅 admin
+
+### Requirement: evaluator SDK register_capability API
+
+系统 SHALL 在 `noj_evaluator_sdk` 提供 `register_capability(name, handler)`，供 evaluate.py 注册可被 solution 调用的能力。
+
+#### Scenario: 注册并处理调用
+
+- **WHEN** evaluate.py 调用 `register_capability("request_llm_completion", handler)`
+- **THEN** solution 的 `call_capability("request_llm_completion", ...)` 被转发到该 handler 执行
+- **THEN** handler 返回值经 codec 编码后作为 result 帧返回
+
+#### Scenario: 重复注册同名 capability
+
+- **WHEN** evaluate.py 对同一名称注册两次
+- **THEN** 第二次注册覆盖第一次（最近注册生效）
+
+#### Scenario: handler 抛异常
+
+- **WHEN** handler 执行时抛出异常
+- **THEN** evaluator 返回 error 帧（code=Exception，含截断 traceback）
+- **THEN** solution 侧抛出对应异常，评测流程不中断（evaluator 可捕获后继续）

--- a/openspec/specs/problem-runtime-config/spec.md
+++ b/openspec/specs/problem-runtime-config/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 定义题目双容器评测运行时配置（`runtime_config`）的规范。该 JSONB 字段存储 Evaluator 与 Solution 容器的运行时参数，支持按题目独立配置双容器评测环境。
-
 ## Requirements
-
 ### Requirement: 题目运行时配置（runtime_config）
 
 系统 SHALL 在 `problems` 表中存储 JSONB 格式的 `runtime_config`，用于描述双容器评测模式下的 Evaluator 与 Solution 各自运行时参数。
@@ -21,6 +19,7 @@
   - `evaluator.command: string`（可选，缺省注入默认值 `python3 /workspace/evaluate.py`）
   - `evaluator.time_limit_ms: number`（必填，> 0）
   - `evaluator.memory_limit_mb: number`（必填，> 0）
+  - `evaluator.network: object`（可选，缺省视为 `{"enabled": false}`）
   - `solution.image: string`（必填）
   - `solution.entry: string`（必填，如 `solution.py`）
   - `solution.call_timeout_ms: number`（必填，> 0）
@@ -145,3 +144,25 @@
 - **WHEN** 用户查询题目列表
 - **THEN** 列表项不包含 `runtime_config` 字段（避免列表响应过大）
 - **THEN** 仅返回基础元数据（id / display_id / title / difficulty 等）
+
+### Requirement: evaluator 网络配置
+
+系统 SHALL 支持按题目配置 evaluator 容器联网开关 `runtime_config.evaluator.network`，缺省关闭（与现状一致）。
+
+#### Scenario: network 字段缺省
+
+- **WHEN** `runtime_config.evaluator.network` 缺省或为 `null`
+- **THEN** 系统视为 `{"enabled": false}`（evaluator 无网，向后兼容）
+
+#### Scenario: network.enabled 为布尔
+
+- **WHEN** admin 设置 `runtime_config.evaluator.network`
+- **THEN** 系统校验 `enabled` 必须为布尔值
+- **WHEN** `enabled` 非布尔（字符串/数字等）
+- **THEN** 返回 HTTP 400 + 明确错误信息（如 `runtime_config.evaluator.network 必须是对象` / `runtime_config.evaluator.network.enabled 必须是布尔值`）
+
+#### Scenario: network.enabled=true 生效
+
+- **WHEN** `runtime_config.evaluator.network.enabled = true` 且提交评测
+- **THEN** judge 以 bridge 网络模式创建 evaluator 容器
+- **THEN** solution 容器仍为 `network_mode: none`

--- a/openspec/specs/problem-runtime-config/spec.md
+++ b/openspec/specs/problem-runtime-config/spec.md
@@ -13,7 +13,7 @@
 
 #### Scenario: RuntimeConfig 结构
 
-- **WHEN** admin 设置 `runtime_config` 字段
+- **WHEN** 用户设置 `runtime_config` 字段
 - **THEN** 必填结构：
   - `evaluator.image: string`（必填，Docker 镜像名）
   - `evaluator.command: string`（可选，缺省注入默认值 `python3 /workspace/evaluate.py`）
@@ -65,10 +65,11 @@
 - **WHEN** admin 发送 `PUT /api/v1/admin/problems/:id`，payload 含 `runtime_config: null`
 - **THEN** 系统返回 HTTP 400（runtime_config 是必填字段，不可清空；统一双容器模式，无单容器回退路径）
 
-#### Scenario: 普通用户创建题目不允许双容器配置
+#### Scenario: 普通用户创建 U 型题目可配置双容器
 
 - **WHEN** 普通用户（role='user'）发送 `POST /api/v1/problems`，payload 含 `runtime_config`
-- **THEN** 系统返回 HTTP 403，提示仅 admin 可配置双容器评测
+- **THEN** 系统按题目类型校验：U 型放行（联网与双容器配置权限与题目创建权限一致，不要求 admin），P 型拒绝（仅 admin 可创建 P 型）
+- **THEN** evaluator 联网门禁与创建/编辑权限一致，不单独设限（设计决策：任何人可对自己题目开启 evaluator 联网）
 
 ### Requirement: 提交流程统一使用双容器路径
 
@@ -156,7 +157,7 @@
 
 #### Scenario: network.enabled 为布尔
 
-- **WHEN** admin 设置 `runtime_config.evaluator.network`
+- **WHEN** 用户设置 `runtime_config.evaluator.network`
 - **THEN** 系统校验 `enabled` 必须为布尔值
 - **WHEN** `enabled` 非布尔（字符串/数字等）
 - **THEN** 返回 HTTP 400 + 明确错误信息（如 `runtime_config.evaluator.network 必须是对象` / `runtime_config.evaluator.network.enabled 必须是布尔值`）


### PR DESCRIPTION
## 变更内容

实现 issue #197：允许 evaluator 联网，solution 通过 RPC 转发（call_capability）。

- **noj-judge**：`runtime_config.evaluator.network.enabled` 控制 evaluator 以 bridge 模式联网（缺省无网，向后兼容）；solution 容器恒 `network_mode: none`；新增 `capability` NDJSON 帧协议（solution → judge → evaluator），`result/error` 帧按 id 匹配返回；`LineParser` 4 MiB 缓冲上限与评测输出 1 MiB 累积上限（防恶意输出拖垮 judge）
- **SDK**：`noj_solution_sdk.call_capability(name, *args)`（host.py 重构为 reader + worker 双线程，避免阻塞死锁）；`noj_evaluator_sdk.register_capability(name, handler)`（错误 trace/message 清洗防路径泄露、返回值类型校验、1 MiB 帧限制、encode 前大小预检）
- **noj-core**：`EvaluatorRuntime.network` 类型与 `validateRuntimeConfig` 校验；**联网门禁与题目创建权限一致（设计决策）**——任何人无需 admin 权限即可在自己有权限的题目内开启 evaluator 联网，P 型题目沿用仅 admin 创建的限制；网络层白名单代理 / egress 过滤不在本期范围（出题人文档与威胁模型已声明横向移动面）
- **noj-ui**：题目编辑器新增「允许 Evaluator 联网」开关
- **文档**：做题人「使用 capability」；出题人「如何提供受限网络能力」（封装精确函数如 `request_llm_completion` 而非 `fetch_url`、SSRF 陷阱、安全清单）
- **测试**：`e2e_network_capability`（bridge/none 网络对比、capability 成功/NotFound/handler 异常闭环）；core 门禁测试；CI（e2e.yml）纳入新 binary
- **OpenSpec**：变更归档 `2026-08-03-capability-network`，主规范同步（新增 `network-capability` spec；`problem-runtime-config` 中联网表述统一为「与题目创建权限一致」）

## 评审响应（PR #206 review #4844235252）

- **F1（阻塞，方案 A）**：确认「任何人无需 admin 权限即可在自己题目内开启 evaluator 联网」为**设计决策**（与题目创建权限一致，非疏漏）。PR 描述 / commit message / spec（含归档 delta）已统一表述；`openspec/specs/network-capability/spec.md` 显式记录该决策与安全边界。白名单代理不处理（见 F5）
- **F2**：`noj_evaluator_sdk` 新增 `estimate_frame_size` 递归大小预算（短路、不复制），capability 返回值在 `encode_value`（base64 膨胀 ~1.33×）之前预检，超大对象直接回 Rejected 而非先吃满内存
- **F3**：handler 异常 `message` 与 `trace` 同样净化（绝对路径 basename 化 + 1 KiB 截断），`str(e)` 不再原始透传给 solution
- **F4**：host.py `SIGTERM`/`SIGINT` handler 先 `_shutdown_all()` 唤醒 pending 并给 worker 放哨兵再退出——原 `sys.exit(0)` 会等待非 daemon worker 线程导致进程挂起（测试实际暴露该 bug）；补测试锁定「SIGTERM → 退出码 0、无 hang」
- **F5**：白名单代理 / egress 过滤**不在本期范围**——全量联网为 v1 设计决策，ICC 互通 / SSRF 横向移动面已在出题人文档与威胁模型中显式声明，留待后续独立 issue 评估

## 验证

- judge：96 单元测试 + clippy 无警告 + E2E 4 新用例 + 既有 8 用例无回归
- SDK：evaluator 44 + solution 25 用例全过（含本次新增的大小预算、message 净化、SIGTERM 退出用例）
- core：27 用例（problems + problem-bundle，含门禁测试）+ 全量 631 用例无回归
- security_review 两轮：修复 LineParser 缓冲上限、评测输出上限后放行；联网权限与题目创建权限一致（设计决策，spec 显式记录）

Closes #197
