### PR TITLE
fix(ui): 修正 EditorWorkspace ResizableSplitter v-model ref 类型

### DIFF
--- a/noj-ui/components/editor/EditorWorkspace.vue
+++ b/noj-ui/components/editor/EditorWorkspace.vue
@@ -90,7 +90,10 @@ const { state: draftState, savedAt: draftSavedAt, clear: clearDraft } = useDraft
 // 侧栏
 const sidebarTab = ref<'description' | 'history' | 'settings'>('description')
 const sidebarVisible = ref(true)
-const sidebarWidth = useResizableSplitter('editor:sidebar:width', 320, 240, 480)
+// 结构出 width 让它成为顶层 ref：v-model 模板用法依赖 Vue 顶层 setup 绑定
+// 的自动 unwrap，对象属性访问的 ref 不会被 unwrap，会报
+// "Invalid prop: type check failed for prop 'modelValue'. Expected Number, got Object"。
+const { width: sidebarWidth } = useResizableSplitter('editor:sidebar:width', 320, 240, 480)
 
 // 提交后实时轮询
 const activeSubmissionId = ref<string | null>(null)
@@ -277,7 +280,7 @@ const toolbarProblem = computed(() => {
 
           <!-- 侧栏（可隐藏 + 可拖拽） -->
           <template v-if="sidebarVisible">
-            <div :style="{ width: `${sidebarWidth.width}px` }" class="flex-shrink-0 transition-[width] duration-200">
+            <div :style="{ width: `${sidebarWidth}px` }" class="flex-shrink-0 transition-[width] duration-200">
               <EditorSidebar
                 :active="sidebarTab"
                 :problem="problem"
@@ -293,7 +296,7 @@ const toolbarProblem = computed(() => {
               />
             </div>
             <ResizableSplitter
-              v-model="sidebarWidth.width"
+              v-model="sidebarWidth"
               :min="240"
               :max="480"
               side="right"


### PR DESCRIPTION
## 根因

`useResizableSplitter` 返回 `{ width: Ref<number>, startDrag, reset }`，原代码把整个对象赋给 `sidebarWidth`，模板里：

```vue
<div :style="{ width: `${sidebarWidth.width}px` }" ...>
<ResizableSplitter v-model="sidebarWidth.width" ...>
```

Vue 3 模板**只对顶层 setup 绑定的 ref 自动 unwrap**，对象属性访问的 ref 不会被 unwrap。结果 `ResizableSplitter` 的 `modelValue: number` 收到的是 `Ref<number>` 对象本身，触发：

```
[Vue warn] Invalid prop: type check failed for prop "modelValue".
Expected Number with value NaN, got Object
```

## 副作用：拖动失效

拖动时 `@update:modelValue` 触发 `sidebarWidth.width = next`，**直接替换 ref 本身**为普通 number，响应式链条断裂，UI 看似能拖但状态永不更新。用户表现为"编辑器中间无法拖动"。

## 修复

结构出 `width`，让它成为顶层 ref：

```ts
- const sidebarWidth = useResizableSplitter('editor:sidebar:width', 320, 240, 480)
+ const { width: sidebarWidth } = useResizableSplitter('editor:sidebar:width', 320, 240, 480)
```

模板中 `v-model="sidebarWidth"` 与 `${sidebarWidth}px` 均依赖 Vue 顶层 ref 自动 unwrap。

## 覆盖

- 路径：`/editor/:id`（题目工作区，EditorWorkspace 唯一消费者）
- 之前已修复 PR #216（pages/problems.vue 难度列）同属 pre-existing bug，单独提交

## 验证

- [x] `deno fmt` / `deno lint` 无变更
- [x] `useResizableSplitter` 返回的其他字段（`startDrag` / `reset`）当前消费者未使用，结构后无影响
- [x] localStorage 持久化读写（`editor:sidebar:width`）未变
- [x] GPG 签名（commit 9182e2d4）