### PR TITLE
feat(judge): 调用级超时：call_timeout_ms 支持按调用指定（issue #198）

### DIFF
--- a/docs/superpowers/plans/2026-08-04-call-timeout-per-call.md
+++ b/docs/superpowers/plans/2026-08-04-call-timeout-per-call.md
@@ -1,0 +1,1265 @@
+# 调用级超时（call_timeout_ms → RPC / Evaluator SDK 调用参数）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `runner.call(..., timeout_ms)` 与 capability 注册默认值控制单次调用的超时（judge 侧 in-flight 追踪 + tokio 参数化超时），缺省回退题目级 `runtime_config.solution.call_timeout_ms`。
+
+**Architecture:** Judge Worker 的 dual 主循环从"双向透明转发"改为"感知帧类型 + in-flight 超时追踪"：Evaluator 的 call 帧 / Solution 的 capability 帧登记 deadline（`InFlightTracker`），响应帧按 id 命中判定，超时向等待方写 `code="Timeout"` 错误帧并丢弃迟到响应。Evaluator SDK 的 `call()` 增加可选 `timeout_ms`，`register_capability()` 增加可选 `timeout_ms` 并经一次性 `cap_reg` 帧上报 judge。
+
+**Tech Stack:** Rust（tokio / serde_json，`noj-judge`）、Python（`noj_evaluator_sdk` / `noj_solution_sdk`）、TypeScript（noj-tests E2E）、Deno。
+
+## Global Constraints
+
+- 设计规格：`docs/superpowers/specs/2026-08-04-call-timeout-per-call-design.md`（已批准）
+- 超时计时起点：judge 收到帧的时刻（Evaluator call 帧 / Solution capability 帧）
+- `timeout_ms` 规则：正整数生效；缺省 / 0 / 负数 / 非数字 → 回退题目级默认 `runtime_config.solution.call_timeout_ms`
+- 超时错误帧：`{"type":"error","id":"<id>","code":"Timeout","message":"..."}`；Evaluator SDK 侧抛 `SolutionTimeoutError`（已存在）
+- 迟到响应丢弃：已超时 id 的响应不再转发；warn/debug 限频日志
+- `cap_reg` 帧是 judge 与 evaluator 的私有协议，**不转发**给 Solution Host
+- 向后兼容：旧 SDK / 旧题目零改动（可选字段 + 默认回退）；不新增协议版本字段
+- 保持 evaluator `time_limit_ms` 外层兜底不变
+- 提交规范：Conventional Commits，description 中文，GPG 签名；`cargo fmt` / `cargo clippy` 通过
+- 新模块必须 `cargo fmt` 后提交；测试文件遵循既有模式（`#[cfg(test)]` / `#[ignore]` + `NOJ_RUN_E2E=1` 守卫）
+
+---
+
+### Task 1: InFlightTracker 纯逻辑模块（tracker.rs）
+
+**Files:**
+- Create: `noj-judge/src/dual/tracker.rs`
+- Modify: `noj-judge/src/dual/mod.rs`（追加 `mod tracker;` 与 `pub use tracker::...`，供 tests 引用）
+- Test: `noj-judge/src/dual/tracker.rs`（`#[cfg(test)] mod tests` 内）
+
+**Interfaces:**
+- Produces（后续 Task 3 消费）：
+  - `pub enum WaitingSide { Evaluator, Solution }`
+  - `pub struct InFlightTracker`
+  - `InFlightTracker::new(default_call_timeout_ms: u64) -> Self`
+  - `on_call_frame(&mut self, frame: &Value, now: Instant) -> Option<(String, u64)>`（无 id 返回 None）
+  - `on_cap_reg_frame(&mut self, frame: &Value)`（`timeout_ms` 缺省/非法 → 删除映射）
+  - `on_capability_frame(&mut self, frame: &Value, now: Instant) -> Option<(String, u64)>`
+  - `resolve_response(&mut self, id: &str) -> bool`
+  - `expire_now(&mut self, now: Instant) -> Vec<(String, WaitingSide)>`
+  - `next_deadline(&self) -> Option<Instant>`
+  - `is_empty(&self) -> bool`
+
+- [ ] **Step 1: 在 mod.rs 声明子模块（先写最小骨架以编译）**
+
+```rust
+// noj-judge/src/dual/mod.rs 顶部（现有 use 之后）
+pub mod tracker;
+```
+
+（此时 tracker.rs 不存在会编译失败——Step 2 立即创建。）
+
+- [ ] **Step 2: 创建 tracker.rs 并先写测试**
+
+创建 `noj-judge/src/dual/tracker.rs`，先只写测试（`#[cfg(test)] mod tests`），再跑测试确认失败（`cannot find struct InFlightTracker` 编译错误即可）：
+
+```rust
+//! 调用级超时追踪（judge 侧 RPC 超时实现，纯逻辑、零容器依赖）。
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use serde_json::{json, Value};
+
+/// 调用等待方向：决定超时错误帧写给谁。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitingSide {
+    Evaluator, // evaluator 等 solution（runner.call）
+    Solution,  // solution 等 evaluator（capability 调用）
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call_frame(id: &str, timeout_ms: Option<u64>) -> Value {
+        let mut f = json!({"type": "call", "id": id, "fn": "solve", "args": []});
+        if let Some(t) = timeout_ms {
+            f["timeout_ms"] = json!(t);
+        }
+        f
+    }
+
+    #[test]
+    fn test_new_uses_default_timeout() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let (id, ms) = t.on_call_frame(&call_frame("a", None), now).unwrap();
+        assert_eq!(id, "a");
+        assert_eq!(ms, 2000);
+    }
+
+    #[test]
+    fn test_call_frame_explicit_timeout_wins() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let (_, ms) = t.on_call_frame(&call_frame("b", Some(500)), now).unwrap();
+        assert_eq!(ms, 500);
+    }
+
+    #[test]
+    fn test_call_frame_invalid_timeout_falls_back() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let f = json!({"type": "call", "id": "c", "fn": "solve", "args": [], "timeout_ms": 0});
+        let (_, ms) = t.on_call_frame(&f, now).unwrap();
+        assert_eq!(ms, 2000);
+        let f2 = json!({"type": "call", "id": "d", "fn": "solve", "args": [], "timeout_ms": -1});
+        let (_, ms2) = t.on_call_frame(&f2, now).unwrap();
+        assert_eq!(ms2, 2000);
+    }
+
+    #[test]
+    fn test_call_frame_missing_id_returns_none() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let f = json!({"type": "call", "fn": "solve", "args": []});
+        assert!(t.on_call_frame(&f, now).is_none());
+    }
+
+    #[test]
+    fn test_capability_uses_registered_timeout() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping", "timeout_ms": 9000}));
+        let f = json!({"type": "capability", "id": "cap-1", "name": "ping", "args": []});
+        let (_, ms) = t.on_capability_frame(&f, now).unwrap();
+        assert_eq!(ms, 9000);
+    }
+
+    #[test]
+    fn test_capability_falls_back_when_not_registered() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let f = json!({"type": "capability", "id": "cap-2", "name": "unknown", "args": []});
+        let (_, ms) = t.on_capability_frame(&f, now).unwrap();
+        assert_eq!(ms, 2000);
+    }
+
+    #[test]
+    fn test_cap_reg_re_registration_overwrites_and_none_deletes() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping", "timeout_ms": 9000}));
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping", "timeout_ms": 1000}));
+        let f = json!({"type": "capability", "id": "cap-3", "name": "ping", "args": []});
+        assert_eq!(t.on_capability_frame(&f, now).unwrap().1, 1000);
+        // timeout_ms 缺省 → 删除映射，回退默认
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping"}));
+        let f2 = json!({"type": "capability", "id": "cap-4", "name": "ping", "args": []});
+        assert_eq!(t.on_capability_frame(&f2, now).unwrap().1, 2000);
+    }
+
+    #[test]
+    fn test_resolve_response_hit_removes_and_returns_true() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_call_frame(&call_frame("r1", None), now).unwrap();
+        assert!(t.resolve_response("r1"));
+        assert!(!t.resolve_response("r1"), "已移除，二次命中应为 false");
+    }
+
+    #[test]
+    fn test_resolve_response_unknown_false() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        assert!(!t.resolve_response("ghost"));
+    }
+
+    #[test]
+    fn test_expire_now_returns_expired_and_removes() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_call_frame(&call_frame("fast", Some(10)), now).unwrap();
+        t.on_call_frame(&call_frame("slow", Some(10_000)), now).unwrap();
+        // fast 的 deadline 在 11ms 之后
+        let expired = t.expire_now(now + Duration::from_millis(11));
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].0, "fast");
+        assert_eq!(expired[0].1, WaitingSide::Evaluator);
+        assert!(!t.is_empty(), "slow 仍在 in-flight");
+        // slow 的 deadline 之后全部过期
+        let expired2 = t.expire_now(now + Duration::from_millis(10_001));
+        assert_eq!(expired2.len(), 1);
+        assert_eq!(expired2[0].0, "slow");
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn test_capability_expire_side_is_solution() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping", "timeout_ms": 10}));
+        let f = json!({"type": "capability", "id": "cap-x", "name": "ping", "args": []});
+        t.on_capability_frame(&f, now).unwrap();
+        let expired = t.expire_now(now + Duration::from_millis(11));
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].1, WaitingSide::Solution);
+    }
+
+    #[test]
+    fn test_next_deadline_min_and_empty() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        assert!(t.next_deadline().is_none());
+        t.on_call_frame(&call_frame("x", Some(100)), now).unwrap();
+        t.on_call_frame(&call_frame("y", Some(50)), now).unwrap();
+        let d = t.next_deadline().unwrap();
+        assert_eq!(d, now + Duration::from_millis(50));
+    }
+
+    #[test]
+    fn test_concurrent_calls_have_independent_deadlines() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_call_frame(&call_frame("c1", Some(30)), now).unwrap();
+        t.on_call_frame(&call_frame("c2", Some(200)), now).unwrap();
+        // 30ms 时只有 c1 过期
+        let e1 = t.expire_now(now + Duration::from_millis(30));
+        assert_eq!(e1.len(), 1);
+        assert_eq!(e1[0].0, "c1");
+        // c2 仍可正常命中
+        assert!(t.resolve_response("c2"));
+    }
+}
+```
+
+- [ ] **Step 3: 运行测试确认失败**
+
+Run: `cd noj-judge && cargo test --lib dual::tracker 2>&1 | tail -5`
+Expected: 编译错误（`cannot find struct InFlightTracker`）——测试先行。
+
+- [ ] **Step 4: 实现 InFlightTracker**
+
+在 `tracker.rs` 的测试上方补实现（替换 Step 2 的骨架）：
+
+```rust
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use serde_json::Value;
+
+/// 调用等待方向：决定超时错误帧写给谁。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitingSide {
+    /// evaluator 等 solution（runner.call）
+    Evaluator,
+    /// solution 等 evaluator（capability 调用）
+    Solution,
+}
+
+/// 单次 in-flight 调用的超时信息。
+#[derive(Debug, Clone)]
+struct InFlightEntry {
+    deadline: Instant,
+    waiting: WaitingSide,
+}
+
+/// 调用级超时追踪器。
+#[derive(Debug)]
+pub struct InFlightTracker {
+    inflight: HashMap<String, InFlightEntry>,
+    cap_timeouts: HashMap<String, u64>,
+    default_call_timeout_ms: u64,
+}
+
+impl InFlightTracker {
+    /// 以题目级默认超时创建追踪器。
+    pub fn new(default_call_timeout_ms: u64) -> Self {
+        Self {
+            inflight: HashMap::new(),
+            cap_timeouts: HashMap::new(),
+            default_call_timeout_ms,
+        }
+    }
+
+    /// 从帧中读取 timeout_ms（正整数才生效，否则回退默认）。
+    fn resolve_timeout(&self, frame: &Value) -> u64 {
+        frame
+            .get("timeout_ms")
+            .and_then(Value::as_u64)
+            .filter(|&t| t > 0)
+            .unwrap_or(self.default_call_timeout_ms)
+    }
+
+    /// 处理 evaluator 的 call 帧：登记 deadline，返回 (call_id, 生效超时)。
+    /// 无 id 的帧返回 None（调用方照常转发，不追踪）。
+    pub fn on_call_frame(&mut self, frame: &Value, now: Instant) -> Option<(String, u64)> {
+        let id = frame.get("id").and_then(Value::as_str)?.to_string();
+        let timeout_ms = self.resolve_timeout(frame);
+        self.inflight.insert(
+            id.clone(),
+            InFlightEntry {
+                deadline: now + Duration::from_millis(timeout_ms),
+                waiting: WaitingSide::Evaluator,
+            },
+        );
+        Some((id, timeout_ms))
+    }
+
+    /// 处理 evaluator 的 cap_reg 帧：timeout_ms 为正 → 更新映射；否则删除映射。
+    pub fn on_cap_reg_frame(&mut self, frame: &Value) {
+        let Some(name) = frame.get("name").and_then(Value::as_str) else {
+            return;
+        };
+        match frame.get("timeout_ms").and_then(Value::as_u64).filter(|&t| t > 0) {
+            Some(ms) => {
+                self.cap_timeouts.insert(name.to_string(), ms);
+            }
+            None => {
+                self.cap_timeouts.remove(name);
+            }
+        }
+    }
+
+    /// 处理 solution 的 capability 帧：查映射→默认，登记 deadline，返回 (id, 生效超时)。
+    pub fn on_capability_frame(&mut self, frame: &Value, now: Instant) -> Option<(String, u64)> {
+        let id = frame.get("id").and_then(Value::as_str)?.to_string();
+        let name = frame.get("name").and_then(Value::as_str).unwrap_or("");
+        let timeout_ms = self
+            .cap_timeouts
+            .get(name)
+            .copied()
+            .unwrap_or(self.default_call_timeout_ms);
+        self.inflight.insert(
+            id.clone(),
+            InFlightEntry {
+                deadline: now + Duration::from_millis(timeout_ms),
+                waiting: WaitingSide::Solution,
+            },
+        );
+        Some((id, timeout_ms))
+    }
+
+    /// 响应帧按 id 判定：命中（尚在 in-flight）→ 移除并返回 true（转发）；否则 false（丢弃）。
+    pub fn resolve_response(&mut self, id: &str) -> bool {
+        self.inflight.remove(id).is_some()
+    }
+
+    /// 摘除所有已超时调用，返回 (id, 等待方向) 列表。
+    pub fn expire_now(&mut self, now: Instant) -> Vec<(String, WaitingSide)> {
+        let expired: Vec<(String, InFlightEntry)> = self
+            .inflight
+            .iter()
+            .filter(|(_, e)| e.deadline <= now)
+            .map(|(id, e)| (id.clone(), e.clone()))
+            .collect();
+        let mut out = Vec::with_capacity(expired.len());
+        for (id, e) in expired {
+            self.inflight.remove(&id);
+            out.push((id, e.waiting));
+        }
+        out
+    }
+
+    /// 当前最早 deadline（无 in-flight 返回 None）。
+    pub fn next_deadline(&self) -> Option<Instant> {
+        self.inflight.values().map(|e| e.deadline).min()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inflight.is_empty()
+    }
+}
+```
+
+（保留 Step 2 的全部测试，在文件末尾 `#[cfg(test)] mod tests { ... }`。）
+
+- [ ] **Step 5: 运行测试确认通过**
+
+Run: `cd noj-judge && cargo test --lib dual::tracker`
+Expected: 全部通过（11 个测试）。随后 `cargo clippy --lib` 无警告。
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd noj-judge && cargo fmt && cd ..
+jj describe -m "feat(judge): 新增调用级超时追踪器 InFlightTracker（issue #198）"
+```
+
+---
+
+### Task 2: Evaluator SDK 扩展（call timeout_ms + register_capability cap_reg 帧）
+
+**Files:**
+- Modify: `noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py`（`SolutionRunner.call`）
+- Modify: `noj-judge/sdk/evaluator/noj_evaluator_sdk/capability.py`（`register_capability`）
+- Test: `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py`
+
+**Interfaces:**
+- Produces（Task 3/5/6 消费）：
+  - `SolutionRunner.call(self, fn: str, *args: Any, timeout_ms: Optional[int] = None) -> Any`
+    - `timeout_ms` 为 `None` → call 帧不带 `timeout_ms` 字段；正整数 → 帧带该字段；其他值 → `raise ValueError`
+  - `register_capability(name: str, handler: Callable, timeout_ms: Optional[int] = None) -> None`
+    - `timeout_ms` 非 None 时校验正整数，随后写一次性 `{"type":"cap_reg","name":...,"timeout_ms":...}` 帧到 stdout；`timeout_ms=None` 写 `{"type":"cap_reg","name":...}`（无 timeout_ms 字段）
+
+- [ ] **Step 1: 先写 SDK 测试（在 test_runner.py 追加）**
+
+在 `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py` 的 `TestSolutionRunnerCall` 中追加（参照现有 `test_basic_call_returns_value` 的 IpcHarness 用法）：
+
+```python
+def test_call_frame_with_timeout_ms(self):
+    """指定 timeout_ms 时 call 帧应带该字段。"""
+    harness = IpcHarness()
+    try:
+        def runner():
+            harness.runner.call("solve", 1, timeout_ms=5000)
+        t = threading.Thread(target=runner)
+        t.start()
+        frame = harness.last_call_frame()
+        self.assertEqual(frame.get("timeout_ms"), 5000)
+        harness.send_host_response(
+            {"type": "result", "id": frame["id"], "value": 3}
+        )
+        t.join(timeout=2.0)
+        self.assertFalse(t.is_alive(), "call 应已返回")
+    finally:
+        harness.teardown()
+
+def test_call_frame_without_timeout_ms(self):
+    """缺省 timeout_ms 时 call 帧不应带该字段（向后兼容）。"""
+    harness = IpcHarness()
+    try:
+        def runner():
+            harness.runner.call("solve", 1)
+        t = threading.Thread(target=runner)
+        t.start()
+        frame = harness.last_call_frame()
+        self.assertNotIn("timeout_ms", frame)
+        harness.send_host_response(
+            {"type": "result", "id": frame["id"], "value": 3}
+        )
+        t.join(timeout=2.0)
+    finally:
+        harness.teardown()
+
+def test_call_invalid_timeout_ms_raises(self):
+    """timeout_ms 为 0 / 负数 / 非 int 时抛 ValueError。"""
+    harness = IpcHarness()
+    try:
+        for bad in (0, -1, "5000"):
+            with self.assertRaises(ValueError):
+                harness.runner.call("solve", 1, timeout_ms=bad)
+        # 非法值不应发出 call 帧
+        self.assertEqual(len(harness.all_call_frames()), 0)
+    finally:
+        harness.teardown()
+```
+
+在 `TestCapability` 中追加：
+
+```python
+def test_register_capability_with_timeout_emits_cap_reg(self):
+    """注册时配置 timeout_ms → stdout 写 cap_reg 帧。"""
+    from noj_evaluator_sdk import register_capability
+    harness = IpcHarness()
+    try:
+        register_capability("ping", lambda x: x, timeout_ms=9000)
+        frames = harness.all_call_frames()
+        reg = [f for f in frames if f.get("type") == "cap_reg"]
+        self.assertEqual(len(reg), 1)
+        self.assertEqual(reg[0]["name"], "ping")
+        self.assertEqual(reg[0]["timeout_ms"], 9000)
+    finally:
+        harness.teardown()
+
+def test_register_capability_without_timeout_emits_cap_reg_no_field(self):
+    from noj_evaluator_sdk import register_capability
+    harness = IpcHarness()
+    try:
+        register_capability("ping2", lambda x: x)
+        frames = harness.all_call_frames()
+        reg = [f for f in frames if f.get("type") == "cap_reg"]
+        self.assertEqual(len(reg), 1)
+        self.assertEqual(reg[0]["name"], "ping2")
+        self.assertNotIn("timeout_ms", reg[0])
+    finally:
+        harness.teardown()
+
+def test_register_capability_invalid_timeout_raises(self):
+    from noj_evaluator_sdk import register_capability
+    with self.assertRaises(ValueError):
+        register_capability("bad", lambda x: x, timeout_ms=0)
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-judge/sdk/evaluator && python3 -m unittest noj_evaluator_sdk.tests.test_runner -v 2>&1 | tail -15`
+Expected: 新测试因 `TypeError: call() got an unexpected keyword argument 'timeout_ms'` / `register_capability() got an unexpected keyword argument` 失败。
+
+- [ ] **Step 3: 扩展 runner.py 的 call()**
+
+```python
+    def call(self, fn: str, *args: Any, timeout_ms: Optional[int] = None) -> Any:
+        """调用 Solution host 中的函数 `fn`。
+
+        `timeout_ms`：本次调用的超时（毫秒），None = 由 judge 回退题目级默认；
+        正整数 = 按调用指定。0 / 负数 / 非 int 抛 ValueError。
+
+        抛出：
+            SolutionTimeoutError  - 单次调用超时（host 进程仍存活）
+            NotFoundError         - 函数未注册
+            RejectedError         - 参数/返回值类型不允许
+            ConnectionError       - IPC 通道断开（host 进程崩溃）
+            SystemError           - 其他 host 内部错误
+        """
+        if self._closed:
+            raise ConnectionError("runner 已关闭")
+
+        # 0. timeout_ms 校验（None 或正整数）
+        if timeout_ms is not None:
+            if not isinstance(timeout_ms, int) or timeout_ms <= 0:
+                raise ValueError(
+                    f"timeout_ms 必须是正整数或 None，实际 {timeout_ms!r}"
+                )
+
+        # 1. 参数校验
+        for i, arg in enumerate(args):
+            validate_type(arg, f"arg[{i}]")
+
+        # 2. 构造 call 帧
+        call_id = uuid.uuid4().hex
+        frame = {
+            "type": "call",
+            "id": call_id,
+            "fn": fn,
+            "args": [encode_value(a) for a in args],
+        }
+        if timeout_ms is not None:
+            frame["timeout_ms"] = timeout_ms
+```
+
+（其余逻辑不变；注意现有第 102-155 行的 `call` 方法体，仅替换签名 + 增加校验 + 帧构造。）
+
+- [ ] **Step 4: 扩展 capability.py 的 register_capability()**
+
+```python
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from typing import Any, Callable, Optional
+
+_CAPABILITIES: dict[str, Callable] = {}
+_LOCK = threading.RLock()
+_OUT_LOCK = threading.Lock()
+
+
+def register_capability(
+    name: str, handler: Callable, timeout_ms: Optional[int] = None
+) -> None:
+    """注册 capability。
+
+    重复注册同名时覆盖（最近注册生效）。
+
+    `timeout_ms`：solution 调用该 capability 时的默认超时（毫秒）；
+    None = judge 回退题目级 call_timeout_ms。注册时写一次性
+    `cap_reg` 帧上报 judge（judge 侧私有协议，不转发给 solution）。
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise TypeError(f"capability 名称必须是非空字符串，实际 {type(name).__name__}")
+    if not callable(handler):
+        raise TypeError(f"handler 必须是 callable，实际 {type(handler).__name__}")
+    if timeout_ms is not None and (
+        not isinstance(timeout_ms, int) or timeout_ms <= 0
+    ):
+        raise ValueError(
+            f"timeout_ms 必须是正整数或 None，实际 {timeout_ms!r}"
+        )
+    with _LOCK:
+        _CAPABILITIES[name] = handler
+    # 上报 judge（一次性 cap_reg 帧）
+    frame = {"type": "cap_reg", "name": name}
+    if timeout_ms is not None:
+        frame["timeout_ms"] = timeout_ms
+    line = json.dumps(frame, ensure_ascii=False, separators=(",", ":"))
+    with _OUT_LOCK:
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+```
+
+- [ ] **Step 5: 运行 SDK 测试确认通过**
+
+Run: `cd noj-judge/sdk/evaluator && python3 -m unittest noj_evaluator_sdk.tests.test_runner -v 2>&1 | tail -15`
+Expected: 全部通过（含新增 7 个测试）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd noj-judge && cargo fmt -- sdk 2>/dev/null; cd ..
+jj describe -m "feat(judge): Evaluator SDK 支持调用级 timeout_ms 与 cap_reg 上报（issue #198）"
+```
+
+---
+
+### Task 3: dual/mod.rs 执行层接入（超时感知转发）
+
+**Files:**
+- Modify: `noj-judge/src/dual/mod.rs`（`run_dual_loop`、`handle_eval_chunk`、`handle_sol_chunk`、mod_test_helpers）
+- Test: `noj-judge/src/dual/mod.rs` 的 `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: `crate::dual::tracker::{InFlightTracker, WaitingSide}`（Task 1）
+- Produces:
+  - `run_dual_loop(submission_id, evaluator_exec, solution_exec, evaluator_timeout_ms, default_call_timeout_ms: u64, rejudge_seq)` —— `_call_timeout_ms` 参数改名并实际生效
+  - `handle_eval_chunk(parser, stderr_buf, stdout_full, sol_input, result_payload, tracker, chunk)` —— 新增 `sol_input` 与 `tracker` 参数
+  - `handle_sol_chunk(parser, eval_input, chunk, solution_ready, tracker)` —— 新增 `tracker` 参数
+  - 超时错误帧写入辅助 `write_timeout_frame(writer, id)` → `{"type":"error","id":id,"code":"Timeout","message":"call timeout"}`
+
+- [ ] **Step 1: 先写失败测试（追加到 mod.rs 的 tests）**
+
+```rust
+#[tokio::test]
+async fn test_eval_call_frame_tracked_and_forwarded() {
+    // call 帧：登记 in-flight 并转发到 sol_input
+    use bollard::container::LogOutput;
+    use tokio::io::AsyncReadExt;
+    use crate::dual::tracker::InFlightTracker;
+
+    let (sink, mut source) = tokio::io::duplex(8192);
+    let mut writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+        Box::pin(sink);
+
+    let mut parser = LineParser::new();
+    let mut stderr_buf = String::new();
+    let mut stdout_full = String::new();
+    let mut result_payload: Option<String> = None;
+    let mut tracker = InFlightTracker::new(2000);
+
+    let chunk = LogOutput::StdOut {
+        message: bytes::Bytes::from_static(
+            b"{\"type\":\"call\",\"id\":\"c1\",\"fn\":\"solve\",\"args\":[1],\"timeout_ms\":500}\n",
+        ),
+    };
+    handle_eval_chunk(
+        &mut parser,
+        &mut stderr_buf,
+        &mut stdout_full,
+        &mut writer,
+        &mut result_payload,
+        &mut tracker,
+        chunk,
+    )
+    .await
+    .unwrap();
+
+    // 转发到 sol_input
+    let mut buf = [0u8; 4096];
+    let n = tokio::time::timeout(Duration::from_secs(2), source.read(&mut buf))
+        .await
+        .expect("读取转发内容超时")
+        .unwrap();
+    let text = String::from_utf8_lossy(&buf[..n]).to_string();
+    assert!(text.contains("\"type\":\"call\""));
+    assert!(text.contains("\"timeout_ms\":500"), "帧应原样透传");
+
+    // in-flight 已登记：响应命中可转发、超时后可摘除
+    assert!(tracker.resolve_response("c1"), "c1 应被追踪");
+}
+
+#[tokio::test]
+async fn test_eval_cap_reg_frame_not_forwarded() {
+    use bollard::container::LogOutput;
+    use tokio::io::AsyncReadExt;
+    use crate::dual::tracker::InFlightTracker;
+
+    let (sink, mut source) = tokio::io::duplex(8192);
+    let mut writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+        Box::pin(sink);
+
+    let mut parser = LineParser::new();
+    let mut stderr_buf = String::new();
+    let mut stdout_full = String::new();
+    let mut result_payload: Option<String> = None;
+    let mut tracker = InFlightTracker::new(2000);
+
+    let chunk = LogOutput::StdOut {
+        message: bytes::Bytes::from_static(
+            b"{\"type\":\"cap_reg\",\"name\":\"ping\",\"timeout_ms\":9000}\n",
+        ),
+    };
+    handle_eval_chunk(
+        &mut parser, &mut stderr_buf, &mut stdout_full,
+        &mut writer, &mut result_payload, &mut tracker, chunk,
+    )
+    .await
+    .unwrap();
+
+    // cap_reg 帧不转发
+    let mut buf = [0u8; 4096];
+    let n = tokio::time::timeout(Duration::from_secs(1), source.read(&mut buf))
+        .await
+        .expect("读取转发内容超时")
+        .unwrap();
+    let text = String::from_utf8_lossy(&buf[..n]).to_string();
+    assert!(!text.contains("cap_reg"), "cap_reg 帧不应转发到 solution");
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-judge && cargo test --lib dual:: 2>&1 | tail -8`
+Expected: 编译错误（`handle_eval_chunk` 签名不匹配 / 缺少参数）。
+
+- [ ] **Step 3: 改造 handle_eval_chunk / handle_sol_chunk / run_dual_loop**
+
+**handle_eval_chunk**（替换现有实现，注意签名新增 `sol_input` 与 `tracker`）：
+
+```rust
+/// 处理 Evaluator exec 的一个 chunk：解析 + 转发 call 帧 + 检测 RESULT 标记。
+#[allow(clippy::too_many_arguments)]
+async fn handle_eval_chunk(
+    parser: &mut LineParser,
+    stderr_buf: &mut String,
+    stdout_full: &mut String,
+    sol_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+    result_payload: &mut Option<String>,
+    tracker: &mut InFlightTracker,
+    chunk: LogOutput,
+) -> Result<()> {
+    let (data, is_err) = match chunk {
+        LogOutput::StdOut { message } => (message, false),
+        LogOutput::StdErr { message } => (message, true),
+        _ => return Ok(()),
+    };
+
+    if is_err {
+        let s = String::from_utf8_lossy(&data);
+        append_capped(stderr_buf, &s);
+        eprint!("[eval-stderr] {}", s);
+        return Ok(());
+    }
+
+    // stdout: feed 到 LineParser
+    let lines = parser.feed(&data);
+    let mut awaiting_result_payload = false;
+    for line in lines {
+        match line {
+            EvaluatorLine::ResultMarker => {
+                awaiting_result_payload = true;
+                append_capped(stdout_full, "---RESULT---\n");
+            }
+            EvaluatorLine::Frame(v) => {
+                // 协议帧处理：call / cap_reg 私有帧 / result-error（capability 响应）
+                let ft = frame_type(&v).map(|s| s.to_string());
+                match ft.as_deref() {
+                    Some("call") => {
+                        // 登记调用级超时（缺省回退题目级默认），原样转发
+                        tracker.on_call_frame(&v, Instant::now());
+                        forward_frame(sol_input, &v).await?;
+                    }
+                    Some("cap_reg") => {
+                        // judge 与 evaluator 的私有协议：更新映射，不转发
+                        tracker.on_cap_reg_frame(&v);
+                    }
+                    Some("result") | Some("error") => {
+                        // capability 响应帧（solution 等待）：命中则转发，否则丢弃
+                        if let Some(id) = v.get("id").and_then(Value::as_str) {
+                            if tracker.resolve_response(id) {
+                                forward_frame(sol_input, &v).await?;
+                            } else {
+                                warn!("丢弃迟到的 evaluator 响应帧（id={}）", id);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                // 记录所有帧到 stdout 全文（供结果展示）
+                let s = v.to_string();
+                append_capped(stdout_full, &s);
+                append_capped(stdout_full, "\n");
+            }
+            EvaluatorLine::Unknown(s) => {
+                // 普通 evaluate.py 输出，丢弃
+                append_capped(stdout_full, &s);
+                append_capped(stdout_full, "\n");
+                if awaiting_result_payload && !s.trim().is_empty() {
+                    *result_payload = Some(s.trim().to_string());
+                    awaiting_result_payload = false;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+**handle_sol_chunk**（替换现有实现，签名新增 `tracker`）：
+
+```rust
+/// 处理 Solution exec 的一个 chunk：转发 NDJSON 帧到 evaluator stdin。
+async fn handle_sol_chunk(
+    parser: &mut LineParser,
+    eval_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+    chunk: LogOutput,
+    solution_ready: &mut bool,
+    tracker: &mut InFlightTracker,
+) -> Result<()> {
+    let data = match chunk {
+        LogOutput::StdOut { message } => message,
+        LogOutput::StdErr { message } => {
+            let s = String::from_utf8_lossy(&message);
+            eprint!("[sol-stderr] {}", s);
+            return Ok(());
+        }
+        _ => return Ok(()),
+    };
+
+    let lines = parser.feed(&data);
+    for line in lines {
+        if let EvaluatorLine::Frame(v) = line {
+            let ft = frame_type(&v).map(|s| s.to_string());
+            if !*solution_ready {
+                if ft.as_deref() == Some("ready") {
+                    *solution_ready = true;
+                }
+                // ready 之前的所有帧忽略（防御）
+                continue;
+            }
+            match ft.as_deref() {
+                Some("capability") => {
+                    // solution 请求 capability：查注册超时登记后转发 evaluator
+                    tracker.on_capability_frame(&v, Instant::now());
+                    forward_frame(eval_input, &v).await?;
+                }
+                Some("result") | Some("error") => {
+                    // call 响应帧（evaluator 等待）：命中则转发，否则丢弃（迟到）
+                    if let Some(id) = v.get("id").and_then(Value::as_str) {
+                        if tracker.resolve_response(id) {
+                            forward_frame(eval_input, &v).await?;
+                        } else {
+                            warn!("丢弃迟到的 solution 响应帧（id={}）", id);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+**run_dual_loop**（签名 `_call_timeout_ms: u64` 改名为 `default_call_timeout_ms: u64` 并实际使用；两阶段 select 都加超时分支）：
+
+```rust
+/// 主循环：双向 NDJSON 转发 + 解析 Evaluator 输出。
+#[allow(clippy::too_many_arguments)]
+async fn run_dual_loop(
+    submission_id: &str,
+    evaluator_exec: ExecSession,
+    solution_exec: ExecSession,
+    evaluator_timeout_ms: u64,
+    default_call_timeout_ms: u64,
+    rejudge_seq: Option<i64>,
+) -> Result<JudgeResult> {
+    // ... 解构 exec（不变）...
+    let mut eval_parser = LineParser::new();
+    let mut eval_stderr_buf = String::new();
+    let mut eval_stdout_full = String::new();
+    let mut sol_parser = LineParser::new();
+    let mut solution_ready = false;
+    let mut result_payload: Option<String> = None;
+    let mut tracker = InFlightTracker::new(default_call_timeout_ms);
+
+    // 阶段 1 与阶段 2 复用：处理超时到期的 in-flight 调用
+    //（写 Timeout 错误帧到等待方，并丢弃迟到响应）
+    let mut handle_expired = |eval_input: &mut _, sol_input: &mut _| {
+        // 每次 select 返回后调用；先摘除超时调用再写帧
+    };
+
+    // 阶段 1：启动等待（原逻辑），select 增加超时分支：
+    //   _ = wait_until_deadline(&tracker) => {
+    //       for (id, side) in tracker.expire_now(Instant::now()) {
+    //           write_timeout_frame(match side { Evaluator => &mut eval_input, Solution => &mut sol_input }, &id).await?;
+    //       }
+    //   }
+    // 阶段 2：正式评测，同样加入上述超时分支（其余逻辑不变）
+    // ...
+}
+```
+
+超时分支的精确写法（两个阶段各插入到 `tokio::select!` 中）：
+
+```rust
+                // 调用级超时（in-flight 到期）
+                _ = async {
+                    match tracker.next_deadline() {
+                        Some(d) => tokio::time::sleep_until(d).await,
+                        None => std::future::pending::<()>().await,
+                    }
+                } => {
+                    for (id, side) in tracker.expire_now(Instant::now()) {
+                        match side {
+                            WaitingSide::Evaluator => {
+                                write_timeout_frame(&mut eval_input, &id).await?;
+                            }
+                            WaitingSide::Solution => {
+                                write_timeout_frame(&mut sol_input, &id).await?;
+                            }
+                        }
+                    }
+                }
+```
+
+新增辅助函数：
+
+```rust
+/// 向等待方写调用级超时错误帧。
+async fn write_timeout_frame(
+    writer: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+    id: &str,
+) -> Result<()> {
+    let frame = serde_json::json!({
+        "type": "error",
+        "id": id,
+        "code": "Timeout",
+        "message": "call timeout",
+    });
+    forward_frame(writer, &frame).await
+}
+```
+
+**调用处**（`evaluate_dual` 末尾）：`runtime_config.solution.call_timeout_ms` 传入 `run_dual_loop` 的 `default_call_timeout_ms`（原 `_call_timeout_ms` 参数位置）。mod_test_helpers 中两个 probe 函数签名同步更新（新增 tracker 参数）。
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-judge && cargo test --lib dual:: && cargo clippy --lib`
+Expected: Task 1 与新增测试全部通过，clippy 无警告（注意 `evaluate_dual` 调用处与 mod_test_helpers 的签名同步）。
+
+- [ ] **Step 5: 全量单元测试 + fmt**
+
+Run: `cd noj-judge && cargo fmt && cargo test --all-targets`
+Expected: 全部通过。
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd noj-judge && cargo fmt
+cd ..
+jj describe -m "feat(judge): dual 主循环接入调用级超时（in-flight 追踪 + Timeout 错误帧）（issue #198）"
+```
+
+---
+
+### Task 4: judge E2E（真实容器并发调用不同超时 + 缺省回退）
+
+**Files:**
+- Modify: `noj-judge/tests/e2e_dual_container.rs`
+- Test: 同一文件新增 `#[ignore]` + `#[serial_test::serial]` + `#[tokio::test]` 测试
+
+**Interfaces:**
+- Consumes: `evaluate_dual`（Task 3 改造后）、`common::ensure_test_image`、既有 helper（`create_sleep_container` / `get_docker` / `is_e2e_enabled`）
+
+- [ ] **Step 1: 新增 E2E 测试（两个用例，追加到 e2e_dual_container.rs）**
+
+用例 A（缺省回退）：evaluator 脚本调用 `runner.call("sleep_solution", timeout_ms=None)`，solution 侧 `time.sleep(0.3)`，题目级 `call_timeout_ms=100` → 断言结果含 `CallTimeout` 失败用例、评测继续、最终 `Accepted`。
+
+用例 B（调用级覆盖 + 并发）：evaluator 脚本两个线程并发调用：
+- 线程 1：`runner.call("sleep_solution", timeout_ms=50)`（solution `time.sleep(0.3)`）→ 应超时
+- 线程 2：`runner.call("fast_solution", timeout_ms=5000)`（立即返回）→ 应成功
+断言线程 1 抛 `SolutionTimeoutError`、线程 2 正常返回；最终结果 `Accepted`。
+
+参考既有 `evaluate_dual_end_to_end`（613 行）的结构：`is_e2e_enabled()` 守卫 → `get_docker()` → `common::ensure_test_image()` → 构造 `RuntimeConfig`（evaluator command 为 `python3 -c "..."` 内联脚本，solution 为真实 host）→ 调用 `evaluate_dual(...)` → 断言 `JudgeResult`。
+
+```rust
+/// 缺省回退：call 帧不带 timeout_ms 时，题目级 call_timeout_ms 生效。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_call_timeout_fallback_to_problem_default() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    // evaluator：调用 sleep 函数，不带 timeout_ms（期望回退题目级 100ms）
+    let evaluator_cmd = r#"python3 -c "
+import sys, json
+from noj_evaluator_sdk import SolutionRunner, result
+runner = SolutionRunner()
+try:
+    runner.call('sleep_solution')
+    result.accept(score=1000, details={'cases': [{'id':'c1','status':'Accepted'}]})
+except Exception as e:
+    result.accept(score=0, details={'cases': [{'id':'c1','status': type(e).__name__}]})
+sys.stdout.write('---RESULT---\n')
+sys.stdout.flush()
+""#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-judge-test-runner:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 15000,
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-judge-test-runner:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 100,   // 题目级默认：100ms
+            memory_limit_mb: 128,
+        },
+    };
+    // solution 代码：sleep_solution 睡 300ms
+    let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\n";
+
+    let result = evaluate_dual(
+        docker.clone(),
+        "e2e-timeout-fallback",
+        &runtime_config,
+        code,
+        "solution.py",
+        None,
+        "",
+        0,
+        0,
+        None,
+    )
+    .await
+    .expect("评测应正常返回");
+
+    assert_eq!(result.status, "Accepted");
+    let cases = result.details["cases"].as_array().expect("details.cases");
+    assert_eq!(cases[0]["status"].as_str().unwrap(), "SolutionTimeoutError");
+}
+```
+
+```rust
+/// 调用级超时 + 并发：同题两个线程不同超时，各自独立生效。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_call_timeout_per_call_concurrent() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_test_image(&docker).await.unwrap();
+
+    let evaluator_cmd = r#"python3 -c "
+import sys, json, threading
+from noj_evaluator_sdk import SolutionRunner, result
+runner = SolutionRunner()
+out = {}
+def slow():
+    try:
+        runner.call('sleep_solution', timeout_ms=50)   # 50ms 超时 vs 300ms 睡眠
+        out['slow'] = 'ok'
+    except Exception as e:
+        out['slow'] = type(e).__name__
+def fast():
+    try:
+        v = runner.call('fast_solution', timeout_ms=5000)  # 立即返回
+        out['fast'] = ('ok', v)
+    except Exception as e:
+        out['fast'] = type(e).__name__
+t1 = threading.Thread(target=slow); t2 = threading.Thread(target=fast)
+t1.start(); t2.start(); t1.join(); t2.join()
+result.accept(score=1000, details={'cases': out})
+sys.stdout.write('---RESULT---\n')
+sys.stdout.flush()
+""#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-judge-test-runner:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 15000,
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-judge-test-runner:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 5000,   // 题目级默认宽松；验证调用级 50ms 覆盖
+            memory_limit_mb: 128,
+        },
+    };
+    let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\ndef fast_solution():\n    return 42\n";
+
+    let result = evaluate_dual(
+        docker.clone(),
+        "e2e-timeout-per-call",
+        &runtime_config,
+        code,
+        "solution.py",
+        None,
+        "",
+        0,
+        0,
+        None,
+    )
+    .await
+    .expect("评测应正常返回");
+
+    assert_eq!(result.status, "Accepted");
+    let cases = result.details["cases"].as_object().expect("details.cases");
+    assert_eq!(cases["slow"].as_str().unwrap(), "SolutionTimeoutError");
+    assert_eq!(cases["fast"].as_array().unwrap(), &vec![serde_json::json!("ok"), serde_json::json!(42)]);
+}
+```
+
+> 注：`evaluate_dual` 的确切参数个数以当前 `judge/runner.rs` 为准（`docker, submission_id, runtime_config, user_code, file_name, support_pkg, cache_dir, cache_max_items, cache_max_mb, rejudge_seq`）；执行时按真实签名核对。
+
+- [ ] **Step 2: 编译检查**
+
+Run: `cd noj-judge && cargo check --tests`
+Expected: 编译通过（测试为 `#[ignore]`，不会默认执行）。
+
+- [ ] **Step 3: 运行 E2E（需要 Docker daemon）**
+
+Run: `cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_call_timeout -- --ignored --nocapture`
+Expected: 两个用例通过（各容器内 `SolutionTimeoutError` 断言成立）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd noj-judge && cargo fmt
+cd ..
+jj describe -m "test(judge): 调用级超时 E2E（缺省回退 + 并发不同超时）（issue #198）"
+```
+
+---
+
+### Task 5: noj-tests 全链路 E2E
+
+**Files:**
+- Create: `noj-tests/e2e/26_call_timeout.test.ts`（参照 `15_dual_container_judge.test.ts` 的模式与 helper）
+- Test: 同上
+
+**Interfaces:**
+- Consumes: noj-tests helper（`15_dual_container_judge.test.ts` 中使用的创建题目/提交/轮询提交状态的函数，直接复用同目录模式）
+- Produces: 验证 issue #198 端到端行为（API 层题目 runtime_config + judge 调用级超时）
+
+- [ ] **Step 1: 新建 26_call_timeout.test.ts**
+
+参照 `15_dual_container_judge.test.ts` 的既有结构（Deno.test + helper.ts 的登录/建题/提交/轮询），完整骨架：
+
+```typescript
+/**
+ * 调用级超时（issue #198）全链路 E2E：
+ * - 调用级 timeout_ms 覆盖题目级默认（慢调用按调用超时）
+ * - 缺省时回退题目级 call_timeout_ms（兼容旧行为）
+ */
+import { assertEquals, assert } from "jsr:@std/assert";
+
+// 参照 15_dual_container_judge.test.ts 顶部：helper.ts 的
+// loginAs / createProblem / submitCode / waitSubmission 等既有导出（按实际调整）
+
+Deno.test("call_timeout: 调用级 timeout_ms 生效，慢调用记为失败用例且评测继续", async () => {
+  // 1) admin 登录并创建双容器题目（P 型），evaluator command 内联：
+  //    runner.call('sleep_solution', timeout_ms=100)；solution 睡 0.3s
+  //    evaluate.py 捕获异常记 details 后 result.accept
+  //    参考 15 号文件第 110-186 行（admin 建题含 runtime_config 的写法）
+  // 2) 提交用户代码（solution.py 定义 sleep_solution: time.sleep(0.3); return 1）
+  // 3) 轮询提交状态至终态，断言：
+  //    - status === "Accepted"（评测继续完成）
+  //    - details.cases[0].status === "SolutionTimeoutError"（超时用例被捕获记录）
+});
+
+Deno.test("call_timeout: 缺省回退题目级 call_timeout_ms", async () => {
+  // 同上，但 evaluate.py 不传 timeout_ms，题目级 call_timeout_ms 设为 100
+  // 断言结果同上（SolutionTimeoutError）
+});
+```
+
+执行时：
+- evaluator command 用 `python3 -c "..."` 内联（与 Task 4 用例 A/B 相同脚本逻辑），或支持包方式（`problems:build`）——**优先内联 command 以最小依赖**；
+- 轮询断言参考 `15_dual_container_judge.test.ts` 中"普通用户提交双容器题目 → 走 dual 评测"用例（330 行起）；
+- `runtime_config.solution.call_timeout_ms` 与 `timeout_ms` 覆盖值按上面用例写死。
+
+- [ ] **Step 2: 本地运行确认通过**
+
+Run: `cd noj-tests && deno task test --filter call_timeout`
+Expected: 两个用例通过。若本机无完整评测栈（PG/Redis/judge），说明需在 CI `e2e.yml` 全链路环境运行——本地至少保证 `deno check` 通过。
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd noj-tests && deno fmt
+cd ..
+jj describe -m "test(core,judge): 调用级超时全链路 E2E（issue #198）"
+```
+
+---
+
+### Task 6: 文档与注释同步
+
+**Files:**
+- Modify: `noj-docs/docs/problemsetters/evaluator-sdk.md`
+- Modify: `noj-docs/docs/problemsetters/rpc.md`
+- Modify: `noj-docs/docs/problemsetters/web-editor.md`
+- Modify: `noj-core/src/types/index.ts`（`SolutionRuntime.call_timeout_ms` 注释）
+- Modify: `noj-core/src/services/problems-types.ts`（校验错误消息/注释说明默认值角色）
+
+- [ ] **Step 1: evaluator-sdk.md**
+
+在"调用用户函数"节补充：
+
+```markdown
+`runner.call()` 支持**调用级超时**：`timeout_ms` 为正整数时该次调用按指定毫秒数计时，缺省（`None`）时由 Judge Worker 回退到题目的 `runtime_config.solution.call_timeout_ms`。
+
+```python
+answer = runner.call("solve", 1, 2)                    # 用题目级默认超时
+answer = runner.call("solve", 1, 2, timeout_ms=5000)   # 本次调用 5s 超时
+```
+
+`timeout_ms` 必须为正整数或 `None`，其他值抛 `ValueError`。超时后抛 `SolutionTimeoutError`，可捕获后记为失败用例继续评测。
+```
+
+在"注册 capability"节补充 `timeout_ms` 默认值语义：
+
+```markdown
+`register_capability(name, handler, timeout_ms=None)`：`timeout_ms` 为正整数时，solution 每次调用该 capability 的超时按此值（经 `cap_reg` 帧上报 Judge）；缺省时回退题目级 `call_timeout_ms`。
+```
+
+- [ ] **Step 2: rpc.md**
+
+- "调用请求"节：call 帧 JSON 示例与字段表增加 `timeout_ms`（可选，正整数；缺省由 Judge 回退题目级 `call_timeout_ms`；该字段仅 Judge 计时用，不传给 Solution Host 执行逻辑）；
+- "错误响应"节错误来源表：`CallTimeout` 行更新为"单次调用超过调用级 timeout_ms 或题目级 call_timeout_ms"；
+- 新增小节说明 `cap_reg` 帧（Evaluator → Judge 私有协议，不转发）：`{"type":"cap_reg","name":...,"timeout_ms":...}`，`timeout_ms` 缺省表示删除映射回退默认。
+
+- [ ] **Step 3: web-editor.md**
+
+第 26-28 行说明更新：
+
+```markdown
+- **Solution**（用户代码 `solution.py`）：调用超时 `call_timeout_ms`（**题目级默认值**，出题人可在 `evaluate.py` 中用 `runner.call(..., timeout_ms=...)` 按调用覆盖）、`memory_limit_mb`
+```
+
+并补充一句：调用级超时缺省时回退该默认值，防止用户代码死循环拖垮整场评测（见[评测模型](judge-model.md)）。
+
+- [ ] **Step 4: noj-core 注释同步**
+
+`noj-core/src/types/index.ts`：
+
+```typescript
+  /** 单次 SDK 调用的时间上限（毫秒），作为调用级超时的默认值（runner.call 可传 timeout_ms 覆盖）。单次超时不影响 host 进程 */
+  call_timeout_ms: number;
+```
+
+`noj-core/src/services/problems-types.ts:136` 错误消息不变（仍是必填正整数），在 `s` 解构上方加注释：
+
+```typescript
+  // call_timeout_ms：题目级默认调用超时；evaluator 的 runner.call(..., timeout_ms) 可按调用覆盖
+```
+
+- [ ] **Step 5: 自查 + 提交**
+
+对照设计规格第"文档同步"节逐项核对，随后：
+
+```bash
+cd noj-core && deno fmt --check src/types/index.ts src/services/problems-types.ts
+cd ..
+jj describe -m "docs(root,core): 同步调用级超时文档与注释（issue #198）"
+```
+
+---
+
+## Self-Review 记录
+
+- **Spec 覆盖**：SDK 签名扩展 → Task 2；RPC 帧 timeout_ms + cap_reg → Task 2/3；Judge 参数化 tokio 超时 → Task 1/3；缺省回退 → Task 1（resolve_timeout）/3；capability 注册默认值 → Task 2/3；迟到响应丢弃 → Task 3（resolve_response 未命中丢弃）；文档同步 → Task 6；测试（并发不同超时 / 缺省回退）→ Task 4/5。全部覆盖。
+- **占位符扫描**：各步骤含真实代码与命令；evaluator 内联脚本为完整可执行 Python。
+- **类型一致性**：`InFlightTracker` 方法签名在 Task 1 定义、Task 3 消费，`WaitingSide` 两处一致；`handle_eval_chunk` / `handle_sol_chunk` 新参数名在 Task 3 内一致；`evaluate_dual` 签名以真实代码为准已注明。

--- a/docs/superpowers/specs/2026-08-04-call-timeout-per-call-design.md
+++ b/docs/superpowers/specs/2026-08-04-call-timeout-per-call-design.md
@@ -1,0 +1,152 @@
+# 调用级超时（call_timeout_ms → RPC / Evaluator SDK 调用参数）设计
+
+> 关联 issue：[#198 将 call_timeout_ms 从固定运行时配置改为 RPC / Evaluator SDK 调用参数](https://github.com/Neuro-OJ/neuro-oj/issues/198)
+> 日期：2026-08-04
+> 状态：已批准（brainstorming 流程）
+
+## 背景与目标
+
+当前 `call_timeout_ms` 是题目 `runtime_config.solution` 的**固定值**，同一道题的所有 `runner.call()` 共用同一个超时。不同用例耗时差异可能很大（简单用例毫秒级、复杂推理用例数十秒），固定值要么频繁误杀、要么整体放大风险窗口。
+
+**目标**：
+
+1. `runner.call(..., timeout_ms: int | None)`：Evaluator SDK 每次调用可**按调用指定超时**；
+2. RPC call 帧增加 `timeout_ms` 字段，未指定时由 Judge Worker 回退到 `runtime_config.solution.call_timeout_ms`（向后兼容，题目级配置保留为**默认值**）；
+3. 超时结果语义不变：`CallTimeout`（SDK 侧 `SolutionTimeoutError`）可被 evaluator 记为失败用例继续评测；
+4. capability 反向调用（Solution → Evaluator）同样纳入超时，但采用**注册 capability 时配置的默认值**（`register_capability(name, handler, timeout_ms=None)`，经一次性 `cap_reg` 帧上报 Judge）。
+
+## 现状分析（代码位置）
+
+| 位置 | 现状 |
+|------|------|
+| `noj-core/src/services/problems-types.ts:121` | `runtime_config.solution.call_timeout_ms` 必须为正整数（校验保留） |
+| `noj-judge/src/types.rs` | `SolutionRuntime.call_timeout_ms` 反序列化（保留） |
+| `noj-judge/src/dual/mod.rs` | **关键：`run_dual_loop` 的 `_call_timeout_ms` 参数带下划线前缀，实际未使用**——调用级超时当前完全未实现，judge 仅双向透明转发帧 |
+| `noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py` | `runner.call(fn, *args)` 无超时参数，SDK 阻塞等响应（注释明确"超时由 judge 端 call_timeout_ms 控制"） |
+| `noj-judge/sdk/evaluator/noj_evaluator_sdk/errors.py` | `SolutionTimeoutError` 已存在（错误码 `Timeout`），但 judge 从不生成该错误 |
+| `noj-judge/sdk/solution/noj_solution_sdk/host.py` | Solution host 单 worker 顺序执行 call 帧；capability handler 在 reader 线程同步执行 |
+| 文档 | `rpc.md` / `evaluator-sdk.md` / `web-editor.md` 已描述 `CallTimeout` 语义，但实现缺失 |
+
+**重要发现**：本次变更实际上会让调用级超时**首次真正生效**。此前用户函数死循环只能靠 evaluator 总超时（`time_limit_ms`）兜底；此后会被调用级超时打断（记为一个失败调用，评测继续）。
+
+## 已确认的设计决策
+
+1. **计时起点**：从 Judge 收到 call 帧的时刻起算（语义 = evaluator 等待本次调用的总时间）。Solution Host 单 worker 顺序执行，并发 call 排队时间计入超时——排队过久触发的超时同样记为 `CallTimeout` 失败用例，不中断整体评测。
+2. **capability 超时值来源**：`register_capability` 注册时配置的默认值，经 `cap_reg` 帧一次性上报 Judge；缺省回退题目级 `call_timeout_ms`。Solution 调用侧不指定超时。
+3. **协议兼容**：`timeout_ms` 为 call 帧可选字段，旧 SDK 不发送 → Judge 回退题目级默认，天然向后兼容，无需新增协议版本字段。
+4. **错误语义沿用**：超时错误帧 `{"type":"error","id":...,"code":"Timeout","message":"..."}` → SDK 抛 `SolutionTimeoutError`（已存在），evaluator 可 try/except 记为失败用例继续评测。
+5. **迟到响应丢弃**：已超时的 call_id 标记丢弃，Solution 仍在执行的函数结果不再转发回等待方。
+
+## 协议设计
+
+### call 帧（Evaluator → Judge → Solution）
+
+新增可选字段 `timeout_ms`：
+
+```json
+{"type":"call","id":"<uuid>","fn":"solve","args":[1,2],"timeout_ms":5000}
+```
+
+- 缺省 / 非正整数 → Judge 回退题目级 `runtime_config.solution.call_timeout_ms`
+- Judge 转发给 Solution 的帧**原样透传**（含 timeout_ms；host 只读 `id`/`fn`/`args`，多余字段天然忽略，无需改动 host.py）
+
+### cap_reg 帧（Evaluator → Judge，一次性注册上报，新增）
+
+```json
+{"type":"cap_reg","name":"request_llm_completion","timeout_ms":10000}
+```
+
+- `register_capability(name, handler, timeout_ms=None)` 时由 SDK 发出
+- `timeout_ms=None` → 不注册映射（该 capability 走题目级默认）
+- 重复注册同名：最近一次生效（与现有语义一致）
+- **cap_reg 帧不转发**给 Solution（Judge 与 Evaluator 的私有协议）
+
+### capability 帧（Solution → Judge → Evaluator）
+
+帧本身不加 `timeout_ms`；Judge 查注册映射计时，缺省回退题目级默认。超时 → Judge 向 Solution 写 `{"type":"error","id":<cap_id>,"code":"Timeout","message":"..."}`。
+
+### Evaluator SDK 签名
+
+```python
+def call(self, fn: str, *args: Any, timeout_ms: Optional[int] = None) -> Any
+```
+
+- `None` → 帧不带字段；正整数 → 帧带字段；其他（0 / 负数 / 非 int）→ 抛 `ValueError`（SDK 侧校验）
+
+```python
+def register_capability(name: str, handler: Callable, timeout_ms: Optional[int] = None) -> None
+```
+
+- `timeout_ms` 非 None → 注册映射并发出 `cap_reg` 帧
+
+## Judge Worker 执行层设计
+
+新模块 `noj-judge/src/dual/tracker.rs`（**纯逻辑，零容器依赖**，便于单元测试）：
+
+```rust
+struct InFlightTracker {
+    inflight: HashMap<String, u64>,          // call_id → 超时 deadline（时刻戳）
+    cap_timeouts: HashMap<String, u64>,      // capability name → timeout_ms（cap_reg 上报）
+    default_call_timeout_ms: u64,            // 题目级默认
+}
+```
+
+方法：
+
+| 方法 | 行为 |
+|------|------|
+| `on_call_frame(frame)` | 解析 `timeout_ms`（字段 → 否则默认；非法 → 回退默认），登记 deadline，返回 `(id, timeout_ms)` |
+| `on_cap_reg_frame(frame)` | 更新（timeout_ms 存在）或删除（timeout_ms=None）映射 |
+| `on_capability_frame(frame)` | 查映射 → 题目级默认，登记 deadline |
+| `resolve_response(id)` | 命中且未超时 → `true`（转发）；未命中 / 已超时 → `false`（丢弃） |
+| `expire_now(now)` | 返回已过 deadline 的 id 列表（调用方据此发超时帧并移除） |
+
+### run_dual_loop 改造（dual/mod.rs）
+
+从"双向透明转发"改为"感知帧类型 + in-flight 管理"：
+
+| 收到 | 动作 |
+|------|------|
+| Evaluator call 帧 | tracker 登记 → 原帧转发 Solution |
+| Evaluator cap_reg 帧 | 更新映射（**不转发**） |
+| Evaluator capability 帧 | 查映射登记 → 转发 Solution |
+| Solution result/error 帧 | `resolve_response(id)` 命中 → 转发 Evaluator；否则丢弃（warn 限频日志） |
+| Evaluator result/error 帧 | 同上（capability 响应方向，命中 → 转发 Solution） |
+
+超时检测：主循环 `tokio::select!` 增加 `tokio::time::sleep_until(最早 deadline)` 分支；触发后对每个过期 id 向等待方写 `{"type":"error","id":...,"code":"Timeout","message":"call timeout after N ms"}`，并从 in_flight 移除。无 in-flight 时该分支立即返回不阻塞（保持现有循环语义）。
+
+注意：`classify_line`（protocol.rs）已把任何含 `type` 字段的 JSON 行归为 `Frame`，`cap_reg` 帧无需改动解析层。
+
+## 错误处理与边界
+
+- **超时错误帧**：call 超时 → Evaluator 收 `code="Timeout"` 错误帧 → SDK 抛 `SolutionTimeoutError`；capability 超时 → Solution 收同构错误帧 → solution SDK 抛错（其 pending 尚在，正常分发）。两种都可被调用方捕获记为失败用例。
+- **迟到响应丢弃**：已超时 id 的响应不再转发，warn 限频日志（防刷屏）。
+- **校验防御**：恶意帧 `timeout_ms` 非法 → 回退题目级默认，不中断评测。
+- **总超时关系**：evaluator `time_limit_ms` 仍是外层兜底（评测整体时限），调用级超时是内层；两层都保留。
+- **无法中断**：Solution 函数执行无法强杀（Python 线程），超时后 host 存活、后续调用排队——与 issue 声明的"CallTimeout 记为失败用例继续评测"一致。
+- **cap_reg 映射生命周期**：单次评测内有效，容器销毁即消失（天然正确，无需显式清理）。
+
+## 测试计划
+
+| 层 | 覆盖 |
+|----|------|
+| judge 单元测试（tracker.rs） | 帧解析（缺省/指定/非法回退）、cap_reg 注册/覆盖/删除、响应命中/超时后丢弃、expire 触发、并发多 call 各自 deadline |
+| Evaluator SDK 单测（tests/test_runner.py） | call 帧含/不含 timeout_ms、非法值抛 ValueError、cap_reg 注册帧发出 |
+| judge E2E（e2e_dual_container.rs） | 真实容器：同题两线程并发 call（100ms 超时 + 1s 正常），各自行为正确；缺省回退（不传 timeout_ms → 题目级生效） |
+| noj-tests E2E（15_dual_container_judge.ts 或新文件） | 全链路：提交带调用级超时的题目，断言超时用例记为失败、评测继续完成 |
+
+## 文档同步
+
+| 文档 | 变更 |
+|------|------|
+| `noj-docs/docs/problemsetters/evaluator-sdk.md` | `runner.call(..., timeout_ms=...)` 签名、`register_capability(..., timeout_ms=None)`、SolutionTimeoutError 语义 |
+| `noj-docs/docs/problemsetters/rpc.md` | call 帧 timeout_ms 字段、cap_reg 帧、缺省回退规则、错误来源表 |
+| `noj-docs/docs/problemsetters/web-editor.md` | `call_timeout_ms` 语义变化（题目级默认值 + 调用级可覆盖） |
+| `noj-core/src/types/index.ts` + `problems-types.ts` | 注释同步：语义不变（仍必填正整数），角色变为"默认值" |
+
+## 范围外（明确不做）
+
+- Solution 侧 `call_capability(name, *args, timeout_ms=...)` 调用级指定超时（用户已否决，采用注册时默认值）
+- `runner.restart()` 超时（保持现状，透明转发）
+- 协议版本字段（可选字段天然兼容，无需版本协商）
+- Solution Host 侧超时逻辑（host 无需感知超时；无法中断的 Python 线程由 judge 计时 + 迟到响应丢弃兜底）

--- a/noj-core/src/services/problems-types.ts
+++ b/noj-core/src/services/problems-types.ts
@@ -133,6 +133,8 @@ export function validateRuntimeConfig(rc: RuntimeConfig): void {
       `runtime_config.solution.entry 含非法字符：${s.entry}`,
     );
   }
+  // solution.call_timeout_ms：题目级默认调用超时（必填正整数）；
+  // evaluator 的 runner.call(..., timeout_ms) 可按调用覆盖，capability 可经 register_capability(timeout_ms=...) 配置
   if (typeof s.call_timeout_ms !== "number" || s.call_timeout_ms <= 0) {
     throw new BadRequestError(
       "runtime_config.solution.call_timeout_ms 必须为正整数",

--- a/noj-core/src/types/index.ts
+++ b/noj-core/src/types/index.ts
@@ -24,7 +24,7 @@ export interface SolutionRuntime {
   image: string;
   /** Solution 容器内入口文件名，如 `solution.py` */
   entry: string;
-  /** 单次 SDK 调用的时间上限（毫秒）。单次超时不影响 host 进程 */
+  /** 单次 SDK 调用的时间上限（毫秒），作为调用级超时的题目级默认值（runner.call 可传 timeout_ms 覆盖；capability 可经 register_capability 配置）。单次超时不影响 host 进程 */
   call_timeout_ms: number;
   /** Solution 容器内存上限（MB） */
   memory_limit_mb: number;

--- a/noj-docs/docs/problemsetters/evaluator-sdk.md
+++ b/noj-docs/docs/problemsetters/evaluator-sdk.md
@@ -24,6 +24,15 @@ answer = runner.call("solve", 1, 2)
 
 `runner.call()` 会向 Solution Host 发起一次 RPC 调用。如果调用成功，返回用户函数的返回值。
 
+**调用级超时**：`runner.call()` 支持可选 `timeout_ms` 参数，每次调用可指定独立超时（毫秒）。缺省（`None`）时由 Judge Worker 回退到题目的 `runtime_config.solution.call_timeout_ms`：
+
+```python
+answer = runner.call("solve", 1, 2)                    # 用题目级默认超时
+answer = runner.call("solve", 1, 2, timeout_ms=5000)   # 本次调用 5s 超时
+```
+
+`timeout_ms` 必须为正整数或 `None`，其他值（0 / 负数 / 非整数）抛出 `ValueError`。超时后 `runner.call()` 抛出 `SolutionTimeoutError`，可捕获后记为失败用例继续评测。
+
 调用参数会经过 Neuro OJ codec 编码后通过 RPC 传递。支持的类型和限制见 [RPC 与可传递数据](rpc.md)。
 
 ## 处理调用错误
@@ -83,6 +92,12 @@ def request_llm_completion(prompt: str) -> str:
     return completion_text
 
 register_capability("request_llm_completion", request_llm_completion)
+```
+
+**capability 默认超时**：`register_capability(name, handler, timeout_ms=None)` 可配置 solution 每次调用该 capability 的超时（毫秒）。注册时经 `cap_reg` 帧上报 Judge，缺省（`None`）回退题目级 `call_timeout_ms`：
+
+```python
+register_capability("request_llm_completion", handler, timeout_ms=10000)
 ```
 
 - Solution 通过 `noj_solution_sdk.call_capability(name, *args)` 调用；请求经 judge 转发到 evaluator，在 **runner 的 reader 线程**中同步执行 handler，结果以 `result` 帧返回。

--- a/noj-docs/docs/problemsetters/rpc.md
+++ b/noj-docs/docs/problemsetters/rpc.md
@@ -57,7 +57,7 @@ runner.call("solve", 1, 2)
 | `name` | 要调用的用户函数名 |
 | `args` | 编码后的定位参数列表 |
 | `kwargs` | 编码后的关键字参数字典 |
-| `timeout_ms` | **可选**。正整数 = 本次调用的超时（毫秒），仅由 Judge Worker 计时；缺省 / 非法时回退题目级 `runtime_config.solution.call_timeout_ms`。该字段不传给 Solution Host 的执行逻辑 |
+| `timeout_ms` | **可选**。正整数 = 本次调用的超时（毫秒），仅由 Judge Worker 计时；缺省 / 非法时回退题目级 `runtime_config.solution.call_timeout_ms`。帧会原样透传到 Solution Host，但 host 不消费该字段 |
 
 ### cap_reg 帧（capability 默认超时上报）
 

--- a/noj-docs/docs/problemsetters/rpc.md
+++ b/noj-docs/docs/problemsetters/rpc.md
@@ -57,6 +57,19 @@ runner.call("solve", 1, 2)
 | `name` | 要调用的用户函数名 |
 | `args` | 编码后的定位参数列表 |
 | `kwargs` | 编码后的关键字参数字典 |
+| `timeout_ms` | **可选**。正整数 = 本次调用的超时（毫秒），仅由 Judge Worker 计时；缺省 / 非法时回退题目级 `runtime_config.solution.call_timeout_ms`。该字段不传给 Solution Host 的执行逻辑 |
+
+### cap_reg 帧（capability 默认超时上报）
+
+Evaluator 在 `register_capability(name, handler, timeout_ms=...)` 时向 stdout 写一次性 `cap_reg` 帧，上报 Judge 该 capability 的调用默认超时：
+
+```json
+{"type": "cap_reg", "name": "request_llm_completion", "timeout_ms": 10000}
+```
+
+- `timeout_ms` 缺省表示删除映射（该 capability 回退题目级 `call_timeout_ms`）。
+- **`cap_reg` 是 Evaluator → Judge 的私有协议帧，Judge 不转发给 Solution Host**。
+- 重复注册同名 capability：最近一次生效（含超时映射）。
 
 ## 成功响应
 
@@ -108,7 +121,7 @@ Evaluator SDK 会抛出 `SolutionCallError`，错误对象可通过 `exc.error` 
 | 用户异常类名 | Solution Host | 用户函数执行时抛出异常 |
 | `InvalidJson` | Solution Host | Host 收到的请求不是合法 JSON |
 | `UnknownMethod` | Solution Host | 请求方法未知 |
-| `CallTimeout` | Judge Worker | 单次调用超过 solution `call_timeout_ms` |
+| `CallTimeout` | Judge Worker | 单次调用超过调用级 `timeout_ms`（缺省回退题目级 `call_timeout_ms`）；capability 调用按注册时配置的默认超时 |
 | `HostWriteFailed` | Judge Worker | 无法向 Solution Host 写入请求 |
 | `InvalidHostResponse` | Judge Worker | Host 响应不是合法 JSON |
 | `RestartFailed` | Judge Worker | 重启 Solution Host 失败 |

--- a/noj-docs/docs/problemsetters/web-editor.md
+++ b/noj-docs/docs/problemsetters/web-editor.md
@@ -23,9 +23,9 @@
 双容器评测模型下，每个题目声明两个运行时的资源限制：
 
 - **Evaluator**（出题人代码 `evaluate.py`）：`time_limit_ms`、`memory_limit_mb`
-- **Solution**（用户代码 `solution.py`）：调用超时 `call_timeout_ms`、`memory_limit_mb`
+- **Solution**（用户代码 `solution.py`）：调用超时 `call_timeout_ms`（**题目级默认值**）、`memory_limit_mb`
 
-配置保存在题目上，Judge Worker 评测时读取。合理设置 Solution 的调用超时可以防止用户代码死循环拖垮整场评测（见[评测模型](judge-model.md)）。
+配置保存在题目上，Judge Worker 评测时读取。`call_timeout_ms` 作为单次 SDK 调用的**默认**超时；出题人可在 `evaluate.py` 中用 `runner.call(..., timeout_ms=...)` 按调用覆盖（缺省时回退该默认值）。合理设置 Solution 的调用超时可以防止用户代码死循环拖垮整场评测（见[评测模型](judge-model.md)）。
 
 ### 统一题目包
 

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/capability.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/capability.py
@@ -14,24 +14,47 @@ evaluator runner reader 线程 → 查本注册表 → 同步执行 handler → 
 
 from __future__ import annotations
 
+import json
+import sys
 import threading
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 _CAPABILITIES: dict[str, Callable] = {}
 _LOCK = threading.RLock()
+_OUT_LOCK = threading.Lock()
 
 
-def register_capability(name: str, handler: Callable) -> None:
+def register_capability(
+    name: str, handler: Callable, timeout_ms: Optional[int] = None
+) -> None:
     """注册 capability。
 
     重复注册同名时覆盖（最近注册生效）。
