### PR TITLE
ci(core): 修复 Core Perf 红状态 + JWT_SECRET 优雅降级 + 添加 PR 模板

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,69 @@
+<!--
+感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
+本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
+-->
+
+## 关联 Issue
+
+<!--
+在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
+GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
+注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
+issue 未提供 / 不适用 → 写 "无"。
+-->
+
+Closes #
+
+## 变更摘要
+
+<!-- 1-3 句话说清做了什么、为什么。 -->
+
+-
+
+## 变更类型
+
+<!-- 勾选所有适用的项 -->
+
+- [ ] `feat` 新功能
+- [ ] `fix` Bug 修复
+- [ ] `refactor` 重构（无行为变化）
+- [ ] `perf` 性能优化
+- [ ] `docs` 文档
+- [ ] `test` 测试
+- [ ] `chore` 杂项 / 构建 / CI
+- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）
+
+## 影响范围
+
+<!-- 勾选所有受影响的模块 / 数据 / 行为 -->
+
+- [ ] `noj-core` 后端
+- [ ] `noj-ui` 前端
+- [ ] `noj-judge` 评测 Worker
+- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
+- [ ] 公共 API（端点 / 请求 / 响应结构变化）
+- [ ] 配置 / 环境变量（`.env.example` 已更新）
+- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
+- [ ] 文档（README / noj-docs）
+
+## 验证清单
+
+<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->
+
+- [ ] `deno fmt` 已运行（noj-core / noj-ui）
+- [ ] `deno lint` 已运行
+- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
+- [ ] 本地 `deno task test` 通过
+- [ ] 新功能 / 修复有对应测试
+- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
+- [ ] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
+- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
+- [ ] GPG 签名可用
+
+## 截图 / 录屏（可选）
+
+<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->
+
+## 补充说明（可选）
+
+<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,10 +301,21 @@ jobs:
       # 校验 JWT_SECRET 长度 ≥32（修复 finding S7）。
       # noj-core main.ts 启动时硬校验，但 CI 在测试环节会先 launch main.ts；
       # 把校验提前到 step 层，错误信息更精准。
+      #
+      # Fork / Dependabot PR 拿不到仓库 secrets，JWT_SECRET 为空——这是
+      # GitHub 保护机制（不能给 untrusted code 跑涉及真 DB 的测试），
+      # 视为预期情况优雅跳过（warning）而非 fail（error）。
       - name: Validate secrets
+        id: validate-secrets
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: |
+          if [ -z "$JWT_SECRET" ]; then
+            echo "::warning::JWT_SECRET 为空（fork / 第三方 PR），跳过 core-test-db"
+            echo "::notice::本 job 需仓库 secrets，仅 trusted PR 跑全量 DB 测试"
+            echo "SKIPPED_NO_SECRETS=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
           if [ "${#JWT_SECRET}" -lt 32 ]; then
             echo "::error::JWT_SECRET must be ≥32 chars (got ${#JWT_SECRET})"
             exit 1
@@ -322,6 +333,9 @@ jobs:
             deno-
 
       - name: 运行测试 (deno test)
+        # JWT_SECRET 缺失时由 validate-secrets step 设置 SKIPPED_NO_SECRETS=true，
+        # 此处跳过整个测试步骤（已在 validate-secrets 阶段 warning 提示）。
+        if: env.SKIPPED_NO_SECRETS != 'true'
         working-directory: noj-core
         env:
           BCRYPT_SALT_ROUNDS: 4
@@ -409,11 +423,14 @@ jobs:
           restore-keys: |
             deno-
 
+      # 修复 core-perf 失败：tests/perf 在 resetDbForTest() 里需要
+      # 38 张表 + 种子数据已存在；未先跑 00_migrate_test.ts 时直接
+      # 撞 "relation does not exist"（2026-08-06 main push 红 CI 根因）。
       - name: 运行性能基准 (NOJ_RUN_PERF=1)
         working-directory: noj-core
         env:
           BCRYPT_SALT_ROUNDS: 4
-        run: deno test -A tests/perf
+        run: deno test -A tests/00_migrate_test.ts tests/perf
 
   # ===========================================================================
   # noj-ui — Nuxt 4 前端（Deno 构建检查）


### PR DESCRIPTION
## 修复的 3 件事

### 1. Core Perf (Benchmark) 在 main 上的红状态 ✅
**根因**：core-perf job 只跑 `deno test -A tests/perf`，未先跑 `00_migrate_test.ts`，导致 `tests/perf/search_bench.test.ts` 在 `await resetDbForTest()` 时撞 `relation "users" does not exist`（实际 111ms 即失败，**不是性能回归**）。

**修复**：把 `tests/00_migrate_test.ts` 加到 perf job 的 test 命令前，让 deno test 按字母序先跑迁移 + 种子，再跑 perf。

### 2. JWT_SECRET 缺失时第三方 PR 优雅降级 ✅
**问题**：Fork / Dependabot PR 拿不到仓库 secrets（GitHub 安全机制），core-test-db 必在 `JWT_SECRET must be ≥32 chars (got 0)` 失败，给 dependabot PR 制造噪声。

**修复**：在 `Validate secrets` step 增加空值分支，`:warning:` + 设置 `SKIPPED_NO_SECRETS=true`；后续 test step 加 `if` 条件跳过。效果：dependabot PR 的 core-test-db 标 warning 跳过而非 fail。

### 3. 添加 PR 模板强制 Closes #XXX 关键字 ✅
**问题**：PR 标题里写 `（issue #186）` 不会被 GitHub 识别为关闭关键字（需要英文 `Closes #186` / `Fixes #186`）。历史上 4 个 issue 因此被遗忘直到我手动关。

**修复**：新增 `.github/pull_request_template.md`，引导贡献者用 GitHub 识别的关键字格式。

## 变更

| 文件 | 变化 |
|------|------|
| `.github/workflows/ci.yml` | +18/-1 |
| `.github/pull_request_template.md` | +69 (新增) |

## 验证

- [x] `git diff` 干净（仅 2 个目标文件）
- [x] GPG 签名（key `0F49774CB31F6CF1`）
- [x] 提交信息符合 Conventional Commits
- [ ] 等 CI 跑通（重点观察 core-perf 是否恢复绿色）

Closes #