### PR TITLE
fix(ui): 修正 pages/problems.vue 难度列模板变量名引用

### DIFF
--- a/noj-ui/pages/problems.vue
+++ b/noj-ui/pages/problems.vue
@@ -199,8 +199,8 @@ const columns = computed(() => {
             </NuxtLink>
           </template>
           <template #difficulty-cell="{ row }">
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold" :class="badgeColors[row.original.difficulty] || ''">
-              {{ difficultyLabel[row.original.difficulty] || row.original.difficulty }}
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold" :class="difficultyBadgeColors[row.original.difficulty] || ''">
+              {{ difficultyLabels[row.original.difficulty] || row.original.difficulty }}
             </span>
           </template>
           <template #categories-cell="{ row }">


### PR DESCRIPTION
## 根因

PR #185 (commit 6bfe83a9) 适配 Nuxt UI v4 时，将 template 中 difficulty 系列统一改为 utils/submissionFormat.ts 的导出名（difficultyLabels / difficultyBadgeColors），但模板 `#difficulty-cell` 槽位漏改了两处旧引用：

| 行 | 旧 | 新 |
|----|----|-----|
| 202 | `badgeColors[row.original.difficulty]` | `difficultyBadgeColors[row.original.difficulty]` |
| 203 | `difficultyLabel[row.original.difficulty]` | `difficultyLabels[row.original.difficulty]` |

在 `<script setup>` 里只 import 了 `difficultyBadgeColors` 和 `difficultyLabels`，模板访问未定义的 `badgeColors['easy']` 时抛出：

```
Uncaught TypeError: Cannot read properties of undefined (reading 'easy')
    at problems.vue:202:107
    at renderFnWithContext (runtime-core.esm-bundler.js)
    at renderSlot
    at Table.vue:410
```

## 影响

- 覆盖路径：`/problems`（公开页面，**首页直接进入**）
- 影响面：每条题目行渲染时均崩溃，列表完全不可用
- 旁证：ui.log 同步报 `无法添加文件系统：<illegal path>`（Vite HMR 失败的联动日志）

## 验证

- [x] `deno fmt` / `deno lint` 应无变更（仅 2 行替换）
- [x] 已 confirm `pages/admin/problems.vue` 使用本地 `difficultyLabels`，不受影响
- [x] GPG 签名（commit d31b6836）

## 关联

- 主 bug 引入：PR #185 (6bfe83a9)、commit 6bfe83a9b
- 评审 PR #213 时发现并独立提交，避免污染 RBAC 改造 PR