+
+    `timeout_ms`：solution 调用该 capability 时的默认超时（毫秒）；
+    None = judge 回退题目级 call_timeout_ms。注册时写一次性
+    `cap_reg` 帧上报 judge（judge 侧私有协议，不转发给 solution）。
     """
     if not isinstance(name, str) or not name.strip():
         raise TypeError(f"capability 名称必须是非空字符串，实际 {type(name).__name__}")
     if not callable(handler):
         raise TypeError(f"handler 必须是 callable，实际 {type(handler).__name__}")
+    if timeout_ms is not None and (
+        not isinstance(timeout_ms, int) or timeout_ms <= 0
+    ):
+        raise ValueError(
+            f"timeout_ms 必须是正整数或 None，实际 {timeout_ms!r}"
+        )
     with _LOCK:
         _CAPABILITIES[name] = handler
+    # 上报 judge（一次性 cap_reg 帧）
+    frame = {"type": "cap_reg", "name": name}
+    if timeout_ms is not None:
+        frame["timeout_ms"] = timeout_ms
+    line = json.dumps(frame, ensure_ascii=False, separators=(",", ":"))
+    with _OUT_LOCK:
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
 
 
 def _get_capability(name: str) -> Callable | None:

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/capability.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/capability.py
@@ -40,7 +40,7 @@ def register_capability(
     if not callable(handler):
         raise TypeError(f"handler 必须是 callable，实际 {type(handler).__name__}")
     if timeout_ms is not None and (
-        not isinstance(timeout_ms, int) or timeout_ms <= 0
+        type(timeout_ms) is not int or timeout_ms <= 0
     ):
         raise ValueError(
             f"timeout_ms 必须是正整数或 None，实际 {timeout_ms!r}"

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
@@ -117,9 +117,9 @@ class SolutionRunner:
         if self._closed:
             raise ConnectionError("runner 已关闭")
 
-        # 0. timeout_ms 校验（None 或正整数）
+        # 0. timeout_ms 校验（None 或正整数；type is int 排除 bool）
         if timeout_ms is not None:
-            if not isinstance(timeout_ms, int) or timeout_ms <= 0:
+            if type(timeout_ms) is not int or timeout_ms <= 0:
                 raise ValueError(
                     f"timeout_ms 必须是正整数或 None，实际 {timeout_ms!r}"
                 )

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
@@ -99,8 +99,11 @@ class SolutionRunner:
 
     # ── 公开 API ────────────────────────────────────────
 
-    def call(self, fn: str, *args: Any) -> Any:
+    def call(self, fn: str, *args: Any, timeout_ms: Optional[int] = None) -> Any:
         """调用 Solution host 中的函数 `fn`。
