### PR TITLE
feat(judge,docs): 明确 evaluator/solution 超时状态映射（issue #202）

### DIFF
--- a/docs/superpowers/plans/2026-08-05-timeout-status-mapping.md
+++ b/docs/superpowers/plans/2026-08-05-timeout-status-mapping.md
@@ -1,0 +1,647 @@
+# evaluator/solution 超时状态映射实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 明确并固化 evaluator 超时（→ SystemError）与 solution 调用超时（未处理 → TLE、被捕获 → evaluator 决定）的最终状态映射，统一错误帧 code 为 `CallTimeout`，并同步五处文档。
+
+**Architecture:** 在 `noj-judge/src/dual/mod.rs` 新增纯函数 `finalize_outcome`（超时种类 × 是否发过 CallTimeout → 最终状态），`run_dual_loop` 维护 `sent_call_timeout` 标志并在三个收尾分支统一走该函数；总超时（Startup/Total）优先 SystemError，`sent_call_timeout=true` 且无 RESULT → TLE；错误帧 code `"Timeout"` 统一为 `"CallTimeout"`（SDK `runner.py` 同步）。强制终止由既有 `dual.destroy()`（`remove_container_force`）保障，无新增 kill 逻辑。
+
+**Tech Stack:** Rust 2021 + Tokio（noj-judge）、Python 3（evaluator SDK）、Docker（E2E）。
+
+**设计文档:** `docs/superpowers/specs/2026-08-05-timeout-status-mapping-design.md`（已批准）
+
+## Global Constraints
+
+- 状态映射规则（顺序即优先级）：`timed_out.is_some()` → SystemError；`sent_call_timeout` → TimeLimitExceeded；否则 SystemError
+- 错误帧 code 统一为 `CallTimeout`，**不保留**旧 code `"Timeout"` 的兼容分支
+- `sent_call_timeout` 仅在 `WaitingSide::Evaluator`（evaluator 等 solution 的 call 超时）分支置位；`WaitingSide::Solution`（capability 反向调用超时）不置位
+- 代码注释与提交描述使用中文；提交信息格式 `type(scope): 中文描述`（Conventional Commits）
+- `cargo fmt` + `cargo clippy` 无警告；E2E 测试带 `#[ignore]` + `#[serial_test::serial]` + `is_e2e_enabled()` 守卫
+- 不修改 noj-core / noj-ui；本地提交用 jj（`jj describe`），GPG 签名已配置
+
+---
+
+## 文件结构
+
+| 文件 | 职责 | 动作 |
+|------|------|------|
+| `noj-judge/src/dual/mod.rs` | `TimeoutKind` enum + `finalize_outcome` 纯函数；`run_dual_loop` 接入（标志 + 分支状态） | 修改 |
+| `noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py` | `_handle_response` 错误码匹配 `"Timeout"` → `"CallTimeout"` | 修改 |
+| `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py` | SDK 单测错误帧 code 断言 | 修改 |
+| `noj-judge/tests/e2e_dual_container.rs` | 新增 3 个 E2E 测试；capability 超时断言 code 更新 | 修改 |
+| `noj-docs/docs/reference/result-status.md` | TLE/SystemError 定义补充超时来源 | 修改 |
+| `noj-docs/docs/problemsetters/rpc.md` | CallTimeout 错误码补充未处理时的状态 | 修改 |
+| `noj-docs/docs/problemsetters/judge-model.md` | 新增「超时与状态映射」小节 | 修改 |
+| `noj-docs/docs/problemsetters/web-editor.md` | 运行时配置两层超时语义补充 | 修改 |
+| `noj-docs/docs/intro/what-is-noj.md` | 时空限制一节状态映射补充 | 修改 |
+
+---
+
+### Task 1: `finalize_outcome` 纯函数 + 单测
+
+**Files:**
+- Modify: `noj-judge/src/dual/mod.rs`（`run_dual_loop` 上方新增函数；`mod tests` 模块 `#[cfg(test)] mod tests {` 内新增测试）
+
+**Interfaces:**
+- Produces: `enum TimeoutKind { Startup, Total }`、`fn finalize_outcome(timed_out: Option<TimeoutKind>, sent_call_timeout: bool) -> JudgeStatus`（`JudgeStatus` 来自 `crate::types`，已有 `as_str()`）
+
+- [ ] **Step 1: 写失败测试**
+
+在 `noj-judge/src/dual/mod.rs` 的 `mod tests` 内新增（放在 `test_build_judge_result_missing_fields` 之后）：
+
+```rust
+#[test]
+fn test_finalize_outcome_mapping() {
+    // 总超时优先：无论是否发过 CallTimeout 都归 SystemError
+    assert_eq!(
+        finalize_outcome(Some(TimeoutKind::Startup), false),
+        JudgeStatus::SystemError
+    );
+    assert_eq!(
+        finalize_outcome(Some(TimeoutKind::Startup), true),
+        JudgeStatus::SystemError
+    );
+    assert_eq!(
+        finalize_outcome(Some(TimeoutKind::Total), false),
+        JudgeStatus::SystemError
+    );
+    assert_eq!(
+        finalize_outcome(Some(TimeoutKind::Total), true),
+        JudgeStatus::SystemError
+    );
+    // 无总超时 + 发过 CallTimeout → TLE（用户代码慢是根因）
+    assert_eq!(
+        finalize_outcome(None, true),
+        JudgeStatus::TimeLimitExceeded
+    );
+    // 无总超时 + 未发过 → SystemError（evaluator 自身异常）
+    assert_eq!(
+        finalize_outcome(None, false),
+        JudgeStatus::SystemError
+    );
+}
+```
+
+注意：`mod tests` 顶部已有 `use super::*;`，可直接引用 `finalize_outcome` / `TimeoutKind`；`JudgeStatus` 需在 `mod tests` 内可用——检查 `mod tests` 现有测试是否引用 `JudgeStatus`（`build_judge_result` 返回 `JudgeResult` 含 `status: String`，可能未直接引用 `JudgeStatus`），若无则测试函数内加 `use crate::types::JudgeStatus;`。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-judge && cargo test finalize_outcome -- --nocapture`
+Expected: FAIL（编译错误 `cannot find function finalize_outcome` 或 `cannot find type TimeoutKind`）
+
+- [ ] **Step 3: 最小实现**
+
+在 `run_dual_loop` 函数之前新增：
+
+```rust
+/// 超时种类：判定最终状态时区分启动期与正式评测期。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimeoutKind {
+    /// 阶段 1：评测程序启动等待超时（容器创建 / 文件注入 / 运行时启动开销）
+    Startup,
+    /// 阶段 2：evaluator 整体执行超过 time_limit_ms
+    Total,
+}
+
+/// 评测收尾判定：把「评测如何结束」映射为最终状态。
+///
+/// 仅在 evaluator 未正常输出 ---RESULT--- 时调用（有 RESULT 走 build_judge_result）。
+/// 规则（顺序即优先级）：
+/// 1. 总超时（Startup/Total）→ SystemError：评测流程未正常完成，做题人不可通过改代码解决；
+/// 2. 曾向 evaluator 发送过 CallTimeout 错误帧 → TimeLimitExceeded：用户代码慢是根因；
+/// 3. 否则 → SystemError：evaluator 自身异常。
+fn finalize_outcome(timed_out: Option<TimeoutKind>, sent_call_timeout: bool) -> JudgeStatus {
+    if timed_out.is_some() {
+        return JudgeStatus::SystemError;
+    }
+    if sent_call_timeout {
+        return JudgeStatus::TimeLimitExceeded;
+    }
+    JudgeStatus::SystemError
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-judge && cargo test finalize_outcome -- --nocapture`
+Expected: PASS（1 个测试，6 个断言）
+
+- [ ] **Step 5: 提交**
+
+```bash
+cd /home/xyber-nova/Github/neuro-oj && jj describe -m "test(judge): finalize_outcome 状态映射纯函数（issue #202）"
+```
+
+---
+
+### Task 2: `run_dual_loop` 接入 `finalize_outcome` + `sent_call_timeout` 标志
+
+**Files:**
+- Modify: `noj-judge/src/dual/mod.rs`（`run_dual_loop` 函数体）
+
+**Interfaces:**
+- Consumes: Task 1 的 `finalize_outcome` / `TimeoutKind`
+- Produces: `run_dual_loop` 行为变更——阶段 1/2 超时返回 SystemError；无 RESULT 退出时按 `sent_call_timeout` 判定 TLE/SystemError
+
+- [ ] **Step 1: 写失败测试（行为验证：现无单测覆盖 run_dual_loop 分支，以 Task 4 E2E 为验收；本任务以编译 + 既有测试不回归为准）**
+
+说明：`run_dual_loop` 依赖真实容器 exec 流，无法单测；本任务步骤 2 的「测试」为 `cargo test` 全量回归（既有 `dual/mod.rs` 单测与 `runner.rs` 单测必须保持通过——它们不覆盖 run_dual_loop 分支，不受行为变更影响）。
+
+- [ ] **Step 2: 实现——声明标志并改造三个收尾分支**
+
+在 `run_dual_loop` 中 `let mut tracker = InFlightTracker::new(default_call_timeout_ms);` 之后新增：
+
+```rust
+// 是否向 evaluator 发送过 CallTimeout 错误帧（solution 调用超时）。
+// 仅 WaitingSide::Evaluator（evaluator 等 solution 的 call）置位；
+// WaitingSide::Solution（capability 反向调用超时）不置位——其错误帧写给 solution，
+// 不构成「evaluator 未处理 CallTimeout」归因。
+let mut sent_call_timeout = false;
+```
+
+**改动 1 — 阶段 1 启动超时分支**（现有代码 `return Ok(JudgeResult::timeout(submission_id, "evaluator startup timeout", rejudge_seq));`）替换为：
+
+```rust
+return Ok(JudgeResult::system_error(
+    submission_id,
+    "evaluator startup timeout",
+    rejudge_seq,
+));
+```
+
+**改动 2 — 阶段 2 总超时分支**（现有代码 `return Ok(JudgeResult::timeout(submission_id, "evaluator total timeout", rejudge_seq));`）替换为：
+
+```rust
+return Ok(JudgeResult::system_error(
+    submission_id,
+    "evaluator total timeout",
+    rejudge_seq,
+));
+```
+
+**改动 3 — 两处 in-flight 到期分支**（阶段 1 与阶段 2 各有一处，代码相同）中，`WaitingSide::Evaluator` 分支改为：
+
+```rust
+WaitingSide::Evaluator => {
+    write_timeout_frame(&mut eval_input, &id).await?;
+    sent_call_timeout = true;
+}
+```
+
+`WaitingSide::Solution` 分支保持不变。
+
+**改动 4 — 无 RESULT 收尾分支**：现有 `None => { ... Ok(JudgeResult::system_error(submission_id, &full_output, rejudge_seq)) }` 的返回值改为：
+
+```rust
+match finalize_outcome(None, sent_call_timeout) {
+    JudgeStatus::TimeLimitExceeded => Ok(JudgeResult::timeout(
+        submission_id,
+        &full_output,
+        rejudge_seq,
+    )),
+    _ => Ok(JudgeResult::system_error(
+        submission_id,
+        &full_output,
+        rejudge_seq,
+    )),
+}
+```
+
+（`full_output` 收集逻辑与 warn 日志保持不变。）
+
+- [ ] **Step 3: 运行测试确认通过**
+
+Run: `cd noj-judge && cargo test --lib`
+Expected: PASS（`finalize_outcome` 单测 + 既有 `dual/mod.rs` / `tracker.rs` / `types.rs` 单测全部通过）
+
+- [ ] **Step 4: 运行 fmt + clippy**
+
+Run: `cd noj-judge && cargo fmt --check && cargo clippy --all-targets -- -D warnings`
+Expected: 无输出（通过）
+
+- [ ] **Step 5: 提交**
+
+```bash
+cd /home/xyber-nova/Github/neuro-oj && jj describe -m "fix(judge): evaluator 总超时归 SystemError、CallTimeout 未处理归 TLE（issue #202）"
+```
+
+---
+
+### Task 3: 错误帧 code 统一为 `CallTimeout`
+
+**Files:**
+- Modify: `noj-judge/src/dual/mod.rs`（`write_timeout_frame`）
+- Modify: `noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py`（`_handle_response`）
+- Modify: `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py`（错误帧 code 断言）
+- Modify: `noj-judge/tests/e2e_dual_container.rs`（`dual_capability_timeout_per_call` 中 code 断言）
+
+**Interfaces:**
+- Produces: 错误帧 `{"type":"error","id":...,"code":"CallTimeout","message":"call timeout"}`；SDK `SolutionTimeoutError` 仅在 `code == "CallTimeout"` 时抛出
+
+- [ ] **Step 1: 写失败测试（SDK 单测先改）**
+
+修改 `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py` 第 227 行附近：
+
+```python
+                    "code": "CallTimeout",
+```
+
+（原为 `"code": "Timeout"`，其余断言不变——`errors.get("e")` 应为 `SolutionTimeoutError`。）
+
+- [ ] **Step 2: 运行 SDK 测试确认失败**
+
+Run: `cd noj-judge/sdk/evaluator && python3 -m unittest discover -s tests -v`
+Expected: FAIL（`_handle_response` 对 `code == "CallTimeout"` 不抛 `SolutionTimeoutError`，断言 `isinstance(..., SolutionTimeoutError)` 失败）
+
+- [ ] **Step 3: 实现——judge 与 SDK 同步修改**
+
+`noj-judge/src/dual/mod.rs` 的 `write_timeout_frame`：
+
+```rust
+let frame = serde_json::json!({
+    "type": "error",
+    "id": id,
+    "code": "CallTimeout",
+    "message": "call timeout",
+});
+```
+
+`noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py` 第 319 行：
+
+```python
+            if code == "CallTimeout":
+                raise SolutionTimeoutError(message)
+```
+
+（不保留 `"Timeout"` 兼容分支。）
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-judge/sdk/evaluator && python3 -m unittest discover -s tests -v`
+Expected: PASS（全部 SDK 单测）
+
+Run: `cd noj-judge && cargo test --lib`
+Expected: PASS
+
+- [ ] **Step 5: 更新 E2E 断言（capability 超时帧 code）**
+
+`noj-judge/tests/e2e_dual_container.rs` 的 `dual_capability_timeout_per_call` 中（约第 891 行）断言 `"Timeout"` 处改为：
+
+```rust
+assert_eq!(
+    ...,
+    "CallTimeout",
+    ...
+);
+```
+
+（以该处现有断言结构为准，仅替换字符串字面量。）
+
+- [ ] **Step 6: 提交**
+
+```bash
+cd /home/xyber-nova/Github/neuro-oj && jj describe -m "fix(judge,sdk): 超时错误帧 code 统一为 CallTimeout（issue #202）"
+```
+
+---
+
+### Task 4: E2E 三种超时场景测试
+
+**Files:**
+- Modify: `noj-judge/tests/e2e_dual_container.rs`（文件末尾追加 3 个测试）
+
+**Interfaces:**
+- Consumes: Task 2 行为变更、Task 3 code 变更
+- Produces: 三个 `#[ignore]` E2E 测试：`dual_evaluator_total_timeout_system_error` / `dual_solution_timeout_unhandled_tle` / `dual_solution_timeout_handled_wrong_answer`
+
+- [ ] **Step 1: 写测试 1——evaluator 总超时 → SystemError**
+
+在 `e2e_dual_container.rs` 末尾追加：
+
+```rust
+/// evaluator 整体超时（time_limit_ms 到期）→ SystemError（评测流程未正常完成）。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_evaluator_total_timeout_system_error() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_sdk_images(&docker).await.unwrap();
+
+    // evaluator：打印首行（进入阶段 2）后死循环，永不输出 ---RESULT---
+    let evaluator_cmd = r#"python3 -c "
+import sys, time
+print('ready', flush=True)
+while True:
+    time.sleep(1)
+""#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 2000, // 2s 总超时
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 5000,
+            memory_limit_mb: 128,
+        },
+    };
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        noj_judge::dual::evaluate_dual(
+            docker.clone(),
+            "e2e-evaluator-total-timeout",
+            &runtime_config,
+            "def solve(): return 1",
+            "solution.py",
+            None,
+            "/tmp/e2e-cache",
+            100,
+            64,
+            None,
+        ),
+    )
+    .await
+    .expect("评测 30s 外层超时")
+    .expect("评测应正常返回");
+
+    assert_eq!(
+        result.status, "SystemError",
+        "evaluator 总超时应归 SystemError: {:?}",
+        result
+    );
+}
+```
+
+- [ ] **Step 2: 运行测试 1 确认通过**
+
+Run: `cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_evaluator_total_timeout_system_error -- --ignored --nocapture`
+Expected: PASS（约 2s 后返回 SystemError）
+
+- [ ] **Step 3: 写测试 2——solution 超时未处理 → TLE**
+
+在文件末尾追加：
+
+```rust
+/// solution 调用超时且 evaluator 未捕获（evaluate.py 崩溃、无 ---RESULT---）→ TLE。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_solution_timeout_unhandled_tle() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_sdk_images(&docker).await.unwrap();
+
+    // evaluator：调用 sleep_solution 但不捕获 SolutionTimeoutError → 异常冒泡崩溃退出
+    let evaluator_cmd = r#"python3 -c "
+from noj_evaluator_sdk import SolutionRunner
+runner = SolutionRunner()
+runner.call('sleep_solution')
+"#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 15000,
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 100, // 100ms 调用超时
+            memory_limit_mb: 128,
+        },
+    };
+    // solution：sleep_solution 睡 300ms（> 100ms 调用超时）
+    let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\n";
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        noj_judge::dual::evaluate_dual(
+            docker.clone(),
+            "e2e-solution-timeout-unhandled",
+            &runtime_config,
+            code,
+            "solution.py",
+            None,
+            "/tmp/e2e-cache",
+            100,
+            64,
+            None,
+        ),
+    )
+    .await
+    .expect("评测 30s 外层超时")
+    .expect("评测应正常返回");
+
+    assert_eq!(
+        result.status, "TimeLimitExceeded",
+        "CallTimeout 未处理应归 TLE: {:?}",
+        result
+    );
+}
+```
+
+- [ ] **Step 4: 运行测试 2 确认通过**
+
+Run: `cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_solution_timeout_unhandled_tle -- --ignored --nocapture`
+Expected: PASS（约 100ms 后 evaluator 崩溃退出 → TLE）
+
+- [ ] **Step 5: 写测试 3——solution 超时被捕获 → evaluator 决定（WrongAnswer）**
+
+在文件末尾追加：
+
+```rust
+/// solution 调用超时被 evaluator 捕获 → 最终状态由 evaluator 决定（此处为 WrongAnswer）。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_solution_timeout_handled_wrong_answer() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_sdk_images(&docker).await.unwrap();
+
+    // evaluator：捕获 SolutionTimeoutError 后记为失败用例（WrongAnswer）
+    let evaluator_cmd = r#"python3 -c "
+from noj_evaluator_sdk import SolutionRunner, SolutionTimeoutError, result
+runner = SolutionRunner()
+try:
+    runner.call('sleep_solution')
+    result.accept(score=1000, details={'cases': [{'id': 'c1', 'status': 'Accepted'}]})
+except SolutionTimeoutError:
+    result.wrong_answer(
+        score=0,
+        message='c1 call timeout',
+        details={'cases': [{'id': 'c1', 'status': 'WrongAnswer'}]},
+    )
+"#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 15000,
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 100,
+            memory_limit_mb: 128,
+        },
+    };
+    let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\n";
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        noj_judge::dual::evaluate_dual(
+            docker.clone(),
+            "e2e-solution-timeout-handled",
+            &runtime_config,
+            code,
+            "solution.py",
+            None,
+            "/tmp/e2e-cache",
+            100,
+            64,
+            None,
+        ),
+    )
+    .await
+    .expect("评测 30s 外层超时")
+    .expect("评测应正常返回");
+
+    assert_eq!(
+        result.status, "WrongAnswer",
+        "CallTimeout 被捕获时状态由 evaluator 决定: {:?}",
+        result
+    );
+}
+```
+
+- [ ] **Step 6: 运行测试 3 确认通过**
+
+Run: `cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_solution_timeout_handled_wrong_answer -- --ignored --nocapture`
+Expected: PASS（最终状态 WrongAnswer）
+
+- [ ] **Step 7: 全量 E2E 回归**
+
+Run: `cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container -- --ignored`
+Expected: PASS（既有 10 个测试 + 新增 3 个，含 Task 3 更新过的 capability 超时断言）
+
+- [ ] **Step 8: 提交**
+
+```bash
+cd /home/xyber-nova/Github/neuro-oj && jj describe -m "test(judge): 补 evaluator 超时/CallTimeout 未处理/被捕获三种 E2E（issue #202）"
+```
+
+---
+
+### Task 5: 文档五处更新
+
+**Files:**
+- Modify: `noj-docs/docs/reference/result-status.md`
+- Modify: `noj-docs/docs/problemsetters/rpc.md`
+- Modify: `noj-docs/docs/problemsetters/judge-model.md`
+- Modify: `noj-docs/docs/problemsetters/web-editor.md`
+- Modify: `noj-docs/docs/intro/what-is-noj.md`
+
+**Interfaces:** 无（纯文档）
+
+- [ ] **Step 1: `reference/result-status.md`**
+
+`TimeLimitExceeded` 一节（现为一句「提交超过时间限制。超时可能发生在 evaluator 执行、用户函数调用或整体评测流程中。」）替换为：
+
+```markdown
+## TimeLimitExceeded
+
+提交超过时间限制。超时来源分两类：
+
+- **单次调用超时**（`call_timeout_ms`）：用户函数单次调用超过调用级超时。Judge Worker 向 evaluator 注入 `CallTimeout` 错误；若 evaluator 未捕获（evaluate.py 异常退出、无 `---RESULT---`），最终状态为 `TimeLimitExceeded`。若 evaluator 捕获并记为失败用例，最终状态由 evaluator 决定（如 `WrongAnswer`）。
+- **整体流程超时**（`time_limit_ms`）：evaluator 整体执行超过时限，由 Judge Worker 强制终止评测，最终状态为 `SystemError`（见下），**不会**落成 `TimeLimitExceeded`。
+```
+
+`SystemError` 一节的「在当前双容器 Python 模型下，下面这些情况通常更容易得到 `SystemError`」列表补充两项：
+
+```markdown
+- evaluator 整体执行超过 `time_limit_ms`（Judge Worker 强制终止）。
+- evaluator 启动超时（评测环境未就绪）。
+```
+
+- [ ] **Step 2: `problemsetters/rpc.md`**
+
+错误来源表（「常见错误来源」中 `CallTimeout` 一行）由：
+
+```markdown
+| `CallTimeout` | Judge Worker | 单次调用超过调用级 `timeout_ms`（缺省回退题目级 `call_timeout_ms`）；capability 调用按注册时配置的默认超时 |
+```
+
+改为：
+
+```markdown
+| `CallTimeout` | Judge Worker | 单次调用超过调用级 `timeout_ms`（缺省回退题目级 `call_timeout_ms`）；capability 调用按注册时配置的默认超时。该错误由 Judge 直接注入；若 evaluator 未捕获（evaluate.py 异常退出、无 `---RESULT---`），最终状态为 `TimeLimitExceeded` |
+```
+
+- [ ] **Step 3: `problemsetters/judge-model.md`**
+
+在「结果状态」相关小节后新增：
+
+```markdown
+### 超时与状态映射
+
+两层超时的最终状态映射：
+
+| 超时来源 | 触发 | 最终状态 |
+| --- | --- | --- |
+| evaluator 整体执行超时 | 评测总时长超过 `time_limit_ms` | `SystemError`（Judge Worker 强制终止，做题人不可通过改代码解决） |
+| 单次调用超时且 evaluator 未捕获 | 调用超过 `call_timeout_ms`，evaluate.py 异常退出、无 `---RESULT---` | `TimeLimitExceeded` |
+| 单次调用超时且 evaluator 捕获 | 同上，但 evaluator 记为失败用例 | 由 evaluator 决定（如 `WrongAnswer`） |
+```
+
+（若文档中已有相近小节，合并扩展而非重复新增。）
+
+- [ ] **Step 4: `problemsetters/web-editor.md`**
+
+「运行时配置」中两层超时说明处（`call_timeout_ms` 作为单次 SDK 调用的**默认**超时……合理设置 Solution 的调用超时可以防止用户代码死循环拖垮整场评测）之后补充：
+
+```markdown
+两层超时的状态语义：`time_limit_ms` 超时表示评测流程未正常完成，最终状态为 `SystemError`；`call_timeout_ms` 超时若未被 evaluator 捕获，最终状态为 `TimeLimitExceeded`，捕获后由 evaluator 自行决定（详见[评测模型](judge-model.md)）。
+```
+
+- [ ] **Step 5: `intro/what-is-noj.md`**
+
+「时空限制」一节（第 82 行附近「**单次调用超时**：`call_timeout_ms` 限制**一次** `runner.call()` 的时长。单次调用超时**不一定**是最终 TLE——evaluator 可以把它当作一个失败用例继续评测，也可以直接判定 TLE。」）之后补充：
+
+```markdown
+若 evaluator 未捕获单次调用超时（evaluate.py 异常退出），最终状态为 `TimeLimitExceeded`；而 evaluator 整体执行超过 `time_limit_ms` 时，Judge Worker 强制终止评测，最终状态为 `SystemError`。
+```
+
+- [ ] **Step 6: 人工检查**
+
+检查五处文档改动与设计文档状态映射表一致（evaluator 超时→SystemError / CallTimeout 未处理→TLE / 捕获→evaluator 决定）；无遗留「TBD/TODO」；链接目标存在。
+
+- [ ] **Step 7: 提交**
+
+```bash
+cd /home/xyber-nova/Github/neuro-oj && jj describe -m "docs: 明确 evaluator/solution 超时状态映射（issue #202）"
+```
+
+---
+
+## 自检结论
+
+- **Spec 覆盖**：状态映射表 5 行 → Task 2（映射）+ Task 4（E2E 验证）+ Task 5（文档）；code 统一 → Task 3；启动超时 → Task 2 改动 1；模块影响评估（core/ui 不动）→ Global Constraints。
+- **占位符**：无 TBD/TODO；所有代码步骤含完整代码。
+- **类型一致性**：`TimeoutKind::{Startup,Total}`、`finalize_outcome(Option<TimeoutKind>, bool) -> JudgeStatus`、`sent_call_timeout: bool` 在 Task 1/2 定义与使用一致；`SolutionTimeoutError` 在 Task 3/4 使用一致；E2E 测试名在 Task 4 各步骤一致。

--- a/docs/superpowers/specs/2026-08-05-timeout-status-mapping-design.md
+++ b/docs/superpowers/specs/2026-08-05-timeout-status-mapping-design.md
@@ -1,0 +1,128 @@
+# evaluator 超时与 solution 超时的行为与状态映射设计
+
+> 关联 issue：[#202 明确 evaluator 超时与 solution 超时的行为与状态映射（含文档更新）](https://github.com/Neuro-OJ/neuro-oj/issues/202)
+> 日期：2026-08-05
+> 状态：已批准（brainstorming 流程）
+
+## 背景与目标
+
+当前运行时配置有两层超时：evaluator 整体执行限时（`runtime_config.evaluator.time_limit_ms`）与单次用户函数调用超时（`runtime_config.solution.call_timeout_ms`，issue #198 起支持按调用指定）。但**超时后的最终状态判定不明确**：
+
+- 调用超时（`CallTimeout`）由 Judge 注入错误帧，若 evaluator 未处理（evaluate.py 因此崩溃退出），最终落成什么状态？
+- evaluator 整体超时后 Judge Worker 如何收尾？
+- 文档（`result-status.md` / `rpc.md` / `judge-model.md`）均未明确。
+
+**目标**：
+
+1. evaluator 超时（整体执行超过 `time_limit_ms`）：Judge Worker 强制终止评测，最终状态 **SystemError**（评测环境/流程未正常完成，做题人不可通过改代码解决）；
+2. solution 超时（单次调用超过 `call_timeout_ms`）：向 evaluator 返回 `CallTimeout` 调用错误；若 evaluator 未捕获或因此异常退出，最终状态为 **TimeLimitExceeded（TLE）**，而不是 SystemError；
+3. `CallTimeout` 被 evaluator 显式处理时，状态由 evaluator 决定（可记为 WrongAnswer 等），语义保持不变；
+4. 文档五处同步更新。
+
+## 现状分析（代码位置）
+
+| 位置 | 现状 |
+|------|------|
+| `noj-judge/src/dual/mod.rs:352` | 阶段 1 启动超时（30s 宽松期）→ `JudgeResult::timeout()` = **TLE**（不符合目标语义） |
+| `noj-judge/src/dual/mod.rs:421` | 阶段 2 evaluator 总超时（`time_limit_ms` 到期）→ `JudgeResult::timeout()` = **TLE**（不符合目标语义） |
+| `noj-judge/src/dual/mod.rs:518` | 无 `---RESULT---` 退出（evaluator 崩溃/EOF）→ `system_error()`；**不区分是否曾发送 CallTimeout**（issue 要求：曾发送且未处理 → TLE） |
+| `noj-judge/src/dual/mod.rs:683` | `write_timeout_frame` 发送 `{"type":"error","code":"Timeout","message":"call timeout"}`——code 与文档错误码表名 `CallTimeout` 不一致 |
+| `noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py:319` | `if code == "Timeout": raise SolutionTimeoutError(...)`——需同步匹配新 code |
+| `noj-judge/src/dual/container.rs:72` | `DualContainer::destroy` 用 `remove_container_force` 强制清理容器——总超时后的"强制终止"已有保障，无需新增 |
+| `noj-core/src/services/submissions-result.ts:73` | SystemError → submission status `error`，其余 → `finished`；无需变更 |
+| 文档 | `result-status.md` TLE/SystemError 定义未区分超时来源；`rpc.md:124` / `evaluator-sdk.md:64` 错误码表已有 `CallTimeout` 名但无未处理时的状态说明；`judge-model.md` / `web-editor.md` / `what-is-noj.md` 无状态映射说明 |
+
+## 已确认的设计决策
+
+1. **启动超时归属 SystemError**：阶段 1（30s 宽松启动期）超时说明评测环境未就绪（容器/镜像/启动失败），做题人无法通过改代码解决，语义与 SystemError 一致；符合 #200「启动开销不计入时限」的精神。
+2. **TLE 判定判据（宽泛标志）**：以「本次评测是否向 evaluator 发送过 CallTimeout 错误帧」为判据——只要发生过 solution 调用超时且最终无 RESULT，即归因 TLE（用户代码慢是根因）。不做"最后一帧"严格归因（复杂且边界难定义）。
+3. **优先级规则**：总超时（阶段 1/2 deadline）优先于 CallTimeout 归因——一旦超时强制终止，一律 SystemError，不因曾发过 CallTimeout 而改判 TLE。
+4. **错误帧 code 统一为 `CallTimeout`**：`write_timeout_frame` 发送 `"code":"CallTimeout"`，SDK `runner.py` 匹配同步更新；**不保留**旧 code `"Timeout"` 的兼容分支（judge 与 SDK 同仓同步发布，E2E 验证新链路；保留反而遗留不一致）。
+5. **实现组织：集中收尾判定（方案 B）**：新增纯函数 `finalize_outcome`，三个超时/退出分支统一走它；纯函数可无 Docker 单测，语义集中可对照文档。
+6. **强制终止**：总超时分支 return 后由既有 `dual.destroy()` 强制删除两个容器，无需新增 kill 逻辑。
+
+## 状态映射表
+
+| 场景 | 触发点 | 最终状态 | 依据 |
+|------|--------|---------|------|
+| evaluator 启动超时（30s 宽松期） | 阶段 1 deadline | **SystemError** | 评测环境未就绪，做题人无法解决 |
+| evaluator 整体执行超时（> `time_limit_ms`） | 阶段 2 deadline | **SystemError** | 评测流程未正常完成；judge 强制终止 |
+| solution 调用超时（> `call_timeout_ms`）且 evaluator 捕获 | evaluator 正常输出 `---RESULT---` | **由 evaluator 决定**（如 WrongAnswer） | 语义保持不变 |
+| solution 调用超时且 evaluator 未捕获（崩溃/EOF、无 RESULT） | 无 RESULT 退出 | **TimeLimitExceeded** | 用户代码慢是根因 |
+| evaluator 异常退出但从未发生调用超时 | 无 RESULT 退出 | **SystemError** | evaluate.py 自身 bug / 环境问题 |
+
+## 代码改动（noj-judge）
+
+### 收尾判定纯函数 `finalize_outcome`
+
+新增（建议 `dual/mod.rs` 内或独立 `dual/outcome.rs`）：
+
+```rust
+/// 评测收尾判定：把「评测如何结束」映射为最终状态。
+/// 仅在 evaluator 未正常输出 ---RESULT--- 时调用（有 RESULT 走 build_judge_result）。
+enum TimeoutKind { Startup, Total }
+
+fn finalize_outcome(
+    timed_out: Option<TimeoutKind>,
+    sent_call_timeout: bool,
+) -> JudgeStatus
+```
+
+规则（顺序即优先级）：
+
+1. `timed_out.is_some()` → `SystemError`（强制终止，优先）；
+2. `sent_call_timeout` → `TimeLimitExceeded`（用户代码慢是根因）；
+3. 否则 → `SystemError`（evaluator 自身异常）。
+
+### `run_dual_loop` 改动
+
+- 新增局部标志 `sent_call_timeout: bool`；阶段 1 与阶段 2 的 in-flight 到期分支在 `write_timeout_frame` 写帧成功后置位；
+- 阶段 1 启动超时分支：`timeout()` → `system_error()`（output 保留 "evaluator startup timeout" 类信息）；
+- 阶段 2 总超时分支：`timeout()` → `system_error()`（output 说明评测总超时，供运营排查）；
+- 无 RESULT 收尾分支（`result_payload.is_none()`）：改用 `finalize_outcome` 判定——`sent_call_timeout=true` 时返回 `timeout()`（TLE），否则保持 `system_error()`；
+- 有 RESULT 分支不变（evaluator 决定状态）。
+
+### 错误帧 code 统一
+
+- `write_timeout_frame`（`dual/mod.rs:683`）：`"code": "Timeout"` → `"code": "CallTimeout"`；
+- SDK `runner.py:319`：`if code == "Timeout"` → `if code == "CallTimeout"`；
+- E2E 断言同步更新。
+
+### 测试
+
+**单测（无 Docker）**：`finalize_outcome` 全分支表驱动测试（`timed_out ∈ {None, Startup, Total} × sent_call_timeout ∈ {false, true}` 组合）。
+
+**E2E（`e2e_dual_container.rs` 新增 3 个 `#[ignore]` 测试）**：
+
+1. **evaluator 超时 → SystemError**：evaluate.py 打印 ready 后死循环，`time_limit_ms` 设短（如 2s），断言最终状态 SystemError；
+2. **solution 超时未处理 → TLE**：evaluate.py 调 `runner.call` 不捕获 `SolutionTimeoutError`（异常冒泡崩溃），`call_timeout_ms` 设短，断言最终状态 TimeLimitExceeded；
+3. **solution 超时被捕获 → evaluator 决定**：evaluate.py `try/except` 后返回 WrongAnswer，断言最终状态由 evaluator 决定（现有 `dual_call_timeout_fallback_to_problem_default` 已断言用例级 `SolutionTimeoutError`，新增断言**最终状态**）。
+
+## 文档更新（五处）
+
+| 文档 | 改动 |
+|------|------|
+| `reference/result-status.md` | `TimeLimitExceeded` 补充超时来源说明：区分「evaluator 整体超时 → SystemError」与「单次调用超时未被 evaluator 处理 → TLE」；`SystemError` 补充「evaluator 整体执行超时、启动超时」两个来源 |
+| `problemsetters/rpc.md` | 错误码表 `CallTimeout` 一行补充：「该错误由 Judge Worker 直接注入；若 evaluator 未捕获（evaluate.py 异常退出、无 `---RESULT---`），最终状态为 `TimeLimitExceeded`」 |
+| `problemsetters/judge-model.md` | 新增/扩展「超时与状态映射」小节：两层超时（`time_limit_ms` / `call_timeout_ms`）× 三种结局（evaluator 捕获 / 未捕获 / 整体超时）的映射表 |
+| `problemsetters/web-editor.md` | 运行时配置说明处补充两层超时语义：`time_limit_ms` 超时 → SystemError（评测流程未完成，做题人不可解决）；`call_timeout_ms` 未处理 → TLE |
+| `intro/what-is-noj.md` | 「时空限制」一节（现第 82 行附近）的单次调用超时描述补充状态映射：未捕获 → TLE；evaluator 整体超时 → SystemError |
+
+## 模块影响评估
+
+- **noj-core**：仅把 SystemError 映射为 submission status `error`，无需变更；
+- **noj-ui**：状态徽章按字符串渲染，无超时文案；
+- **noj-judge**：改动集中在 `dual/mod.rs` + SDK `runner.py` + 测试。
+
+## 验收清单
+
+- [ ] `cargo test`（含 `finalize_outcome` 单测）通过
+- [ ] E2E 三种超时场景（`NOJ_RUN_E2E=1`）通过：总超时→SystemError / CallTimeout 未处理→TLE / 捕获→evaluator 决定
+- [ ] 文档五处同步更新
+- [ ] `cargo fmt` + `cargo clippy` 无警告
+
+## 风险与权衡
+
+- **宽泛归因的误判边界**：evaluator 捕获了 CallTimeout 继续评测、最终因自身 bug 崩溃 → 仍判 TLE。权衡后接受：用户代码超时是评测链断裂的根因，且该场景罕见；严格归因（最后一帧）复杂度收益不成比例。
+- **code 改名兼容**：旧 SDK（匹配 `"Timeout"`）与新 judge 不兼容。judge 与 SDK 同仓同步发布，E2E 覆盖新链路，接受。
+- **总超时优先 SystemError 可能掩盖 TLE**：evaluator 死循环等待超时调用时，总超时先到 → SystemError 而非 TLE。语义上总超时=评测流程未完成，正确。

--- a/noj-docs/docs/intro/what-is-noj.md
+++ b/noj-docs/docs/intro/what-is-noj.md
@@ -79,7 +79,7 @@ Neuro OJ 通过双容器提供**有限的互联网能力**：
 传统 OJ 的"时间限制"限制整个用户程序从头到尾的运行时间，超时即 TLE。Neuro OJ 的限制分两层：
 
 - **Evaluator 整体限制**：`time_limit_ms` / `memory_limit_mb` 作用在 evaluator 容器上，覆盖整个评测流程（含用户函数调用）。
-- **单次调用超时**：`call_timeout_ms` 限制**一次** `runner.call()` 的时长。单次调用超时**不一定**是最终 TLE——evaluator 可以把它当作一个失败用例继续评测，也可以直接判定 TLE。这给了出题人更大的评分控制力（例如部分用例超时仍可给分）。
+- **单次调用超时**：`call_timeout_ms` 限制**一次** `runner.call()` 的时长。单次调用超时**不一定**是最终 TLE——evaluator 可以把它当作一个失败用例继续评测，也可以直接判定 TLE。这给了出题人更大的评分控制力（例如部分用例超时仍可给分）。若 evaluator 未捕获单次调用超时（evaluate.py 异常退出），最终状态为 `TimeLimitExceeded`；而 evaluator 整体执行超过 `time_limit_ms` 时，Judge Worker 强制终止评测，最终状态为 `SystemError`。
 
 内存限制同样按容器分别设置：solution 容器（用户代码）与 evaluator 容器（评测代码）各自独立，互不挤占。
 

--- a/noj-docs/docs/problemsetters/evaluator-sdk.md
+++ b/noj-docs/docs/problemsetters/evaluator-sdk.md
@@ -61,7 +61,7 @@ except SolutionCallError as exc:
 | `NotCallable` | 同名对象存在，但不可调用 |
 | `InvalidFunctionName` | 函数名不是非空字符串 |
 | 用户异常类名 | 用户函数执行时抛出了该异常 |
-| `CallTimeout` | 单次调用超过 `call_timeout_ms` |
+| `CallTimeout` | 单次调用超过 `call_timeout_ms`。若 evaluator 未捕获（evaluate.py 异常退出、无 `---RESULT---`），最终状态为 `TimeLimitExceeded` |
 | `InvalidRpcResponse` | Judge Worker 返回给 evaluator 的响应不是合法 JSON |
 | `RpcChannelClosed` | evaluator 无法继续从 Judge Worker 读取 RPC 响应 |
 

--- a/noj-docs/docs/problemsetters/judge-model.md
+++ b/noj-docs/docs/problemsetters/judge-model.md
@@ -46,6 +46,19 @@ Solution 容器运行用户提交的 `solution.py` 和 Solution Host。Solution 
 - 只有当 Evaluator 自己显式返回 `runtime_error()`，或 Judge Worker / Solution Host 在调用前就无法正常工作时，才更可能看到 `RuntimeError` / `SystemError`。
 - 用户代码语法错误、模块导入失败、Solution Host 启动失败，通常会在调用前被判为 `SystemError`，因为这时 Evaluator 还没有拿到可继续评分的函数实例。
 
+### 超时与状态映射
+
+两层超时的最终状态映射：
+
+| 超时来源 | 触发 | 最终状态 |
+| --- | --- | --- |
+| evaluator 整体执行超时 | 评测总时长超过 `time_limit_ms` | `SystemError`（Judge Worker 强制终止，做题人不可通过改代码解决） |
+| 单次调用超时且 evaluator 未捕获 | 调用超过 `call_timeout_ms`，evaluate.py 异常退出、无 `---RESULT---` | `TimeLimitExceeded` |
+| 单次调用超时且 evaluator 捕获 | 同上，但 evaluator 记为失败用例 | 由 evaluator 决定（如 `WrongAnswer`） |
+| evaluator 异常退出且从未发生调用超时 | evaluate.py 自身 bug、环境问题、无 `---RESULT---` | `SystemError` |
+
+evaluator 启动超时（评测环境未就绪）同样归 `SystemError`。
+
 Solution Host 在同一次评测中是 persistent 的：多次 `runner.call()` 默认会调用同一个 Python 模块实例，因此用户模块的全局状态会在调用之间保留。Evaluator 可以通过 `runner.restart()` 请求重启 Solution Host，但普通题目通常不需要这样做。
 
 用户代码的 stdout 会被重定向到 stderr。这保证用户的 `print()` 不会污染 Solution Host 的协议 stdout。最终 Solution stderr 会附加到评测输出中，便于调试。

--- a/noj-docs/docs/problemsetters/rpc.md
+++ b/noj-docs/docs/problemsetters/rpc.md
@@ -121,7 +121,7 @@ Evaluator SDK 会抛出 `SolutionCallError`，错误对象可通过 `exc.error` 
 | 用户异常类名 | Solution Host | 用户函数执行时抛出异常 |
 | `InvalidJson` | Solution Host | Host 收到的请求不是合法 JSON |
 | `UnknownMethod` | Solution Host | 请求方法未知 |
-| `CallTimeout` | Judge Worker | 单次调用超过调用级 `timeout_ms`（缺省回退题目级 `call_timeout_ms`）；capability 调用按注册时配置的默认超时 |
+| `CallTimeout` | Judge Worker | 单次调用超过调用级 `timeout_ms`（缺省回退题目级 `call_timeout_ms`）；capability 调用按注册时配置的默认超时。该错误由 Judge 直接注入；若 evaluator 未捕获（evaluate.py 异常退出、无 `---RESULT---`），最终状态为 `TimeLimitExceeded` |
 | `HostWriteFailed` | Judge Worker | 无法向 Solution Host 写入请求 |
 | `InvalidHostResponse` | Judge Worker | Host 响应不是合法 JSON |
 | `RestartFailed` | Judge Worker | 重启 Solution Host 失败 |

--- a/noj-docs/docs/problemsetters/web-editor.md
+++ b/noj-docs/docs/problemsetters/web-editor.md
@@ -27,6 +27,8 @@
 
 配置保存在题目上，Judge Worker 评测时读取。`call_timeout_ms` 作为单次 SDK 调用的**默认**超时；出题人可在 `evaluate.py` 中用 `runner.call(..., timeout_ms=...)` 按调用覆盖（缺省时回退该默认值）。合理设置 Solution 的调用超时可以防止用户代码死循环拖垮整场评测（见[评测模型](judge-model.md)）。
 
+两层超时的状态语义：`time_limit_ms` 超时表示评测流程未正常完成，最终状态为 `SystemError`；`call_timeout_ms` 超时若未被 evaluator 捕获，最终状态为 `TimeLimitExceeded`，捕获后由 evaluator 自行决定（详见[评测模型](judge-model.md)）。
+
 ### 统一题目包
 
 编辑器中通过拖拽或选择文件上传**统一题目包**（zip）：

--- a/noj-docs/docs/reference/result-status.md
+++ b/noj-docs/docs/reference/result-status.md
@@ -18,7 +18,10 @@
 
 ## TimeLimitExceeded
 
-提交超过时间限制。超时可能发生在 evaluator 执行、用户函数调用或整体评测流程中。
+提交超过时间限制。超时来源分两类：
+
+- **单次调用超时**（`call_timeout_ms`）：用户函数单次调用超过调用级超时。Judge Worker 向 evaluator 注入 `CallTimeout` 错误；若 evaluator 未捕获（evaluate.py 异常退出、无 `---RESULT---`），最终状态为 `TimeLimitExceeded`。若 evaluator 捕获并记为失败用例，最终状态由 evaluator 决定（如 `WrongAnswer`）。
+- **整体流程超时**（`time_limit_ms`）：evaluator 整体执行超过时限，由 Judge Worker 强制终止评测，最终状态为 `SystemError`（见下），**不会**落成 `TimeLimitExceeded`。
 
 ## MemoryLimitExceeded
 
@@ -38,5 +41,7 @@
 - 用户代码语法错误，导致模块无法导入。
 - 纯净评测包缺失 `evaluate.py` 或 evaluator 自身崩溃。
 - 运行时镜像不存在或白名单配置错误。
+- evaluator 整体执行超过 `time_limit_ms`（Judge Worker 强制终止）。
+- evaluator 启动超时（评测环境未就绪）。
 
 做题人遇到 SystemError 时，一般不应通过修改答案逻辑解决，而应联系运营者或出题人排查。

--- a/noj-judge/AGENTS.md
+++ b/noj-judge/AGENTS.md
@@ -136,11 +136,10 @@ cargo fmt
   │     ├─ 超时 → stop_container(SIGTERM) + kill_container(SIGKILL) → exit_code = -1
   │     └─ 正常 → 读取 stdout/stderr + exit_code
   ├─ 8. 等待 Evaluator stdout 出现 ---RESULT--- 标记，解析 JSON {status, score, details}
-  │     ├─ 有标记 → 解析结果
-  │     ├─ 无标记 + exit 0 → SystemError
-  │     ├─ 无标记 + exit ≠ 0 → RuntimeError
-  │     ├─ exit = -1 → TimeLimitExceeded
-  │     └─ exit = 137 → MemoryLimitExceeded
+  │     ├─ 有标记 → 解析结果（状态由 evaluator 决定）
+  │     ├─ 总超时（启动超时 / time_limit_ms）→ SystemError（finalize_outcome 优先）
+  │     ├─ 无标记 + 曾发送 CallTimeout 错误帧 → TimeLimitExceeded
+  │     └─ 无标记 + 未发送 → SystemError
   └─ 9. 发 `shutdown` 到 Solution → RAII 清理两个容器
 ```
 
@@ -153,7 +152,7 @@ cargo fmt
 - 超时后两步终止：先 `stop_container(t: kill_grace_secs)` 发 SIGTERM，再
   `kill_container()` 发 SIGKILL
 - 超时后从 `docker logs` 捕获已产生的输出（`follow: false`）
-- 超时退出码固定为 `-1`（即使容器后来报告不同退出码）
+- 超时退出码固定为 `-1`（即使容器后来报告不同退出码；该值仅用于日志记录，不参与最终状态判定——状态由 `finalize_outcome` 按超时来源与 CallTimeout 归因决定）
 - 内存峰值读取使用相同 exec 基础设施，5s 超时 + 2s kill grace
 
 ## MQ 消息格式

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py
@@ -316,7 +316,7 @@ class SolutionRunner:
         if frame.get("type") == "error":
             code = frame.get("code", "SystemError")
             message = frame.get("message", "")
-            if code == "Timeout":
+            if code == "CallTimeout":
                 raise SolutionTimeoutError(message)
             if code == "NotFound":
                 raise NotFoundError(message)

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py
@@ -224,7 +224,7 @@ class TestSolutionRunnerCall(unittest.TestCase):
                 {
                     "type": "error",
                     "id": call_frame["id"],
-                    "code": "Timeout",
+                    "code": "CallTimeout",
                     "message": "exceeded 500ms",
                 }
             )

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -301,6 +301,32 @@ pub async fn evaluate_dual(
     result
 }
 
+/// 超时种类：判定最终状态时区分启动期与正式评测期。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimeoutKind {
+    /// 阶段 1：评测程序启动等待超时（容器创建 / 文件注入 / 运行时启动开销）
+    Startup,
+    /// 阶段 2：evaluator 整体执行超过 time_limit_ms
+    Total,
+}
+
+/// 评测收尾判定：把「评测如何结束」映射为最终状态。
+///
+/// 仅在 evaluator 未正常输出 ---RESULT--- 时调用（有 RESULT 走 build_judge_result）。
+/// 规则（顺序即优先级）：
+/// 1. 总超时（Startup/Total）→ SystemError：评测流程未正常完成，做题人不可通过改代码解决；
+/// 2. 曾向 evaluator 发送过 CallTimeout 错误帧 → TimeLimitExceeded：用户代码慢是根因；
+/// 3. 否则 → SystemError：evaluator 自身异常。
+fn finalize_outcome(timed_out: Option<TimeoutKind>, sent_call_timeout: bool) -> JudgeStatus {
+    if timed_out.is_some() {
+        return JudgeStatus::SystemError;
+    }
+    if sent_call_timeout {
+        return JudgeStatus::TimeLimitExceeded;
+    }
+    JudgeStatus::SystemError
+}
+
 /// 主循环：双向 NDJSON 转发 + 解析 Evaluator 输出。
 #[allow(clippy::too_many_arguments)]
 async fn run_dual_loop(
@@ -335,6 +361,12 @@ async fn run_dual_loop(
     // 调用级超时追踪器（题目级 call_timeout_ms 作为缺省回退值）
     let mut tracker = InFlightTracker::new(default_call_timeout_ms);
 
+    // 是否向 evaluator 发送过 CallTimeout 错误帧（solution 调用超时）。
+    // 仅 WaitingSide::Evaluator（evaluator 等 solution 的 call）置位；
+    // WaitingSide::Solution（capability 反向调用超时）不置位——其错误帧写给 solution，
+    // 不构成「evaluator 未处理 CallTimeout」归因。
+    let mut sent_call_timeout = false;
+
     // 评测程序启动等待上限：容器创建 / 文件注入 / Python 启动等开销
     // 不计入题目时限（issue：秒过的代码不应因启动开销 TLE）。
     const EVALUATOR_STARTUP_TIMEOUT_MS: u64 = 30_000;
@@ -349,7 +381,21 @@ async fn run_dual_loop(
         tokio::select! {
             _ = &mut startup_deadline => {
                 warn!("Evaluator 启动超时（{}ms）: {}", EVALUATOR_STARTUP_TIMEOUT_MS, submission_id);
-                return Ok(JudgeResult::timeout(submission_id, "evaluator startup timeout", rejudge_seq));
+                return Ok(match finalize_outcome(
+                    Some(TimeoutKind::Startup),
+                    sent_call_timeout,
+                ) {
+                    JudgeStatus::TimeLimitExceeded => JudgeResult::timeout(
+                        submission_id,
+                        "evaluator startup timeout",
+                        rejudge_seq,
+                    ),
+                    _ => JudgeResult::system_error(
+                        submission_id,
+                        "evaluator startup timeout",
+                        rejudge_seq,
+                    ),
+                });
             }
             // 调用级超时（in-flight 到期）
             _ = async {
@@ -362,6 +408,7 @@ async fn run_dual_loop(
                     match side {
                         WaitingSide::Evaluator => {
                             write_timeout_frame(&mut eval_input, &id).await?;
+                            sent_call_timeout = true;
                         }
                         WaitingSide::Solution => {
                             write_timeout_frame(&mut sol_input, &id).await?;
@@ -418,7 +465,18 @@ async fn run_dual_loop(
                 // 总超时
                 _ = &mut deadline => {
                     warn!("Evaluator 总超时: {}", submission_id);
-                    return Ok(JudgeResult::timeout(submission_id, "evaluator total timeout", rejudge_seq));
+                    return Ok(match finalize_outcome(Some(TimeoutKind::Total), sent_call_timeout) {
+                        JudgeStatus::TimeLimitExceeded => JudgeResult::timeout(
+                            submission_id,
+                            "evaluator total timeout",
+                            rejudge_seq,
+                        ),
+                        _ => JudgeResult::system_error(
+                            submission_id,
+                            "evaluator total timeout",
+                            rejudge_seq,
+                        ),
+                    });
                 }
 
                 // 调用级超时（in-flight 到期）
@@ -432,6 +490,7 @@ async fn run_dual_loop(
                         match side {
                             WaitingSide::Evaluator => {
                                 write_timeout_frame(&mut eval_input, &id).await?;
+                                sent_call_timeout = true;
                             }
                             WaitingSide::Solution => {
                                 write_timeout_frame(&mut sol_input, &id).await?;
@@ -515,11 +574,18 @@ async fn run_dual_loop(
                 }
             }
             let full_output = crate::merge_output(&eval_stdout_full, &eval_stderr_buf);
-            Ok(JudgeResult::system_error(
-                submission_id,
-                &full_output,
-                rejudge_seq,
-            ))
+            match finalize_outcome(None, sent_call_timeout) {
+                JudgeStatus::TimeLimitExceeded => Ok(JudgeResult::timeout(
+                    submission_id,
+                    &full_output,
+                    rejudge_seq,
+                )),
+                _ => Ok(JudgeResult::system_error(
+                    submission_id,
+                    &full_output,
+                    rejudge_seq,
+                )),
+            }
         }
     }
 }
@@ -680,7 +746,7 @@ async fn write_timeout_frame(
     let frame = serde_json::json!({
         "type": "error",
         "id": id,
-        "code": "Timeout",
+        "code": "CallTimeout",
         "message": "call timeout",
     });
     forward_frame(writer, &frame).await
@@ -801,6 +867,31 @@ mod tests {
         let r = build_judge_result("sid-3", &parsed, "", "");
         assert_eq!(r.status, "SystemError");
         assert_eq!(r.score, 0);
+    }
+
+    #[test]
+    fn test_finalize_outcome_mapping() {
+        // 总超时优先：无论是否发过 CallTimeout 都归 SystemError
+        assert_eq!(
+            finalize_outcome(Some(TimeoutKind::Startup), false),
+            JudgeStatus::SystemError
+        );
+        assert_eq!(
+            finalize_outcome(Some(TimeoutKind::Startup), true),
+            JudgeStatus::SystemError
+        );
+        assert_eq!(
+            finalize_outcome(Some(TimeoutKind::Total), false),
+            JudgeStatus::SystemError
+        );
+        assert_eq!(
+            finalize_outcome(Some(TimeoutKind::Total), true),
+            JudgeStatus::SystemError
+        );
+        // 无总超时 + 发过 CallTimeout → TLE（用户代码慢是根因）
+        assert_eq!(finalize_outcome(None, true), JudgeStatus::TimeLimitExceeded);
+        // 无总超时 + 未发过 → SystemError（evaluator 自身异常）
+        assert_eq!(finalize_outcome(None, false), JudgeStatus::SystemError);
     }
 
     #[tokio::test]

--- a/noj-judge/tests/e2e_dual_container.rs
+++ b/noj-judge/tests/e2e_dual_container.rs
@@ -4,14 +4,19 @@
 //! - dual_basic: A+B Problem Accepted
 //! - dual_persistent: 多次 call 复用 host 状态
 //! - dual_timeout: call_timeout_ms 单次超时
+//! - dual_call_timeout_fallback: 调用级超时缺省回退题目级默认
+//! - dual_call_timeout_per_call_concurrent: 调用级超时按调用独立生效
+//! - dual_capability_timeout_per_call: capability 注册超时（cap_reg）
+//! - dual_evaluator_total_timeout: evaluator 总超时 → SystemError
+//! - dual_solution_timeout_unhandled: CallTimeout 未处理 → TLE
+//! - dual_solution_timeout_handled: CallTimeout 被捕获 → evaluator 决定
 //! - dual_solution_exception: 用户异常 + sanitize trace
 //! - dual_solution_no_network: Solution 无网络
 //! - dual_solution_module_shadowing: PYTHONPATH shadowing 不影响 Evaluator
 //! - dual_solution_read_evaluator_env: 隔离环境变量
-//! - dual_legacy_fallback: 旧 JudgeTask 走单容器
 //!
-//! 注：本测试使用现有 `noj-judge-test-runner` 镜像 + 容器内拷贝 SDK 源码。
-//! 不需要单独的 dual 镜像，验证 orchestrator 协议层正确性即可。
+//! 注：本测试使用 `noj-e2e-sdk-evaluator` / `noj-e2e-sdk-solution` 镜像
+//! （common::ensure_sdk_images 按需构建，内含 SDK 源码）。
 
 mod common;
 
@@ -888,8 +893,197 @@ except Exception as e:
     );
     assert_eq!(
         cap["code"].as_str().unwrap(),
-        "Timeout",
-        "CapabilityError.code 应为 Timeout: {:?}",
+        "CallTimeout",
+        "CapabilityError.code 应为 CallTimeout: {:?}",
         result.details
+    );
+}
+
+/// evaluator 整体超时（time_limit_ms 到期）→ SystemError（评测流程未正常完成）。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_evaluator_total_timeout_system_error() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_sdk_images(&docker).await.unwrap();
+
+    // evaluator：打印首行（进入阶段 2）后死循环，永不输出 ---RESULT---
+    let evaluator_cmd = r#"python3 -c "
+import sys, time
+print('ready', flush=True)
+while True:
+    time.sleep(1)
+"#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 2000, // 2s 总超时
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 5000,
+            memory_limit_mb: 128,
+        },
+    };
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        noj_judge::dual::evaluate_dual(
+            docker.clone(),
+            "e2e-evaluator-total-timeout",
+            &runtime_config,
+            "def solve(): return 1",
+            "solution.py",
+            None,
+            "/tmp/e2e-cache",
+            100,
+            64,
+            None,
+        ),
+    )
+    .await
+    .expect("评测 30s 外层超时")
+    .expect("评测应正常返回");
+
+    assert_eq!(
+        result.status, "SystemError",
+        "evaluator 总超时应归 SystemError: {:?}",
+        result
+    );
+}
+
+/// solution 调用超时且 evaluator 未捕获（evaluate.py 崩溃、无 ---RESULT---）→ TLE。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_solution_timeout_unhandled_tle() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_sdk_images(&docker).await.unwrap();
+
+    // evaluator：调用 sleep_solution 但不捕获 SolutionTimeoutError → 异常冒泡崩溃退出
+    let evaluator_cmd = r#"python3 -c "
+from noj_evaluator_sdk import SolutionRunner
+runner = SolutionRunner()
+runner.call('sleep_solution')
+"#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 15000,
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 100, // 100ms 调用超时
+            memory_limit_mb: 128,
+        },
+    };
+    // solution：sleep_solution 睡 300ms（> 100ms 调用超时）
+    let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\n";
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        noj_judge::dual::evaluate_dual(
+            docker.clone(),
+            "e2e-solution-timeout-unhandled",
+            &runtime_config,
+            code,
+            "solution.py",
+            None,
+            "/tmp/e2e-cache",
+            100,
+            64,
+            None,
+        ),
+    )
+    .await
+    .expect("评测 30s 外层超时")
+    .expect("评测应正常返回");
+
+    assert_eq!(
+        result.status, "TimeLimitExceeded",
+        "CallTimeout 未处理应归 TLE: {:?}",
+        result
+    );
+}
+
+/// solution 调用超时被 evaluator 捕获 → 最终状态由 evaluator 决定（此处为 WrongAnswer）。
+#[ignore]
+#[serial_test::serial]
+#[tokio::test]
+async fn dual_solution_timeout_handled_wrong_answer() {
+    if !is_e2e_enabled() {
+        return;
+    }
+    let docker = get_docker().expect("docker");
+    common::ensure_sdk_images(&docker).await.unwrap();
+
+    // evaluator：捕获 SolutionTimeoutError 后记为失败用例（WrongAnswer）
+    let evaluator_cmd = r#"python3 -c "
+from noj_evaluator_sdk import SolutionRunner, SolutionTimeoutError, result
+runner = SolutionRunner()
+try:
+    runner.call('sleep_solution')
+    result.accept(score=1000, details={'cases': [{'id': 'c1', 'status': 'Accepted'}]})
+except SolutionTimeoutError:
+    result.wrong_answer(
+        score=0,
+        message='c1 call timeout',
+        details={'cases': [{'id': 'c1', 'status': 'WrongAnswer'}]},
+    )
+"#;
+    let runtime_config = RuntimeConfig {
+        evaluator: EvaluatorRuntime {
+            image: "noj-e2e-sdk-evaluator:latest".to_string(),
+            command: evaluator_cmd.to_string(),
+            time_limit_ms: 15000,
+            memory_limit_mb: 256,
+            network: None,
+        },
+        solution: SolutionRuntime {
+            image: "noj-e2e-sdk-solution:latest".to_string(),
+            entry: "solution.py".to_string(),
+            call_timeout_ms: 100,
+            memory_limit_mb: 128,
+        },
+    };
+    let code = "import time\ndef sleep_solution():\n    time.sleep(0.3)\n    return 1\n";
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        noj_judge::dual::evaluate_dual(
+            docker.clone(),
+            "e2e-solution-timeout-handled",
+            &runtime_config,
+            code,
+            "solution.py",
+            None,
+            "/tmp/e2e-cache",
+            100,
+            64,
+            None,
+        ),
+    )
+    .await
+    .expect("评测 30s 外层超时")
+    .expect("评测应正常返回");
+
+    assert_eq!(
+        result.status, "WrongAnswer",
+        "CallTimeout 被捕获时状态由 evaluator 决定: {:?}",
+        result
     );
 }

--- a/openspec/changes/timeout-status-mapping/.openspec.yaml
+++ b/openspec/changes/timeout-status-mapping/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/timeout-status-mapping/design.md
+++ b/openspec/changes/timeout-status-mapping/design.md
@@ -1,0 +1,81 @@
+## Context
+
+当前评测有两层超时：evaluator 整体执行限时（`runtime_config.evaluator.time_limit_ms`）与单次用户函数调用超时（`runtime_config.solution.call_timeout_ms`，issue #198 起支持按调用指定）。但超时后的最终状态判定不明确且与目标语义不符：
+
+- `noj-judge/src/dual/mod.rs:421`：evaluator 总超时 → `JudgeResult::timeout()` = `TimeLimitExceeded`（应为 SystemError——评测流程未正常完成，做题人不可通过改代码解决）；
+- `noj-judge/src/dual/mod.rs:352`：启动超时（30s 宽松期）同样返回 TLE；
+- `noj-judge/src/dual/mod.rs:518`：无 `---RESULT---` 退出统一判 SystemError，不区分是否曾发送过调用超时错误帧（曾发送且 evaluator 未处理时应为 TLE）；
+- `noj-judge/src/dual/mod.rs:683`：错误帧 `code: "Timeout"` 与文档错误码表名 `CallTimeout` 不一致。
+
+已批准的详细设计：`docs/superpowers/specs/2026-08-05-timeout-status-mapping-design.md`；实施计划：`docs/superpowers/plans/2026-08-05-timeout-status-mapping.md`。
+
+## Goals / Non-Goals
+
+**Goals:**
+- evaluator 总超时（启动超时 + 整体执行超过 `time_limit_ms`）→ Judge Worker 强制终止，最终状态 SystemError
+- solution 单次调用超时：judge 注入 `CallTimeout` 错误帧；evaluator 未捕获（无 RESULT 退出）→ TLE；捕获 → 由 evaluator 决定
+- 错误帧 code 统一为 `CallTimeout`（judge 发送端 + SDK 匹配端 + 测试断言），不保留旧 code 兼容
+- 收尾判定集中为纯函数 `finalize_outcome`，可无 Docker 单测
+- 五处文档同步更新
+
+**Non-Goals:**
+- 不修改 noj-core / noj-ui（core 仅把 SystemError 映射为 submission status `error`，无状态判定逻辑；UI 按字符串渲染）
+- 不新增强制终止逻辑（既有 `DualContainer::destroy` → `remove_container_force` 已保障容器清理）
+- 不引入严格归因（"最后一帧"判定）——见 Decisions
+- 不改动 capability 反向调用超时的错误帧接收方（写给 solution，不构成 evaluator 归因）
+
+## Decisions
+
+**D1: 收尾判定纯函数 `finalize_outcome`（方案 B：集中收尾判定）**
+
+```rust
+enum TimeoutKind { Startup, Total }
+
+fn finalize_outcome(timed_out: Option<TimeoutKind>, sent_call_timeout: bool) -> JudgeStatus
+```
+
+规则（顺序即优先级）：`timed_out.is_some()` → SystemError；`sent_call_timeout` → TimeLimitExceeded；否则 SystemError。
+
+- 备选 A（最小内联）：标志 + 分支就地改状态。改动最小但判定逻辑散布主循环，无法单独单测。
+- 备选 C（tracker 扩展）：把归因状态放进 `InFlightTracker`。耦合加深，tracker 职责从"超时计时"扩大为"状态归因"。
+- 选 B：语义集中、可对照文档、纯函数表驱动单测成本最低。
+
+**D2: TLE 判定判据——宽泛标志（发生过调用超时即归因）**
+
+`sent_call_timeout` 标志在 judge 向 evaluator 写入 `CallTimeout` 错误帧（`WaitingSide::Evaluator` 分支，即 solution 调用超时）时置位。无 RESULT 退出时标志为真 → TLE。
+
+- 备选严格归因（"最后一次写出的帧是 CallTimeout"）：更精确但边界难定义、复杂度不成比例。
+- 权衡接受：evaluator 捕获 CallTimeout 后继续评测、最终因自身 bug 崩溃的场景会误判 TLE——但用户代码超时是评测链断裂的根因，且该场景罕见。
+
+**D3: 优先级——总超时优先于 CallTimeout 归因**
+
+阶段 1/2 deadline 一旦触发直接返回 SystemError，不因曾发过 CallTimeout 而改判 TLE。语义：总超时 = 评测流程未完成（环境侧问题），强制终止是最高优先级。
+
+**D4: 错误帧 code 统一为 `CallTimeout`，不保留旧兼容**
+
+`write_timeout_frame` 发送 `code: "CallTimeout"`；SDK `runner.py:319` 匹配同步改。judge 与 SDK 同仓同步发布，E2E 验证新链路；保留旧 code 反而遗留不一致。
+
+**D5: 标志置位范围——仅 `WaitingSide::Evaluator`**
+
+`WaitingSide::Solution`（solution 等 evaluator 的 capability 反向调用超时）的错误帧写给 solution，不构成"evaluator 未处理 CallTimeout"归因，不置位。
+
+**D6: 强制终止复用既有销毁路径**
+
+总超时分支 return 后由 `run_dual_loop` 调用方的 `dual.destroy()`（`remove_container_force`）强制清理两个容器，无新增 kill 逻辑。
+
+## Risks / Trade-offs
+
+- [宽泛归因误判边界] evaluator 捕获 CallTimeout 后因自身 bug 崩溃 → 判 TLE 而非 SystemError → 接受：用户代码超时是根因，场景罕见；严格归因收益不成比例
+- [code 改名兼容] 旧 SDK（匹配 `"Timeout"`）与新 judge 不兼容 → judge 与 SDK 同仓同步发布，E2E 覆盖新链路，接受
+- [总超时可能掩盖 TLE] evaluator 死循环等待超时调用时总超时先到 → SystemError 而非 TLE → 语义上总超时 = 评测流程未完成，正确
+- [E2E 依赖 Docker] 三种超时场景测试需 Docker daemon → 按既有 `#[ignore]` + `NOJ_RUN_E2E=1` 守卫模式，CI 的 judge-sandbox job 覆盖
+
+## Migration Plan
+
+- 无数据迁移；无协议版本字段变更（错误帧 code 是内部协议字符串，judge 与 SDK 同仓发布）
+- 部署顺序：judge + SDK 镜像同步构建发布；旧 code `"Timeout"` 帧在升级窗口内不再产生
+- 回滚：还原 `dual/mod.rs` / `runner.py` 提交即可，无持久化状态
+
+## Open Questions
+
+- 无（三项关键决策已与用户确认：启动超时归 SystemError、宽泛归因判据、code 统一 CallTimeout）

--- a/openspec/changes/timeout-status-mapping/proposal.md
+++ b/openspec/changes/timeout-status-mapping/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+当前评测有两层超时（evaluator 整体 `time_limit_ms` 与单次调用 `call_timeout_ms`），但超时后的最终状态判定不明确且与预期语义不符：evaluator 总超时当前落成 `TimeLimitExceeded`（应为 `SystemError`——评测流程未正常完成，做题人不可通过改代码解决）；solution 调用超时未处理导致 evaluate.py 崩溃时落成 `SystemError`（应为 `TimeLimitExceeded`——用户代码慢是根因）。文档（result-status.md / rpc.md / judge-model.md 等）均未明确这些映射。
+
+## What Changes
+
+- evaluator 总超时（启动超时与整体执行超过 `time_limit_ms`）→ Judge Worker 强制终止评测，最终状态统一为 **SystemError**
+- solution 单次调用超时（`call_timeout_ms`）→ Judge 向 evaluator 注入 `CallTimeout` 错误帧；若 evaluator 未捕获（无 `---RESULT---` 退出）→ 最终状态 **TimeLimitExceeded**；被捕获则状态由 evaluator 决定（语义不变）
+- 错误帧 `code` 从 `"Timeout"` 统一为 **`"CallTimeout"`**（judge 发送端 + SDK 匹配端 + 测试断言），不保留旧 code 兼容
+- 新增纯函数 `finalize_outcome` 集中收尾判定（优先级：总超时 > CallTimeout 归因），配套单测与 E2E 三种场景测试
+- 文档五处同步更新（result-status / rpc / judge-model / web-editor / what-is-noj）
+
+## Capabilities
+
+### New Capabilities
+
+（无——超时与状态映射属于既有 judge-worker 能力的修正）
+
+### Modified Capabilities
+
+- `judge-worker`: 「单次调用超时」场景错误帧 code 改为 `CallTimeout`；「Evaluator 总时间超时」场景最终状态由 `TimeLimitExceeded` 改为 `SystemError`；新增「CallTimeout 未处理 → TLE」与「启动超时 → SystemError」场景；错误帧 code 枚举 `Timeout` 改为 `CallTimeout`
+
+## Impact
+
+- `noj-judge/src/dual/mod.rs`：`run_dual_loop` 三个收尾分支 + `write_timeout_frame` + 新增 `finalize_outcome` / `TimeoutKind`（核心改动）
+- `noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py`：`_handle_response` 错误码匹配
+- 测试：`noj-judge/src/dual/mod.rs` 单测、`noj-judge/tests/e2e_dual_container.rs`（3 个新 E2E + 1 处断言更新）、SDK `tests/test_runner.py` 断言更新
+- 文档：`noj-docs/docs/{reference/result-status.md, problemsetters/rpc.md, problemsetters/judge-model.md, problemsetters/web-editor.md, intro/what-is-noj.md}`
+- 无依赖变更；noj-core / noj-ui 不受影响

--- a/openspec/changes/timeout-status-mapping/specs/judge-worker/spec.md
+++ b/openspec/changes/timeout-status-mapping/specs/judge-worker/spec.md
@@ -1,0 +1,98 @@
+## MODIFIED Requirements
+
+### Requirement: 双容器评测编排（dual mode）
+
+系统 SHALL 支持按题目一次任务启动 Evaluator + Solution 两个容器，按 NDJSON 协议在两个容器之间转发调用消息。
+
+#### Scenario: 启动 Evaluator + Solution 双容器
+
+- **WHEN** JudgeTask.mode === 'dual'
+- **THEN** judge 启动 Evaluator 容器（网络隔离、不立即执行 evaluate.py）
+- **THEN** judge 通过 `docker exec tar xf` 注入支持包文件到 Evaluator 容器的 `/workspace` 目录
+- **THEN** judge 启动 Solution 容器（无网络、无支持包、不传 Evaluator 环境变量）
+- **THEN** judge 通过 docker exec 在 Evaluator 容器内运行 `runtime_config.evaluator.command`
+- **THEN** judge 通过 docker exec 在 Solution 容器内运行 `python3 -m noj_solution_sdk.host --entry <solution.entry>`
+- **THEN** Solution host 启动后 5 秒内必须发送 `ready` 帧，否则判 SystemError
+
+#### Scenario: NDJSON 帧转发（Evaluator → Solution）
+
+- **WHEN** Evaluator SDK 调用 `SolutionRunner.call(fn, ...args)`
+- **THEN** SDK 通过 stdout 输出一行 NDJSON 帧 `{type: 'call', id, fn, args}`
+- **THEN** judge 读取 evaluator exec stdout 中的 NDJSON 帧，原样转发到 solution host stdin
+- **THEN** Solution host 处理后通过 stdout 输出 `result` 或 `error` 帧
+- **THEN** judge 读取 solution exec stdout 中的响应帧，原样回写到 evaluator exec stdin
+- **THEN** SDK 从 stdin 读到响应帧后阻塞调用返回
+
+#### Scenario: 多次调用复用同一 Solution host
+
+- **WHEN** 一次评测内多次调用 `SolutionRunner.call()`
+- **THEN** 全部调用复用同一 Solution host 进程（persistent 模式）
+- **THEN** Solution host 内的全局状态在调用之间持续存在
+- **WHEN** `runner.restart()` 被调用
+- **THEN** judge 关闭旧 Solution host 进程，启动新 host 进程
+
+#### Scenario: 单次调用超时（call_timeout_ms）
+
+- **WHEN** 某次 `runner.call()` 超过 `runtime_config.solution.call_timeout_ms`（或调用级 `timeout_ms`）
+- **THEN** judge 停止向 solution host stdin 写入
+- **THEN** SDK 收到 `code: 'CallTimeout'` 错误帧（抛 `SolutionTimeoutError`）
+- **THEN** Solution host 进程继续运行（不退出）
+- **WHEN** evaluator 未捕获 `SolutionTimeoutError`（evaluate.py 异常退出、未输出 `---RESULT---`）
+- **THEN** JudgeResult.status = 'TimeLimitExceeded'
+- **WHEN** evaluator 捕获 `SolutionTimeoutError` 并记为失败用例
+- **THEN** 最终状态由 evaluator 决定（如 `WrongAnswer`）
+
+#### Scenario: Evaluator 总时间超时
+
+- **WHEN** Evaluator 容器总执行时间超过 `runtime_config.evaluator.time_limit_ms`
+- **THEN** judge `docker stop -t kill_grace_secs` Evaluator 容器
+- **THEN** judge `docker kill` Evaluator 容器（如未退）
+- **THEN** judge `docker rm -f` Solution 容器
+- **THEN** JudgeResult.status = 'SystemError'
+
+#### Scenario: Evaluator 启动超时
+
+- **WHEN** Evaluator 启动等待超过宽松上限（容器创建 / 文件注入 / 运行时启动开销，不计入题目时限）
+- **THEN** judge 强制终止评测
+- **THEN** JudgeResult.status = 'SystemError'
+
+#### Scenario: Evaluator OOM
+
+- **WHEN** Evaluator 容器因 RSS 超限被 Docker kill（退出码 137）
+- **THEN** JudgeResult.status = 'MemoryLimitExceeded'
+
+#### Scenario: Solution OOM
+
+- **WHEN** Solution 容器 RSS 超 `runtime_config.solution.memory_limit_mb`
+- **THEN** Solution host 守护进程触发 SystemError
+- **THEN** judge 关闭 Solution 容器 + Evaluator 容器
+- **THEN** JudgeResult.status = 'SystemError'
+
+### Requirement: NDJSON 协议帧类型与字段
+
+系统 SHALL 在 Evaluator / Solution 容器之间传输 NDJSON 帧，定义统一的帧类型与字段。
+
+#### Scenario: 帧类型枚举
+
+- **WHEN** 任何容器发送 NDJSON 帧
+- **THEN** `type` 字段必须是下列之一：`ready` / `call` / `result` / `error` / `log` / `shutdown`
+- **WHEN** `type` 为非法值
+- **THEN** 接收方记录 warn 日志并丢弃该帧
+
+#### Scenario: 错误码枚举
+
+- **WHEN** `type === 'error'`
+- **THEN** `code` 字段必须是下列之一：`CallTimeout` / `NotFound` / `Exception` / `SystemError` / `Rejected`
+
+#### Scenario: 类型安全序列化
+
+- **WHEN** Evaluator SDK 序列化 `runner.call()` 参数
+- **THEN** 仅接受 `None` / `bool` / `int` / `float` / `str` / `bytes` / `list` / `dict` 七种类型
+- **WHEN** 参数包含其他类型（如自定义类、函数、模块、socket、生成器）
+- **THEN** Solution host 抛 `code: 'Rejected'`，host 进程继续运行
+
+#### Scenario: Trace 路径清洗
+
+- **WHEN** Solution host 格式化用户代码异常的 traceback
+- **THEN** 仅保留文件 basename + 行号 + 类名 + 消息
+- **THEN** 剥离所有绝对路径（不暴露 SDK 安装路径或容器镜像 layout）

--- a/openspec/changes/timeout-status-mapping/tasks.md
+++ b/openspec/changes/timeout-status-mapping/tasks.md
@@ -1,0 +1,48 @@
+## 1. finalize_outcome 纯函数
+
+- [ ] 1.1 在 `noj-judge/src/dual/mod.rs` 的 `mod tests` 中新增 `test_finalize_outcome_mapping` 表驱动测试（6 断言：Startup/Total × sent_call_timeout ∈ {true,false} → SystemError；None+true → TimeLimitExceeded；None+false → SystemError），`JudgeStatus` 若未导入则在测试内 `use crate::types::JudgeStatus;`
+- [ ] 1.2 运行 `cd noj-judge && cargo test finalize_outcome -- --nocapture` 确认失败（编译错误：找不到函数/类型）
+- [ ] 1.3 在 `run_dual_loop` 前新增 `enum TimeoutKind { Startup, Total }` 与 `fn finalize_outcome(timed_out: Option<TimeoutKind>, sent_call_timeout: bool) -> JudgeStatus`（规则：timed_out → SystemError；sent_call_timeout → TimeLimitExceeded；否则 SystemError），中文注释说明优先级
+- [ ] 1.4 运行 `cd noj-judge && cargo test finalize_outcome -- --nocapture` 确认通过
+- [ ] 1.5 提交：`jj describe -m "test(judge): finalize_outcome 状态映射纯函数（issue #202）"`
+
+## 2. run_dual_loop 接入 finalize_outcome
+
+- [ ] 2.1 在 `run_dual_loop` 中 `InFlightTracker::new` 之后新增 `let mut sent_call_timeout = false;`（注释说明仅 WaitingSide::Evaluator 置位）
+- [ ] 2.2 阶段 1 启动超时分支：`JudgeResult::timeout` 改为 `JudgeResult::system_error`（output 保留 "evaluator startup timeout"）
+- [ ] 2.3 阶段 2 总超时分支：`JudgeResult::timeout` 改为 `JudgeResult::system_error`（output 保留 "evaluator total timeout"）
+- [ ] 2.4 两处 in-flight 到期分支的 `WaitingSide::Evaluator` 分支在 `write_timeout_frame` 成功后加 `sent_call_timeout = true;`；`WaitingSide::Solution` 分支不变
+- [ ] 2.5 无 RESULT 收尾分支：返回值改为 `match finalize_outcome(None, sent_call_timeout) { JudgeStatus::TimeLimitExceeded => Ok(JudgeResult::timeout(submission_id, &full_output, rejudge_seq)), _ => Ok(JudgeResult::system_error(submission_id, &full_output, rejudge_seq)) }`
+- [ ] 2.6 运行 `cd noj-judge && cargo test --lib` 确认全部通过；`cargo fmt --check && cargo clippy --all-targets -- -D warnings` 无警告
+- [ ] 2.7 提交：`jj describe -m "fix(judge): evaluator 总超时归 SystemError、CallTimeout 未处理归 TLE（issue #202）"`
+
+## 3. 错误帧 code 统一为 CallTimeout
+
+- [ ] 3.1 修改 `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py` 第 227 行附近错误帧 code 断言 `"Timeout"` → `"CallTimeout"`
+- [ ] 3.2 运行 `cd noj-judge/sdk/evaluator && python3 -m unittest discover -s tests -v` 确认失败（SDK 仍匹配旧 code）
+- [ ] 3.3 `noj-judge/src/dual/mod.rs` `write_timeout_frame`：`"code": "Timeout"` → `"code": "CallTimeout"`
+- [ ] 3.4 `noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py` 第 319 行：`if code == "Timeout":` → `if code == "CallTimeout":`（不保留旧兼容分支）
+- [ ] 3.5 运行 SDK 单测（unittest discover）与 `cd noj-judge && cargo test --lib` 确认通过
+- [ ] 3.6 更新 `noj-judge/tests/e2e_dual_container.rs` `dual_capability_timeout_per_call` 中 code 断言 `"Timeout"` → `"CallTimeout"`
+- [ ] 3.7 提交：`jj describe -m "fix(judge,sdk): 超时错误帧 code 统一为 CallTimeout（issue #202）"`
+
+## 4. E2E 三种超时场景测试
+
+- [ ] 4.1 在 `noj-judge/tests/e2e_dual_container.rs` 末尾新增 `dual_evaluator_total_timeout_system_error`：evaluate.py 打印 ready 后死循环、`time_limit_ms: 2000`，断言 `result.status == "SystemError"`（`#[ignore]` + `#[serial_test::serial]` + `is_e2e_enabled()` 守卫）
+- [ ] 4.2 运行 `cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_evaluator_total_timeout_system_error -- --ignored --nocapture` 确认通过
+- [ ] 4.3 新增 `dual_solution_timeout_unhandled_tle`：evaluator 调 `runner.call('sleep_solution')` 不捕获（异常冒泡崩溃）、`call_timeout_ms: 100`、solution sleep 300ms，断言 `result.status == "TimeLimitExceeded"`
+- [ ] 4.4 运行同上命令（换测试名）确认通过
+- [ ] 4.5 新增 `dual_solution_timeout_handled_wrong_answer`：evaluator `try/except SolutionTimeoutError` 后 `result.wrong_answer(...)`，断言 `result.status == "WrongAnswer"`
+- [ ] 4.6 运行同上命令（换测试名）确认通过
+- [ ] 4.7 全量回归：`cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container -- --ignored`（既有测试 + 新增 3 个全部通过）
+- [ ] 4.8 提交：`jj describe -m "test(judge): 补 evaluator 超时/CallTimeout 未处理/被捕获三种 E2E（issue #202）"`
+
+## 5. 文档五处更新
+
+- [ ] 5.1 `noj-docs/docs/reference/result-status.md`：TimeLimitExceeded 一节改为区分「单次调用超时未捕获 → TLE」与「整体流程超时 → SystemError」；SystemError 列表补充「evaluator 整体执行超过 time_limit_ms」与「evaluator 启动超时」
+- [ ] 5.2 `noj-docs/docs/problemsetters/rpc.md`：错误来源表 CallTimeout 一行补充「该错误由 Judge 直接注入；若 evaluator 未捕获（evaluate.py 异常退出、无 ---RESULT---），最终状态为 TimeLimitExceeded」
+- [ ] 5.3 `noj-docs/docs/problemsetters/judge-model.md`：新增「超时与状态映射」小节（三层映射表：整体超时→SystemError / 调用超时未捕获→TLE / 捕获→evaluator 决定）
+- [ ] 5.4 `noj-docs/docs/problemsetters/web-editor.md`：运行时配置两层超时语义补充（time_limit_ms→SystemError；call_timeout_ms 未捕获→TLE）
+- [ ] 5.5 `noj-docs/docs/intro/what-is-noj.md`：时空限制一节单次调用超时描述后补充状态映射
+- [ ] 5.6 人工检查五处与设计文档状态映射表一致、无 TBD/TODO
+- [ ] 5.7 提交：`jj describe -m "docs: 明确 evaluator/solution 超时状态映射（issue #202）"`

--- a/openspec/changes/timeout-status-mapping/tasks.md
+++ b/openspec/changes/timeout-status-mapping/tasks.md
@@ -1,48 +1,48 @@
 ## 1. finalize_outcome 纯函数
 
-- [ ] 1.1 在 `noj-judge/src/dual/mod.rs` 的 `mod tests` 中新增 `test_finalize_outcome_mapping` 表驱动测试（6 断言：Startup/Total × sent_call_timeout ∈ {true,false} → SystemError；None+true → TimeLimitExceeded；None+false → SystemError），`JudgeStatus` 若未导入则在测试内 `use crate::types::JudgeStatus;`
-- [ ] 1.2 运行 `cd noj-judge && cargo test finalize_outcome -- --nocapture` 确认失败（编译错误：找不到函数/类型）
-- [ ] 1.3 在 `run_dual_loop` 前新增 `enum TimeoutKind { Startup, Total }` 与 `fn finalize_outcome(timed_out: Option<TimeoutKind>, sent_call_timeout: bool) -> JudgeStatus`（规则：timed_out → SystemError；sent_call_timeout → TimeLimitExceeded；否则 SystemError），中文注释说明优先级
-- [ ] 1.4 运行 `cd noj-judge && cargo test finalize_outcome -- --nocapture` 确认通过
-- [ ] 1.5 提交：`jj describe -m "test(judge): finalize_outcome 状态映射纯函数（issue #202）"`
+- [x] 1.1 在 `noj-judge/src/dual/mod.rs` 的 `mod tests` 中新增 `test_finalize_outcome_mapping` 表驱动测试（6 断言：Startup/Total × sent_call_timeout ∈ {true,false} → SystemError；None+true → TimeLimitExceeded；None+false → SystemError），`JudgeStatus` 若未导入则在测试内 `use crate::types::JudgeStatus;`
+- [x] 1.2 运行 `cd noj-judge && cargo test finalize_outcome -- --nocapture` 确认失败（编译错误：找不到函数/类型）
+- [x] 1.3 在 `run_dual_loop` 前新增 `enum TimeoutKind { Startup, Total }` 与 `fn finalize_outcome(timed_out: Option<TimeoutKind>, sent_call_timeout: bool) -> JudgeStatus`（规则：timed_out → SystemError；sent_call_timeout → TimeLimitExceeded；否则 SystemError），中文注释说明优先级
+- [x] 1.4 运行 `cd noj-judge && cargo test finalize_outcome -- --nocapture` 确认通过
+- [x] 1.5 提交：`jj describe -m "test(judge): finalize_outcome 状态映射纯函数（issue #202）"`
 
 ## 2. run_dual_loop 接入 finalize_outcome
 
-- [ ] 2.1 在 `run_dual_loop` 中 `InFlightTracker::new` 之后新增 `let mut sent_call_timeout = false;`（注释说明仅 WaitingSide::Evaluator 置位）
-- [ ] 2.2 阶段 1 启动超时分支：`JudgeResult::timeout` 改为 `JudgeResult::system_error`（output 保留 "evaluator startup timeout"）
-- [ ] 2.3 阶段 2 总超时分支：`JudgeResult::timeout` 改为 `JudgeResult::system_error`（output 保留 "evaluator total timeout"）
-- [ ] 2.4 两处 in-flight 到期分支的 `WaitingSide::Evaluator` 分支在 `write_timeout_frame` 成功后加 `sent_call_timeout = true;`；`WaitingSide::Solution` 分支不变
-- [ ] 2.5 无 RESULT 收尾分支：返回值改为 `match finalize_outcome(None, sent_call_timeout) { JudgeStatus::TimeLimitExceeded => Ok(JudgeResult::timeout(submission_id, &full_output, rejudge_seq)), _ => Ok(JudgeResult::system_error(submission_id, &full_output, rejudge_seq)) }`
-- [ ] 2.6 运行 `cd noj-judge && cargo test --lib` 确认全部通过；`cargo fmt --check && cargo clippy --all-targets -- -D warnings` 无警告
-- [ ] 2.7 提交：`jj describe -m "fix(judge): evaluator 总超时归 SystemError、CallTimeout 未处理归 TLE（issue #202）"`
+- [x] 2.1 在 `run_dual_loop` 中 `InFlightTracker::new` 之后新增 `let mut sent_call_timeout = false;`（注释说明仅 WaitingSide::Evaluator 置位）
+- [x] 2.2 阶段 1 启动超时分支：`JudgeResult::timeout` 改为 `JudgeResult::system_error`（output 保留 "evaluator startup timeout"）
+- [x] 2.3 阶段 2 总超时分支：`JudgeResult::timeout` 改为 `JudgeResult::system_error`（output 保留 "evaluator total timeout"）
+- [x] 2.4 两处 in-flight 到期分支的 `WaitingSide::Evaluator` 分支在 `write_timeout_frame` 成功后加 `sent_call_timeout = true;`；`WaitingSide::Solution` 分支不变
+- [x] 2.5 无 RESULT 收尾分支：返回值改为 `match finalize_outcome(None, sent_call_timeout) { JudgeStatus::TimeLimitExceeded => Ok(JudgeResult::timeout(submission_id, &full_output, rejudge_seq)), _ => Ok(JudgeResult::system_error(submission_id, &full_output, rejudge_seq)) }`
+- [x] 2.6 运行 `cd noj-judge && cargo test --lib` 确认全部通过；`cargo fmt --check && cargo clippy --all-targets -- -D warnings` 无警告
+- [x] 2.7 提交：`jj describe -m "fix(judge): evaluator 总超时归 SystemError、CallTimeout 未处理归 TLE（issue #202）"`
 
 ## 3. 错误帧 code 统一为 CallTimeout
 
-- [ ] 3.1 修改 `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py` 第 227 行附近错误帧 code 断言 `"Timeout"` → `"CallTimeout"`
-- [ ] 3.2 运行 `cd noj-judge/sdk/evaluator && python3 -m unittest discover -s tests -v` 确认失败（SDK 仍匹配旧 code）
-- [ ] 3.3 `noj-judge/src/dual/mod.rs` `write_timeout_frame`：`"code": "Timeout"` → `"code": "CallTimeout"`
-- [ ] 3.4 `noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py` 第 319 行：`if code == "Timeout":` → `if code == "CallTimeout":`（不保留旧兼容分支）
-- [ ] 3.5 运行 SDK 单测（unittest discover）与 `cd noj-judge && cargo test --lib` 确认通过
-- [ ] 3.6 更新 `noj-judge/tests/e2e_dual_container.rs` `dual_capability_timeout_per_call` 中 code 断言 `"Timeout"` → `"CallTimeout"`
-- [ ] 3.7 提交：`jj describe -m "fix(judge,sdk): 超时错误帧 code 统一为 CallTimeout（issue #202）"`
+- [x] 3.1 修改 `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_runner.py` 第 227 行附近错误帧 code 断言 `"Timeout"` → `"CallTimeout"`
+- [x] 3.2 运行 `cd noj-judge/sdk/evaluator && python3 -m unittest discover -s tests -v` 确认失败（SDK 仍匹配旧 code）
+- [x] 3.3 `noj-judge/src/dual/mod.rs` `write_timeout_frame`：`"code": "Timeout"` → `"code": "CallTimeout"`
+- [x] 3.4 `noj-judge/sdk/evaluator/noj_evaluator_sdk/runner.py` 第 319 行：`if code == "Timeout":` → `if code == "CallTimeout":`（不保留旧兼容分支）
+- [x] 3.5 运行 SDK 单测（unittest discover）与 `cd noj-judge && cargo test --lib` 确认通过
+- [x] 3.6 更新 `noj-judge/tests/e2e_dual_container.rs` `dual_capability_timeout_per_call` 中 code 断言 `"Timeout"` → `"CallTimeout"`
+- [x] 3.7 提交：`jj describe -m "fix(judge,sdk): 超时错误帧 code 统一为 CallTimeout（issue #202）"`
 
 ## 4. E2E 三种超时场景测试
 
-- [ ] 4.1 在 `noj-judge/tests/e2e_dual_container.rs` 末尾新增 `dual_evaluator_total_timeout_system_error`：evaluate.py 打印 ready 后死循环、`time_limit_ms: 2000`，断言 `result.status == "SystemError"`（`#[ignore]` + `#[serial_test::serial]` + `is_e2e_enabled()` 守卫）
-- [ ] 4.2 运行 `cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_evaluator_total_timeout_system_error -- --ignored --nocapture` 确认通过
-- [ ] 4.3 新增 `dual_solution_timeout_unhandled_tle`：evaluator 调 `runner.call('sleep_solution')` 不捕获（异常冒泡崩溃）、`call_timeout_ms: 100`、solution sleep 300ms，断言 `result.status == "TimeLimitExceeded"`
-- [ ] 4.4 运行同上命令（换测试名）确认通过
-- [ ] 4.5 新增 `dual_solution_timeout_handled_wrong_answer`：evaluator `try/except SolutionTimeoutError` 后 `result.wrong_answer(...)`，断言 `result.status == "WrongAnswer"`
-- [ ] 4.6 运行同上命令（换测试名）确认通过
-- [ ] 4.7 全量回归：`cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container -- --ignored`（既有测试 + 新增 3 个全部通过）
-- [ ] 4.8 提交：`jj describe -m "test(judge): 补 evaluator 超时/CallTimeout 未处理/被捕获三种 E2E（issue #202）"`
+- [x] 4.1 在 `noj-judge/tests/e2e_dual_container.rs` 末尾新增 `dual_evaluator_total_timeout_system_error`：evaluate.py 打印 ready 后死循环、`time_limit_ms: 2000`，断言 `result.status == "SystemError"`（`#[ignore]` + `#[serial_test::serial]` + `is_e2e_enabled()` 守卫）
+- [x] 4.2 运行 `cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container dual_evaluator_total_timeout_system_error -- --ignored --nocapture` 确认通过
+- [x] 4.3 新增 `dual_solution_timeout_unhandled_tle`：evaluator 调 `runner.call('sleep_solution')` 不捕获（异常冒泡崩溃）、`call_timeout_ms: 100`、solution sleep 300ms，断言 `result.status == "TimeLimitExceeded"`
+- [x] 4.4 运行同上命令（换测试名）确认通过
+- [x] 4.5 新增 `dual_solution_timeout_handled_wrong_answer`：evaluator `try/except SolutionTimeoutError` 后 `result.wrong_answer(...)`，断言 `result.status == "WrongAnswer"`
+- [x] 4.6 运行同上命令（换测试名）确认通过
+- [x] 4.7 全量回归：`cd noj-judge && NOJ_RUN_E2E=1 cargo test --test e2e_dual_container -- --ignored`（既有测试 + 新增 3 个全部通过）
+- [x] 4.8 提交：`jj describe -m "test(judge): 补 evaluator 超时/CallTimeout 未处理/被捕获三种 E2E（issue #202）"`
 
 ## 5. 文档五处更新
 
-- [ ] 5.1 `noj-docs/docs/reference/result-status.md`：TimeLimitExceeded 一节改为区分「单次调用超时未捕获 → TLE」与「整体流程超时 → SystemError」；SystemError 列表补充「evaluator 整体执行超过 time_limit_ms」与「evaluator 启动超时」
-- [ ] 5.2 `noj-docs/docs/problemsetters/rpc.md`：错误来源表 CallTimeout 一行补充「该错误由 Judge 直接注入；若 evaluator 未捕获（evaluate.py 异常退出、无 ---RESULT---），最终状态为 TimeLimitExceeded」
-- [ ] 5.3 `noj-docs/docs/problemsetters/judge-model.md`：新增「超时与状态映射」小节（三层映射表：整体超时→SystemError / 调用超时未捕获→TLE / 捕获→evaluator 决定）
-- [ ] 5.4 `noj-docs/docs/problemsetters/web-editor.md`：运行时配置两层超时语义补充（time_limit_ms→SystemError；call_timeout_ms 未捕获→TLE）
-- [ ] 5.5 `noj-docs/docs/intro/what-is-noj.md`：时空限制一节单次调用超时描述后补充状态映射
-- [ ] 5.6 人工检查五处与设计文档状态映射表一致、无 TBD/TODO
-- [ ] 5.7 提交：`jj describe -m "docs: 明确 evaluator/solution 超时状态映射（issue #202）"`
+- [x] 5.1 `noj-docs/docs/reference/result-status.md`：TimeLimitExceeded 一节改为区分「单次调用超时未捕获 → TLE」与「整体流程超时 → SystemError」；SystemError 列表补充「evaluator 整体执行超过 time_limit_ms」与「evaluator 启动超时」
+- [x] 5.2 `noj-docs/docs/problemsetters/rpc.md`：错误来源表 CallTimeout 一行补充「该错误由 Judge 直接注入；若 evaluator 未捕获（evaluate.py 异常退出、无 ---RESULT---），最终状态为 TimeLimitExceeded」
+- [x] 5.3 `noj-docs/docs/problemsetters/judge-model.md`：新增「超时与状态映射」小节（三层映射表：整体超时→SystemError / 调用超时未捕获→TLE / 捕获→evaluator 决定）
+- [x] 5.4 `noj-docs/docs/problemsetters/web-editor.md`：运行时配置两层超时语义补充（time_limit_ms→SystemError；call_timeout_ms 未捕获→TLE）
+- [x] 5.5 `noj-docs/docs/intro/what-is-noj.md`：时空限制一节单次调用超时描述后补充状态映射
+- [x] 5.6 人工检查五处与设计文档状态映射表一致、无 TBD/TODO
+- [x] 5.7 提交：`jj describe -m "docs: 明确 evaluator/solution 超时状态映射（issue #202）"`


### PR DESCRIPTION
## 背景

当前评测有两层超时（evaluator 整体 `time_limit_ms` 与单次调用 `call_timeout_ms`），但超时后的最终状态判定不明确且与预期语义不符：

- evaluator 总超时（含启动超时）当前落成 `TimeLimitExceeded` —— 应为 `SystemError`（评测流程未正常完成，做题人不可通过改代码解决）
- solution 调用超时未处理导致 evaluate.py 崩溃时当前落成 `SystemError` —— 应为 `TimeLimitExceeded`（用户代码慢是根因）
- 错误帧 `code` 为 `"Timeout"`，与文档错误码表名 `CallTimeout` 不一致

## 变更内容

- **收尾判定集中化**：新增纯函数 `finalize_outcome(timed_out, sent_call_timeout)`（`noj-judge/src/dual/mod.rs`）——优先级：总超时（Startup/Total）→ `SystemError`；曾发送 CallTimeout 错误帧 → `TimeLimitExceeded`；否则 `SystemError`。6 断言表驱动单测
- **`run_dual_loop` 接入**：`sent_call_timeout` 标志仅在 `WaitingSide::Evaluator`（evaluator 等 solution 的 call 超时）置位；阶段 1/2 超时分支与无 RESULT 收尾分支统一走 `finalize_outcome`；evaluator 超时后由既有 `destroy()` 强制终止容器
- **错误帧 code 统一为 `CallTimeout`**：judge `write_timeout_frame` + Evaluator SDK `runner.py` 匹配（不保留旧 `"Timeout"` 兼容，judge 与 SDK 同仓同步发布）+ SDK 单测与 E2E 断言同步
- **E2E 三种超时场景**（`e2e_dual_container.rs`，真实容器）：总超时 → SystemError / CallTimeout 未处理 → TLE / 被捕获 → evaluator 决定（WrongAnswer）
- **文档五处**：result-status.md / rpc.md / judge-model.md / web-editor.md / what-is-noj.md 明确两层超时的状态映射；另同步 evaluator-sdk.md 与 noj-judge/AGENTS.md 流程图

## 状态映射（固化语义）

| 场景 | 最终状态 |
| --- | --- |
| evaluator 整体/启动超时（Judge 强制终止） | `SystemError` |
| 单次调用超时且 evaluator 未捕获（无 `---RESULT---`） | `TimeLimitExceeded` |
| 单次调用超时被 evaluator 捕获 | 由 evaluator 决定（如 `WrongAnswer`） |
| evaluator 异常退出且从未发生调用超时 | `SystemError` |

## 测试

- `cargo test --lib`：114 个单测通过（含 `finalize_outcome` 6 断言）
- `cargo clippy --all-targets -- -D warnings`：0 警告；`cargo fmt` 干净
- SDK `python3 -m unittest`：`test_call_raises_timeout` 等通过（既有 `test_logging_config` 加载问题与本变更无关）
- `NOJ_RUN_E2E=1 cargo test --test e2e_dual_container -- --ignored`：14/14 通过（含 3 个新超时场景测试）

## 说明

本 PR 由 AI 编码助手（Reasonix 会话）基于已批准的设计文档（`docs/superpowers/specs/2026-08-05-timeout-status-mapping-design.md`）与 OpenSpec 提案（`openspec/changes/timeout-status-mapping/`）实现，经双轴代码评审（Standards/Spec）通过。

Closes #202
