### PR TITLE
fix(core): 编辑器模板与评测参考实现分离，新增 template.py 优先级

### DIFF
--- a/noj-core/data/problems-src/1001/template.py
+++ b/noj-core/data/problems-src/1001/template.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+T0-LMCC：星港舱门报码归一化（starter code）
+
+你需要实现 solve 函数：
+  - 输入：report 字符串（舱门报码原始描述）
+  - 输出：JSON 字符串，格式为 {"gate_id": "X-YY", "status": "open|closed|fault"}
+
+可参考的提示：
+  - 用正则提取"X号门"或"X号楼"的阿拉伯数字编号
+  - 区域关键词（东/西/南/北/主/外 等）映射到单字母
+  - 状态优先级：故障 > 关闭 > 开启
+"""
+
+
+def solve(report: str) -> str:
+    """入口函数：由 noj_solution_sdk.host 调用"""
+    # TODO: 在此实现题目要求的归一化逻辑
+    raise NotImplementedError("请实现 solve 函数")

--- a/noj-core/data/problems-src/1002/template.py
+++ b/noj-core/data/problems-src/1002/template.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""
+T0-LMCC：传感器数据滤波（starter code）
+
+你需要实现 solve 函数：
+  - 输入：input_str 字符串
+      第一行：n 和 k（空格分隔）
+      第二行：n 个整数（传感器读数，空格分隔）
+  - 输出：n-k+1 个浮点数（保留两位小数），空格分隔
+
+可参考的提示：
+  - 滑动窗口大小为 k
+  - 每次窗口向后移动 1 位，重新计算窗口内均值
+  - 输出格式 "0.00 1.50 2.00"
+"""
+
+
+def solve(input_str: str) -> str:
+    """入口函数：由 noj_solution_sdk.host 调用"""
+    # TODO: 在此实现滑动窗口平均
+    raise NotImplementedError("请实现 solve 函数")