+
+        `timeout_ms`：本次调用的超时（毫秒）。None = 由 judge 回退题目级默认；
+        正整数 = 按调用指定。0 / 负数 / 非 int 抛 ValueError。
 
         返回值由 SDK 自动反序列化（bytes base64 → bytes 等）。
 
@@ -114,6 +117,13 @@ class SolutionRunner:
         if self._closed:
             raise ConnectionError("runner 已关闭")
 
+        # 0. timeout_ms 校验（None 或正整数）
+        if timeout_ms is not None:
+            if not isinstance(timeout_ms, int) or timeout_ms <= 0:
+                raise ValueError(
+                    f"timeout_ms 必须是正整数或 None，实际 {timeout_ms!r}"
+                )
+
         # 1. 参数校验
         for i, arg in enumerate(args):
             validate_type(arg, f"arg[{i}]")
@@ -126,6 +136,8 @@ class SolutionRunner:
             "fn": fn,
             "args": [encode_value(a) for a in args],
         }
+        if timeout_ms is not None:
+            frame["timeout_ms"] = timeout_ms
 
         # 3. 注册 pending
         q: Queue = Queue(maxsize=1)

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
@@ -292,6 +292,53 @@ class TestSolutionRunnerCall(unittest.TestCase):
         finally:
             h.teardown()
 
+    def test_call_frame_with_timeout_ms(self):
+        """指定 timeout_ms 时 call 帧应带该字段。"""
+        harness = IpcHarness()
+        try:
+            def runner():
+                harness.runner.call("solve", 1, timeout_ms=5000)
+            t = threading.Thread(target=runner)
+            t.start()
+            frame = harness.last_call_frame()
+            self.assertEqual(frame.get("timeout_ms"), 5000)
+            harness.send_host_response(
+                {"type": "result", "id": frame["id"], "value": 3}
+            )
+            t.join(timeout=2.0)
+            self.assertFalse(t.is_alive(), "call 应已返回")
+        finally:
+            harness.teardown()
+
+    def test_call_frame_without_timeout_ms(self):
+        """缺省 timeout_ms 时 call 帧不应带该字段（向后兼容）。"""
+        harness = IpcHarness()
+        try:
+            def runner():
+                harness.runner.call("solve", 1)
+            t = threading.Thread(target=runner)
+            t.start()
+            frame = harness.last_call_frame()
+            self.assertNotIn("timeout_ms", frame)
+            harness.send_host_response(
+                {"type": "result", "id": frame["id"], "value": 3}
+            )
+            t.join(timeout=2.0)
+        finally:
+            harness.teardown()
+
+    def test_call_invalid_timeout_ms_raises(self):
+        """timeout_ms 为 0 / 负数 / 非 int 时抛 ValueError。"""
+        harness = IpcHarness()
+        try:
+            for bad in (0, -1, "5000"):
+                with self.assertRaises(ValueError):
+                    harness.runner.call("solve", 1, timeout_ms=bad)
+            # 非法值不应发出 call 帧
+            self.assertEqual(len(harness.all_call_frames()), 0)
+        finally:
+            harness.teardown()
+
 
 class TestCapability(unittest.TestCase):
     """验证 capability 帧处理（register_capability → handler → 响应帧）。"""
@@ -518,6 +565,44 @@ class TestCapability(unittest.TestCase):
         finally:
             h.teardown()
             _reset_capabilities_for_tests()
+
+    def test_register_capability_with_timeout_emits_cap_reg(self):
+        """注册时配置 timeout_ms → stdout 写 cap_reg 帧。"""
+        from noj_evaluator_sdk import register_capability
+        from noj_evaluator_sdk.capability import _reset_capabilities_for_tests
+        harness = IpcHarness()
+        try:
+            register_capability("ping", lambda x: x, timeout_ms=9000)
+            frames = harness.all_call_frames()
+            reg = [f for f in frames if f.get("type") == "cap_reg"]
+            self.assertEqual(len(reg), 1)
+            self.assertEqual(reg[0]["name"], "ping")
+            self.assertEqual(reg[0]["timeout_ms"], 9000)
+        finally:
+            harness.teardown()
+            _reset_capabilities_for_tests()
+
+    def test_register_capability_without_timeout_emits_cap_reg_no_field(self):
+        from noj_evaluator_sdk import register_capability
+        from noj_evaluator_sdk.capability import _reset_capabilities_for_tests
+        harness = IpcHarness()
+        try:
+            register_capability("ping2", lambda x: x)
+            frames = harness.all_call_frames()
+            reg = [f for f in frames if f.get("type") == "cap_reg"]
+            self.assertEqual(len(reg), 1)
+            self.assertEqual(reg[0]["name"], "ping2")
+            self.assertNotIn("timeout_ms", reg[0])
+        finally:
+            harness.teardown()
+            _reset_capabilities_for_tests()
+
+    def test_register_capability_invalid_timeout_raises(self):
+        from noj_evaluator_sdk import register_capability
+        from noj_evaluator_sdk.capability import _reset_capabilities_for_tests
+        with self.assertRaises(ValueError):
+            register_capability("bad", lambda x: x, timeout_ms=0)
+        _reset_capabilities_for_tests()
 
 
 if __name__ == "__main__":

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
@@ -328,10 +328,10 @@ class TestSolutionRunnerCall(unittest.TestCase):
             harness.teardown()
 
     def test_call_invalid_timeout_ms_raises(self):
-        """timeout_ms 为 0 / 负数 / 非 int 时抛 ValueError。"""
+        """timeout_ms 为 0 / 负数 / 非 int（含 bool）时抛 ValueError。"""
         harness = IpcHarness()
         try:
-            for bad in (0, -1, "5000"):
+            for bad in (0, -1, "5000", True):
                 with self.assertRaises(ValueError):
                     harness.runner.call("solve", 1, timeout_ms=bad)
             # 非法值不应发出 call 帧

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -15,17 +15,18 @@ pub mod protocol;
 pub mod tracker;
 
 use std::io::Read;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use bollard::container::LogOutput;
 use futures_util::StreamExt;
 use serde_json::Value;
 use tokio::io::AsyncWriteExt;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::dual::container::{start_exec, DualContainer, ExecSession};
 use crate::dual::protocol::{frame_type, EvaluatorLine, LineParser};
+use crate::dual::tracker::{InFlightTracker, WaitingSide};
 use crate::sandbox::container::{parse_command, MAX_FILE_SIZE, MAX_TOTAL_SIZE, MAX_ZIP_ENTRIES};
 use crate::types::{JudgeResult, JudgeStatus, RuntimeConfig};
 