--- a/noj-core/data/problems-src/1003/template.py
+++ b/noj-core/data/problems-src/1003/template.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""
+T0-LMCC：A+B Problem（starter code）
+
+你需要实现 solve 函数：
+  - 输入：input_str 字符串（一行两个整数，空格分隔）
+  - 输出：两个整数之和（字符串形式）
+"""
+
+
+def solve(input_str: str) -> str:
+    """入口函数：由 noj_solution_sdk.host 调用"""
+    # TODO: 解析输入，计算并返回 a + b
+    raise NotImplementedError("请实现 solve 函数")

--- a/noj-core/src/routes/problems.ts
+++ b/noj-core/src/routes/problems.ts
@@ -295,20 +295,23 @@ router.get("/:id/support-package", authMiddleware, async (c) => {
 });
 
 /**
- * 获取题目初始代码模板（submission.py）。
+ * 获取题目初始代码模板（starter code）。
  * GET /api/v1/problems/:id/template
  *
  * 用于编辑器在没有用户本地草稿时填入的初始代码：
- * - 题目源码目录有 submission.py → 返回内容
- * - 没有 → 404
+ * - 题目源码目录有 template.py → 返回内容（推荐：出题人提供 starter）
+ * - 没有 → 回退到 submission_sample.py / submission.py（reference solution，仅兜底）
+ * - 都没有 → 404
+ *
+ * template.py 与 submission_sample.py 是两种独立用途：
+ * - template.py：前端编辑器 starter（给用户看的）
+ * - submission_sample.py：评测 reference solution（给 judge 看的）
  */
 router.get("/:id/template", authMiddleware, async (c) => {
   const id = c.req.param("id") as string;
   const problem = await resolveProblem(id);
   // problems-src 目录按题号（number）命名；题目 id 为服务端生成的 UUID，
   // 必须用 number 定位源码目录（如 data/problems-src/1001/）。
-  // 模板内容优先读取 submission_sample.py（与 solution.entry 一致），
-  // 兼容旧题目录的 submission.py。
   const tpl = await getProblemTemplate(problem.number);
   if (!tpl) {
     return c.json({ error: "该题目没有初始代码模板" }, 404);

--- a/noj-core/src/services/support-package.ts
+++ b/noj-core/src/services/support-package.ts
@@ -182,11 +182,13 @@ export async function getProblemTemplate(
   problemNumber: number,
 ): Promise<{ content: string; language: string } | null> {
   // TODO: 生产环境从 support package 解压或单独的对象存储读取
-  // 参考实现统一命名为 submission_sample.py（与 problem.json 的 solution.entry
-  // 一致）；兼容旧题目录仍保留 submission.py 的情况。
+  // 编辑器模板（前端 /editor/:id 初始填充）与评测参考实现是两种独立用途，
+  // 优先读取题目源目录的 template.py（题目出题人提供的 starter code），
+  // 缺失时回退到 submission_sample.py / submission.py（reference solution，
+  // 仅作为兜底，避免出题人未提供 template.py 时编辑器空白）。
   // problems-src 目录按题号命名（1001/1002/1003），题目 id 为 UUID，
   // 因此调用方必须传入 number 而非 id。
-  const candidates = ["submission_sample.py", "submission.py"];
+  const candidates = ["template.py", "submission_sample.py", "submission.py"];
   for (const fileName of candidates) {
     const fsPath = resolve(
       Deno.cwd(),


### PR DESCRIPTION
## 根因

`data/problems-src/<id>/submission_sample.py` 承担了**两个不同用途**：

| 用途 | 消费者 | 期望内容 |
|------|--------|---------|
| Reference solution（评测比对） | Judge | 完整正确实现 |
| 编辑器 starter（前端预填） | 用户 | 题目骨架 + 提示 |

后端 `getProblemTemplate` 与 `routes/problems.ts` 直接读取 `submission_sample.py`，导致 `/editor/:id` 打开时 Monaco 编辑器**预填完整答案**（如 1003 写好 `a + b` 的算法、1001 写好 CN_NUM/AREA_MAP 解析逻辑），用户一眼看到答案，做题体验完全破坏。

## 修复

### 1. 后端查找顺序调整

`noj-core/src/services/support-package.ts`：

```ts
- const candidates = ["submission_sample.py", "submission.py"];
+ const candidates = ["template.py", "submission_sample.py", "submission.py"];
```

- `template.py`：新约定（starter code，出题人提供）
- `submission_sample.py`：保留作为 reference solution（仅兜底）
- `submission.py`：旧题目录兼容路径

### 2. 3 道示例题新增 template.py

为 1001/1002/1003 提供 starter：

```python
def solve(input_str: str) -> str:
    """入口函数：由 noj_solution_sdk.host 调用"""
    # TODO: 在此实现题目要求的逻辑
    raise NotImplementedError("请实现 solve 函数")
```

含函数签名 + 题目背景提示 + `NotImplementedError` 占位。

### 3. 注释同步更新

`routes/problems.ts` 路由注释区分两种文件用途，避免后续接手者混淆。

## 行为变化

| 维度 | 改前 | 改后 |
|------|------|------|
| 编辑器初始内容 | 完整算法实现 | 函数骨架 + 提示 |
| 评测比对 | 仍读 `submission_sample.py` | 不变 |
| 旧题（无 template.py） | 直接用 reference solution | 仍回退到 reference solution（兼容） |

## 验证

```bash
# 1003 模板不再包含算法模式
curl /api/v1/problems/P1003/template | jq -r '.data.content' | grep -F 'a, b = map(int, line.split())'
# → 空（无匹配）

# 1001 模板不再包含解析逻辑
curl /api/v1/problems/P1001/template | jq -r '.data.content' | grep -F 'CN_NUM ='
# → 空（无匹配）

# deno typecheck
deno check src/services/support-package.ts src/routes/problems.ts
# → Check 无错误
```

## 后续建议

- 旧题（生产部署后导入的题目）若没有 template.py，会回退到 reference solution pre-filled。
  可在 OpenSpec 起草一个 "为缺 template.py 的题目自动生成 starter" 的脚本，遍历
  support package 解压 `submission_sample.py` 改写为 `def solve(): pass` 模板。
- 此 PR 不引入该自动生成逻辑，避免大批量改文件。

## 提交

- 5 文件：+67 / -8
- 1 commit：`b29303fc`（GPG ✅）