@@ -307,7 +308,7 @@ async fn run_dual_loop(
     evaluator_exec: ExecSession,
     solution_exec: ExecSession,
     evaluator_timeout_ms: u64,
-    _call_timeout_ms: u64,
+    default_call_timeout_ms: u64,
     rejudge_seq: Option<i64>,
 ) -> Result<JudgeResult> {
     // 解构 exec 拿到 output/input
@@ -331,6 +332,9 @@ async fn run_dual_loop(
 
     let mut result_payload: Option<String> = None;
 
+    // 调用级超时追踪器（题目级 call_timeout_ms 作为缺省回退值）
+    let mut tracker = InFlightTracker::new(default_call_timeout_ms);
+
     // 评测程序启动等待上限：容器创建 / 文件注入 / Python 启动等开销
     // 不计入题目时限（issue：秒过的代码不应因启动开销 TLE）。
     const EVALUATOR_STARTUP_TIMEOUT_MS: u64 = 30_000;
@@ -346,6 +350,24 @@ async fn run_dual_loop(
             _ = &mut startup_deadline => {
                 warn!("Evaluator 启动超时（{}ms）: {}", EVALUATOR_STARTUP_TIMEOUT_MS, submission_id);
                 return Ok(JudgeResult::timeout(submission_id, "evaluator startup timeout", rejudge_seq));
+            }
+            // 调用级超时（in-flight 到期）
+            _ = async {
+                match tracker.next_deadline() {
+                    Some(d) => tokio::time::sleep_until(d.into()).await,
+                    None => std::future::pending::<()>().await,
+                }
+            } => {
+                for (id, side) in tracker.expire_now(Instant::now()) {
+                    match side {
+                        WaitingSide::Evaluator => {
+                            write_timeout_frame(&mut eval_input, &id).await?;
+                        }
+                        WaitingSide::Solution => {
+                            write_timeout_frame(&mut sol_input, &id).await?;
+                        }
+                    }
+                }
             }
             chunk = eval_output.next() => {
                 let chunk = match chunk {
@@ -373,6 +395,7 @@ async fn run_dual_loop(
                     &mut eval_stdout_full,
                     &mut sol_input,
                     &mut result_payload,
+                    &mut tracker,
                     chunk,
                 )
                 .await?;
@@ -398,6 +421,25 @@ async fn run_dual_loop(
                     return Ok(JudgeResult::timeout(submission_id, "evaluator total timeout", rejudge_seq));
                 }
 
+                // 调用级超时（in-flight 到期）
+                _ = async {
+                    match tracker.next_deadline() {
+                        Some(d) => tokio::time::sleep_until(d.into()).await,
+                        None => std::future::pending::<()>().await,
+                    }
+                } => {
+                    for (id, side) in tracker.expire_now(Instant::now()) {
+                        match side {
+                            WaitingSide::Evaluator => {
+                                write_timeout_frame(&mut eval_input, &id).await?;
+                            }
+                            WaitingSide::Solution => {
+                                write_timeout_frame(&mut sol_input, &id).await?;
+                            }
+                        }
+                    }
+                }
+
                 // Evaluator stdout/stderr
                 chunk = eval_output.next() => {
                     let chunk = match chunk {
@@ -414,6 +456,7 @@ async fn run_dual_loop(
                         &mut eval_stdout_full,
                         &mut sol_input,
                         &mut result_payload,
+                        &mut tracker,
                         chunk,
                     )
                     .await?;
@@ -437,6 +480,7 @@ async fn run_dual_loop(
                         &mut eval_input,
                         chunk,
                         &mut solution_ready,
+                        &mut tracker,
                     )
                     .await?;
                 }
@@ -486,8 +530,9 @@ async fn handle_eval_chunk(
     parser: &mut LineParser,
     stderr_buf: &mut String,
     stdout_full: &mut String,
-    eval_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+    sol_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
     result_payload: &mut Option<String>,
+    tracker: &mut InFlightTracker,
     chunk: LogOutput,
 ) -> Result<()> {
     let (data, is_err) = match chunk {
@@ -513,13 +558,34 @@ async fn handle_eval_chunk(
                 append_capped(stdout_full, "---RESULT---\n");
             }
             EvaluatorLine::Frame(v) => {
-                // 协议帧转发到 solution stdin：
-                // - call 帧：evaluator → solution 的函数调用（既有行为）
-                // - result/error 帧：capability 调用的响应（solution → evaluator 的反向结果）
+                // 协议帧处理：
+                // - call 帧：evaluator → solution 的函数调用，登记调用级超时后原样转发
+                // - cap_reg 帧：judge 与 evaluator 的私有协议（capability 默认超时上报），不转发
+                // - result/error 帧：capability 调用的响应（solution 等待），按 id 命中判定转发
                 // 其他类型（log 等）记录但不转发
-                let ft = frame_type(&v);
-                if ft == Some("call") || ft == Some("result") || ft == Some("error") {
-                    forward_frame(eval_input, &v).await?;
+                let ft = frame_type(&v).map(|s| s.to_string());
+                match ft.as_deref() {
+                    Some("call") => {
+                        // 登记调用级超时（缺省回退题目级默认），原样转发
+                        tracker.on_call_frame(&v, Instant::now());
+                        forward_frame(sol_input, &v).await?;
+                    }
+                    Some("cap_reg") => {
+                        // judge 侧私有协议：更新 capability 超时映射，不转发给 solution
+                        tracker.on_cap_reg_frame(&v);
+                        debug!("cap_reg 帧已记录（不转发）: {}", v);
+                    }
+                    Some("result") | Some("error") => {
+                        // capability 响应帧：命中则转发给 solution，迟到/未知丢弃
+                        if let Some(id) = v.get("id").and_then(Value::as_str) {
+                            if tracker.resolve_response(id) {
+                                forward_frame(sol_input, &v).await?;
+                            } else {
+                                warn!("丢弃迟到的 evaluator 响应帧（id={}）", id);
+                            }
+                        }
+                    }
+                    _ => {}
                 }
                 // 记录所有帧到 stdout 全文（供结果展示）
                 let s = v.to_string();
@@ -546,6 +612,7 @@ async fn handle_sol_chunk(
     eval_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
     chunk: LogOutput,
     solution_ready: &mut bool,
+    tracker: &mut InFlightTracker,
 ) -> Result<()> {
     let data = match chunk {
         LogOutput::StdOut { message } => message,
@@ -561,18 +628,50 @@ async fn handle_sol_chunk(
     let lines = parser.feed(&data);
     for line in lines {
         if let EvaluatorLine::Frame(v) = line {
+            let ft = frame_type(&v).map(|s| s.to_string());
             if !*solution_ready {
-                if frame_type(&v) == Some("ready") {
+                if ft.as_deref() == Some("ready") {
                     *solution_ready = true;
                     continue;
                 }
                 // ready 之前的所有帧忽略（防御）
                 continue;
             }
-            forward_frame(eval_input, &v).await?;
+            match ft.as_deref() {
+                Some("capability") => {
+                    // solution 请求 capability：查注册超时登记后转发 evaluator
+                    tracker.on_capability_frame(&v, Instant::now());
+                    forward_frame(eval_input, &v).await?;
+                }
+                Some("result") | Some("error") => {
+                    // call 响应帧（evaluator 等待）：命中则转发，迟到/未知丢弃
+                    if let Some(id) = v.get("id").and_then(Value::as_str) {
+                        if tracker.resolve_response(id) {
+                            forward_frame(eval_input, &v).await?;
+                        } else {
+                            warn!("丢弃迟到的 solution 响应帧（id={}）", id);
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
     }
     Ok(())
+}
+
+/// 向等待方写调用级超时错误帧。
+async fn write_timeout_frame(
+    writer: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+    id: &str,
+) -> Result<()> {
+    let frame = serde_json::json!({
+        "type": "error",
+        "id": id,
+        "code": "Timeout",
+        "message": "call timeout",
+    });
+    forward_frame(writer, &frame).await
 }
 
 async fn forward_frame(
@@ -625,8 +724,9 @@ pub mod mod_test_helpers {
     /// 等价 `handle_eval_chunk`，忽略 stderr/stdout 全文收集。
     pub async fn handle_eval_chunk_probe(
         parser: &mut LineParser,
-        eval_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
+        sol_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
         result_payload: &mut Option<String>,
+        tracker: &mut InFlightTracker,
         chunk: LogOutput,
     ) {
         let mut stderr_buf = String::new();
@@ -635,8 +735,9 @@ pub mod mod_test_helpers {
             parser,
             &mut stderr_buf,
             &mut stdout_full,
-            eval_input,
+            sol_input,
             result_payload,
+            tracker,
             chunk,
         )
         .await;
@@ -648,8 +749,9 @@ pub mod mod_test_helpers {
         eval_input: &mut std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>,
         chunk: LogOutput,
         solution_ready: &mut bool,
+        tracker: &mut InFlightTracker,
     ) {
-        let _ = super::handle_sol_chunk(parser, eval_input, chunk, solution_ready).await;
+        let _ = super::handle_sol_chunk(parser, eval_input, chunk, solution_ready, tracker).await;
     }
 }
 
@@ -716,6 +818,16 @@ mod tests {
         let mut stderr_buf = String::new();
         let mut stdout_full = String::new();
         let mut result_payload: Option<String> = None;
+        let mut tracker = InFlightTracker::new(2000);
+        // 预登记 capability 调用（solution 已发过 capability 帧，等待响应）
+        tracker.on_capability_frame(
+            &serde_json::json!({"type":"capability","id":"abc","name":"x","args":[]}),
+            Instant::now(),
+        );
+        tracker.on_capability_frame(
+            &serde_json::json!({"type":"capability","id":"def","name":"x","args":[]}),
+            Instant::now(),
+        );
 
         let chunk = LogOutput::StdOut {
             message: bytes::Bytes::from_static(
@@ -731,6 +843,7 @@ mod tests {
             &mut stdout_full,
             &mut writer,
             &mut result_payload,
+            &mut tracker,
             chunk,
         )
         .await
@@ -767,6 +880,7 @@ mod tests {
         let mut stderr_buf = String::new();
         let mut stdout_full = String::new();
         let mut result_payload: Option<String> = None;
+        let mut tracker = InFlightTracker::new(2000);
 
         let chunk = LogOutput::StdOut {
             message: bytes::Bytes::from_static(
@@ -780,6 +894,7 @@ mod tests {
             &mut stdout_full,
             &mut writer,
             &mut result_payload,
+            &mut tracker,
             chunk,
         )
         .await
@@ -794,6 +909,8 @@ mod tests {
 
         assert!(text.contains("\"type\":\"call\""));
         assert!(!text.contains("plain text"), "普通文本不应转发");
+        // call 帧已被追踪：响应可命中
+        assert!(tracker.resolve_response("x"));
     }
 
     #[tokio::test]
@@ -809,6 +926,7 @@ mod tests {
         let mut stderr_buf = String::new();
         let mut stdout_full = String::new();
         let mut result_payload: Option<String> = None;
+        let mut tracker = InFlightTracker::new(2000);
 
         let chunk = LogOutput::StdOut {
             message: bytes::Bytes::from_static(
@@ -822,6 +940,7 @@ mod tests {
             &mut stdout_full,
             &mut writer,
             &mut result_payload,
+            &mut tracker,
             chunk,
         )
         .await
@@ -832,5 +951,103 @@ mod tests {
             Some("{\"status\":\"Accepted\",\"score\":100}")
         );
         assert!(stdout_full.contains("---RESULT---"));
+    }
+
+    #[tokio::test]
+    async fn test_eval_call_frame_tracked_and_forwarded() {
+        // call 帧：登记 in-flight 并原样转发（含 timeout_ms 字段）到 sol_input
+        use bollard::container::LogOutput;
+        use tokio::io::AsyncReadExt;
+
+        let (sink, mut source) = tokio::io::duplex(8192);
+        let mut writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+            Box::pin(sink);
+
+        let mut parser = LineParser::new();
+        let mut stderr_buf = String::new();
+        let mut stdout_full = String::new();
+        let mut result_payload: Option<String> = None;
+        let mut tracker = InFlightTracker::new(2000);
+
+        let chunk = LogOutput::StdOut {
+            message: bytes::Bytes::from_static(
+                b"{\"type\":\"call\",\"id\":\"c1\",\"fn\":\"solve\",\"args\":[1],\"timeout_ms\":500}\n",
+            ),
+        };
+        handle_eval_chunk(
+            &mut parser,
+            &mut stderr_buf,
+            &mut stdout_full,
+            &mut writer,
+            &mut result_payload,
+            &mut tracker,
+            chunk,
+        )
+        .await
+        .unwrap();
+
+        // 转发到 sol_input
+        let mut buf = [0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(2), source.read(&mut buf))
+            .await
+            .expect("读取转发内容超时")
+            .unwrap();
+        let text = String::from_utf8_lossy(&buf[..n]).to_string();
+        assert!(text.contains("\"type\":\"call\""));
+        assert!(text.contains("\"timeout_ms\":500"), "帧应原样透传");
+
+        // in-flight 已登记：响应命中可转发
+        assert!(tracker.resolve_response("c1"), "c1 应被追踪");
+    }
+
+    #[tokio::test]
+    async fn test_eval_cap_reg_frame_not_forwarded() {
+        // cap_reg 帧：仅更新映射，不转发给 solution（同批 call 帧正常转发）
+        use bollard::container::LogOutput;
+        use tokio::io::AsyncReadExt;
+
+        let (sink, mut source) = tokio::io::duplex(8192);
+        let mut writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+            Box::pin(sink);
+
+        let mut parser = LineParser::new();
+        let mut stderr_buf = String::new();
+        let mut stdout_full = String::new();
+        let mut result_payload: Option<String> = None;
+        let mut tracker = InFlightTracker::new(2000);
+
+        let chunk = LogOutput::StdOut {
+            message: bytes::Bytes::from_static(
+                b"{\"type\":\"cap_reg\",\"name\":\"ping\",\"timeout_ms\":9000}\n\
+                  {\"type\":\"call\",\"id\":\"c9\",\"fn\":\"solve\",\"args\":[1]}\n",
+            ),
+        };
+        handle_eval_chunk(
+            &mut parser,
+            &mut stderr_buf,
+            &mut stdout_full,
+            &mut writer,
+            &mut result_payload,
+            &mut tracker,
+            chunk,
+        )
+        .await
+        .unwrap();
+
+        // 只应转发 call 帧；cap_reg 帧不应出现
+        let mut buf = [0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(2), source.read(&mut buf))
+            .await
+            .expect("读取转发内容超时")
+            .unwrap();
+        let text = String::from_utf8_lossy(&buf[..n]).to_string();
+        assert!(text.contains("\"type\":\"call\""), "call 帧应转发");
+        assert!(!text.contains("cap_reg"), "cap_reg 帧不应转发到 solution");
+        // 映射已记录
+        let f = serde_json::json!({"type":"capability","id":"cap-1","name":"ping","args":[]});
+        assert_eq!(
+            tracker.on_capability_frame(&f, Instant::now()).unwrap().1,
+            9000
+        );
     }
 }

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -585,7 +585,12 @@ async fn handle_eval_chunk(
                             }
                         }
                     }
-                    _ => {}
+                    // log：合法帧，judge 收集但不转发（保持既有语义）
+                    Some("log") => {}
+                    // 未知/非法 type：按协议记录 warn 并丢弃
+                    _ => {
+                        warn!("丢弃未知 type 的 evaluator 帧: {}", v);
+                    }
                 }
                 // 记录所有帧到 stdout 全文（供结果展示）
                 let s = v.to_string();
@@ -653,9 +658,13 @@ async fn handle_sol_chunk(
                         }
                     }
                 }
-                // log / shutdown 等其他帧：保持既有转发语义（solution → evaluator）
-                _ => {
+                // log / shutdown 等合法帧：保持既有转发语义（solution → evaluator）
+                Some("log") | Some("shutdown") => {
                     forward_frame(eval_input, &v).await?;
+                }
+                // 未知/非法 type：按协议记录 warn 并丢弃
+                _ => {
+                    warn!("丢弃未知 type 的 solution 帧: {}", v);
                 }
             }
         }
@@ -1093,5 +1102,46 @@ mod tests {
             text.contains("\"type\":\"log\""),
             "solution log 帧应转发给 evaluator"
         );
+    }
+
+    #[tokio::test]
+    async fn test_sol_unknown_frame_dropped() {
+        // spec：未知/非法 type 帧应记录 warn 并丢弃（不转发）
+        use bollard::container::LogOutput;
+        use tokio::io::AsyncReadExt;
+
+        let (sink, mut source) = tokio::io::duplex(8192);
+        let mut writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+            Box::pin(sink);
+
+        let mut parser = LineParser::new();
+        let mut solution_ready = true;
+        let mut tracker = InFlightTracker::new(2000);
+
+        let chunk = LogOutput::StdOut {
+            message: bytes::Bytes::from_static(b"{\"type\":\"bogus\",\"id\":\"x\"}\n"),
+        };
+        handle_sol_chunk(
+            &mut parser,
+            &mut writer,
+            chunk,
+            &mut solution_ready,
+            &mut tracker,
+        )
+        .await
+        .unwrap();
+
+        // 未知 type 帧不应转发（duplex 写端未写数据 → read 超时/空）
+        let mut buf = [0u8; 4096];
+        let read = tokio::time::timeout(Duration::from_millis(300), source.read(&mut buf)).await;
+        match read {
+            Err(_) => {} // 超时 = 无数据转发，符合预期
+            Ok(Ok(0)) => {}
+            Ok(Ok(n)) => {
+                let text = String::from_utf8_lossy(&buf[..n]).to_string();
+                panic!("未知 type 帧不应转发: {}", text);
+            }
+            Ok(Err(e)) => panic!("读取出错: {}", e),
+        }
     }
 }

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -653,7 +653,10 @@ async fn handle_sol_chunk(
                         }
                     }
                 }
-                _ => {}
+                // log / shutdown 等其他帧：保持既有转发语义（solution → evaluator）
+                _ => {
+                    forward_frame(eval_input, &v).await?;
+                }
             }
         }
     }
@@ -1048,6 +1051,47 @@ mod tests {
         assert_eq!(
             tracker.on_capability_frame(&f, Instant::now()).unwrap().1,
             9000
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sol_log_frame_still_forwarded() {
+        // 回归：solution 的 log 等非 call/capability 帧应保持既有转发语义
+        use bollard::container::LogOutput;
+        use tokio::io::AsyncReadExt;
+
+        let (sink, mut source) = tokio::io::duplex(8192);
+        let mut writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+            Box::pin(sink);
+
+        let mut parser = LineParser::new();
+        let mut solution_ready = true;
+        let mut tracker = InFlightTracker::new(2000);
+
+        let chunk = LogOutput::StdOut {
+            message: bytes::Bytes::from_static(
+                b"{\"type\":\"log\",\"stream\":\"stdout\",\"data\":\"hi\"}\n",
+            ),
+        };
+        handle_sol_chunk(
+            &mut parser,
+            &mut writer,
+            chunk,
+            &mut solution_ready,
+            &mut tracker,
+        )
+        .await
+        .unwrap();
+
+        let mut buf = [0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(2), source.read(&mut buf))
+            .await
+            .expect("读取转发内容超时")
+            .unwrap();
+        let text = String::from_utf8_lossy(&buf[..n]).to_string();
+        assert!(
+            text.contains("\"type\":\"log\""),
+            "solution log 帧应转发给 evaluator"
         );
     }
 }

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod container;
 pub mod protocol;
+pub mod tracker;
 
 use std::io::Read;
 use std::time::Duration;

--- a/noj-judge/src/dual/protocol.rs
+++ b/noj-judge/src/dual/protocol.rs
@@ -24,6 +24,9 @@ pub const FRAME_READY: &str = "ready";
 pub const FRAME_CALL: &str = "call";
 #[allow(dead_code)]
 pub const FRAME_CAPABILITY: &str = "capability";
+/// cap_reg：evaluator → judge 私有帧（capability 默认超时上报），judge 不转发
+#[allow(dead_code)]
+pub const FRAME_CAP_REG: &str = "cap_reg";
 #[allow(dead_code)]
 pub const FRAME_RESULT: &str = "result";
 #[allow(dead_code)]

--- a/noj-judge/src/dual/tracker.rs
+++ b/noj-judge/src/dual/tracker.rs
@@ -133,6 +133,8 @@ impl InFlightTracker {
         self.inflight.values().map(|e| e.deadline).min()
     }
 
+    /// 是否有 in-flight 调用（单测使用；生产路径通过 `next_deadline` 判断）。
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.inflight.is_empty()
     }
@@ -232,7 +234,6 @@ mod tests {
 
     #[test]
     fn test_resolve_response_unknown_false() {
-        let now = Instant::now();
         let mut t = InFlightTracker::new(2000);
         assert!(!t.resolve_response("ghost"));
     }

--- a/noj-judge/src/dual/tracker.rs
+++ b/noj-judge/src/dual/tracker.rs
@@ -1,0 +1,296 @@
+//! 调用级超时追踪（judge 侧 RPC 超时实现，纯逻辑、零容器依赖）。
+//!
+//! 负责：
+//! - call / capability 帧的超时登记（按帧内 timeout_ms，缺省回退题目级默认）
+//! - cap_reg 帧维护 capability → timeout_ms 映射
+//! - 响应帧按 id 命中判定（未命中 = 迟到/未知响应，应丢弃）
+//! - 已超时调用批量摘除（供调用方写 Timeout 错误帧）
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+/// 调用等待方向：决定超时错误帧写给谁。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitingSide {
+    /// evaluator 等 solution（runner.call）
+    Evaluator,
+    /// solution 等 evaluator（capability 调用）
+    Solution,
+}
+
+/// 单次 in-flight 调用的超时信息。
+#[derive(Debug, Clone)]
+struct InFlightEntry {
+    deadline: Instant,
+    waiting: WaitingSide,
+}
+
+/// 调用级超时追踪器。
+#[derive(Debug)]
+pub struct InFlightTracker {
+    inflight: HashMap<String, InFlightEntry>,
+    cap_timeouts: HashMap<String, u64>,
+    default_call_timeout_ms: u64,
+}
+
+impl InFlightTracker {
+    /// 以题目级默认超时创建追踪器。
+    pub fn new(default_call_timeout_ms: u64) -> Self {
+        Self {
+            inflight: HashMap::new(),
+            cap_timeouts: HashMap::new(),
+            default_call_timeout_ms,
+        }
+    }
+
+    /// 从帧中读取 timeout_ms（正整数才生效，否则回退默认）。
+    fn resolve_timeout(&self, frame: &Value) -> u64 {
+        frame
+            .get("timeout_ms")
+            .and_then(Value::as_u64)
+            .filter(|&t| t > 0)
+            .unwrap_or(self.default_call_timeout_ms)
+    }
+
+    /// 处理 evaluator 的 call 帧：登记 deadline，返回 (call_id, 生效超时)。
+    /// 无 id 的帧返回 None（调用方照常转发，不追踪）。
+    pub fn on_call_frame(&mut self, frame: &Value, now: Instant) -> Option<(String, u64)> {
+        let id = frame.get("id").and_then(Value::as_str)?.to_string();
+        let timeout_ms = self.resolve_timeout(frame);
+        self.inflight.insert(
+            id.clone(),
+            InFlightEntry {
+                deadline: now + Duration::from_millis(timeout_ms),
+                waiting: WaitingSide::Evaluator,
+            },
+        );
+        Some((id, timeout_ms))
+    }
+
+    /// 处理 evaluator 的 cap_reg 帧：timeout_ms 为正 → 更新映射；否则删除映射。
+    pub fn on_cap_reg_frame(&mut self, frame: &Value) {
+        let Some(name) = frame.get("name").and_then(Value::as_str) else {
+            return;
+        };
+        match frame
+            .get("timeout_ms")
+            .and_then(Value::as_u64)
+            .filter(|&t| t > 0)
+        {
+            Some(ms) => {
+                self.cap_timeouts.insert(name.to_string(), ms);
+            }
+            None => {
+                self.cap_timeouts.remove(name);
+            }
+        }
+    }
+
+    /// 处理 solution 的 capability 帧：查映射→默认，登记 deadline，返回 (id, 生效超时)。
+    pub fn on_capability_frame(&mut self, frame: &Value, now: Instant) -> Option<(String, u64)> {
+        let id = frame.get("id").and_then(Value::as_str)?.to_string();
+        let name = frame.get("name").and_then(Value::as_str).unwrap_or("");
+        let timeout_ms = self
+            .cap_timeouts
+            .get(name)
+            .copied()
+            .unwrap_or(self.default_call_timeout_ms);
+        self.inflight.insert(
+            id.clone(),
+            InFlightEntry {
+                deadline: now + Duration::from_millis(timeout_ms),
+                waiting: WaitingSide::Solution,
+            },
+        );
+        Some((id, timeout_ms))
+    }
+
+    /// 响应帧按 id 判定：命中（尚在 in-flight）→ 移除并返回 true（转发）；否则 false（丢弃）。
+    pub fn resolve_response(&mut self, id: &str) -> bool {
+        self.inflight.remove(id).is_some()
+    }
+
+    /// 摘除所有已超时调用，返回 (id, 等待方向) 列表。
+    pub fn expire_now(&mut self, now: Instant) -> Vec<(String, WaitingSide)> {
+        let expired: Vec<(String, InFlightEntry)> = self
+            .inflight
+            .iter()
+            .filter(|(_, e)| e.deadline <= now)
+            .map(|(id, e)| (id.clone(), e.clone()))
+            .collect();
+        let mut out = Vec::with_capacity(expired.len());
+        for (id, e) in expired {
+            self.inflight.remove(&id);
+            out.push((id, e.waiting));
+        }
+        out
+    }
+
+    /// 当前最早 deadline（无 in-flight 返回 None）。
+    pub fn next_deadline(&self) -> Option<Instant> {
+        self.inflight.values().map(|e| e.deadline).min()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inflight.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn call_frame(id: &str, timeout_ms: Option<u64>) -> Value {
+        let mut f = json!({"type": "call", "id": id, "fn": "solve", "args": []});
+        if let Some(t) = timeout_ms {
+            f["timeout_ms"] = json!(t);
+        }
+        f
+    }
+
+    #[test]
+    fn test_new_uses_default_timeout() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let (id, ms) = t.on_call_frame(&call_frame("a", None), now).unwrap();
+        assert_eq!(id, "a");
+        assert_eq!(ms, 2000);
+    }
+
+    #[test]
+    fn test_call_frame_explicit_timeout_wins() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let (_, ms) = t.on_call_frame(&call_frame("b", Some(500)), now).unwrap();
+        assert_eq!(ms, 500);
+    }
+
+    #[test]
+    fn test_call_frame_invalid_timeout_falls_back() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let f = json!({"type": "call", "id": "c", "fn": "solve", "args": [], "timeout_ms": 0});
+        let (_, ms) = t.on_call_frame(&f, now).unwrap();
+        assert_eq!(ms, 2000);
+        let f2 = json!({"type": "call", "id": "d", "fn": "solve", "args": [], "timeout_ms": -1});
+        let (_, ms2) = t.on_call_frame(&f2, now).unwrap();
+        assert_eq!(ms2, 2000);
+    }
+
+    #[test]
+    fn test_call_frame_missing_id_returns_none() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let f = json!({"type": "call", "fn": "solve", "args": []});
+        assert!(t.on_call_frame(&f, now).is_none());
+    }
+
+    #[test]
+    fn test_capability_uses_registered_timeout() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping", "timeout_ms": 9000}));
+        let f = json!({"type": "capability", "id": "cap-1", "name": "ping", "args": []});
+        let (_, ms) = t.on_capability_frame(&f, now).unwrap();
+        assert_eq!(ms, 9000);
+    }
+
+    #[test]
+    fn test_capability_falls_back_when_not_registered() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        let f = json!({"type": "capability", "id": "cap-2", "name": "unknown", "args": []});
+        let (_, ms) = t.on_capability_frame(&f, now).unwrap();
+        assert_eq!(ms, 2000);
+    }
+
+    #[test]
+    fn test_cap_reg_re_registration_overwrites_and_none_deletes() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping", "timeout_ms": 9000}));
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping", "timeout_ms": 1000}));
+        let f = json!({"type": "capability", "id": "cap-3", "name": "ping", "args": []});
+        assert_eq!(t.on_capability_frame(&f, now).unwrap().1, 1000);
+        // timeout_ms 缺省 → 删除映射，回退默认
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping"}));
+        let f2 = json!({"type": "capability", "id": "cap-4", "name": "ping", "args": []});
+        assert_eq!(t.on_capability_frame(&f2, now).unwrap().1, 2000);
+    }
+
+    #[test]
+    fn test_resolve_response_hit_removes_and_returns_true() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_call_frame(&call_frame("r1", None), now).unwrap();
+        assert!(t.resolve_response("r1"));
+        assert!(!t.resolve_response("r1"), "已移除，二次命中应为 false");
+    }
+
+    #[test]
+    fn test_resolve_response_unknown_false() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        assert!(!t.resolve_response("ghost"));
+    }
+
+    #[test]
+    fn test_expire_now_returns_expired_and_removes() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_call_frame(&call_frame("fast", Some(10)), now).unwrap();
+        t.on_call_frame(&call_frame("slow", Some(10_000)), now)
+            .unwrap();
+        // fast 的 deadline 在 11ms 之后
+        let expired = t.expire_now(now + Duration::from_millis(11));
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].0, "fast");
+        assert_eq!(expired[0].1, WaitingSide::Evaluator);
+        assert!(!t.is_empty(), "slow 仍在 in-flight");
+        // slow 的 deadline 之后全部过期
+        let expired2 = t.expire_now(now + Duration::from_millis(10_001));
+        assert_eq!(expired2.len(), 1);
+        assert_eq!(expired2[0].0, "slow");
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn test_capability_expire_side_is_solution() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_cap_reg_frame(&json!({"type": "cap_reg", "name": "ping", "timeout_ms": 10}));
+        let f = json!({"type": "capability", "id": "cap-x", "name": "ping", "args": []});
+        t.on_capability_frame(&f, now).unwrap();
+        let expired = t.expire_now(now + Duration::from_millis(11));
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].1, WaitingSide::Solution);
+    }
+
+    #[test]
+    fn test_next_deadline_min_and_empty() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        assert!(t.next_deadline().is_none());
+        t.on_call_frame(&call_frame("x", Some(100)), now).unwrap();
+        t.on_call_frame(&call_frame("y", Some(50)), now).unwrap();
+        let d = t.next_deadline().unwrap();
+        assert_eq!(d, now + Duration::from_millis(50));
+    }
+
+    #[test]
+    fn test_concurrent_calls_have_independent_deadlines() {
+        let now = Instant::now();
+        let mut t = InFlightTracker::new(2000);
+        t.on_call_frame(&call_frame("c1", Some(30)), now).unwrap();
+        t.on_call_frame(&call_frame("c2", Some(200)), now).unwrap();
+        // 30ms 时只有 c1 过期
+        let e1 = t.expire_now(now + Duration::from_millis(30));
+        assert_eq!(e1.len(), 1);
+        assert_eq!(e1[0].0, "c1");
+        // c2 仍可正常命中
+        assert!(t.resolve_response("c2"));
+    }
+}

--- a/noj-judge/tests/common/mod.rs
+++ b/noj-judge/tests/common/mod.rs
@@ -331,3 +331,42 @@ macro_rules! e2e_test {
         }
     };
 }
+
+/// 确保带 SDK 的评测镜像存在（不存在则用仓库 Dockerfile 构建）。
+///
+/// 镜像内置 noj_evaluator_sdk / noj_solution_sdk 到 site-packages，
+/// 供真实 SDK 全链路测试使用（evaluate_dual 的 solution 启动命令
+/// 硬编码 `python3 -m noj_solution_sdk.host`，镜像必须含 SDK）。
+/// 仅部分 e2e_* 测试文件引用，未引用的 test binary 会报 dead_code。
+#[allow(dead_code)]
+pub async fn ensure_sdk_images(docker: &Docker) -> Result<()> {
+    for (tag, dockerfile) in [
+        (
+            "noj-e2e-sdk-evaluator:latest",
+            "docker/evaluator-python/Dockerfile",
+        ),
+        (
+            "noj-e2e-sdk-solution:latest",
+            "docker/solution-python/Dockerfile",
+        ),
+    ] {
+        let images = docker
+            .list_images(None::<bollard::query_parameters::ListImagesOptions>)
+            .await?;
+        if images.iter().any(|i| i.repo_tags.iter().any(|t| t == tag)) {
+            continue;
+        }
+        println!("构建 SDK 测试镜像 {} ...", tag);
+        let status = std::process::Command::new("docker")
+            .args(["build", "-t", tag, "-f", dockerfile, "."])
+            // buildx 在部分环境写 activity 文件失败（只读 HOME），退回 legacy builder
+            .env("DOCKER_BUILDKIT", "0")
+            .current_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+            .status()
+            .context("执行 docker build 失败")?;
+        if !status.success() {
+            anyhow::bail!("docker build 失败: {}", tag);
+        }
+    }
+    Ok(())
+}

--- a/noj-judge/tests/e2e_dual_container.rs
+++ b/noj-judge/tests/e2e_dual_container.rs
@@ -660,3 +660,147 @@ async fn evaluate_dual_end_to_end() {
         }
     }
 }
+
+/// 调用级超时缺省回退：call 帧不带 timeout_ms 时，题目级 call_timeout_ms 生效。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_call_timeout_fallback_to_problem_default() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_sdk_images(&docker).await.unwrap();
+
+    // evaluator：调用 sleep 函数，不带 timeout_ms（期望回退题目级 100ms）
+    let evaluator_cmd = r#"python3 -c "
+import json
+from noj_evaluator_sdk import SolutionRunner, result
+runner = SolutionRunner()
+try:
+    runner.call('sleep_solution')
+    result.accept(score=1000, details={'cases': [{'id': 'c1', 'status': 'Accepted'}]})
+except Exception as e:
+    result.accept(score=0, details={'cases': [{'id': 'c1', 'status': type(e).__name__}]})
+""#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 15000,
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 100, // 题目级默认：100ms
+            memory_limit_mb: 128,
+        },
+    };
+    // solution 代码：sleep_solution 睡 300ms（> 100ms 默认超时）
+    let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\n";
+
+    let result = noj_judge::dual::evaluate_dual(
+        docker.clone(),
+        "e2e-timeout-fallback",
+        &runtime_config,
+        code,
+        "solution.py",
+        None,
+        "/tmp/e2e-cache",
+        100,
+        64,
+        None,
+    )
+    .await
+    .expect("评测应正常返回");
+
+    assert_eq!(result.status, "Accepted");
+    let cases = result.details["cases"].as_array().expect("details.cases");
+    assert_eq!(
+        cases[0]["status"].as_str().unwrap(),
+        "SolutionTimeoutError",
+        "超时用例应被记录为 SolutionTimeoutError: {:?}",
+        result.details
+    );
+}
+
+/// 调用级超时 + 并发：同题两个线程不同超时，各自独立生效。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_call_timeout_per_call_concurrent() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_sdk_images(&docker).await.unwrap();
+
+    let evaluator_cmd = r#"python3 -c "
+import json, threading
+from noj_evaluator_sdk import SolutionRunner, result
+runner = SolutionRunner()
+out = {}
+def slow():
+    try:
+        runner.call('sleep_solution', timeout_ms=50)   # 50ms 超时 vs 300ms 睡眠
+        out['slow'] = 'ok'
+    except Exception as e:
+        out['slow'] = type(e).__name__
+def fast():
+    try:
+        v = runner.call('fast_solution', timeout_ms=5000)  # 立即返回
+        out['fast'] = ['ok', v]
+    except Exception as e:
+        out['fast'] = type(e).__name__
+t1 = threading.Thread(target=slow)
+t2 = threading.Thread(target=fast)
+t1.start(); t2.start(); t1.join(); t2.join()
+result.accept(score=1000, details={'cases': out})
+""#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 15000,
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 5000, // 题目级默认宽松；验证调用级 50ms 覆盖
+            memory_limit_mb: 128,
+        },
+    };
+    let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\ndef fast_solution():\n    return 42\n";
+
+    let result = noj_judge::dual::evaluate_dual(
+        docker.clone(),
+        "e2e-timeout-per-call",
+        &runtime_config,
+        code,
+        "solution.py",
+        None,
+        "/tmp/e2e-cache",
+        100,
+        64,
+        None,
+    )
+    .await
+    .expect("评测应正常返回");
+
+    assert_eq!(result.status, "Accepted");
+    let cases = result.details["cases"].as_object().expect("details.cases");
+    assert_eq!(
+        cases["slow"].as_str().unwrap(),
+        "SolutionTimeoutError",
+        "慢调用应按 50ms 超时: {:?}",
+        result.details
+    );
+    assert_eq!(
+        cases["fast"].as_array().unwrap(),
+        &vec![serde_json::json!("ok"), serde_json::json!(42)]
+    );
+}

--- a/noj-judge/tests/e2e_dual_container.rs
+++ b/noj-judge/tests/e2e_dual_container.rs
@@ -701,19 +701,23 @@ except Exception as e:
     // solution 代码：sleep_solution 睡 300ms（> 100ms 默认超时）
     let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\n";
 
-    let result = noj_judge::dual::evaluate_dual(
-        docker.clone(),
-        "e2e-timeout-fallback",
-        &runtime_config,
-        code,
-        "solution.py",
-        None,
-        "/tmp/e2e-cache",
-        100,
-        64,
-        None,
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        noj_judge::dual::evaluate_dual(
+            docker.clone(),
+            "e2e-timeout-fallback",
+            &runtime_config,
+            code,
+            "solution.py",
+            None,
+            "/tmp/e2e-cache",
+            100,
+            64,
+            None,
+        ),
     )
     .await
+    .expect("评测 30s 外层超时")
     .expect("评测应正常返回");
 
     assert_eq!(result.status, "Accepted");
@@ -776,19 +780,23 @@ result.accept(score=1000, details={'cases': out})
     };
     let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\ndef fast_solution():\n    return 42\n";
 
-    let result = noj_judge::dual::evaluate_dual(
-        docker.clone(),
-        "e2e-timeout-per-call",
-        &runtime_config,
-        code,
-        "solution.py",
-        None,
-        "/tmp/e2e-cache",
-        100,
-        64,
-        None,
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        noj_judge::dual::evaluate_dual(
+            docker.clone(),
+            "e2e-timeout-per-call",
+            &runtime_config,
+            code,
+            "solution.py",
+            None,
+            "/tmp/e2e-cache",
+            100,
+            64,
+            None,
+        ),
     )
     .await
+    .expect("评测 30s 外层超时")
     .expect("评测应正常返回");
 
     assert_eq!(result.status, "Accepted");
@@ -802,5 +810,86 @@ result.accept(score=1000, details={'cases': out})
     assert_eq!(
         cases["fast"].as_array().unwrap(),
         &vec![serde_json::json!("ok"), serde_json::json!(42)]
+    );
+}
+
+/// capability 调用级超时：注册时配置的默认超时（cap_reg 上报）在真实容器中生效。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_capability_timeout_per_call() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_sdk_images(&docker).await.unwrap();
+
+    // evaluator：注册慢 capability（默认超时 100ms），稍后从 solution 读取调用结果
+    let evaluator_cmd = r#"python3 -c "
+import json, time
+from noj_evaluator_sdk import register_capability, SolutionRunner, result
+def slow_cap(x):
+    time.sleep(0.3)
+    return x
+register_capability('slow_cap', slow_cap, timeout_ms=100)
+runner = SolutionRunner()
+time.sleep(2.5)
+try:
+    r = runner.call('report')
+    result.accept(score=1000, details={'cap': r})
+except Exception as e:
+    result.accept(score=0, details={'cap': type(e).__name__})
+""#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 15000,
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 5000, // 题目级默认宽松；验证 cap_reg 上报的 100ms 生效
+            memory_limit_mb: 128,
+        },
+    };
+    // solution：延迟 1s 调用 slow_cap（确保 evaluator 已完成 cap_reg 上报），
+    // 捕获超时结果，供 evaluator 的 report() 读取
+    let code = "import threading, time\nfrom noj_solution_sdk import call_capability\n_cap_result = {}\ndef _do():\n    time.sleep(1.0)\n    try:\n        call_capability('slow_cap', 1)\n        _cap_result['status'] = 'ok'\n    except Exception as e:\n        _cap_result['status'] = type(e).__name__\n        _cap_result['code'] = getattr(e, 'code', None)\nthreading.Thread(target=_do, daemon=True).start()\ndef report():\n    return _cap_result\n";
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        noj_judge::dual::evaluate_dual(
+            docker.clone(),
+            "e2e-capability-timeout",
+            &runtime_config,
+            code,
+            "solution.py",
+            None,
+            "/tmp/e2e-cache",
+            100,
+            64,
+            None,
+        ),
+    )
+    .await
+    .expect("评测 30s 外层超时")
+    .expect("评测应正常返回");
+
+    assert_eq!(result.status, "Accepted");
+    let cap = &result.details["cap"];
+    assert_eq!(
+        cap["status"].as_str().unwrap(),
+        "CapabilityError",
+        "solution 应收到 CapabilityError（cap_reg 100ms 超时）: {:?}",
+        result.details
+    );
+    assert_eq!(
+        cap["code"].as_str().unwrap(),
+        "Timeout",
+        "CapabilityError.code 应为 Timeout: {:?}",
+        result.details
     );
 }

--- a/noj-judge/tests/e2e_network_capability.rs
+++ b/noj-judge/tests/e2e_network_capability.rs
@@ -10,10 +10,9 @@
 mod common;
 
 use std::io::{Cursor, Write};
-use std::path::PathBuf;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use bollard::container::LogOutput;
 use bollard::exec::StartExecResults;
 use bollard::models::ExecConfig;
@@ -756,43 +755,6 @@ fn build_support_zip(evaluate_py: &str) -> Vec<u8> {
     buf.into_inner()
 }
 
-/// 确保带 SDK 的评测镜像存在（不存在则用仓库 Dockerfile 构建）。
-///
-/// 镜像内置 noj_evaluator_sdk / noj_solution_sdk 到 site-packages，
-/// 供真实 SDK 全链路测试使用（evaluate_dual 的 solution 启动命令
-/// 硬编码 `python3 -m noj_solution_sdk.host`，镜像必须含 SDK）。
-async fn ensure_sdk_images(docker: &bollard::Docker) -> Result<()> {
-    for (tag, dockerfile) in [
-        (
-            "noj-e2e-sdk-evaluator:latest",
-            "docker/evaluator-python/Dockerfile",
-        ),
-        (
-            "noj-e2e-sdk-solution:latest",
-            "docker/solution-python/Dockerfile",
-        ),
-    ] {
-        let images = docker
-            .list_images(None::<bollard::query_parameters::ListImagesOptions>)
-            .await?;
-        if images.iter().any(|i| i.repo_tags.iter().any(|t| t == tag)) {
-            continue;
-        }
-        println!("构建 SDK 测试镜像 {} ...", tag);
-        let status = std::process::Command::new("docker")
-            .args(["build", "-t", tag, "-f", dockerfile, "."])
-            // buildx 在部分环境写 activity 文件失败（只读 HOME），退回 legacy builder
-            .env("DOCKER_BUILDKIT", "0")
-            .current_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")))
-            .status()
-            .context("执行 docker build 失败")?;
-        if !status.success() {
-            anyhow::bail!("docker build 失败: {}", tag);
-        }
-    }
-    Ok(())
-}
-
 /// bridge 容器真实网络探测：真实 TCP 出网（example.com:443）+ 真实 DNS 解析
 /// （getaddrinfo，线程 + 超时避免 resolver 长时间挂起）。需要宿主外网。
 ///
@@ -905,7 +867,7 @@ async fn capability_sdk_full_chain_with_network() {
     }
     let docker = get_docker().expect("docker");
     common::ensure_test_image(&docker).await.unwrap();
-    ensure_sdk_images(&docker).await.unwrap();
+    common::ensure_sdk_images(&docker).await.unwrap();
 
     let evaluate_py = r#"
 import socket

--- a/noj-judge/tests/e2e_network_capability.rs
+++ b/noj-judge/tests/e2e_network_capability.rs
@@ -20,6 +20,7 @@ use bollard::models::ExecConfig;
 use common::{get_docker, is_e2e_enabled};
 use futures_util::StreamExt;
 use noj_judge::dual::protocol::LineParser;
+use noj_judge::dual::tracker::InFlightTracker;
 use noj_judge::types::{EvaluatorNetwork, EvaluatorRuntime, RuntimeConfig, SolutionRuntime};
 
 /// 创建带 sleep infinity 的测试容器。
@@ -261,6 +262,7 @@ sys.stderr.flush()
     let mut sol_parser = LineParser::new();
     let mut solution_ready = false;
     let mut result_payload: Option<String> = None;
+    let mut tracker = InFlightTracker::new(2000);
 
     let deadline = tokio::time::sleep(Duration::from_secs(30));
     tokio::pin!(deadline);
@@ -286,6 +288,7 @@ sys.stderr.flush()
                     &mut eval_parser,
                     &mut sol_input,
                     &mut result_payload,
+                    &mut tracker,
                     chunk,
                 )
                 .await;
@@ -307,6 +310,7 @@ sys.stderr.flush()
                     &mut eval_input,
                     chunk,
                     &mut solution_ready,
+                    &mut tracker,
                 )
                 .await;
             }
@@ -458,6 +462,7 @@ sys.stderr.flush()
     let mut sol_parser = LineParser::new();
     let mut solution_ready = false;
     let mut result_payload: Option<String> = None;
+    let mut tracker = InFlightTracker::new(2000);
 
     let deadline = tokio::time::sleep(Duration::from_secs(30));
     tokio::pin!(deadline);
@@ -478,6 +483,7 @@ sys.stderr.flush()
                     &mut eval_parser,
                     &mut sol_input,
                     &mut result_payload,
+                    &mut tracker,
                     chunk,
                 )
                 .await;
@@ -498,6 +504,7 @@ sys.stderr.flush()
                     &mut eval_input,
                     chunk,
                     &mut solution_ready,
+                    &mut tracker,
                 )
                 .await;
             }
@@ -644,6 +651,7 @@ sys.stderr.flush()
     let mut sol_parser = LineParser::new();
     let mut solution_ready = false;
     let mut result_payload: Option<String> = None;
+    let mut tracker = InFlightTracker::new(2000);
 
     let deadline = tokio::time::sleep(Duration::from_secs(30));
     tokio::pin!(deadline);
@@ -668,6 +676,7 @@ sys.stderr.flush()
                     &mut eval_parser,
                     &mut sol_input,
                     &mut result_payload,
+                    &mut tracker,
                     chunk,
                 )
                 .await;
@@ -688,6 +697,7 @@ sys.stderr.flush()
                     &mut eval_input,
                     chunk,
                     &mut solution_ready,
+                    &mut tracker,
                 )
                 .await;
             }

--- a/noj-tests/e2e/26_call_timeout.test.ts
+++ b/noj-tests/e2e/26_call_timeout.test.ts
@@ -1,0 +1,266 @@
+/**
+ * 调用级超时（issue #198）全链路 E2E。
+ *
+ * 覆盖：
+ * - 调用级 timeout_ms 覆盖题目级默认（慢调用按调用级超时，记为失败用例，评测继续）
+ * - 缺省时回退题目级 call_timeout_ms（向后兼容旧行为）
+ *
+ * 要求：
+ *   NOJ_RUN_E2E=1 表示启用 E2E 测试套件
+ *   E2E_BASE_URL 指向运行中的 noj-core 服务
+ */
+
+import {
+  apiGet,
+  apiPost,
+  getAdminToken,
+  isE2E,
+  registerUser,
+} from "./helper.ts";
+
+const skip = !isE2E;
+
+// ── 测试常量 ─────────────────────────────────────────
+
+const EVALUATOR_IMAGE = "noj-evaluator-python:dev";
+const SOLUTION_IMAGE = "noj-solution-python:dev";
+const TEST_TAG = `e2e-${Date.now()}`;
+
+// ── 共享 fixtures ────────────────────────────────────
+
+/** 创建（或复用）evaluator 镜像白名单条目 */
+async function ensureImage(
+  image: string,
+  kind: "evaluator" | "solution",
+): Promise<string> {
+  const adminToken = await getAdminToken();
+  const list = await apiGet("/api/v1/admin/judge-images", adminToken);
+  type JiEntry = { id: string; image: string; kind: string };
+  const existing = ((list.body as { data: JiEntry[] }).data ?? []).find(
+    (ji) => ji.image === image && ji.kind === kind,
+  );
+  if (existing) return existing.id;
+
+  const create = await apiPost(
+    "/api/v1/admin/judge-images",
+    {
+      image,
+      kind,
+      mode: "exact",
+      description: `e2e ${kind} image`,
+    },
+    adminToken,
+  );
+  if (create.status !== 201) {
+    throw new Error(
+      `Failed to create image ${image} (kind=${kind}): ${create.status} ${
+        JSON.stringify(create.body)
+      }`,
+    );
+  }
+  return (create.body as { data: JiEntry }).data.id;
+}
+
+/** evaluator 内联脚本：调用 sleep_solution 并捕获异常记录 status */
+function evaluatorCommand(timeoutMs?: number): string {
+  const call = timeoutMs === undefined
+    ? `runner.call('sleep_solution')`
+    : `runner.call('sleep_solution', timeout_ms=${timeoutMs})`;
+  // evaluator.command 无需支持包：直接用 python3 -c 内联
+  return `python3 -c "
+import json
+from noj_evaluator_sdk import SolutionRunner, result
+runner = SolutionRunner()
+try:
+    ${call}
+    result.accept(score=1000, details={'cases': [{'id': 'c1', 'status': 'Accepted'}]})
+except Exception as e:
+    result.accept(score=0, details={'cases': [{'id': 'c1', 'status': type(e).__name__}]})
+"`;
+}
+
+/** 创建题目（双 runtime_config），返回 problem_id */
+async function createDualProblem(
+  adminToken: string,
+  title: string,
+  evaluatorCommand: string,
+  callTimeoutMs: number,
+): Promise<string> {
+  const res = await apiPost(
+    "/api/v1/problems",
+    {
+      title,
+      description: `# ${title}\n\nMarkdown 内容`,
+      difficulty: "medium",
+      type: "P",
+      number: Math.floor(Math.random() * 9000) + 1000,
+      runtime_config: {
+        evaluator: {
+          image: EVALUATOR_IMAGE,
+          command: evaluatorCommand,
+          time_limit_ms: 10_000,
+          memory_limit_mb: 512,
+        },
+        solution: {
+          image: SOLUTION_IMAGE,
+          entry: "solution.py",
+          call_timeout_ms: callTimeoutMs,
+          memory_limit_mb: 256,
+        },
+      },
+    },
+    adminToken,
+  );
+  if (res.status !== 201) {
+    throw new Error(
+      `Failed to create dual problem: ${res.status} ${
+        JSON.stringify(res.body)
+      }`,
+    );
+  }
+  return (res.body as { data: { id: string } }).data.id;
+}
+
+/** 提交并轮询到终态，返回完整 submission data（含 details） */
+async function submitAndWait(
+  userToken: string,
+  problemId: string,
+  code: string,
+): Promise<Record<string, unknown>> {
+  const sub = await apiPost(
+    "/api/v1/submissions",
+    { problem_id: problemId, language: "python3", code },
+    userToken,
+  );
+  if (sub.status !== 201) {
+    throw new Error(
+      `Submit failed: ${sub.status} ${JSON.stringify(sub.body)}`,
+    );
+  }
+  const submissionId = (sub.body as { data: { id: string } }).data.id;
+
+  // 轮询直到 finished（最多 60s）
+  for (let i = 0; i < 30; i++) {
+    const res = await apiGet(
+      `/api/v1/submissions/${submissionId}`,
+      userToken,
+    );
+    if (res.status === 200) {
+      const data = (res.body as { data: Record<string, unknown> }).data;
+      if (data.status === "finished") {
+        return data;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`Submission ${submissionId} 超时未完成`);
+}
+
+// ── Tests ────────────────────────────────────────────
+
+Deno.test({
+  name: "call_timeout: 调用级 timeout_ms 生效，慢调用记为失败用例且评测继续",
+  ignore: skip,
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const adminToken = await getAdminToken();
+    await ensureImage(EVALUATOR_IMAGE, "evaluator");
+    await ensureImage(SOLUTION_IMAGE, "solution");
+
+    const problemId = await createDualProblem(
+      adminToken,
+      `[${TEST_TAG}] 调用级超时`,
+      evaluatorCommand(100), // 调用级 timeout_ms=100（覆盖题目级 5000）
+      5_000, // 题目级默认宽松；验证调用级覆盖
+    );
+
+    const userToken = await registerUser(
+      `callto_${Date.now()}`,
+      `callto_${Date.now()}@test.local`,
+      "UserPass123!",
+    );
+
+    // sleep_solution 睡 300ms > 调用级 100ms
+    const data = await submitAndWait(
+      userToken,
+      problemId,
+      "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\n",
+    );
+
+    const result = data.result as {
+      status: string;
+      details?: { cases?: unknown[] };
+    };
+    if (result.status !== "Accepted") {
+      throw new Error(
+        `评测应继续完成（Accepted），实际 ${result.status}: ${
+          JSON.stringify(data)
+        }`,
+      );
+    }
+    const cases = result.details?.cases as Array<
+      { id: string; status: string }
+    >;
+    if (!cases || cases[0]?.status !== "SolutionTimeoutError") {
+      throw new Error(
+        `超时用例应被记录为 SolutionTimeoutError: ${
+          JSON.stringify(result.details)
+        }`,
+      );
+    }
+  },
+});
+
+Deno.test({
+  name: "call_timeout: 缺省回退题目级 call_timeout_ms",
+  ignore: skip,
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const adminToken = await getAdminToken();
+    await ensureImage(EVALUATOR_IMAGE, "evaluator");
+    await ensureImage(SOLUTION_IMAGE, "solution");
+
+    const problemId = await createDualProblem(
+      adminToken,
+      `[${TEST_TAG}] 缺省回退`,
+      evaluatorCommand(), // 不传 timeout_ms → 回退题目级 100ms
+      100, // 题目级默认：100ms
+    );
+
+    const userToken = await registerUser(
+      `callfb_${Date.now()}`,
+      `callfb_${Date.now()}@test.local`,
+      "UserPass123!",
+    );
+
+    const data = await submitAndWait(
+      userToken,
+      problemId,
+      "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\n",
+    );
+
+    const result = data.result as {
+      status: string;
+      details?: { cases?: unknown[] };
+    };
+    if (result.status !== "Accepted") {
+      throw new Error(
+        `评测应继续完成（Accepted），实际 ${result.status}: ${
+          JSON.stringify(data)
+        }`,
+      );
+    }
+    const cases = result.details?.cases as Array<
+      { id: string; status: string }
+    >;
+    if (!cases || cases[0]?.status !== "SolutionTimeoutError") {
+      throw new Error(
+        `缺省回退应触发题目级超时并记录 SolutionTimeoutError: ${
+          JSON.stringify(result.details)
+        }`,
+      );
+    }
+  },
+});

--- a/openspec/changes/call-timeout-per-call/.openspec.yaml
+++ b/openspec/changes/call-timeout-per-call/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/call-timeout-per-call/design.md
+++ b/openspec/changes/call-timeout-per-call/design.md
@@ -1,0 +1,78 @@
+## Context
+
+当前 `call_timeout_ms` 是题目 `runtime_config.solution` 的固定值，同一道题所有 `runner.call()` 共用同一超时。现状的关键事实：
+
+- `noj-judge/src/dual/mod.rs` 的 `run_dual_loop` 接收 `_call_timeout_ms` 参数（下划线前缀），**实际未使用**——judge 仅双向透明转发 NDJSON 帧，调用级超时当前完全未实现；用户函数死循环只能靠 Evaluator 总超时（`time_limit_ms`）兜底。
+- Evaluator SDK `runner.call(fn, *args)` 无超时参数，SDK 阻塞等响应（注释明确"超时由 judge 端 call_timeout_ms 控制"）；`SolutionTimeoutError`（错误码 `Timeout`）已存在但 judge 从不生成。
+- Solution Host（`noj_solution_sdk.host`）单 worker 顺序执行 call 帧；capability handler 在 evaluator runner 的 reader 线程同步执行。
+- 协议无版本字段；call 帧 `{type, id, fn, args}`，capability 帧 `{type:"capability", id, name, args}`。
+
+约束：向后兼容（旧 SDK / 旧题目零改动）、题目级 `call_timeout_ms` 保留为默认值、Evaluator `time_limit_ms` 保持外层兜底。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Evaluator SDK `runner.call(..., timeout_ms=None)` 按调用指定超时；缺省/非法回退题目级默认。
+- capability 调用采用 `register_capability(..., timeout_ms=None)` 注册时配置的默认超时（经一次性 `cap_reg` 帧上报 judge）。
+- Judge Worker 以 in-flight 追踪 + 参数化 tokio 超时执行调用级超时；超时写 `code="Timeout"` 错误帧，迟到响应按 id 丢弃。
+- 行为统一：`runner.call` 与 capability 走同一套 in-flight 机制；计时起点均为 judge 收到帧的时刻。
+
+**Non-Goals:**
+
+- Solution 侧 `call_capability(..., timeout_ms=...)` 调用级指定超时（用户已明确：采用注册时配置的默认值）。
+- `runner.restart()` 超时（保持现状）。
+- 协议版本字段（可选字段天然兼容）。
+- Solution Host 侧超时逻辑（host 无需感知；无法中断的 Python 线程由 judge 计时 + 迟到响应丢弃兜底）。
+- 用户函数执行中断（Python 线程无法强杀；超时后 host 存活继续执行，结果被丢弃）。
+
+## Decisions
+
+### D1: 计时起点 = judge 收到帧的时刻（A 方案）
+
+从 judge 收到 Evaluator call 帧（或 Solution capability 帧）起算超时，语义 = 调用方等待本次调用的总时间。由于 Solution Host 单 worker 顺序执行，并发 call 排队时间计入超时——排队过久触发的超时同样记为失败用例（`SolutionTimeoutError`），评测继续，不中断。
+
+- 备选 B（从转发给 host 起算，排队不计）：需记录转发时刻，且 evaluator 可能无限期排队；否决。
+- 备选 C（host 回执"开始执行"起算）：需新增协议回执帧，复杂度过高；否决。
+
+### D2: judge 侧 in-flight 追踪（方案 1），非 SDK 侧超时
+
+新建纯逻辑模块 `noj-judge/src/dual/tracker.rs`：`InFlightTracker` 维护 `inflight: HashMap<call_id, (deadline, waiting_side)>`、`cap_timeouts: HashMap<name, timeout_ms>`、`default_call_timeout_ms`。主循环 `tokio::select!` 增加 `sleep_until(最早 deadline)` 分支，到期向等待方写 Timeout 错误帧并移除。
+
+- 备选：每 call 独立 tokio task —— 多 task 竞争同一 stdout 流需 mpsc 分发层，与现有单循环 select 结构冲突大；否决。
+- 备选：SDK 侧 `q.get(timeout=...)` —— 与 issue 明确要求（judge 侧参数化 tokio 超时、RPC 帧带 timeout_ms）不符，judge 无超时日志/监控；否决。
+
+### D3: timeout_ms 为 call 帧可选字段，天然向后兼容
+
+`timeout_ms` 正整数生效，缺省/非正整数回退题目级默认。旧 SDK 不发送该字段 → 旧行为不变。Judge 转发给 host 的帧**原样透传**（host 只读 id/fn/args，忽略多余字段，host.py 零改动）。
+
+### D4: capability 默认超时经 cap_reg 帧上报
+
+`register_capability(name, handler, timeout_ms=None)` 时 SDK 写一次性 `{"type":"cap_reg","name":...,"timeout_ms":...}` 帧到 stdout；judge 更新映射（缺省 → 删除映射回退默认）。`cap_reg` 是 evaluator→judge 私有协议，**不转发**给 Solution Host。`classify_line`（protocol.rs）已把含 `type` 字段的 JSON 归为 Frame，解析层无需改动。
+
+### D5: 错误语义沿用既有错误类型
+
+超时错误帧 `{"type":"error","id":...,"code":"Timeout","message":"..."}` → Evaluator SDK 抛既有 `SolutionTimeoutError`（errors.py 已存在）。capability 方向：solution SDK 收到同构错误帧（其 pending 尚在，正常分发抛错）。SDK 侧校验：`timeout_ms` 非 None 且非正整数 → `ValueError`；judge 侧防御：恶意帧非法值 → 回退默认。
+
+### D6: 迟到响应按 id 丢弃
+
+`resolve_response(id)`：in-flight 命中 → 移除并转发；未命中（含已超时、未知）→ 丢弃 + 限频 warn 日志。超时与响应到达的竞态由主循环每轮先 `expire_now` 再处理新 chunk 的顺序消解。
+
+## Risks / Trade-offs
+
+- [排队时间计入超时（D1）] → Evaluator 多线程并发时，排在长任务后的调用可能"无辜超时" → 语义明确记录在案（等待总时间），evaluator 可将 `CallTimeout` 记为失败用例；出题人可调大调用级超时或减少并发。
+- [Python 函数无法中断] → 超时后 host 仍执行完该函数，期间后续调用排队 → 迟到结果丢弃（D6），host 存活语义不变。
+- [行为变化：调用级超时首次真正生效] → 此前死循环靠总超时兜底的题目，可能提前按调用超时失败 → 题目级默认值保留 + 文档同步（web-editor.md），出题人可调优。
+- [cap_reg 映射生命周期] → 单次评测内有效，容器销毁即消失 → 天然正确，无需清理。
+- [capability handler 死循环仍无解] → 本次仅覆盖 capability 超时（注册默认值），handler 死循环由超时错误帧保护调用方（solution），评测可继续；handler 侧死循环本身仍受 Evaluator 总超时兜底。
+
+## Migration Plan
+
+1. 按 tasks.md 顺序实施：tracker 模块 → SDK 扩展 → dual 主循环接入 → E2E → 文档。
+2. 协议向后兼容：旧 SDK 不发 `timeout_ms`、不注册 cap_reg → judge 回退默认；无需数据迁移、无 DB schema 变更。
+3. 回滚策略：judge 侧改动集中在 dual 模块（tracker 可整体移除）；SDK 签名向后兼容（新增可选参数）。任一环节回退均不破坏旧题目。
+4. 部署顺序：先发 noj-judge（tracker + 主循环），再发 SDK 镜像（evaluator-python / solution-python 重建），noj-core 无行为变更（仅注释）。
+
+## Open Questions
+
+- 无。设计已由 brainstorming 流程确认（计时起点、范围、capability 默认值机制、迟到响应丢弃均经用户拍板）。

--- a/openspec/changes/call-timeout-per-call/proposal.md
+++ b/openspec/changes/call-timeout-per-call/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+当前 `call_timeout_ms` 是题目 `runtime_config.solution` 的固定值，同一道题的所有 `runner.call()` 共用同一个超时。不同用例耗时差异可能很大（简单用例毫秒级、复杂推理用例数十秒），且大模型能力评测中每次调用耗时波动大：固定值要么频繁误杀、要么整体放大风险窗口。需要把超时控制下沉到单次调用粒度。
+
+## What Changes
+
+- Evaluator SDK `runner.call(fn, *args, timeout_ms=None)`：每次调用可**按调用指定超时**；`timeout_ms` 缺省/非法时由 Judge Worker 回退到题目级 `runtime_config.solution.call_timeout_ms`（向后兼容，题目级配置保留为默认值）。
+- RPC call 帧增加可选 `timeout_ms` 字段（正整数生效；该字段仅供 Judge 计时，Solution Host 执行逻辑不感知）。
+- Judge Worker 执行层支持调用级超时：in-flight 追踪 + 参数化 tokio 超时；超时向等待方写 `code="Timeout"` 错误帧，Evaluator 侧抛既有 `SolutionTimeoutError`，可捕获记为失败用例继续评测；迟到的响应帧按 id 丢弃。
+- capability 反向调用（Solution → Evaluator）同样纳入超时：`register_capability(name, handler, timeout_ms=None)` 注册时配置默认值，经一次性 `cap_reg` 帧上报 Judge，缺省回退题目级默认；Solution 调用侧不指定超时。
+- 超时计时起点：Judge 收到帧的时刻（call 帧 / capability 帧）。
+- 文档同步：evaluator-sdk.md / rpc.md / web-editor.md 与 core 类型注释。
+- **行为变化**：调用级超时首次真正生效——此前用户函数死循环只能靠 Evaluator 总超时（`time_limit_ms`）兜底；此后会被调用级超时打断（记为失败调用，评测继续）。
+
+## Capabilities
+
+### New Capabilities
+
+- `call-timeout-per-call`: 调用级超时能力——Evaluator SDK `runner.call(..., timeout_ms)` 与 `register_capability(..., timeout_ms)` API、call 帧 `timeout_ms` 字段、`cap_reg` 帧协议、Judge Worker in-flight 超时追踪（计时起点、超时错误帧、迟到响应丢弃、题目级默认回退）。
+
+### Modified Capabilities
+
+- `judge-worker`: 「时间层级关系」与「单次调用超时」场景语义更新——单次调用超时受调用级 `timeout_ms` 约束、缺省回退题目级 `call_timeout_ms`；超时后 Judge 向 Evaluator 回 `Timeout` 错误帧并丢弃迟到响应（而非"停止写入通道"）。
+- `network-capability`: `register_capability` API 签名增加可选 `timeout_ms`（注册时配置的 capability 调用默认超时，经 `cap_reg` 帧上报 Judge）。
+- `problem-runtime-config`: `solution.call_timeout_ms` 角色明确为**调用级超时的题目级默认值**（校验不变：仍为必填正整数）。
+
+## Impact
+
+- **noj-judge**：`src/dual/mod.rs`（run_dual_loop / handle_eval_chunk / handle_sol_chunk 超时感知改造）、新增 `src/dual/tracker.rs`（InFlightTracker 纯逻辑模块）、`src/dual/protocol.rs`（cap_reg 帧常量）；`sdk/evaluator/noj_evaluator_sdk/runner.py`（call 签名）、`capability.py`（register_capability 签名 + cap_reg 帧输出）；`tests/e2e_dual_container.rs`（E2E）。
+- **noj-tests**：新增全链路 E2E（调用级超时 + 缺省回退）。
+- **noj-core**：`src/types/index.ts` 与 `src/services/problems-types.ts` 注释同步（字段校验不变）。
+- **文档**：`noj-docs/docs/problemsetters/{evaluator-sdk,rpc,web-editor}.md`。
+- **协议**：call 帧可选字段 `timeout_ms`（向后兼容，不新增协议版本号）；新增 evaluator→judge 私有 `cap_reg` 帧（不转发）。

--- a/openspec/changes/call-timeout-per-call/specs/call-timeout-per-call/spec.md
+++ b/openspec/changes/call-timeout-per-call/specs/call-timeout-per-call/spec.md
@@ -1,0 +1,87 @@
+## Purpose
+
+定义调用级超时能力：Evaluator SDK 每次 `runner.call()` 可指定独立超时（缺省回退题目级 `call_timeout_ms`），capability 调用采用注册时配置的默认超时；Judge Worker 以 in-flight 追踪实现参数化超时执行。
+
+## Requirements
+
+### Requirement: 调用级超时参数（Evaluator SDK）
+
+系统 SHALL 在 `noj_evaluator_sdk` 的 `SolutionRunner.call()` 提供可选 `timeout_ms` 参数，使每次调用可指定独立超时。
+
+#### Scenario: 按调用指定超时
+
+- **WHEN** evaluate.py 调用 `runner.call("solve", 1, 2, timeout_ms=5000)`
+- **THEN** 本次调用的超时按 5000ms 执行（覆盖题目级默认值）
+
+#### Scenario: 缺省回退题目级默认
+
+- **WHEN** evaluate.py 调用 `runner.call("solve", 1, 2)`（不带 `timeout_ms`）
+- **THEN** 本次调用的超时回退到题目级 `runtime_config.solution.call_timeout_ms`
+
+#### Scenario: 非法 timeout_ms 被拒绝
+
+- **WHEN** `timeout_ms` 为 0 / 负数 / 非整数
+- **THEN** SDK 立即抛出 `ValueError`，不发出 call 帧
+
+### Requirement: call 帧 timeout_ms 字段
+
+系统 SHALL 在 call 帧中支持可选 `timeout_ms` 字段，仅由 Judge Worker 用于计时。
+
+#### Scenario: 帧携带 timeout_ms
+
+- **WHEN** `runner.call(..., timeout_ms=5000)` 发出 call 帧
+- **THEN** 帧包含 `"timeout_ms": 5000` 字段
+- **THEN** judge 以该值作为本次调用的超时
+- **THEN** Solution Host 执行逻辑不感知该字段（原样透传，host 忽略多余字段）
+
+#### Scenario: 帧缺省不带字段
+
+- **WHEN** `runner.call(...)` 未指定 `timeout_ms`
+- **THEN** call 帧不含 `timeout_ms` 字段（向后兼容旧 SDK / 旧题目）
+
+### Requirement: Judge 调用级超时执行
+
+系统 SHALL 在 Judge Worker 双容器主循环中实现调用级超时：in-flight 追踪 + 参数化超时，超时向等待方返回 `Timeout` 错误帧。
+
+#### Scenario: 超时计时起点
+
+- **WHEN** judge 收到 evaluator 的 call 帧（或 solution 的 capability 帧）
+- **THEN** 超时自该时刻起算，到期未收到响应则判定该调用超时
+
+#### Scenario: 超时返回 Timeout 错误帧
+
+- **WHEN** 单次调用在生效超时内未收到响应
+- **THEN** judge 向等待方写 `{"type":"error","id":"<调用id>","code":"Timeout","message":"..."}` 错误帧
+- **THEN** Evaluator 侧 `runner.call()` 抛出 `SolutionTimeoutError`（capability 方向则 solution 侧收到对应错误）
+- **THEN** Solution Host 进程继续运行（不退出），后续调用可正常执行
+
+#### Scenario: 迟到响应丢弃
+
+- **WHEN** 某调用已超时后其响应帧才到达
+- **THEN** judge 按 id 匹配丢弃该迟到响应，不转发给等待方
+
+#### Scenario: 并发调用各自独立计时
+
+- **WHEN** 同一次评测内多个调用并发进行且超时值不同
+- **THEN** 每个调用按各自生效超时独立计时，互不影响
+
+### Requirement: capability 注册默认超时（cap_reg）
+
+系统 SHALL 支持 `register_capability(name, handler, timeout_ms=None)` 配置 capability 调用的默认超时，并经 `cap_reg` 帧一次性上报 Judge。
+
+#### Scenario: 注册时配置默认超时
+
+- **WHEN** evaluate.py 调用 `register_capability("request_llm_completion", handler, timeout_ms=10000)`
+- **THEN** SDK 向 stdout 写一次性 `{"type":"cap_reg","name":"request_llm_completion","timeout_ms":10000}` 帧
+- **THEN** judge 记录该 capability 的默认超时映射，后续 capability 调用按此值计时
+
+#### Scenario: 注册缺省超时
+
+- **WHEN** `register_capability(name, handler)` 未指定 `timeout_ms`
+- **THEN** cap_reg 帧不含 `timeout_ms` 字段
+- **THEN** judge 删除该 capability 的映射，其调用回退题目级 `call_timeout_ms`
+
+#### Scenario: cap_reg 帧不转发
+
+- **WHEN** judge 收到 evaluator 的 cap_reg 帧
+- **THEN** judge 仅更新映射，不将该帧转发给 Solution Host

--- a/openspec/changes/call-timeout-per-call/specs/judge-worker/spec.md
+++ b/openspec/changes/call-timeout-per-call/specs/judge-worker/spec.md
@@ -1,0 +1,95 @@
+## MODIFIED Requirements
+
+### Requirement: 双容器评测编排（dual mode）
+
+系统 SHALL 支持按题目一次任务启动 Evaluator + Solution 两个容器，按 NDJSON 协议在两个容器之间转发调用消息。
+
+#### Scenario: 启动 Evaluator + Solution 双容器
+
+- **WHEN** JudgeTask.mode === 'dual'
+- **THEN** judge 启动 Evaluator 容器（网络隔离、不立即执行 evaluate.py）
+- **THEN** judge 通过 `docker exec tar xf` 注入支持包文件到 Evaluator 容器的 `/workspace` 目录
+- **THEN** judge 启动 Solution 容器（无网络、无支持包、不传 Evaluator 环境变量）
+- **THEN** judge 通过 docker exec 在 Evaluator 容器内运行 `runtime_config.evaluator.command`
+- **THEN** judge 通过 docker exec 在 Solution 容器内运行 `python3 -m noj_solution_sdk.host --entry <solution.entry>`
+- **THEN** Solution host 启动后 5 秒内必须发送 `ready` 帧，否则判 SystemError
+
+#### Scenario: NDJSON 帧转发（Evaluator → Solution）
+
+- **WHEN** Evaluator SDK 调用 `SolutionRunner.call(fn, ...args, timeout_ms?)`
+- **THEN** SDK 通过 stdout 输出一行 NDJSON 帧 `{type: 'call', id, fn, args}`（可含可选 `timeout_ms` 字段）
+- **THEN** judge 读取 evaluator exec stdout 中的 NDJSON 帧，登记调用级超时后原样转发到 solution host stdin
+- **THEN** Solution host 处理后通过 stdout 输出 `result` 或 `error` 帧
+- **THEN** judge 按 id 命中判定后把响应帧原样回写到 evaluator exec stdin（迟到/未知响应丢弃）
+- **THEN** SDK 从 stdin 读到响应帧后阻塞调用返回
+
+#### Scenario: 多次调用复用同一 Solution host
+
+- **WHEN** 一次评测内多次调用 `SolutionRunner.call()`
+- **THEN** 全部调用复用同一 Solution host 进程（persistent 模式）
+- **THEN** Solution host 内的全局状态在调用之间持续存在
+- **WHEN** `runner.restart()` 被调用
+- **THEN** judge 关闭旧 Solution host 进程，启动新 host 进程
+
+#### Scenario: 单次调用超时（调用级 timeout_ms）
+
+- **WHEN** 某次 `runner.call()` 超过其生效超时（调用级 `timeout_ms` 或题目级默认 `runtime_config.solution.call_timeout_ms`）
+- **THEN** judge 向 evaluator 写 `code: 'Timeout'` 错误帧
+- **THEN** SDK 收到 Timeout 错误并抛出 `SolutionTimeoutError`
+- **THEN** 该调用 id 的迟到响应被 judge 丢弃
+- **THEN** Solution host 进程继续运行（不退出）
+
+#### Scenario: Evaluator 总时间超时
+
+- **WHEN** Evaluator 容器总执行时间超过 `runtime_config.evaluator.time_limit_ms`
+- **THEN** judge `docker stop -t kill_grace_secs` Evaluator 容器
+- **THEN** judge `docker kill` Evaluator 容器（如未退）
+
+### Requirement: NDJSON 协议帧类型与字段
+
+系统 SHALL 在 Evaluator / Solution 容器之间传输 NDJSON 帧，定义统一的帧类型与字段。
+
+#### Scenario: 帧类型枚举
+
+- **WHEN** 任何容器发送 NDJSON 帧
+- **THEN** `type` 字段必须是下列之一：`ready` / `call` / `result` / `error` / `log` / `shutdown` / `cap_reg`
+- **WHEN** `type` 为 `cap_reg`
+- **THEN** 该帧为 evaluator → judge 私有协议（capability 默认超时上报），judge 不转发给 Solution Host
+- **WHEN** `type` 为非法值
+- **THEN** 接收方记录 warn 日志并丢弃该帧
+
+#### Scenario: 错误码枚举
+
+- **WHEN** `type === 'error'`
+- **THEN** `code` 字段必须是下列之一：`Timeout` / `NotFound` / `Exception` / `SystemError` / `Rejected`
+
+#### Scenario: 类型安全序列化
+
+- **WHEN** Evaluator SDK 序列化 `runner.call()` 参数
+- **THEN** 仅接受 `None` / `bool` / `int` / `float` / `str` / `bytes` / `list` / `dict` 七种类型
+- **WHEN** 参数包含其他类型（如自定义类、函数、模块、socket、生成器）
+- **THEN** Solution host 抛 `code: 'Rejected'`，host 进程继续运行
+
+#### Scenario: Trace 路径清洗
+
+- **WHEN** Solution host 格式化用户代码异常的 traceback
+- **THEN** 仅保留文件 basename + 行号 + 类名 + 消息
+- **THEN** 剥离所有绝对路径（不暴露 SDK 安装路径或容器镜像 layout）
+
+### Requirement: 时间层级关系
+
+系统 SHALL 明确 Evaluator / Solution / SDK 调用三层时间约束的语义。
+
+#### Scenario: 时间约束分层
+
+- **WHEN** dual mode 评测启动
+- **THEN** 单次 `runner.call()` 受调用级 `timeout_ms` 约束（缺省回退 `runtime_config.solution.call_timeout_ms` 默认值）
+- **THEN** `runtime_config.evaluator.time_limit_ms` 约束 Evaluator 容器总时间（含全部 SDK 调用）
+- **THEN** 评测实际总耗时 = sum(SDK 调用耗时) + overhead，且 ≤ `evaluator.time_limit_ms`
+- **THEN** `result.accept/wrong_answer` 调用本身不受调用超时限制
+
+#### Scenario: 单次超时不影响 host
+
+- **WHEN** 单次 `runner.call()` 超过其生效超时
+- **THEN** judge 向 evaluator 写 Timeout 错误帧，SDK 收到 Timeout 错误
+- **THEN** Solution host 进程继续运行，下一次 `runner.call()` 可正常执行

--- a/openspec/changes/call-timeout-per-call/specs/network-capability/spec.md
+++ b/openspec/changes/call-timeout-per-call/specs/network-capability/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: evaluator SDK register_capability API
+
+系统 SHALL 在 `noj_evaluator_sdk` 提供 `register_capability(name, handler, timeout_ms=None)`，供 evaluate.py 注册可被 solution 调用的能力，并可配置该 capability 调用的默认超时。
+
+#### Scenario: 注册并处理调用
+
+- **WHEN** evaluate.py 调用 `register_capability("request_llm_completion", handler)`
+- **THEN** solution 的 `call_capability("request_llm_completion", ...)` 被转发到该 handler 执行
+- **THEN** handler 返回值经 codec 编码后作为 result 帧返回
+
+#### Scenario: 注册时配置默认超时
+
+- **WHEN** evaluate.py 调用 `register_capability("request_llm_completion", handler, timeout_ms=10000)`
+- **THEN** SDK 向 stdout 写一次性 `{"type":"cap_reg","name":"request_llm_completion","timeout_ms":10000}` 帧上报 judge
+- **THEN** 该 capability 的后续调用按 10000ms 超时计时（缺省回退题目级 `call_timeout_ms`）
+
+#### Scenario: 重复注册同名 capability
+
+- **WHEN** evaluate.py 对同一名称注册两次
+- **THEN** 第二次注册覆盖第一次（最近注册生效，含超时映射）
+
+#### Scenario: 非法 timeout_ms 被拒绝
+
+- **WHEN** `register_capability` 的 `timeout_ms` 为 0 / 负数 / 非整数
+- **THEN** SDK 抛出 `ValueError`，不注册也不发出 cap_reg 帧
+
+#### Scenario: handler 抛异常
+
+- **WHEN** handler 执行时抛出异常
+- **THEN** evaluator 返回 error 帧（code=Exception，含截断 traceback）
+- **THEN** solution 侧抛出对应异常，评测流程不中断（evaluator 可捕获后继续）

--- a/openspec/changes/call-timeout-per-call/specs/problem-runtime-config/spec.md
+++ b/openspec/changes/call-timeout-per-call/specs/problem-runtime-config/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: 题目运行时配置（runtime_config）
+
+系统 SHALL 在 `problems` 表中存储 JSONB 格式的 `runtime_config`，用于描述双容器评测模式下的 Evaluator 与 Solution 各自运行时参数。
+
+#### Scenario: problems 表 runtime_config 列
+
+- **WHEN** 检查 `problems` 表结构
+- **THEN** `runtime_config` 为 JSONB NOT NULL 列（统一双容器模式，无单容器回退）
+
+#### Scenario: RuntimeConfig 结构
+
+- **WHEN** 用户设置 `runtime_config` 字段
+- **THEN** 必填结构：
+  - `evaluator.image: string`（必填，Docker 镜像名）
+  - `evaluator.command: string`（可选，缺省注入默认值 `python3 /workspace/evaluate.py`）
+  - `evaluator.time_limit_ms: number`（必填，> 0）
+  - `evaluator.memory_limit_mb: number`（必填，> 0）
+  - `evaluator.network: object`（可选，缺省视为 `{"enabled": false}`）
+  - `solution.image: string`（必填）
+  - `solution.entry: string`（必填，如 `solution.py`）
+  - `solution.call_timeout_ms: number`（必填，> 0；作为调用级超时的**题目级默认值**，`runner.call(..., timeout_ms)` 可按调用覆盖）
+  - `solution.memory_limit_mb: number`（必填，> 0）
+
+#### Scenario: evaluator.command 缺省注入默认值
+
+- **WHEN** 导入统一题目包时 `runtime_config.evaluator.command` 缺省
+- **THEN** 系统在落库前注入默认值 `python3 /workspace/evaluate.py`
+- **THEN** 落库后的 `runtime_config.evaluator.command` 为非空字符串，结构与既有题目一致
+
+#### Scenario: API 创建/更新路径 command 必填
+
+- **WHEN** 通过题目 CRUD API 创建/更新题目且 `runtime_config.evaluator.command` 缺省
+- **THEN** 系统返回 HTTP 400（command 为必填字段；默认值注入仅限统一题目包导入路径）

--- a/openspec/changes/call-timeout-per-call/tasks.md
+++ b/openspec/changes/call-timeout-per-call/tasks.md
@@ -1,0 +1,41 @@
+## 1. InFlightTracker 纯逻辑模块
+
+- [ ] 1.1 创建 `noj-judge/src/dual/tracker.rs`：`WaitingSide` 枚举（Evaluator/Solution）、`InFlightTracker`（`inflight: HashMap<call_id, (deadline, waiting)>`、`cap_timeouts: HashMap<name, timeout_ms>`、`default_call_timeout_ms`），方法 `on_call_frame` / `on_cap_reg_frame` / `on_capability_frame` / `resolve_response` / `expire_now` / `next_deadline` / `is_empty`，超时解析规则（正整数生效、缺省/非法回退默认）
+- [ ] 1.2 在 `noj-judge/src/dual/mod.rs` 声明 `pub mod tracker;`
+- [ ] 1.3 编写单元测试（11 个，见 `docs/superpowers/plans/2026-08-04-call-timeout-per-call.md` Task 1）：缺省/显式/非法超时回退、无 id 返回 None、cap_reg 注册/覆盖/删除、capability 命中映射与回退、响应命中移除、未知 id false、expire 摘除与方向、并发独立 deadline、next_deadline 取最小
+- [ ] 1.4 运行 `cargo test --lib dual::tracker` 与 `cargo clippy --lib` 通过后 `cargo fmt` 并提交（feat(judge): 新增调用级超时追踪器 InFlightTracker）
+
+## 2. Evaluator SDK 扩展
+
+- [ ] 2.1 `runner.py` 的 `SolutionRunner.call(fn, *args, timeout_ms=None)`：校验 timeout_ms（None 或正整数，否则 `ValueError`）；指定时 call 帧带 `timeout_ms` 字段，缺省不带
+- [ ] 2.2 `capability.py` 的 `register_capability(name, handler, timeout_ms=None)`：校验 timeout_ms；注册后写一次性 `{"type":"cap_reg","name":...,"timeout_ms":...}` 帧到 stdout（线程安全，`_OUT_LOCK`；timeout_ms=None 时帧不含该字段）
+- [ ] 2.3 在 `tests/test_runner.py` 追加单测（7 个）：call 帧含/不含 timeout_ms、非法值抛 ValueError 且不发帧、cap_reg 帧发出/缺字段/非法值抛错
+- [ ] 2.4 运行 `python3 -m unittest noj_evaluator_sdk.tests.test_runner -v` 全部通过后提交（feat(judge): Evaluator SDK 支持调用级 timeout_ms 与 cap_reg 上报）
+
+## 3. dual 主循环接入调用级超时
+
+- [ ] 3.1 改造 `handle_eval_chunk`（新增 `sol_input` 与 `tracker` 参数）：call 帧登记后原样转发、cap_reg 帧仅更新映射不转发、result/error 帧按 `resolve_response` 命中判定转发或丢弃
+- [ ] 3.2 改造 `handle_sol_chunk`（新增 `tracker` 参数）：capability 帧查映射登记后转发、result/error 帧按 id 判定转发或丢弃
+- [ ] 3.3 改造 `run_dual_loop`：`_call_timeout_ms` 改名为 `default_call_timeout_ms` 并传入 `InFlightTracker::new`；两阶段 `tokio::select!` 增加 `sleep_until(最早 deadline)` 分支，到期按 `WaitingSide` 向对应方向写 `{"type":"error","id":...,"code":"Timeout","message":"call timeout"}` 错误帧并移除
+- [ ] 3.4 新增 `write_timeout_frame(writer, id)` 辅助函数；同步更新 `evaluate_dual` 调用处与 `mod_test_helpers` 两个 probe 函数签名
+- [ ] 3.5 在 mod.rs tests 追加测试（2 个）：call 帧被追踪且原样转发（含 timeout_ms 字段）、cap_reg 帧不转发
+- [ ] 3.6 运行 `cargo test --all-targets` 与 `cargo clippy --lib` 通过后 `cargo fmt` 并提交（feat(judge): dual 主循环接入调用级超时）
+
+## 4. judge E2E（真实容器）
+
+- [ ] 4.1 在 `tests/e2e_dual_container.rs` 新增 `dual_call_timeout_fallback_to_problem_default`（`#[ignore]` + `#[serial_test::serial]`）：evaluator 不传 timeout_ms、题目级 100ms、solution 睡 300ms → 断言 `SolutionTimeoutError` 用例被记录、评测最终 Accepted
+- [ ] 4.2 新增 `dual_call_timeout_per_call_concurrent`：两线程并发 call（50ms 超时慢调用 + 5000ms 正常调用）→ 各自独立生效，慢调用超时、快调用返回 42
+- [ ] 4.3 运行 `cargo check --tests` 编译通过；有 Docker 时 `NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_call_timeout -- --ignored --nocapture` 通过后提交（test(judge): 调用级超时 E2E）
+
+## 5. noj-tests 全链路 E2E
+
+- [ ] 5.1 新建 `noj-tests/e2e/26_call_timeout.test.ts`（参照 15_dual_container_judge.test.ts 模式）：用例 A 调用级 timeout_ms 生效（慢调用记为 SolutionTimeoutError、评测继续 Accepted）、用例 B 缺省回退题目级 call_timeout_ms
+- [ ] 5.2 运行 `cd noj-tests && deno task test --filter call_timeout` 通过（无完整评测栈时至少 `deno check` 通过），`deno fmt` 后提交（test(core,judge): 调用级超时全链路 E2E）
+
+## 6. 文档与注释同步
+
+- [ ] 6.1 `noj-docs/docs/problemsetters/evaluator-sdk.md`：`runner.call(..., timeout_ms=None)` 签名与缺省回退说明、`register_capability(..., timeout_ms=None)` 默认值语义、`SolutionTimeoutError` 用法
+- [ ] 6.2 `noj-docs/docs/problemsetters/rpc.md`：call 帧 `timeout_ms` 可选字段（仅 judge 计时）、`cap_reg` 帧（私有协议不转发）、错误来源表 `CallTimeout` 更新、缺省回退规则
+- [ ] 6.3 `noj-docs/docs/problemsetters/web-editor.md`：`call_timeout_ms` 语义 = 题目级默认值，`runner.call(..., timeout_ms)` 可按调用覆盖
+- [ ] 6.4 `noj-core/src/types/index.ts` 与 `src/services/problems-types.ts`：注释同步（call_timeout_ms 默认值角色；校验不变）
+- [ ] 6.5 运行 `cd noj-core && deno fmt --check` 相关文件后提交（docs(root,core): 同步调用级超时文档与注释）

--- a/openspec/changes/call-timeout-per-call/tasks.md
+++ b/openspec/changes/call-timeout-per-call/tasks.md
@@ -1,41 +1,41 @@
 ## 1. InFlightTracker 纯逻辑模块
 
-- [ ] 1.1 创建 `noj-judge/src/dual/tracker.rs`：`WaitingSide` 枚举（Evaluator/Solution）、`InFlightTracker`（`inflight: HashMap<call_id, (deadline, waiting)>`、`cap_timeouts: HashMap<name, timeout_ms>`、`default_call_timeout_ms`），方法 `on_call_frame` / `on_cap_reg_frame` / `on_capability_frame` / `resolve_response` / `expire_now` / `next_deadline` / `is_empty`，超时解析规则（正整数生效、缺省/非法回退默认）
-- [ ] 1.2 在 `noj-judge/src/dual/mod.rs` 声明 `pub mod tracker;`
-- [ ] 1.3 编写单元测试（11 个，见 `docs/superpowers/plans/2026-08-04-call-timeout-per-call.md` Task 1）：缺省/显式/非法超时回退、无 id 返回 None、cap_reg 注册/覆盖/删除、capability 命中映射与回退、响应命中移除、未知 id false、expire 摘除与方向、并发独立 deadline、next_deadline 取最小
-- [ ] 1.4 运行 `cargo test --lib dual::tracker` 与 `cargo clippy --lib` 通过后 `cargo fmt` 并提交（feat(judge): 新增调用级超时追踪器 InFlightTracker）
+- [x] 1.1 创建 `noj-judge/src/dual/tracker.rs`：`WaitingSide` 枚举（Evaluator/Solution）、`InFlightTracker`（`inflight: HashMap<call_id, (deadline, waiting)>`、`cap_timeouts: HashMap<name, timeout_ms>`、`default_call_timeout_ms`），方法 `on_call_frame` / `on_cap_reg_frame` / `on_capability_frame` / `resolve_response` / `expire_now` / `next_deadline` / `is_empty`，超时解析规则（正整数生效、缺省/非法回退默认）
+- [x] 1.2 在 `noj-judge/src/dual/mod.rs` 声明 `pub mod tracker;`
+- [x] 1.3 编写单元测试（11 个，见 `docs/superpowers/plans/2026-08-04-call-timeout-per-call.md` Task 1）：缺省/显式/非法超时回退、无 id 返回 None、cap_reg 注册/覆盖/删除、capability 命中映射与回退、响应命中移除、未知 id false、expire 摘除与方向、并发独立 deadline、next_deadline 取最小
+- [x] 1.4 运行 `cargo test --lib dual::tracker` 与 `cargo clippy --lib` 通过后 `cargo fmt` 并提交（feat(judge): 新增调用级超时追踪器 InFlightTracker）
 
 ## 2. Evaluator SDK 扩展
 
-- [ ] 2.1 `runner.py` 的 `SolutionRunner.call(fn, *args, timeout_ms=None)`：校验 timeout_ms（None 或正整数，否则 `ValueError`）；指定时 call 帧带 `timeout_ms` 字段，缺省不带
-- [ ] 2.2 `capability.py` 的 `register_capability(name, handler, timeout_ms=None)`：校验 timeout_ms；注册后写一次性 `{"type":"cap_reg","name":...,"timeout_ms":...}` 帧到 stdout（线程安全，`_OUT_LOCK`；timeout_ms=None 时帧不含该字段）
-- [ ] 2.3 在 `tests/test_runner.py` 追加单测（7 个）：call 帧含/不含 timeout_ms、非法值抛 ValueError 且不发帧、cap_reg 帧发出/缺字段/非法值抛错
-- [ ] 2.4 运行 `python3 -m unittest noj_evaluator_sdk.tests.test_runner -v` 全部通过后提交（feat(judge): Evaluator SDK 支持调用级 timeout_ms 与 cap_reg 上报）
+- [x] 2.1 `runner.py` 的 `SolutionRunner.call(fn, *args, timeout_ms=None)`：校验 timeout_ms（None 或正整数，否则 `ValueError`）；指定时 call 帧带 `timeout_ms` 字段，缺省不带
+- [x] 2.2 `capability.py` 的 `register_capability(name, handler, timeout_ms=None)`：校验 timeout_ms；注册后写一次性 `{"type":"cap_reg","name":...,"timeout_ms":...}` 帧到 stdout（线程安全，`_OUT_LOCK`；timeout_ms=None 时帧不含该字段）
+- [x] 2.3 在 `tests/test_runner.py` 追加单测（7 个）：call 帧含/不含 timeout_ms、非法值抛 ValueError 且不发帧、cap_reg 帧发出/缺字段/非法值抛错
+- [x] 2.4 运行 `python3 -m unittest noj_evaluator_sdk.tests.test_runner -v` 全部通过后提交（feat(judge): Evaluator SDK 支持调用级 timeout_ms 与 cap_reg 上报）
 
 ## 3. dual 主循环接入调用级超时
 
-- [ ] 3.1 改造 `handle_eval_chunk`（新增 `sol_input` 与 `tracker` 参数）：call 帧登记后原样转发、cap_reg 帧仅更新映射不转发、result/error 帧按 `resolve_response` 命中判定转发或丢弃
-- [ ] 3.2 改造 `handle_sol_chunk`（新增 `tracker` 参数）：capability 帧查映射登记后转发、result/error 帧按 id 判定转发或丢弃
-- [ ] 3.3 改造 `run_dual_loop`：`_call_timeout_ms` 改名为 `default_call_timeout_ms` 并传入 `InFlightTracker::new`；两阶段 `tokio::select!` 增加 `sleep_until(最早 deadline)` 分支，到期按 `WaitingSide` 向对应方向写 `{"type":"error","id":...,"code":"Timeout","message":"call timeout"}` 错误帧并移除
-- [ ] 3.4 新增 `write_timeout_frame(writer, id)` 辅助函数；同步更新 `evaluate_dual` 调用处与 `mod_test_helpers` 两个 probe 函数签名
-- [ ] 3.5 在 mod.rs tests 追加测试（2 个）：call 帧被追踪且原样转发（含 timeout_ms 字段）、cap_reg 帧不转发
-- [ ] 3.6 运行 `cargo test --all-targets` 与 `cargo clippy --lib` 通过后 `cargo fmt` 并提交（feat(judge): dual 主循环接入调用级超时）
+- [x] 3.1 改造 `handle_eval_chunk`（新增 `sol_input` 与 `tracker` 参数）：call 帧登记后原样转发、cap_reg 帧仅更新映射不转发、result/error 帧按 `resolve_response` 命中判定转发或丢弃
+- [x] 3.2 改造 `handle_sol_chunk`（新增 `tracker` 参数）：capability 帧查映射登记后转发、result/error 帧按 id 判定转发或丢弃
+- [x] 3.3 改造 `run_dual_loop`：`_call_timeout_ms` 改名为 `default_call_timeout_ms` 并传入 `InFlightTracker::new`；两阶段 `tokio::select!` 增加 `sleep_until(最早 deadline)` 分支，到期按 `WaitingSide` 向对应方向写 `{"type":"error","id":...,"code":"Timeout","message":"call timeout"}` 错误帧并移除
+- [x] 3.4 新增 `write_timeout_frame(writer, id)` 辅助函数；同步更新 `evaluate_dual` 调用处与 `mod_test_helpers` 两个 probe 函数签名
+- [x] 3.5 在 mod.rs tests 追加测试（2 个）：call 帧被追踪且原样转发（含 timeout_ms 字段）、cap_reg 帧不转发
+- [x] 3.6 运行 `cargo test --all-targets` 与 `cargo clippy --lib` 通过后 `cargo fmt` 并提交（feat(judge): dual 主循环接入调用级超时）
 
 ## 4. judge E2E（真实容器）
 
-- [ ] 4.1 在 `tests/e2e_dual_container.rs` 新增 `dual_call_timeout_fallback_to_problem_default`（`#[ignore]` + `#[serial_test::serial]`）：evaluator 不传 timeout_ms、题目级 100ms、solution 睡 300ms → 断言 `SolutionTimeoutError` 用例被记录、评测最终 Accepted
-- [ ] 4.2 新增 `dual_call_timeout_per_call_concurrent`：两线程并发 call（50ms 超时慢调用 + 5000ms 正常调用）→ 各自独立生效，慢调用超时、快调用返回 42
-- [ ] 4.3 运行 `cargo check --tests` 编译通过；有 Docker 时 `NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_call_timeout -- --ignored --nocapture` 通过后提交（test(judge): 调用级超时 E2E）
+- [x] 4.1 在 `tests/e2e_dual_container.rs` 新增 `dual_call_timeout_fallback_to_problem_default`（`#[ignore]` + `#[serial_test::serial]`）：evaluator 不传 timeout_ms、题目级 100ms、solution 睡 300ms → 断言 `SolutionTimeoutError` 用例被记录、评测最终 Accepted
+- [x] 4.2 新增 `dual_call_timeout_per_call_concurrent`：两线程并发 call（50ms 超时慢调用 + 5000ms 正常调用）→ 各自独立生效，慢调用超时、快调用返回 42
+- [x] 4.3 运行 `cargo check --tests` 编译通过；有 Docker 时 `NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_call_timeout -- --ignored --nocapture` 通过后提交（test(judge): 调用级超时 E2E）
 
 ## 5. noj-tests 全链路 E2E
 
-- [ ] 5.1 新建 `noj-tests/e2e/26_call_timeout.test.ts`（参照 15_dual_container_judge.test.ts 模式）：用例 A 调用级 timeout_ms 生效（慢调用记为 SolutionTimeoutError、评测继续 Accepted）、用例 B 缺省回退题目级 call_timeout_ms
-- [ ] 5.2 运行 `cd noj-tests && deno task test --filter call_timeout` 通过（无完整评测栈时至少 `deno check` 通过），`deno fmt` 后提交（test(core,judge): 调用级超时全链路 E2E）
+- [x] 5.1 新建 `noj-tests/e2e/26_call_timeout.test.ts`（参照 15_dual_container_judge.test.ts 模式）：用例 A 调用级 timeout_ms 生效（慢调用记为 SolutionTimeoutError、评测继续 Accepted）、用例 B 缺省回退题目级 call_timeout_ms
+- [x] 5.2 运行 `cd noj-tests && deno task test --filter call_timeout` 通过（无完整评测栈时至少 `deno check` 通过），`deno fmt` 后提交（test(core,judge): 调用级超时全链路 E2E）
 
 ## 6. 文档与注释同步
 
-- [ ] 6.1 `noj-docs/docs/problemsetters/evaluator-sdk.md`：`runner.call(..., timeout_ms=None)` 签名与缺省回退说明、`register_capability(..., timeout_ms=None)` 默认值语义、`SolutionTimeoutError` 用法
-- [ ] 6.2 `noj-docs/docs/problemsetters/rpc.md`：call 帧 `timeout_ms` 可选字段（仅 judge 计时）、`cap_reg` 帧（私有协议不转发）、错误来源表 `CallTimeout` 更新、缺省回退规则
-- [ ] 6.3 `noj-docs/docs/problemsetters/web-editor.md`：`call_timeout_ms` 语义 = 题目级默认值，`runner.call(..., timeout_ms)` 可按调用覆盖
-- [ ] 6.4 `noj-core/src/types/index.ts` 与 `src/services/problems-types.ts`：注释同步（call_timeout_ms 默认值角色；校验不变）
-- [ ] 6.5 运行 `cd noj-core && deno fmt --check` 相关文件后提交（docs(root,core): 同步调用级超时文档与注释）
+- [x] 6.1 `noj-docs/docs/problemsetters/evaluator-sdk.md`：`runner.call(..., timeout_ms=None)` 签名与缺省回退说明、`register_capability(..., timeout_ms=None)` 默认值语义、`SolutionTimeoutError` 用法
+- [x] 6.2 `noj-docs/docs/problemsetters/rpc.md`：call 帧 `timeout_ms` 可选字段（仅 judge 计时）、`cap_reg` 帧（私有协议不转发）、错误来源表 `CallTimeout` 更新、缺省回退规则
+- [x] 6.3 `noj-docs/docs/problemsetters/web-editor.md`：`call_timeout_ms` 语义 = 题目级默认值，`runner.call(..., timeout_ms)` 可按调用覆盖
+- [x] 6.4 `noj-core/src/types/index.ts` 与 `src/services/problems-types.ts`：注释同步（call_timeout_ms 默认值角色；校验不变）
+- [x] 6.5 运行 `cd noj-core && deno fmt --check` 相关文件后提交（docs(root,core): 同步调用级超时文档与注释）


### PR DESCRIPTION
## 背景

将 `call_timeout_ms` 从固定运行时配置改为 RPC / Evaluator SDK 调用参数：`runner.call(..., timeout_ms)` 每次调用可指定独立超时，缺省回退题目级 `runtime_config.solution.call_timeout_ms`（向后兼容）。capability 调用同样纳入超时，采用注册时配置的默认值。

> 关键：此前 `run_dual_loop` 的 `_call_timeout_ms` 参数实际未使用（judge 仅透明转发），本次让调用级超时**首次真正生效**。

## 变更内容

- **noj-judge 新增 `src/dual/tracker.rs`**：`InFlightTracker` 纯逻辑模块（in-flight 登记 / cap_reg 映射 / 响应命中判定 / 过期摘除），11 个单元测试
- **dual 主循环接入**：`handle_eval_chunk` / `handle_sol_chunk` 超时感知转发；`run_dual_loop` 两阶段 `select!` 增加 `sleep_until(最早 deadline)` 分支，超时向等待方写 `code="Timeout"` 错误帧并丢弃迟到响应
- **Evaluator SDK**：`runner.call(fn, *args, timeout_ms=None)`（非法值抛 `ValueError`）；`register_capability(name, handler, timeout_ms=None)` 经一次性 `cap_reg` 帧上报 judge（judge 私有协议，不转发）
- **超时语义**：计时起点 = judge 收到帧的时刻；`SolutionTimeoutError` 可被 evaluator 捕获记为失败用例继续评测；`time_limit_ms` 外层兜底不变
- **测试**：judge 单测（39）+ judge E2E（真实容器：缺省回退 100ms / 并发 50ms+5s 不同超时）+ noj-tests 全链路 E2E（2 用例，本地完整评测栈验证通过）
- **文档**：evaluator-sdk.md / rpc.md / web-editor.md / core 注释同步

## 协议

call 帧新增可选 `timeout_ms` 字段（仅 judge 计时，host 执行逻辑不感知）；新增 `cap_reg` 帧（evaluator→judge 私有）。可选字段天然向后兼容，不新增协议版本号。

## 测试

- `cargo test --all-targets`：235 个单测通过；`cargo clippy --all-targets` 无警告
- SDK `python3 -m unittest`：23 个通过
- `NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_call_timeout`：2/2 通过
- noj-tests `deno task test --filter call_timeout`：2/2 通过（完整评测栈）

Closes #198