### PR TITLE
feat(core,ui): 支持公告系统（#231）

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -284,7 +284,8 @@ jobs:
             e2e/23_network_capability.test.ts \
             e2e/24_import_bundle.test.ts \
             e2e/25_rbac.test.ts \
-            e2e/26_call_timeout.test.ts &
+            e2e/26_call_timeout.test.ts \
+            e2e/28_announcements.test.ts &
           p3=$!
           fail=0
           wait "$p1" || fail=1

--- a/noj-core/drizzle/0035_spotty_mother_askani.sql
+++ b/noj-core/drizzle/0035_spotty_mother_askani.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "announcements" (
+	"id" text PRIMARY KEY NOT NULL,
+	"title" text NOT NULL,
+	"content" text NOT NULL,
+	"is_pinned" boolean DEFAULT false NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_by" text NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "announcements" ADD CONSTRAINT "announcements_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_announcements_active_pinned_created" ON "announcements" USING btree ("is_active","is_pinned","created_at");

--- a/noj-core/drizzle/0036_glorious_nightshade.sql
+++ b/noj-core/drizzle/0036_glorious_nightshade.sql
@@ -1,0 +1,28 @@
+ALTER TABLE "audit_logs" DROP CONSTRAINT "audit_logs_action_check";--> statement-breakpoint
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_action_check" CHECK ("audit_logs"."action" IN (
+        'users.role_change',
+        'users.ban',
+        'users.unban',
+        'problems.delete',
+        'problems.runtime_config_changed',
+        'problems.imported',
+        'categories.delete',
+        'submissions.rejudge',
+        'settings.update',
+        'ip_ban.create',
+        'ip_ban.delete',
+        'auth.login_success',
+        'auth.login_failure',
+        'auth.register',
+        'auth.change_password',
+        'auth.forgot_password_request',
+        'auth.password_reset',
+        'community.post_moderated',
+        'community.report_resolved',
+        'community.sanction_created',
+        'community.sanction_revoked',
+        'community.preset_applied',
+        'announcement.create',
+        'announcement.update',
+        'announcement.delete'
+      ));

--- a/noj-core/drizzle/meta/0035_snapshot.json
+++ b/noj-core/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,4749 @@
+{
+  "id": "e5c2d756-c62d-41df-8675-9b3487a73ef0",
+  "prevId": "0d1d118f-8e20-44a1-9158-2ade6f89dc30",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_announcements_active_pinned_created": {
+          "name": "idx_announcements_active_pinned_created",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audit_logs_admin_id_idx": {
+          "name": "audit_logs_admin_id_idx",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_admin_id_users_id_fk": {
+          "name": "audit_logs_admin_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'users.role_change',\n        'users.ban',\n        'users.unban',\n        'problems.delete',\n        'problems.runtime_config_changed',\n        'problems.imported',\n        'categories.delete',\n        'submissions.rejudge',\n        'settings.update',\n        'ip_ban.create',\n        'ip_ban.delete',\n        'auth.login_success',\n        'auth.login_failure',\n        'auth.register',\n        'auth.change_password',\n        'auth.forgot_password_request',\n        'auth.password_reset',\n        'community.post_moderated',\n        'community.report_resolved',\n        'community.sanction_created',\n        'community.sanction_revoked',\n        'community.preset_applied'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkin_date": {
+          "name": "checkin_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streak": {
+          "name": "streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "check_ins_user_id_users_id_fk": {
+          "name": "check_ins_user_id_users_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "check_ins_user_date_unique": {
+          "name": "check_ins_user_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "checkin_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_activity_events": {
+      "name": "community_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_activity_events_actor": {
+          "name": "idx_community_activity_events_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_activity_events_actor_id_users_id_fk": {
+          "name": "community_activity_events_actor_id_users_id_fk",
+          "tableFrom": "community_activity_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_activity_events_dedupe_unique": {
+          "name": "community_activity_events_dedupe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "type",
+            "subject_type",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "community_activity_events_type_check": {
+          "name": "community_activity_events_type_check",
+          "value": "\"community_activity_events\".\"type\" IN ('first_accepted', 'solution_published', 'contest_joined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_board_role_grants": {
+      "name": "community_board_role_grants",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_read": {
+          "name": "can_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_post": {
+          "name": "can_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_moderate": {
+          "name": "can_moderate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_community_board_role_grants_role": {
+          "name": "idx_community_board_role_grants_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_board_role_grants_board_id_community_boards_id_fk": {
+          "name": "community_board_role_grants_board_id_community_boards_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_board_role_grants_role_id_roles_id_fk": {
+          "name": "community_board_role_grants_role_id_roles_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_board_role_grants_board_id_role_id_pk": {
+          "name": "community_board_role_grants_board_id_role_id_pk",
+          "columns": [
+            "board_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_boards": {
+      "name": "community_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_boards_sort": {
+          "name": "idx_community_boards_sort",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_boards_slug_unique": {
+          "name": "community_boards_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_bookmarks": {
+      "name": "community_bookmarks",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_bookmarks_user": {
+          "name": "idx_community_bookmarks_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_bookmarks_post_id_community_posts_id_fk": {
+          "name": "community_bookmarks_post_id_community_posts_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_bookmarks_user_id_users_id_fk": {
+          "name": "community_bookmarks_user_id_users_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_bookmarks_post_id_user_id_pk": {
+          "name": "community_bookmarks_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comment_likes": {
+      "name": "community_comment_likes",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comment_likes_user": {
+          "name": "idx_community_comment_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comment_likes_comment_id_community_comments_id_fk": {
+          "name": "community_comment_likes_comment_id_community_comments_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comment_likes_user_id_users_id_fk": {
+          "name": "community_comment_likes_user_id_users_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_comment_likes_comment_id_user_id_pk": {
+          "name": "community_comment_likes_comment_id_user_id_pk",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comments_post": {
+          "name": "idx_community_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_author": {
+          "name": "idx_community_comments_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_parent": {
+          "name": "idx_community_comments_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_author_id_users_id_fk": {
+          "name": "community_comments_author_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_parent_id_community_comments_id_fk": {
+          "name": "community_comments_parent_id_community_comments_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_comments_status_check": {
+          "name": "community_comments_status_check",
+          "value": "\"community_comments\".\"status\" IN ('pending', 'published', 'hidden', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_follows": {
+      "name": "community_follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followee_id": {
+          "name": "followee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_follows_followee": {
+          "name": "idx_community_follows_followee",
+          "columns": [
+            {
+              "expression": "followee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_follows_follower_id_users_id_fk": {
+          "name": "community_follows_follower_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_follows_followee_id_users_id_fk": {
+          "name": "community_follows_followee_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_follows_follower_id_followee_id_pk": {
+          "name": "community_follows_follower_id_followee_id_pk",
+          "columns": [
+            "follower_id",
+            "followee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_follows_not_self_check": {
+          "name": "community_follows_not_self_check",
+          "value": "\"community_follows\".\"follower_id\" <> \"community_follows\".\"followee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_moderation_actions": {
+      "name": "community_moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_moderation_actions_target": {
+          "name": "idx_community_moderation_actions_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_moderation_actions_moderator": {
+          "name": "idx_community_moderation_actions_moderator",
+          "columns": [
+            {
+              "expression": "moderator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_moderation_actions_moderator_id_users_id_fk": {
+          "name": "community_moderation_actions_moderator_id_users_id_fk",
+          "tableFrom": "community_moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_notifications": {
+      "name": "community_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_notifications_recipient": {
+          "name": "idx_community_notifications_recipient",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_unread": {
+          "name": "idx_community_notifications_unread",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_actor": {
+          "name": "idx_community_notifications_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_post": {
+          "name": "idx_community_notifications_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_comment": {
+          "name": "idx_community_notifications_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_notifications_recipient_id_users_id_fk": {
+          "name": "community_notifications_recipient_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_notifications_actor_id_users_id_fk": {
+          "name": "community_notifications_actor_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_post_id_community_posts_id_fk": {
+          "name": "community_notifications_post_id_community_posts_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_comment_id_community_comments_id_fk": {
+          "name": "community_notifications_comment_id_community_comments_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_notifications_type_check": {
+          "name": "community_notifications_type_check",
+          "value": "\"community_notifications\".\"type\" IN ('reply', 'like', 'follow', 'moderation')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_post_likes": {
+      "name": "community_post_likes",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_post_likes_user": {
+          "name": "idx_community_post_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_post_likes_post_id_community_posts_id_fk": {
+          "name": "community_post_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_post_likes_user_id_users_id_fk": {
+          "name": "community_post_likes_user_id_users_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_post_likes_post_id_user_id_pk": {
+          "name": "community_post_likes_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_posts_author": {
+          "name": "idx_community_posts_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_problem": {
+          "name": "idx_community_posts_problem",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_board": {
+          "name": "idx_community_posts_board",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_published": {
+          "name": "idx_community_posts_published",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_pending": {
+          "name": "idx_community_posts_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_posts_author_id_users_id_fk": {
+          "name": "community_posts_author_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_problem_id_problems_id_fk": {
+          "name": "community_posts_problem_id_problems_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_board_id_community_boards_id_fk": {
+          "name": "community_posts_board_id_community_boards_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_posts_type_check": {
+          "name": "community_posts_type_check",
+          "value": "\"community_posts\".\"type\" IN ('solution', 'discussion', 'moment')"
+        },
+        "community_posts_status_check": {
+          "name": "community_posts_status_check",
+          "value": "\"community_posts\".\"status\" IN ('draft', 'pending', 'published', 'hidden', 'deleted')"
+        },
+        "community_posts_context_check": {
+          "name": "community_posts_context_check",
+          "value": "(\n        (\"community_posts\".\"type\" = 'solution' AND \"community_posts\".\"problem_id\" IS NOT NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'discussion' AND \"community_posts\".\"board_id\" IS NOT NULL AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'moment' AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_reports": {
+      "name": "community_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_reports_pending": {
+          "name": "idx_community_reports_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_reports\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_reporter": {
+          "name": "idx_community_reports_reporter",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_post": {
+          "name": "idx_community_reports_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_comment": {
+          "name": "idx_community_reports_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_reports_reporter_id_users_id_fk": {
+          "name": "community_reports_reporter_id_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_reports_post_id_community_posts_id_fk": {
+          "name": "community_reports_post_id_community_posts_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_comment_id_community_comments_id_fk": {
+          "name": "community_reports_comment_id_community_comments_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_resolved_by_users_id_fk": {
+          "name": "community_reports_resolved_by_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_reports_target_check": {
+          "name": "community_reports_target_check",
+          "value": "num_nonnulls(\"community_reports\".\"post_id\", \"community_reports\".\"comment_id\") = 1"
+        },
+        "community_reports_status_check": {
+          "name": "community_reports_status_check",
+          "value": "\"community_reports\".\"status\" IN ('pending', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_sanctions": {
+      "name": "community_sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_community_sanctions_active": {
+          "name": "idx_community_sanctions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_sanctions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_sanctions_creator": {
+          "name": "idx_community_sanctions_creator",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_sanctions_user_id_users_id_fk": {
+          "name": "community_sanctions_user_id_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_created_by_users_id_fk": {
+          "name": "community_sanctions_created_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_revoked_by_users_id_fk": {
+          "name": "community_sanctions_revoked_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_clarifications": {
+      "name": "contest_clarifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to_id": {
+          "name": "reply_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contest_clarifications_contest_id_contests_id_fk": {
+          "name": "contest_clarifications_contest_id_contests_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_problem_id_problems_id_fk": {
+          "name": "contest_clarifications_problem_id_problems_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_sender_id_users_id_fk": {
+          "name": "contest_clarifications_sender_id_users_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_reply_to_id_contest_clarifications_id_fk": {
+          "name": "contest_clarifications_reply_to_id_contest_clarifications_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contest_clarifications",
+          "columnsFrom": [
+            "reply_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_participants": {
+      "name": "contest_participants",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_participants_user": {
+          "name": "idx_contest_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_participants_contest_id_contests_id_fk": {
+          "name": "contest_participants_contest_id_contests_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_participants_user_id_users_id_fk": {
+          "name": "contest_participants_user_id_users_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_participants_contest_id_user_id_pk": {
+          "name": "contest_participants_contest_id_user_id_pk",
+          "columns": [
+            "contest_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_problems": {
+      "name": "contest_problems",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contest_problems_contest_id_contests_id_fk": {
+          "name": "contest_problems_contest_id_contests_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_problems_problem_id_problems_id_fk": {
+          "name": "contest_problems_problem_id_problems_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_problems_contest_id_problem_id_pk": {
+          "name": "contest_problems_contest_id_problem_id_pk",
+          "columns": [
+            "contest_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "contest_problems_contest_label_unique": {
+          "name": "contest_problems_contest_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "label"
+          ]
+        },
+        "contest_problems_contest_sort_order_unique": {
+          "name": "contest_problems_contest_sort_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contests": {
+      "name": "contests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affect_global_ranking": {
+          "name": "affect_global_ranking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announcement": {
+          "name": "announcement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contests_created_by": {
+          "name": "idx_contests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_start_time": {
+          "name": "idx_contests_start_time",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_end_time": {
+          "name": "idx_contests_end_time",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contests_created_by_users_id_fk": {
+          "name": "contests_created_by_users_id_fk",
+          "tableFrom": "contests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "contests_type_check": {
+          "name": "contests_type_check",
+          "value": "\"contests\".\"type\" IN ('icpc', 'ioi', 'oi')"
+        },
+        "contests_time_check": {
+          "name": "contests_time_check",
+          "value": "\"contests\".\"end_time\" > \"contests\".\"start_time\""
+        },
+        "contests_config_check": {
+          "name": "contests_config_check",
+          "value": "jsonb_typeof(\"contests\".\"config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_reads": {
+      "name": "conversation_reads",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_reads_user_id_users_id_fk": {
+          "name": "conversation_reads_user_id_users_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_reads_conversation_id_conversations_id_fk": {
+          "name": "conversation_reads_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_reads_user_id_conversation_id_pk": {
+          "name": "conversation_reads_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_conversations_user1_id": {
+          "name": "idx_conversations_user1_id",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_user2_id": {
+          "name": "idx_conversations_user2_id",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_message_at": {
+          "name": "idx_conversations_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user1_id_users_id_fk": {
+          "name": "conversations_user1_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_user2_id_users_id_fk": {
+          "name": "conversations_user2_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_user_pair_unique": {
+          "name": "conversations_user_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1_id",
+            "user2_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversations_user_order_check": {
+          "name": "conversations_user_order_check",
+          "value": "\"conversations\".\"user1_id\" < \"conversations\".\"user2_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eval_results_submission_id": {
+          "name": "idx_eval_results_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eval_results_created_at": {
+          "name": "idx_eval_results_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_submission_id_submissions_id_fk": {
+          "name": "evaluation_results_submission_id_submissions_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ip_bans": {
+      "name": "ip_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_or_cidr": {
+          "name": "ip_or_cidr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ip_bans_ip_or_cidr": {
+          "name": "idx_ip_bans_ip_or_cidr",
+          "columns": [
+            {
+              "expression": "ip_or_cidr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ip_bans_expires_at": {
+          "name": "idx_ip_bans_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ip_bans_created_by_users_id_fk": {
+          "name": "ip_bans_created_by_users_id_fk",
+          "tableFrom": "ip_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judge_images": {
+      "name": "judge_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exact'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evaluator'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_images_mode_check": {
+          "name": "judge_images_mode_check",
+          "value": "\"judge_images\".\"mode\" IN ('exact', 'all_versions')"
+        },
+        "judge_images_kind_check": {
+          "name": "judge_images_kind_check",
+          "value": "\"judge_images\".\"kind\" IN ('evaluator', 'solution')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_deletions": {
+      "name": "message_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_message_deletions_message_id": {
+          "name": "idx_message_deletions_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_deletions_user_id_users_id_fk": {
+          "name": "message_deletions_user_id_users_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_deletions_message_id_messages_id_fk": {
+          "name": "message_deletions_message_id_messages_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_deletions_user_id_message_id_pk": {
+          "name": "message_deletions_user_id_message_id_pk",
+          "columns": [
+            "user_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_created": {
+          "name": "idx_messages_conversation_created",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_sender_id": {
+          "name": "idx_messages_sender_id",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_users_id_fk": {
+          "name": "messages_sender_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.objective_questions": {
+      "name": "objective_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_questions_paper_id": {
+          "name": "idx_objective_questions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_questions_paper_id_problems_id_fk": {
+          "name": "objective_questions_paper_id_problems_id_fk",
+          "tableFrom": "objective_questions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_questions_paper_sort_unique": {
+          "name": "objective_questions_paper_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_questions_type_check": {
+          "name": "objective_questions_type_check",
+          "value": "\"objective_questions\".\"type\" IN ('single', 'multiple', 'judge')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.objective_submissions": {
+      "name": "objective_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finished'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_submissions_paper_id": {
+          "name": "idx_objective_submissions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_id": {
+          "name": "idx_objective_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_paper_created": {
+          "name": "idx_objective_submissions_user_paper_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_contest_id": {
+          "name": "idx_objective_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_submissions_paper_id_problems_id_fk": {
+          "name": "objective_submissions_paper_id_problems_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_user_id_users_id_fk": {
+          "name": "objective_submissions_user_id_users_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_contest_id_contests_id_fk": {
+          "name": "objective_submissions_contest_id_contests_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_submissions_contest_unique": {
+          "name": "objective_submissions_contest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "user_id",
+            "contest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_submissions_type_check": {
+          "name": "objective_submissions_type_check",
+          "value": "\"objective_submissions\".\"submission_type\" IN ('practice', 'contest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_password_reset_tokens_user_id": {
+          "name": "idx_password_reset_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_password_reset_tokens_expires_at": {
+          "name": "idx_password_reset_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_resource_action_unique": {
+          "name": "permissions_resource_action_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resource",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "support_package_storage_url": {
+          "name": "support_package_storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_config": {
+          "name": "runtime_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'U'"
+        },
+        "is_objective": {
+          "name": "is_objective",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_problems_search_vector": {
+          "name": "idx_problems_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "problems_type_number_unique": {
+          "name": "problems_type_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "problems_type_check": {
+          "name": "problems_type_check",
+          "value": "\"problems\".\"type\" IN ('U', 'P')"
+        },
+        "problems_runtime_config_check": {
+          "name": "problems_runtime_config_check",
+          "value": "\"problems\".\"runtime_config\" IS NULL OR jsonb_typeof(\"problems\".\"runtime_config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problems_categories": {
+      "name": "problems_categories",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "problems_categories_problem_id_problems_id_fk": {
+          "name": "problems_categories_problem_id_problems_id_fk",
+          "tableFrom": "problems_categories",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "problems_categories_category_id_categories_id_fk": {
+          "name": "problems_categories_category_id_categories_id_fk",
+          "tableFrom": "problems_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "problems_categories_problem_id_category_id_pk": {
+          "name": "problems_categories_problem_id_category_id_pk",
+          "columns": [
+            "problem_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_roles_parent_id": {
+          "name": "idx_roles_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_parent_id_roles_id_fk": {
+          "name": "roles_parent_id_roles_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejudge_seq": {
+          "name": "rejudge_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_submissions_user_id": {
+          "name": "idx_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_problem_id": {
+          "name": "idx_submissions_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_status": {
+          "name": "idx_submissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_id": {
+          "name": "idx_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_problem_user": {
+          "name": "idx_submissions_contest_problem_user",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_user_id_created_at": {
+          "name": "idx_submissions_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_problem_id_problems_id_fk": {
+          "name": "submissions_problem_id_problems_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_contest_id_contests_id_fk": {
+          "name": "submissions_contest_id_contests_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_settings_updated_at": {
+          "name": "idx_system_settings_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_bans": {
+      "name": "user_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "banned_until": {
+          "name": "banned_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "banned_by": {
+          "name": "banned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_at": {
+          "name": "unbanned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_by": {
+          "name": "unbanned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_bans_user": {
+          "name": "idx_user_bans_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_bans_active": {
+          "name": "idx_user_bans_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "unbanned_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_bans_user_id_users_id_fk": {
+          "name": "user_bans_user_id_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bans_banned_by_users_id_fk": {
+          "name": "user_bans_banned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "banned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_bans_unbanned_by_users_id_fk": {
+          "name": "user_bans_unbanned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "unbanned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_activity_visibility": {
+          "name": "community_activity_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'following'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_search_vector": {
+          "name": "idx_users_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_community_activity_visibility_check": {
+          "name": "users_community_activity_visibility_check",
+          "value": "\"users\".\"community_activity_visibility\" IN ('hidden', 'following', 'everyone')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/noj-core/drizzle/meta/0036_snapshot.json
+++ b/noj-core/drizzle/meta/0036_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "e5c2d756-c62d-41df-8675-9b3487a73ef0",
-  "prevId": "0d1d118f-8e20-44a1-9158-2ade6f89dc30",
+  "id": "e4d67b89-57fc-474d-a40a-9a4d6f2cabf4",
+  "prevId": "e5c2d756-c62d-41df-8675-9b3487a73ef0",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -231,7 +231,7 @@
       "checkConstraints": {
         "audit_logs_action_check": {
           "name": "audit_logs_action_check",
-          "value": "\"audit_logs\".\"action\" IN (\n        'users.role_change',\n        'users.ban',\n        'users.unban',\n        'problems.delete',\n        'problems.runtime_config_changed',\n        'problems.imported',\n        'categories.delete',\n        'submissions.rejudge',\n        'settings.update',\n        'ip_ban.create',\n        'ip_ban.delete',\n        'auth.login_success',\n        'auth.login_failure',\n        'auth.register',\n        'auth.change_password',\n        'auth.forgot_password_request',\n        'auth.password_reset',\n        'community.post_moderated',\n        'community.report_resolved',\n        'community.sanction_created',\n        'community.sanction_revoked',\n        'community.preset_applied'\n      )"
+          "value": "\"audit_logs\".\"action\" IN (\n        'users.role_change',\n        'users.ban',\n        'users.unban',\n        'problems.delete',\n        'problems.runtime_config_changed',\n        'problems.imported',\n        'categories.delete',\n        'submissions.rejudge',\n        'settings.update',\n        'ip_ban.create',\n        'ip_ban.delete',\n        'auth.login_success',\n        'auth.login_failure',\n        'auth.register',\n        'auth.change_password',\n        'auth.forgot_password_request',\n        'auth.password_reset',\n        'community.post_moderated',\n        'community.report_resolved',\n        'community.sanction_created',\n        'community.sanction_revoked',\n        'community.preset_applied',\n        'announcement.create',\n        'announcement.update',\n        'announcement.delete'\n      )"
         }
       },
       "isRLSEnabled": false

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1786193874871,
       "tag": "0035_spotty_mother_askani",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1786196950857,
+      "tag": "0036_glorious_nightshade",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1786188250775,
       "tag": "0034_known_rockslide",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1786193874871,
+      "tag": "0035_spotty_mother_askani",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -16,6 +16,7 @@ import conversations from "./routes/conversations.ts";
 import community from "./routes/community.ts";
 import search from "./routes/search.ts";
 import contests from "./routes/contests.ts";
+import announcements from "./routes/announcements.ts";
 import sse, { contestSse, statsSse } from "./routes/sse.ts";
 import { AppError } from "./lib/errors.ts";
 import { logger } from "./lib/logging.ts";
@@ -152,6 +153,10 @@ export function createApp(): Hono {
   app.route("/api/v1/community", community);
   app.route("/api/v1/contests", contests);
   app.route("/api/v1/search", search);
+  // 公告公开路由：必须在 sse 之前注册——sse 实例的全局 authMiddleware
+  // 会拦截所有挂载在其后的路由；公告 SSE 端点 /announcements/events
+  // 注册在本实例内（announcements.ts），位于 /:id 参数路由之前
+  app.route("/api/v1/announcements", announcements);
   // 评测镜像公开列表（必须在 sse 路由之前注册，避免被 SSE 的 authMiddleware 拦截）
   app.get("/api/v1/judge-images", async (c) => {
     const items = await listJudgeImages();

--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -5,6 +5,7 @@ import health from "./routes/health.ts";
 import stats from "./routes/stats.ts";
 import auth from "./routes/auth.ts";
 import admin from "./routes/admin.ts";
+import adminAnnouncements from "./routes/admin-announcements.ts";
 import categories from "./routes/categories.ts";
 import problems from "./routes/problems.ts";
 import checkin from "./routes/checkin.ts";
@@ -142,6 +143,9 @@ export function createApp(): Hono {
   app.route("/", health);
   app.route("/api/v1/auth", auth);
   app.route("/api/v1/admin", admin);
+  // 公告管理：细粒度权限（admin:full_access 通配放行 或 announcement:manage），
+  // 独立于 admin 实例（admin 实例组级 adminMiddleware 仅放行 full_access）
+  app.route("/api/v1/admin/announcements", adminAnnouncements);
   app.route("/api/v1/categories", categories);
   app.route("/api/v1/problems", problems);
   app.route("/api/v1/checkin", checkin);

--- a/noj-core/src/db/schema-ddl.ts
+++ b/noj-core/src/db/schema-ddl.ts
@@ -597,4 +597,5 @@ export const ALL_TABLES = [
   "community_moderation_actions",
   "community_sanctions",
   "community_notifications",
+  "announcements",
 ] as const;

--- a/noj-core/src/db/schema-ddl.ts
+++ b/noj-core/src/db/schema-ddl.ts
@@ -280,7 +280,8 @@ export const SCHEMA_DDL: string[] = [
       'auth.login_success','auth.login_failure','auth.register',
       'auth.change_password','auth.forgot_password_request','auth.password_reset',
       'community.post_moderated','community.report_resolved',
-      'community.sanction_created','community.sanction_revoked','community.preset_applied')
+      'community.sanction_created','community.sanction_revoked','community.preset_applied',
+      'announcement.create','announcement.update','announcement.delete')
     ))
   `,
 
@@ -452,6 +453,18 @@ export const SCHEMA_DDL: string[] = [
     read_at TEXT,
     created_at TEXT NOT NULL
   )`,
+
+  // 18. announcements (issue #231)
+  `CREATE TABLE IF NOT EXISTS announcements (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    is_pinned BOOLEAN NOT NULL DEFAULT false,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_by TEXT NOT NULL REFERENCES users(id),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
 ];
 
 export const SCHEMA_INDEXES: string[] = [
@@ -473,6 +486,8 @@ export const SCHEMA_INDEXES: string[] = [
   // 客观题表索引（与 schema.ts 定义一致，PGlite 测试模式）
   "CREATE INDEX IF NOT EXISTS idx_objective_questions_paper_id ON objective_questions (paper_id)",
   "CREATE INDEX IF NOT EXISTS idx_objective_submissions_paper_id ON objective_submissions (paper_id)",
+  // 公告公开列表查询索引（与 schema.ts 定义一致，PGlite 测试模式）
+  "CREATE INDEX IF NOT EXISTS idx_announcements_active_pinned_created ON announcements (is_active, is_pinned, created_at)",
   "CREATE INDEX IF NOT EXISTS idx_objective_submissions_user_id ON objective_submissions (user_id)",
   "CREATE INDEX IF NOT EXISTS idx_objective_submissions_user_paper_created ON objective_submissions (user_id, paper_id, created_at)",
   "CREATE INDEX IF NOT EXISTS idx_objective_submissions_contest_id ON objective_submissions (contest_id)",

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -763,7 +763,10 @@ export const auditLogs = pgTable(
         'community.report_resolved',
         'community.sanction_created',
         'community.sanction_revoked',
-        'community.preset_applied'
+        'community.preset_applied',
+        'announcement.create',
+        'announcement.update',
+        'announcement.delete'
       )`,
     ),
     adminIdx: index("audit_logs_admin_id_idx").on(table.admin_id),

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -685,6 +685,42 @@ export const systemSettings = pgTable(
 );
 
 /**
+ * 公告表（issue #231）。
+ * 站内广播（维护通知、活动预告等），由运营者（admin）管理。
+ * - 公开列表仅返回 is_active=true，排序 is_pinned DESC, created_at DESC
+ * - 下架 = is_active 置 false（不物理删除，保留历史）
+ * - content 为 Markdown 文本
+ */
+export const announcements = pgTable(
+  "announcements",
+  {
+    id: text("id").primaryKey(),
+    /** 标题，1–100 字符 */
+    title: text("title").notNull(),
+    /** Markdown 正文，1–50000 字符 */
+    content: text("content").notNull(),
+    /** 是否置顶（公开列表优先展示） */
+    is_pinned: boolean("is_pinned").notNull().default(false),
+    /** 是否发布中（false = 已下架，公开列表不可见） */
+    is_active: boolean("is_active").notNull().default(true),
+    /** 创建者用户 id */
+    created_by: text("created_by").notNull().references(() => users.id),
+    /** ISO 8601，创建时间 */
+    created_at: text("created_at").notNull(),
+    /** ISO 8601，最后更新时间 */
+    updated_at: text("updated_at").notNull(),
+  },
+  (table) => ({
+    /** 公开列表查询：仅 active + 置顶优先 + 最新在前 */
+    activePinnedCreatedIdx: index("idx_announcements_active_pinned_created").on(
+      table.is_active,
+      table.is_pinned,
+      table.created_at,
+    ),
+  }),
+);
+
+/**
  * 审计日志表（issue #101）。
  * 记录所有管理员操作的详细信息：admin_id、action、target、detail、ip、time。
  * service 层通过 logAudit() 同步写入；后台任务定期清理过期记录。

--- a/noj-core/src/lib/event-bus.ts
+++ b/noj-core/src/lib/event-bus.ts
@@ -32,6 +32,8 @@ export const Channels = {
   },
   /** 统计数据变更：noj:events:stats */
   stats: `${EVENT_CHANNEL_PREFIX}stats`,
+  /** 公告变更：noj:events:announcements */
+  announcements: `${EVENT_CHANNEL_PREFIX}announcements`,
 } as const;
 
 /**

--- a/noj-core/src/routes/admin-announcements.ts
+++ b/noj-core/src/routes/admin-announcements.ts
@@ -1,0 +1,108 @@
+/**
+ * 公告管理路由（issue #231）。
+ *
+ * 提供（挂载前缀 /api/v1/admin/announcements，见 app.ts）：
+ * - GET /api/v1/admin/announcements：全量列表（含未发布/已下架），分页 + 可选 is_active 筛选
+ * - POST /api/v1/admin/announcements：创建公告
+ * - PUT /api/v1/admin/announcements/:id：更新公告（部分更新；发布/下架 = 更新 is_active）
+ * - DELETE /api/v1/admin/announcements/:id：物理删除
+ *
+ * 权限模型（与主 admin 路由不同）：
+ * 主 admin 路由（routes/admin.ts）组级挂载 adminMiddleware，仅放行持有
+ * `admin:full_access` 的用户；公告管理采用细粒度权限 `announcement:manage`，
+ * 持有 `admin:full_access`（通配放行）**或显式拥有** `announcement:manage`
+ * 的用户均可放行（spec: admin-authorization / announcement-management）。
+ * 因此本实例不挂 adminMiddleware，改用细粒度中间件：
+ * `assertPermission(c, "announcement:manage")` + `runWithContext` 注入
+ * RequestContext（与 adminMiddleware 同款，供 service 层 logAudit /
+ * created_by 使用）。
+ */
+
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth.ts";
+import { parseJsonBody } from "../lib/request.ts";
+import { getClientIp } from "../lib/rate-limit-env.ts";
+import { assertPermission } from "../lib/permissions.ts";
+import { runWithContext } from "../lib/requestContext.ts";
+import { parsePagination } from "../lib/pagination.ts";
+import {
+  createAnnouncement,
+  deleteAnnouncement,
+  listAdminAnnouncements,
+  updateAnnouncement,
+} from "../services/announcements.ts";
+import type {
+  CreateAnnouncementInput,
+  UpdateAnnouncementInput,
+} from "../services/announcements.ts";
+
+const router = new Hono<{ Variables: { userId: string; userRole: string } }>();
+
+// 组级中间件：认证 + 细粒度权限（admin:full_access 通配放行 或
+// announcement:manage）+ RequestContext 注入（审计日志埋点）。
+router.use("*", authMiddleware, async (c, next) => {
+  await assertPermission(c, "announcement:manage");
+  return runWithContext(
+    {
+      actorId: c.get("userId"),
+      actorIp: getClientIp(c),
+      actorRole: c.get("userRole"),
+    },
+    () => next(),
+  );
+});
+
+/**
+ * 管理员获取公告列表（含未发布/已下架）。
+ * GET /api/v1/admin/announcements?page=1&per_page=20&is_active=true
+ * is_active 筛选可选：true / false / 缺省（全部）。
+ */
+router.get("/", async (c) => {
+  await assertPermission(c, "announcement:manage");
+  const { page, perPage } = parsePagination(c);
+  const isActiveParam = c.req.query("is_active");
+  const isActive = isActiveParam === "true"
+    ? true
+    : isActiveParam === "false"
+    ? false
+    : undefined;
+  const result = await listAdminAnnouncements(page, perPage, isActive);
+  return c.json(result);
+});
+
+/**
+ * 管理员创建公告。
+ * POST /api/v1/admin/announcements
+ * body: { title, content, is_pinned?, is_active? }
+ */
+router.post("/", async (c) => {
+  await assertPermission(c, "announcement:manage");
+  const body = await parseJsonBody<CreateAnnouncementInput>(c);
+  const item = await createAnnouncement(body);
+  return c.json({ data: item }, 201);
+});
+
+/**
+ * 管理员更新公告（部分更新语义；发布/下架 = 更新 is_active）。
+ * PUT /api/v1/admin/announcements/:id
+ */
+router.put("/:id", async (c) => {
+  await assertPermission(c, "announcement:manage");
+  const id = c.req.param("id") as string;
+  const body = await parseJsonBody<UpdateAnnouncementInput>(c);
+  const item = await updateAnnouncement(id, body);
+  return c.json({ data: item });
+});
+
+/**
+ * 管理员删除公告。
+ * DELETE /api/v1/admin/announcements/:id
+ */
+router.delete("/:id", async (c) => {
+  await assertPermission(c, "announcement:manage");
+  const id = c.req.param("id") as string;
+  await deleteAnnouncement(id);
+  return c.body(null, 204);
+});
+
+export default router;

--- a/noj-core/src/routes/admin.ts
+++ b/noj-core/src/routes/admin.ts
@@ -30,6 +30,17 @@ import {
 } from "../services/users.ts";
 import { addIpBan, listIpBans, removeIpBan } from "../services/banlist.ts";
 import {
+  createAnnouncement,
+  deleteAnnouncement,
+  listAdminAnnouncements,
+  updateAnnouncement,
+} from "../services/announcements.ts";
+import type {
+  CreateAnnouncementInput,
+  UpdateAnnouncementInput,
+} from "../services/announcements.ts";
+import { assertPermission } from "../lib/permissions.ts";
+import {
   listSettings,
   resetSetting,
   updateSetting,
@@ -623,6 +634,61 @@ router.delete("/roles/:id", async (c) => {
 router.get("/permissions", async (c) => {
   const result = await listPermissions();
   return c.json({ data: result });
+});
+
+// ─── 公告管理 ─────────────────────────────────────────────
+
+/**
+ * 管理员获取公告列表（含未发布/已下架）。
+ * GET /api/v1/admin/announcements?page=1&per_page=20&is_active=true
+ * is_active 筛选可选：true / false / 缺省（全部）。
+ */
+router.get("/announcements", async (c) => {
+  await assertPermission(c, "announcement:manage");
+  const { page, perPage } = parsePagination(c);
+  const isActiveParam = c.req.query("is_active");
+  const isActive = isActiveParam === "true"
+    ? true
+    : isActiveParam === "false"
+    ? false
+    : undefined;
+  const result = await listAdminAnnouncements(page, perPage, isActive);
+  return c.json(result);
+});
+
+/**
+ * 管理员创建公告。
+ * POST /api/v1/admin/announcements
+ * body: { title, content, is_pinned?, is_active? }
+ */
+router.post("/announcements", async (c) => {
+  await assertPermission(c, "announcement:manage");
+  const body = await parseJsonBody<CreateAnnouncementInput>(c);
+  const item = await createAnnouncement(body);
+  return c.json({ data: item }, 201);
+});
+
+/**
+ * 管理员更新公告（部分更新语义；发布/下架 = 更新 is_active）。
+ * PUT /api/v1/admin/announcements/:id
+ */
+router.put("/announcements/:id", async (c) => {
+  await assertPermission(c, "announcement:manage");
+  const id = c.req.param("id") as string;
+  const body = await parseJsonBody<UpdateAnnouncementInput>(c);
+  const item = await updateAnnouncement(id, body);
+  return c.json({ data: item });
+});
+
+/**
+ * 管理员删除公告。
+ * DELETE /api/v1/admin/announcements/:id
+ */
+router.delete("/announcements/:id", async (c) => {
+  await assertPermission(c, "announcement:manage");
+  const id = c.req.param("id") as string;
+  await deleteAnnouncement(id);
+  return c.body(null, 204);
 });
 
 export default router;

--- a/noj-core/src/routes/admin.ts
+++ b/noj-core/src/routes/admin.ts
@@ -30,17 +30,6 @@ import {
 } from "../services/users.ts";
 import { addIpBan, listIpBans, removeIpBan } from "../services/banlist.ts";
 import {
-  createAnnouncement,
-  deleteAnnouncement,
-  listAdminAnnouncements,
-  updateAnnouncement,
-} from "../services/announcements.ts";
-import type {
-  CreateAnnouncementInput,
-  UpdateAnnouncementInput,
-} from "../services/announcements.ts";
-import { assertPermission } from "../lib/permissions.ts";
-import {
   listSettings,
   resetSetting,
   updateSetting,
@@ -76,8 +65,17 @@ import { buildPaginationMeta, parsePagination } from "../lib/pagination.ts";
 
 const router = new Hono<{ Variables: { userId: string; userRole: string } }>();
 
-// 路由组级中间件：所有 admin 端点均需认证 + 管理员权限
-router.use("*", authMiddleware, adminMiddleware);
+// 路由组级中间件：所有 admin 端点均需认证 + 管理员权限。
+// 例外：公告管理端点（/announcements*）已抽至独立 router
+// （routes/admin-announcements.ts，细粒度权限 announcement:manage，
+// admin:full_access 通配放行或显式拥有该权限均可），此处对公告路径跳过
+// adminMiddleware——否则组级通配 use 会先行拦截细粒度权限持有者。
+router.use("*", authMiddleware, async (c, next) => {
+  if (c.req.path.startsWith("/api/v1/admin/announcements")) {
+    return next();
+  }
+  return await adminMiddleware(c, next);
+});
 
 // ─── 用户管理 ───────────────────────────────────────────────
 
@@ -634,61 +632,6 @@ router.delete("/roles/:id", async (c) => {
 router.get("/permissions", async (c) => {
   const result = await listPermissions();
   return c.json({ data: result });
-});
-
-// ─── 公告管理 ─────────────────────────────────────────────
-
-/**
- * 管理员获取公告列表（含未发布/已下架）。
- * GET /api/v1/admin/announcements?page=1&per_page=20&is_active=true
- * is_active 筛选可选：true / false / 缺省（全部）。
- */
-router.get("/announcements", async (c) => {
-  await assertPermission(c, "announcement:manage");
-  const { page, perPage } = parsePagination(c);
-  const isActiveParam = c.req.query("is_active");
-  const isActive = isActiveParam === "true"
-    ? true
-    : isActiveParam === "false"
-    ? false
-    : undefined;
-  const result = await listAdminAnnouncements(page, perPage, isActive);
-  return c.json(result);
-});
-
-/**
- * 管理员创建公告。
- * POST /api/v1/admin/announcements
- * body: { title, content, is_pinned?, is_active? }
- */
-router.post("/announcements", async (c) => {
-  await assertPermission(c, "announcement:manage");
-  const body = await parseJsonBody<CreateAnnouncementInput>(c);
-  const item = await createAnnouncement(body);
-  return c.json({ data: item }, 201);
-});
-
-/**
- * 管理员更新公告（部分更新语义；发布/下架 = 更新 is_active）。
- * PUT /api/v1/admin/announcements/:id
- */
-router.put("/announcements/:id", async (c) => {
-  await assertPermission(c, "announcement:manage");
-  const id = c.req.param("id") as string;
-  const body = await parseJsonBody<UpdateAnnouncementInput>(c);
-  const item = await updateAnnouncement(id, body);
-  return c.json({ data: item });
-});
-
-/**
- * 管理员删除公告。
- * DELETE /api/v1/admin/announcements/:id
- */
-router.delete("/announcements/:id", async (c) => {
-  await assertPermission(c, "announcement:manage");
-  const id = c.req.param("id") as string;
-  await deleteAnnouncement(id);
-  return c.body(null, 204);
 });
 
 export default router;

--- a/noj-core/src/routes/announcements.ts
+++ b/noj-core/src/routes/announcements.ts
@@ -1,0 +1,81 @@
+/**
+ * 公告公开路由（issue #231）。
+ *
+ * 提供：
+ * - GET /api/v1/announcements：公开列表（仅 active，置顶优先 + 分页）
+ * - GET /api/v1/announcements/events：公告变更 SSE（需登录，注册在 /:id 之前，
+ *   避免被参数路由捕获；此端点必须留在本实例内——若放 sse.ts 并挂载于其后，
+ *   公开路由会被 sse 实例的全局 authMiddleware 拦截，见 app.ts 挂载注释）
+ * - GET /api/v1/announcements/:id：公开详情（非 active / 不存在 → 404）
+ *
+ * 挂载前缀为 /api/v1/announcements（见 app.ts），本文件内为相对路径。
+ */
+
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth.ts";
+import { Channels, onEvent } from "../lib/event-bus.ts";
+import { createSseStream } from "../lib/sse-stream.ts";
+import { parsePagination } from "../lib/pagination.ts";
+import {
+  getPublicAnnouncement,
+  listPublicAnnouncements,
+} from "../services/announcements.ts";
+
+const router = new Hono();
+
+/**
+ * 公开公告列表。
+ * GET /api/v1/announcements?page=1&per_page=20
+ * 仅返回 is_active=true 的公告，排序 is_pinned DESC, created_at DESC。
+ */
+router.get("/", async (c) => {
+  const { page, perPage } = parsePagination(c);
+  const result = await listPublicAnnouncements(page, perPage);
+  return c.json(result);
+});
+
+/**
+ * 公告变更 SSE 端点。
+ *
+ * 登录用户可订阅。收到 `announcement:updated` 事件后，
+ * 前端应重新拉取公告列表（首页轮播 / 公开列表页），
+ * 与 `queue:changed` 同模式：事件 data 仅作触发通知，不含公告完整数据。
+ *
+ * 事件格式：
+ *   event: announcement:updated
+ *   data: { type: "announcement:updated" }
+ */
+router.get("/events", authMiddleware, (c) => {
+  return createSseStream(
+    c,
+    ({ stream, closed, close, onUnsubscribe }) => {
+      onUnsubscribe(
+        onEvent(
+          Channels.announcements,
+          (_channel, message) => {
+            if (closed) return;
+            stream.writeSSE({
+              event: "announcement:updated",
+              data: message,
+            }).catch(() => {
+              close();
+            });
+          },
+        ),
+      );
+    },
+  );
+});
+
+/**
+ * 公开公告详情。
+ * GET /api/v1/announcements/:id
+ * 非 active 或不存在 → 404（NotFoundError 由 app.ts 统一处理）。
+ */
+router.get("/:id", async (c) => {
+  const id = c.req.param("id") as string;
+  const detail = await getPublicAnnouncement(id);
+  return c.json(detail);
+});
+
+export default router;

--- a/noj-core/src/services/announcements.ts
+++ b/noj-core/src/services/announcements.ts
@@ -1,0 +1,310 @@
+/**
+ * 公告服务层（issue #231）。
+ *
+ * 提供：
+ * - listPublicAnnouncements()：公开列表（仅 active，置顶优先 + 分页）
+ * - getPublicAnnouncement()：公开详情（非 active / 不存在 → 404）
+ * - listAdminAnnouncements()：管理列表（含未发布/已下架，可选 is_active 筛选）
+ * - createAnnouncement() / updateAnnouncement() / deleteAnnouncement()：管理 CRUD
+ *
+ * 约定：
+ * - 细粒度权限（assertPermission("announcement:manage")）在路由层 handler 内执行，
+ *   服务层经 getRequestContext() 取操作者（adminMiddleware 已注入）。
+ * - 全部写操作记录审计日志（announcement.create / update / delete）。
+ * - 写成功后 publishEvent 广播变更（fire-and-forget，Redis 不可用时跳过，
+ *   由前端页面加载 / 轮询 fallback 兜底，与既有事件机制一致）。
+ */
+
+import { and, count, desc, eq } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+import { announcements } from "../db/schema.ts";
+import { NotFoundError, ValidationError } from "../lib/errors.ts";
+import { Channels, publishEvent } from "../lib/event-bus.ts";
+import { getRequestContext } from "../lib/requestContext.ts";
+import { buildPaginationMeta, type PaginationMeta } from "../lib/pagination.ts";
+import { logAudit } from "./audit-log.ts";
+
+/** 列表摘要截断长度（Markdown 源码字符数） */
+const EXCERPT_LENGTH = 120;
+/** 标题长度上限 */
+const TITLE_MAX = 100;
+/** 内容长度上限 */
+const CONTENT_MAX = 50000;
+
+/** 公开列表项（不含 content 全文） */
+export interface AnnouncementSummary {
+  id: string;
+  title: string;
+  is_pinned: boolean;
+  created_at: string;
+  updated_at: string;
+  /** content Markdown 源码截断 120 字符 */
+  excerpt: string;
+}
+
+/** 公开详情（含 content 全文） */
+export interface AnnouncementDetail {
+  id: string;
+  title: string;
+  content: string;
+  is_pinned: boolean;
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+}
+
+/** 管理列表项（含 content 全文与发布状态） */
+export interface AdminAnnouncementItem {
+  id: string;
+  title: string;
+  content: string;
+  is_pinned: boolean;
+  is_active: boolean;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** 创建公告入参（is_pinned / is_active 缺省 false / true） */
+export interface CreateAnnouncementInput {
+  title: string;
+  content: string;
+  is_pinned?: boolean;
+  is_active?: boolean;
+}
+
+/** 更新公告入参（部分更新语义；发布/下架 = 更新 is_active） */
+export interface UpdateAnnouncementInput {
+  title?: string;
+  content?: string;
+  is_pinned?: boolean;
+  is_active?: boolean;
+}
+
+/** 公开列表响应 */
+export interface PublicAnnouncementListResponse {
+  data: AnnouncementSummary[];
+  meta: PaginationMeta;
+}
+
+/** 管理列表响应 */
+export interface AdminAnnouncementListResponse {
+  data: AdminAnnouncementItem[];
+  meta: PaginationMeta;
+}
+
+/** 广播公告变更（fire-and-forget，失败仅记日志，不阻塞写流程） */
+function broadcastAnnouncementUpdate(): void {
+  publishEvent(
+    Channels.announcements,
+    JSON.stringify({ type: "announcement:updated" }),
+  );
+}
+
+/** 标题 / 内容长度校验（title 1–100、content 1–50000），非法抛 400 */
+function validateFields(title?: string, content?: string): void {
+  if (title !== undefined) {
+    const t = title.trim();
+    if (t.length < 1 || t.length > TITLE_MAX) {
+      throw new ValidationError(`title 长度必须在 1–${TITLE_MAX} 字符之间`);
+    }
+  }
+  if (content !== undefined) {
+    const c = content.trim();
+    if (c.length < 1 || c.length > CONTENT_MAX) {
+      throw new ValidationError(`content 长度必须在 1–${CONTENT_MAX} 字符之间`);
+    }
+  }
+}
+
+/**
+ * 公开列表：仅 active，置顶优先（is_pinned DESC）+ 最新在前（created_at DESC）。
+ */
+export async function listPublicAnnouncements(
+  page: number,
+  perPage: number,
+): Promise<PublicAnnouncementListResponse> {
+  const db = getDb();
+  const offset = (page - 1) * perPage;
+  const where = eq(announcements.is_active, true);
+
+  const [rows, totalRow] = await Promise.all([
+    db.select().from(announcements)
+      .where(where)
+      .orderBy(desc(announcements.is_pinned), desc(announcements.created_at))
+      .limit(perPage)
+      .offset(offset),
+    db.select({ value: count() }).from(announcements).where(where),
+  ]);
+
+  const data = rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    is_pinned: row.is_pinned,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    excerpt: row.content.slice(0, EXCERPT_LENGTH),
+  }));
+
+  return { data, meta: buildPaginationMeta(page, perPage, totalRow[0].value) };
+}
+
+/**
+ * 公开详情：仅 active 可见；非 active 或不存在 → NotFoundError（404）。
+ */
+export async function getPublicAnnouncement(
+  id: string,
+): Promise<AnnouncementDetail> {
+  const db = getDb();
+  const [row] = await db.select().from(announcements)
+    .where(and(eq(announcements.id, id), eq(announcements.is_active, true)))
+    .limit(1);
+
+  if (!row) {
+    throw new NotFoundError("公告不存在或已下架");
+  }
+
+  return {
+    id: row.id,
+    title: row.title,
+    content: row.content,
+    is_pinned: row.is_pinned,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    created_by: row.created_by,
+  };
+}
+
+/**
+ * 管理列表：全量（含未发布/已下架），最新在前，分页 + 可选 is_active 筛选。
+ */
+export async function listAdminAnnouncements(
+  page: number,
+  perPage: number,
+  isActive?: boolean,
+): Promise<AdminAnnouncementListResponse> {
+  const db = getDb();
+  const offset = (page - 1) * perPage;
+  const conditions = isActive === undefined
+    ? []
+    : [eq(announcements.is_active, isActive)];
+
+  const [rows, totalRow] = await Promise.all([
+    db.select().from(announcements)
+      .where(and(...conditions))
+      .orderBy(desc(announcements.created_at))
+      .limit(perPage)
+      .offset(offset),
+    db.select({ value: count() }).from(announcements).where(and(...conditions)),
+  ]);
+
+  return {
+    data: rows.map((row) => ({ ...row })),
+    meta: buildPaginationMeta(page, perPage, totalRow[0].value),
+  };
+}
+
+/**
+ * 创建公告。created_by 写入当前操作者（RequestContext）。
+ */
+export async function createAnnouncement(
+  input: CreateAnnouncementInput,
+): Promise<AdminAnnouncementItem> {
+  validateFields(input.title, input.content);
+
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+  const actorId = getRequestContext().actorId;
+
+  await db.insert(announcements).values({
+    id,
+    title: input.title.trim(),
+    content: input.content.trim(),
+    is_pinned: input.is_pinned ?? false,
+    is_active: input.is_active ?? true,
+    created_by: actorId,
+    created_at: now,
+    updated_at: now,
+  });
+
+  const [row] = await db.select().from(announcements)
+    .where(eq(announcements.id, id))
+    .limit(1);
+
+  await logAudit(
+    "announcement.create",
+    { action: "announcement.create", title: row!.title },
+    { type: "announcement", id },
+  );
+  broadcastAnnouncementUpdate();
+
+  return { ...row! };
+}
+
+/**
+ * 更新公告（部分更新语义）；发布/下架 = 更新 is_active。
+ *
+ * @throws {NotFoundError} 公告不存在
+ */
+export async function updateAnnouncement(
+  id: string,
+  input: UpdateAnnouncementInput,
+): Promise<AdminAnnouncementItem> {
+  validateFields(input.title, input.content);
+
+  const db = getDb();
+  const existing = await db.select().from(announcements)
+    .where(eq(announcements.id, id))
+    .limit(1);
+  if (existing.length === 0) {
+    throw new NotFoundError("公告不存在");
+  }
+
+  const updates: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+  if (input.title !== undefined) updates.title = input.title.trim();
+  if (input.content !== undefined) updates.content = input.content.trim();
+  if (input.is_pinned !== undefined) updates.is_pinned = input.is_pinned;
+  if (input.is_active !== undefined) updates.is_active = input.is_active;
+
+  await db.update(announcements).set(updates).where(eq(announcements.id, id));
+
+  const [row] = await db.select().from(announcements)
+    .where(eq(announcements.id, id))
+    .limit(1);
+
+  await logAudit(
+    "announcement.update",
+    { action: "announcement.update", title: row!.title },
+    { type: "announcement", id },
+  );
+  broadcastAnnouncementUpdate();
+
+  return { ...row! };
+}
+
+/**
+ * 物理删除公告。
+ *
+ * @throws {NotFoundError} 公告不存在
+ */
+export async function deleteAnnouncement(id: string): Promise<void> {
+  const db = getDb();
+  const existing = await db.select().from(announcements)
+    .where(eq(announcements.id, id))
+    .limit(1);
+  if (existing.length === 0) {
+    throw new NotFoundError("公告不存在");
+  }
+
+  await db.delete(announcements).where(eq(announcements.id, id));
+
+  await logAudit(
+    "announcement.delete",
+    { action: "announcement.delete", title: existing[0].title },
+    { type: "announcement", id },
+  );
+  broadcastAnnouncementUpdate();
+}

--- a/noj-core/src/services/announcements.ts
+++ b/noj-core/src/services/announcements.ts
@@ -206,10 +206,20 @@ export async function listAdminAnnouncements(
 
 /**
  * 创建公告。created_by 写入当前操作者（RequestContext）。
+ *
+ * @throws {ValidationError} title / content 缺失或长度非法（HTTP 400）
  */
 export async function createAnnouncement(
   input: CreateAnnouncementInput,
 ): Promise<AdminAnnouncementItem> {
+  // 必填校验：title / content 必须存在（否则会绕过 validateFields，
+  // 落到 DB NOT NULL 约束抛 500，而非 spec 要求的 400）
+  if (
+    typeof input.title !== "string" ||
+    typeof input.content !== "string"
+  ) {
+    throw new ValidationError("缺少必填字段：title、content");
+  }
   validateFields(input.title, input.content);
 
   const db = getDb();

--- a/noj-core/src/services/seed-rbac.ts
+++ b/noj-core/src/services/seed-rbac.ts
@@ -72,6 +72,7 @@ const ADMIN_DEFAULT_PERMISSIONS: Array<{ resource: string; action: string }> = [
   { resource: "community_moderation", action: "lock" },
   { resource: "community_moderation", action: "sanction" },
   { resource: "community_board", action: "manage" },
+  { resource: "announcement", action: "manage" },
 ];
 
 // ── 工具 ──────────────────────────────────────────────────

--- a/noj-core/src/types/audit-log.ts
+++ b/noj-core/src/types/audit-log.ts
@@ -28,7 +28,10 @@ export type AuditAction =
   | "community.report_resolved"
   | "community.sanction_created"
   | "community.sanction_revoked"
-  | "community.preset_applied";
+  | "community.preset_applied"
+  | "announcement.create"
+  | "announcement.update"
+  | "announcement.delete";
 
 /** 按 action 强类型的 detail（discriminated union） */
 export type AuditDetail =
@@ -122,7 +125,10 @@ export type AuditDetail =
   | {
     action: "community.preset_applied";
     preset: "public" | "private" | "knowledge";
-  };
+  }
+  | { action: "announcement.create"; title: string }
+  | { action: "announcement.update"; title: string }
+  | { action: "announcement.delete"; title: string };
 
 /** audit_logs 表的响应类型 */
 export interface AuditLogEntry {

--- a/noj-core/src/types/index.ts
+++ b/noj-core/src/types/index.ts
@@ -251,6 +251,8 @@ export const PERMISSION_DEFS: Array<{
     action: "manage",
     description: "管理社区板块",
   },
+  // 公告
+  { resource: "announcement", action: "manage", description: "管理公告" },
   // 系统
   { resource: "system", action: "settings", description: "系统设置" },
   { resource: "system", action: "judge_images", description: "管理评测镜像" },

--- a/noj-core/tests/routes/announcements.test.ts
+++ b/noj-core/tests/routes/announcements.test.ts
@@ -1,0 +1,279 @@
+/**
+ * 公告路由层测试（issue #231）。
+ *
+ * 覆盖：公开列表（未登录 200 / 置顶排序 / 下架不可见 / 分页 meta / 详情 404）、
+ * 管理端点（非 admin 403 / 创建 201 / 发布下架 / 删除 204 / 更新 404 / 校验 400）、
+ * RBAC seed（announcement:manage 权限存在且 admin 角色拥有）。
+ *
+ * 依赖 PGlite 内存数据库 + JWT_SECRET（helper 自动 seed RBAC）。
+ */
+import { assertEquals } from "jsr:@std/assert@^1";
+import { and, eq } from "drizzle-orm";
+import { createUserToken, initRedisForTest } from "../lib/helper.ts";
+import { createApp } from "../../src/app.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { permissions, rolePermissions, roles } from "../../src/db/schema.ts";
+
+const hasDb = true; // PGlite 内存数据库始终可用
+const hasEnv = !!Deno.env.get("JWT_SECRET");
+const skipDb = !hasDb;
+const skipEnv = !hasEnv;
+
+const ts = Date.now();
+
+/** admin 创建一条公告，返回 { id, res } */
+async function createViaApi(
+  token: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const app = createApp();
+  const res = await app.request("/api/v1/admin/announcements", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      title: `公告-${ts}`,
+      content: "公告正文",
+      ...overrides,
+    }),
+  });
+  const body = await res.json();
+  return { id: body.data?.id as string, res, body };
+}
+
+Deno.test({
+  name: "announcements route: 公开列表未登录 200 空列表 + 404",
+  ignore: skipDb,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    await initRedisForTest();
+    const app = createApp();
+
+    const listRes = await app.request("/api/v1/announcements");
+    assertEquals(listRes.status, 200);
+    const body = await listRes.json();
+    assertEquals(Array.isArray(body.data), true);
+    assertEquals(body.meta.total, 0);
+
+    const detailRes = await app.request(
+      "/api/v1/announcements/00000000-0000-0000-0000-000000000000",
+    );
+    assertEquals(detailRes.status, 404);
+  },
+});
+
+Deno.test({
+  name: "announcements route: 非 admin 写操作 403",
+  ignore: skipDb || skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const token = await createUserToken();
+    const app = createApp();
+    const res = await app.request("/api/v1/admin/announcements", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ title: "x", content: "y" }),
+    });
+    assertEquals(res.status, 403);
+  },
+});
+
+Deno.test({
+  name: "announcements route: admin 发布 → 公开可见 → 置顶排序 → 下架消失",
+  ignore: skipDb || skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    await initRedisForTest();
+    const token = await createUserToken("admin");
+    const app = createApp();
+
+    // 先建普通公告，再建置顶公告（置顶较新，验证置顶优先）
+    const normal = await createViaApi(token);
+    assertEquals(normal.res.status, 201);
+    const pinned = await createViaApi(token, { is_pinned: true });
+    assertEquals(pinned.res.status, 201);
+
+    // 公开列表：置顶在前
+    const listRes = await app.request("/api/v1/announcements");
+    const list = await listRes.json();
+    assertEquals(list.data[0].id, pinned.id);
+    assertEquals(list.data[0].title, `公告-${ts}`);
+    assertEquals(list.data[0].excerpt, "公告正文");
+    assertEquals("content" in list.data[0], false);
+    assertEquals(list.meta.total, 2);
+
+    // 详情可读全文
+    const detailRes = await app.request(
+      `/api/v1/announcements/${pinned.id}`,
+    );
+    assertEquals(detailRes.status, 200);
+    const detail = await detailRes.json();
+    assertEquals(detail.content, "公告正文");
+    assertEquals(detail.is_pinned, true);
+
+    // 下架置顶公告 → 公开列表消失 + 详情 404
+    const unpublishRes = await app.request(
+      `/api/v1/admin/announcements/${pinned.id}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ is_active: false }),
+      },
+    );
+    assertEquals(unpublishRes.status, 200);
+
+    const listAfter = await app.request("/api/v1/announcements");
+    const after = await listAfter.json();
+    assertEquals(after.meta.total, 1);
+    assertEquals(after.data[0].id, normal.id);
+
+    const detailAfter = await app.request(
+      `/api/v1/announcements/${pinned.id}`,
+    );
+    assertEquals(detailAfter.status, 404);
+  },
+});
+
+Deno.test({
+  name: "announcements route: 分页 meta 生效",
+  ignore: skipDb || skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const token = await createUserToken("admin");
+    for (let i = 0; i < 3; i++) {
+      await createViaApi(token, { title: `公告-${ts}-${i}` });
+    }
+    const app = createApp();
+    const res = await app.request("/api/v1/announcements?page=2&per_page=1");
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.meta.page, 2);
+    assertEquals(body.meta.per_page, 1);
+    assertEquals(body.meta.total, 3);
+    assertEquals(body.data.length, 1);
+  },
+});
+
+Deno.test({
+  name: "announcements route: 创建校验 400 + 更新不存在 404 + 删除 204",
+  ignore: skipDb || skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const token = await createUserToken("admin");
+    const app = createApp();
+
+    // 空 title → 400
+    const bad = await app.request("/api/v1/admin/announcements", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ title: "", content: "x" }),
+    });
+    assertEquals(bad.status, 400);
+
+    // 更新不存在 → 404
+    const missing = await app.request(
+      "/api/v1/admin/announcements/00000000-0000-0000-0000-000000000000",
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ title: "x" }),
+      },
+    );
+    assertEquals(missing.status, 404);
+
+    // 创建 → 删除 → 204
+    const created = await createViaApi(token);
+    const delRes = await app.request(
+      `/api/v1/admin/announcements/${created.id}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    assertEquals(delRes.status, 204);
+  },
+});
+
+Deno.test({
+  name: "announcements route: 管理列表含下架 + is_active 筛选",
+  ignore: skipDb || skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const token = await createUserToken("admin");
+    await createViaApi(token, { is_active: false });
+
+    const app = createApp();
+    const headers = { Authorization: `Bearer ${token}` };
+
+    const allRes = await app.request("/api/v1/admin/announcements", {
+      headers,
+    });
+    const all = await allRes.json();
+    assertEquals(all.meta.total, 1);
+
+    const activeRes = await app.request(
+      "/api/v1/admin/announcements?is_active=true",
+      { headers },
+    );
+    const active = await activeRes.json();
+    assertEquals(active.meta.total, 0);
+  },
+});
+
+Deno.test({
+  name: "announcements route: RBAC seed 含 announcement:manage 且 admin 拥有",
+  ignore: skipDb || skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    await createUserToken("admin"); // 触发 ensureRbacSeeds
+
+    const db = getDb();
+    const perm = await db.select().from(permissions).where(
+      and(
+        eq(permissions.resource, "announcement"),
+        eq(permissions.action, "manage"),
+      ),
+    );
+    assertEquals(perm.length, 1);
+
+    // admin 角色显式拥有该权限
+    const adminRole = await db.select().from(roles)
+      .where(eq(roles.name, "admin")).limit(1);
+    assertEquals(adminRole.length, 1);
+    const grants = await db.select().from(rolePermissions).where(
+      and(
+        eq(rolePermissions.role_id, adminRole[0].id),
+        eq(rolePermissions.permission_id, perm[0].id),
+      ),
+    );
+    assertEquals(grants.length, 1);
+  },
+});

--- a/noj-core/tests/routes/announcements.test.ts
+++ b/noj-core/tests/routes/announcements.test.ts
@@ -12,7 +12,13 @@ import { and, eq } from "drizzle-orm";
 import { createUserToken, initRedisForTest } from "../lib/helper.ts";
 import { createApp } from "../../src/app.ts";
 import { getDb, resetDbForTest } from "../../src/db/connection.ts";
-import { permissions, rolePermissions, roles } from "../../src/db/schema.ts";
+import {
+  permissions,
+  rolePermissions,
+  roles,
+  userRoles,
+  users,
+} from "../../src/db/schema.ts";
 
 const hasDb = true; // PGlite 内存数据库始终可用
 const hasEnv = !!Deno.env.get("JWT_SECRET");
@@ -191,6 +197,28 @@ Deno.test({
     });
     assertEquals(bad.status, 400);
 
+    // 完全缺字段 → 400（不得落 DB NOT NULL 抛 500）
+    const emptyBody = await app.request("/api/v1/admin/announcements", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({}),
+    });
+    assertEquals(emptyBody.status, 400);
+
+    // 仅可选字段 → 400
+    const partialBody = await app.request("/api/v1/admin/announcements", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ is_pinned: true }),
+    });
+    assertEquals(partialBody.status, 400);
+
     // 更新不存在 → 404
     const missing = await app.request(
       "/api/v1/admin/announcements/00000000-0000-0000-0000-000000000000",
@@ -243,6 +271,78 @@ Deno.test({
     );
     const active = await activeRes.json();
     assertEquals(active.meta.total, 0);
+  },
+});
+
+Deno.test({
+  name:
+    "announcements route: 仅 announcement:manage 用户（无 full_access）可通过管理端点",
+  ignore: skipDb || skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    await createUserToken("admin"); // 触发 ensureRbacSeeds
+
+    const db = getDb();
+    // 查 announcement:manage 权限 id
+    const [perm] = await db.select().from(permissions).where(
+      and(
+        eq(permissions.resource, "announcement"),
+        eq(permissions.action, "manage"),
+      ),
+    );
+    if (!perm) throw new Error("announcement:manage 权限未 seed");
+
+    // 创建仅含 announcement:manage 的自定义角色（无 admin:full_access）
+    const roleId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    await db.insert(roles).values({
+      id: roleId,
+      name: `ann_operator_${Date.now()}`,
+      description: "公告运营角色（测试）",
+      is_system: false,
+      is_default: false,
+      created_at: now,
+      updated_at: now,
+    });
+    await db.insert(rolePermissions).values({
+      role_id: roleId,
+      permission_id: perm.id,
+    });
+
+    // 创建用户并关联该角色（无 admin 角色 → 无 admin:full_access）
+    const userId = crypto.randomUUID();
+    await db.insert(users).values({
+      id: userId,
+      username: `ann_op_user_${Date.now()}`,
+      email: `${userId}@test.local`,
+      password_hash: "x",
+      must_change_password: false,
+      created_at: now,
+      updated_at: now,
+    });
+    await db.insert(userRoles).values({ user_id: userId, role_id: roleId });
+
+    const { signToken } = await import("../../src/lib/jwt.ts");
+    const token = await signToken({ sub: userId, role: "user" });
+
+    const app = createApp();
+    const res = await app.request("/api/v1/admin/announcements", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ title: `运营公告-${ts}`, content: "正文" }),
+    });
+    assertEquals(res.status, 201);
+
+    // 管理列表同样放行
+    const listRes = await app.request("/api/v1/admin/announcements", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEquals(listRes.status, 200);
   },
 });
 

--- a/noj-core/tests/services/announcements.test.ts
+++ b/noj-core/tests/services/announcements.test.ts
@@ -1,0 +1,273 @@
+/**
+ * 公告服务层测试（issue #231）。
+ *
+ * 覆盖：CRUD 校验（400）、公开列表仅 active + 置顶排序 + excerpt 截断 + 分页、
+ * 非 active 详情 404、审计日志、删除。
+ *
+ * 依赖 PGlite 内存数据库（无 DATABASE_URL 也可运行）。
+ * 服务层经 getRequestContext() 取操作者，测试用 enterTestContext 注入。
+ */
+import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import { desc, eq } from "drizzle-orm";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { announcements, auditLogs, users } from "../../src/db/schema.ts";
+import { NotFoundError, ValidationError } from "../../src/lib/errors.ts";
+import {
+  enterTestContext,
+  leaveTestContext,
+} from "../../src/lib/requestContext.ts";
+import {
+  createAnnouncement,
+  deleteAnnouncement,
+  getPublicAnnouncement,
+  listAdminAnnouncements,
+  listPublicAnnouncements,
+  updateAnnouncement,
+} from "../../src/services/announcements.ts";
+
+const hasDb = true; // PGlite 内存数据库始终可用
+const skip = !hasDb;
+
+const TEST_CTX = {
+  actorId: "test-admin-uuid",
+  actorIp: "192.168.1.100",
+  actorRole: "admin",
+};
+
+/** 重置 DB + 清理 ALS + 插入测试用户（enterTestContext 需在测试 fn 内调用，
+ * 经 async helper 中转时 enterWith 上下文不会传播回调用方） */
+async function setup() {
+  await resetDbForTest();
+  leaveTestContext(); // 清理前序测试可能的 ALS 泄漏
+  const db = getDb();
+  const now = new Date().toISOString();
+  await db.insert(users).values({
+    id: TEST_CTX.actorId,
+    username: "test-admin",
+    email: "test-admin@example.com",
+    password_hash: "",
+    created_at: now,
+    updated_at: now,
+  }).onConflictDoNothing();
+}
+
+Deno.test({
+  name: "announcements service: create 默认置顶/发布 + 审计日志",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setup();
+    enterTestContext(TEST_CTX);
+    const item = await createAnnouncement({
+      title: "维护通知",
+      content: "本周六凌晨系统维护",
+    });
+    assertEquals(item.is_pinned, false);
+    assertEquals(item.is_active, true);
+    assertEquals(item.created_by, TEST_CTX.actorId);
+
+    const db = getDb();
+    const logs = await db.select().from(auditLogs);
+    assertEquals(logs.length, 1);
+    assertEquals(logs[0].action, "announcement.create");
+    assertEquals(logs[0].target_id, item.id);
+  },
+});
+
+Deno.test({
+  name: "announcements service: 创建校验 title/content 长度",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setup();
+    enterTestContext(TEST_CTX);
+    await assertRejects(
+      () => createAnnouncement({ title: "", content: "x" }),
+      ValidationError,
+    );
+    await assertRejects(
+      () => createAnnouncement({ title: "a".repeat(101), content: "x" }),
+      ValidationError,
+    );
+    await assertRejects(
+      () => createAnnouncement({ title: "ok", content: "" }),
+      ValidationError,
+    );
+    await assertRejects(
+      () => createAnnouncement({ title: "ok", content: "x".repeat(50001) }),
+      ValidationError,
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "announcements service: 公开列表仅 active + 置顶优先 + excerpt 截断 + 分页",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setup();
+    enterTestContext(TEST_CTX);
+    const longContent = "段落" + "x".repeat(200) + "尾部";
+    // 置顶（较旧）
+    await createAnnouncement({
+      title: "置顶公告",
+      content: longContent,
+      is_pinned: true,
+    });
+    // 非置顶（较新）
+    await createAnnouncement({ title: "普通公告", content: "普通内容" });
+    // 下架
+    const inactive = await createAnnouncement({
+      title: "已下架",
+      content: "不可见",
+      is_active: false,
+    });
+
+    const list = await listPublicAnnouncements(1, 20);
+    assertEquals(list.meta.total, 2);
+    // 置顶优先：旧置顶排在新非置顶之前
+    assertEquals(list.data[0].title, "置顶公告");
+    assertEquals(list.data[1].title, "普通公告");
+    // excerpt 截断 120 字符
+    assertEquals(list.data[0].excerpt.length, 120);
+    // 列表项不含 content 全文
+    assertEquals("content" in list.data[0], false);
+    // 下架公告不在列表
+    assertEquals(list.data.some((a) => a.id === inactive.id), false);
+  },
+});
+
+Deno.test({
+  name: "announcements service: 公开详情 active 可见 / 下架 404",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setup();
+    enterTestContext(TEST_CTX);
+    const active = await createAnnouncement({ title: "在线", content: "全文" });
+    const inactive = await createAnnouncement({
+      title: "下线",
+      content: "x",
+      is_active: false,
+    });
+
+    const detail = await getPublicAnnouncement(active.id);
+    assertEquals(detail.content, "全文");
+    assertEquals(detail.created_by, TEST_CTX.actorId);
+
+    await assertRejects(
+      () => getPublicAnnouncement(inactive.id),
+      NotFoundError,
+    );
+    await assertRejects(
+      () => getPublicAnnouncement("00000000-0000-0000-0000-000000000000"),
+      NotFoundError,
+    );
+  },
+});
+
+Deno.test({
+  name: "announcements service: 管理列表含下架 + is_active 筛选 + 审计 update",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setup();
+    enterTestContext(TEST_CTX);
+    const a = await createAnnouncement({ title: "A", content: "a" });
+    const b = await createAnnouncement({
+      title: "B",
+      content: "b",
+      is_active: false,
+    });
+
+    // 全量：2 条，最新在前
+    const all = await listAdminAnnouncements(1, 20);
+    assertEquals(all.meta.total, 2);
+    assertEquals(all.data[0].title, "B");
+
+    // is_active 筛选
+    const activeOnly = await listAdminAnnouncements(1, 20, true);
+    assertEquals(activeOnly.meta.total, 1);
+    assertEquals(activeOnly.data[0].id, a.id);
+
+    // 部分更新：下架 A
+    const updated = await updateAnnouncement(a.id, { is_active: false });
+    assertEquals(updated.is_active, false);
+    assertEquals(updated.title, "A");
+
+    // 不存在 → 404
+    await assertRejects(
+      () =>
+        updateAnnouncement("00000000-0000-0000-0000-000000000000", {
+          title: "x",
+        }),
+      NotFoundError,
+    );
+
+    // 审计含 update
+    const db = getDb();
+    const logs = await db.select().from(auditLogs).where(
+      eq(auditLogs.action, "announcement.update"),
+    );
+    assertEquals(logs.length, 1);
+    assertEquals(logs[0].target_id, a.id);
+    assertEquals(b.id !== undefined, true);
+  },
+});
+
+Deno.test({
+  name: "announcements service: 删除 + 审计 + 不存在 404",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setup();
+    enterTestContext(TEST_CTX);
+    const item = await createAnnouncement({ title: "待删", content: "x" });
+
+    await deleteAnnouncement(item.id);
+
+    const db = getDb();
+    const rows = await db.select().from(announcements)
+      .where(eq(announcements.id, item.id));
+    assertEquals(rows.length, 0);
+
+    const logs = await db.select().from(auditLogs).where(
+      eq(auditLogs.action, "announcement.delete"),
+    );
+    assertEquals(logs.length, 1);
+
+    await assertRejects(
+      () => deleteAnnouncement("00000000-0000-0000-0000-000000000000"),
+      NotFoundError,
+    );
+  },
+});
+
+Deno.test({
+  name: "announcements service: update 校验 title 超长",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await setup();
+    enterTestContext(TEST_CTX);
+    const item = await createAnnouncement({ title: "ok", content: "x" });
+    await assertRejects(
+      () => updateAnnouncement(item.id, { title: "a".repeat(200) }),
+      ValidationError,
+    );
+    // 校验失败不落库
+    const db = getDb();
+    const rows = await db.select().from(announcements)
+      .where(eq(announcements.id, item.id))
+      .orderBy(desc(announcements.created_at));
+    assertEquals(rows[0].title, "ok");
+  },
+});

--- a/noj-tests/e2e/28_announcements.test.ts
+++ b/noj-tests/e2e/28_announcements.test.ts
@@ -1,0 +1,242 @@
+/**
+ * 公告系统 E2E 集成测试（issue #231）。
+ *
+ * 覆盖验收标准：
+ * - admin 发布 → 公开列表/首页可见（置顶优先）→ 下架消失
+ * - 非 admin 无写权限（403）
+ * - 置顶排序生效
+ * - SSE announcement:updated 广播
+ */
+
+import {
+  api,
+  apiDelete,
+  apiGet,
+  apiPost,
+  apiPut,
+  BASE_URL,
+  e2eTest,
+  getAdminToken,
+  isE2E,
+  registerUser,
+  waitForServer,
+} from "./helper.ts";
+
+// 读取 SSE 流的前几个事件，带超时
+async function readSSEEvents(
+  url: string,
+  token: string,
+  maxEvents: number,
+  timeoutMs = 15000,
+): Promise<string[]> {
+  const events: string[] = [];
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: "Bearer " + token },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      clearTimeout(timer);
+      return events;
+    }
+    const reader = res.body?.getReader();
+    if (!reader) {
+      clearTimeout(timer);
+      return events;
+    }
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (events.length < maxEvents) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith("event:")) {
+          events.push(trimmed.slice(6).trim());
+        }
+      }
+    }
+    controller.abort();
+    clearTimeout(timer);
+    return events;
+  } catch {
+    clearTimeout(timer);
+    return events;
+  }
+}
+
+let adminToken = "";
+let userToken = "";
+const ts = Date.now().toString(36);
+let pinnedId = "";
+let normalId = "";
+
+e2eTest("[e2e/announcements] Setup: 管理员与普通用户就绪", async () => {
+  if (!isE2E) return;
+  await waitForServer();
+  adminToken = await getAdminToken();
+  userToken = await registerUser(
+    `ann_user_${ts}`,
+    `ann_user_${ts}@e2e.com`,
+    "TestPass1234",
+  );
+  console.log("  ✓ 公告 E2E 用户就绪");
+});
+
+e2eTest(
+  "[e2e/announcements] 1. admin 发布公告 → 公开列表可见（置顶优先）",
+  async () => {
+    if (!isE2E) return;
+    // 先创建普通公告，再创建置顶公告（置顶较新，验证置顶优先而非时间优先）
+    const normal = await apiPost(
+      "/api/v1/admin/announcements",
+      { title: `普通公告-${ts}`, content: "普通公告正文" },
+      adminToken,
+    );
+    if (normal.status !== 201) {
+      throw new Error(`创建普通公告失败: ${JSON.stringify(normal.body)}`);
+    }
+    normalId = (normal.body as { data: { id: string } }).data.id;
+
+    const pinned = await apiPost(
+      "/api/v1/admin/announcements",
+      { title: `置顶公告-${ts}`, content: "置顶公告正文", is_pinned: true },
+      adminToken,
+    );
+    if (pinned.status !== 201) {
+      throw new Error(`创建置顶公告失败: ${JSON.stringify(pinned.body)}`);
+    }
+    pinnedId = (pinned.body as { data: { id: string } }).data.id;
+
+    // 公开列表：置顶优先 + 不含 content 全文
+    const listRes = await apiGet("/api/v1/announcements");
+    if (listRes.status !== 200) {
+      throw new Error(`公开列表失败: ${JSON.stringify(listRes.body)}`);
+    }
+    const list = listRes.body as {
+      data: Array<
+        { id: string; title: string; is_pinned: boolean; excerpt?: string }
+      >;
+      meta: { total: number };
+    };
+    if (list.data[0].id !== pinnedId) {
+      throw new Error("置顶公告应排在第一位");
+    }
+    if (list.data[0].is_pinned !== true) {
+      throw new Error("第一条应为置顶公告");
+    }
+    if (list.data.some((a) => a.id === normalId) !== true) {
+      throw new Error("普通公告应可见");
+    }
+    if ("content" in list.data[0]) {
+      throw new Error("公开列表不应包含 content 全文");
+    }
+
+    // 详情可读全文
+    const detailRes = await apiGet(`/api/v1/announcements/${pinnedId}`);
+    const detail = detailRes.body as { content?: string; title?: string };
+    if (detailRes.status !== 200 || detail.content !== "置顶公告正文") {
+      throw new Error(`详情应返回全文: ${JSON.stringify(detailRes.body)}`);
+    }
+    console.log("  ✓ admin 发布 → 公开可见 + 置顶优先");
+  },
+);
+
+e2eTest("[e2e/announcements] 2. 非 admin 无写权限", async () => {
+  if (!isE2E) return;
+  const res = await apiPost(
+    "/api/v1/admin/announcements",
+    { title: "越权", content: "x" },
+    userToken,
+  );
+  if (res.status !== 403) {
+    throw new Error(`普通用户写入应 403，实际 ${res.status}`);
+  }
+  console.log("  ✓ 非 admin 写操作 403");
+});
+
+e2eTest(
+  "[e2e/announcements] 3. admin 下架 → 公开列表消失 + 详情 404",
+  async () => {
+    if (!isE2E) return;
+    // 下架置顶公告
+    const unpublish = await apiPut(
+      `/api/v1/admin/announcements/${pinnedId}`,
+      { is_active: false },
+      adminToken,
+    );
+    if (unpublish.status !== 200) {
+      throw new Error(`下架失败: ${JSON.stringify(unpublish.body)}`);
+    }
+
+    const listRes = await apiGet("/api/v1/announcements");
+    const list = listRes.body as {
+      data: Array<{ id: string }>;
+      meta: { total: number };
+    };
+    if (list.data.some((a) => a.id === pinnedId)) {
+      throw new Error("下架公告不应出现在公开列表");
+    }
+    if (list.data[0].id !== normalId) {
+      throw new Error("剩余公告应正常展示");
+    }
+
+    const detailRes = await apiGet(`/api/v1/announcements/${pinnedId}`);
+    if (detailRes.status !== 404) {
+      throw new Error(`下架公告详情应 404，实际 ${detailRes.status}`);
+    }
+
+    // 管理列表仍可见（含已下架）
+    const adminList = await apiGet("/api/v1/admin/announcements", adminToken);
+    const adminData = adminList.body as {
+      data: Array<{ id: string; is_active: boolean }>;
+    };
+    const found = adminData.data.find((a) => a.id === pinnedId);
+    if (!found || found.is_active !== false) {
+      throw new Error("管理列表应包含已下架公告");
+    }
+    console.log("  ✓ 下架 → 公开消失 + 管理可见");
+  },
+);
+
+e2eTest("[e2e/announcements] 4. SSE 广播 announcement:updated", async () => {
+  if (!isE2E) return;
+  // 并行：连接 SSE 读取事件 + 触发公告更新
+  const eventPromise = readSSEEvents(
+    `${BASE_URL}/api/v1/announcements/events`,
+    adminToken,
+    1,
+    15000,
+  );
+  // 等待连接建立后触发更新（重新发布置顶公告）
+  await new Promise((r) => setTimeout(r, 1500));
+  await apiPut(
+    `/api/v1/admin/announcements/${pinnedId}`,
+    { is_active: true, is_pinned: true },
+    adminToken,
+  );
+  const events = await eventPromise;
+  if (!events.includes("announcement:updated")) {
+    throw new Error(
+      `未收到 announcement:updated，实际事件: ${events.join(", ")}`,
+    );
+  }
+  console.log("  ✓ SSE announcement:updated 广播");
+});
+
+e2eTest("[e2e/announcements] Cleanup: 删除公告", async () => {
+  if (!isE2E) return;
+  if (pinnedId) {
+    await apiDelete(`/api/v1/admin/announcements/${pinnedId}`, adminToken);
+  }
+  if (normalId) {
+    await apiDelete(`/api/v1/admin/announcements/${normalId}`, adminToken);
+  }
+  console.log("  ✓ 公告清理完成");
+});

--- a/noj-tests/e2e/28_announcements.test.ts
+++ b/noj-tests/e2e/28_announcements.test.ts
@@ -12,6 +12,7 @@ import {
   api,
   apiDelete,
   apiGet,
+  apiPatch,
   apiPost,
   apiPut,
   BASE_URL,
@@ -148,6 +149,47 @@ e2eTest(
   },
 );
 
+e2eTest(
+  "[e2e/announcements] 1b. 首页轮播数据源契约（per_page=5）",
+  async () => {
+    if (!isE2E) return;
+    // 首页轮播消费 GET /api/v1/announcements?per_page=5（见 pages/index.vue），
+    // 此处验证该数据契约：分页参数、轮播渲染字段、置顶优先、不含 content 全文。
+    const res = await apiGet("/api/v1/announcements?per_page=5");
+    if (res.status !== 200) {
+      throw new Error(`轮播数据源请求失败: ${JSON.stringify(res.body)}`);
+    }
+    const body = res.body as {
+      data: Array<
+        { id: string; title: string; is_pinned: boolean; excerpt?: string }
+      >;
+      meta: { per_page: number; total: number };
+    };
+    if (body.meta.per_page !== 5) {
+      throw new Error(`轮播数据源 per_page 应为 5，实际 ${body.meta.per_page}`);
+    }
+    if (body.data.length === 0) {
+      throw new Error("轮播数据源不应为空（用例 1 已发布 2 条公告）");
+    }
+    // 字段契约：轮播渲染所需字段必须存在，content 全文不得包含
+    for (const item of body.data) {
+      for (const key of ["id", "title", "is_pinned", "excerpt"]) {
+        if (!(key in item)) {
+          throw new Error(`轮播项缺少字段 ${key}: ${JSON.stringify(item)}`);
+        }
+      }
+      if ("content" in item) {
+        throw new Error("轮播项不应包含 content 全文");
+      }
+    }
+    // 置顶优先（沿用用例 1 的置顶公告）
+    if (body.data[0].is_pinned !== true) {
+      throw new Error("轮播第一条应为置顶公告");
+    }
+    console.log("  ✓ 首页轮播数据契约（per_page=5 + 字段 + 置顶优先）");
+  },
+);
+
 e2eTest("[e2e/announcements] 2. 非 admin 无写权限", async () => {
   if (!isE2E) return;
   const res = await apiPost(
@@ -229,6 +271,91 @@ e2eTest("[e2e/announcements] 4. SSE 广播 announcement:updated", async () => {
   }
   console.log("  ✓ SSE announcement:updated 广播");
 });
+
+e2eTest(
+  "[e2e/announcements] 5. 仅 announcement:manage 用户可管理公告（细粒度 RBAC）",
+  async () => {
+    if (!isE2E) return;
+    // 验证 P0 修复：无 admin:full_access 但显式拥有 announcement:manage 的用户
+    // 可调用公告管理端点（spec: 持有 admin:full_access 通配放行或显式拥有该权限）。
+    // 1. 查 announcement:manage 权限 id（响应按 resource 分组）
+    const permRes = await apiGet("/api/v1/admin/permissions", adminToken);
+    const perms = permRes.body as {
+      data?: Record<string, Array<{ id: string; action: string }>>;
+    };
+    const annPerm = (perms.data?.announcement ?? []).find(
+      (p) => p.action === "manage",
+    );
+    if (!annPerm) throw new Error("缺少 announcement:manage 权限");
+
+    // 2. 查 user 角色 id（保留基础权限，避免影响测试用户其它行为）
+    const rolesRes = await apiGet("/api/v1/admin/roles", adminToken);
+    const roles = rolesRes.body as {
+      data?: Array<{ id: string; name: string }>;
+    };
+    const userRole = (roles.data ?? []).find((r) => r.name === "user");
+    if (!userRole) throw new Error("缺少 user 角色");
+
+    // 3. 创建仅含 announcement:manage 的自定义角色（无 admin:full_access）
+    const roleName = `ann_operator_${ts}`;
+    const createRes = await apiPost(
+      "/api/v1/admin/roles",
+      {
+        name: roleName,
+        description: "公告运营角色（E2E）",
+        permission_ids: [annPerm.id],
+      },
+      adminToken,
+    );
+    if (createRes.status !== 201) {
+      throw new Error(`创建角色失败: ${JSON.stringify(createRes.body)}`);
+    }
+    const roleId = (createRes.body as { data: { id: string } }).data.id;
+
+    // 4. 按 username 查测试用户 id
+    const userRes = await apiGet(
+      `/api/v1/admin/users?keyword=ann_user_${ts}`,
+      adminToken,
+    );
+    const userData = userRes.body as {
+      data?: Array<{ id: string; username: string }>;
+    };
+    const target = (userData.data ?? []).find(
+      (u) => u.username === `ann_user_${ts}`,
+    );
+    if (!target) throw new Error("找不到测试用户 ann_user_" + ts);
+
+    // 5. 赋角色（user + ann_operator）
+    const patchRes = await apiPatch(
+      `/api/v1/admin/users/${target.id}/role`,
+      { role_ids: [userRole.id, roleId] },
+      adminToken,
+    );
+    if (patchRes.status !== 200) {
+      throw new Error(`赋角色失败: ${JSON.stringify(patchRes.body)}`);
+    }
+
+    // 6. 该用户（无 admin:full_access）调用管理端点 → 应放行 201
+    const postRes = await apiPost(
+      "/api/v1/admin/announcements",
+      { title: `运营公告-${ts}`, content: "正文" },
+      userToken,
+    );
+    if (postRes.status !== 201) {
+      throw new Error(
+        `细粒度授权用户写入应 201，实际 ${postRes.status}: ${
+          JSON.stringify(postRes.body)
+        }`,
+      );
+    }
+    const opAnnId = (postRes.body as { data: { id: string } }).data.id;
+
+    // 7. 清理：删除公告 + 角色
+    await apiDelete(`/api/v1/admin/announcements/${opAnnId}`, adminToken);
+    await apiDelete(`/api/v1/admin/roles/${roleId}`, adminToken);
+    console.log("  ✓ 细粒度 announcement:manage 用户可管理公告");
+  },
+);
 
 e2eTest("[e2e/announcements] Cleanup: 删除公告", async () => {
   if (!isE2E) return;

--- a/noj-ui/layouts/admin.vue
+++ b/noj-ui/layouts/admin.vue
@@ -37,6 +37,7 @@ const navGroups: NavGroup[] = [
       { label: "提交管理", to: "/admin/submissions", icon: 'i-lucide-files' },
       { label: "评测镜像", to: "/admin/judge-images", icon: 'i-lucide-container' },
       { label: "社区管理", to: "/admin/community", icon: 'i-lucide-messages-square' },
+      { label: "公告管理", to: "/admin/announcements", icon: 'i-lucide-megaphone' },
     ],
   },
   {

--- a/noj-ui/pages/admin/announcements.vue
+++ b/noj-ui/pages/admin/announcements.vue
@@ -54,6 +54,14 @@ const columns = [
       return isNaN(d.getTime()) ? "-" : d.toLocaleString("zh-CN")
     },
   },
+  {
+    accessorKey: "created_at",
+    header: "创建时间",
+    cell: (info: { getValue: () => string }) => {
+      const d = new Date(info.getValue() as string)
+      return isNaN(d.getTime()) ? "-" : d.toLocaleString("zh-CN")
+    },
+  },
   { accessorKey: "actions", header: "操作" },
 ]
 

--- a/noj-ui/pages/admin/announcements.vue
+++ b/noj-ui/pages/admin/announcements.vue
@@ -1,0 +1,221 @@
+<script setup lang="ts">
+import { extractApiError } from '~/utils/apiError'
+
+definePageMeta({
+  layout: "admin",
+  middleware: "admin",
+  ssr: false,
+})
+
+useRequireLogin()
+
+interface AdminAnnouncement {
+  id: string
+  title: string
+  content: string
+  is_pinned: boolean
+  is_active: boolean
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+const { api } = useApi()
+
+const { items, loading, error, load, onPageChange, currentPage, totalPages } = useAdminList<AdminAnnouncement>({
+  path: "/api/v1/admin/announcements",
+  fetchOptions: { dataField: "data", totalField: "meta.total" },
+})
+
+const columns = [
+  {
+    accessorKey: "title",
+    header: "标题",
+    cell: (info: { getValue: () => string }) => {
+      const v = info.getValue() as string
+      return v.length > 30 ? `${v.slice(0, 30)}…` : v
+    },
+  },
+  {
+    accessorKey: "is_pinned",
+    header: "置顶",
+    cell: (info: { getValue: () => boolean }) => info.getValue() ? "是" : "否",
+  },
+  {
+    accessorKey: "is_active",
+    header: "状态",
+    cell: (info: { getValue: () => boolean }) => info.getValue() ? "已发布" : "已下架",
+  },
+  {
+    accessorKey: "updated_at",
+    header: "更新时间",
+    cell: (info: { getValue: () => string }) => {
+      const d = new Date(info.getValue() as string)
+      return isNaN(d.getTime()) ? "-" : d.toLocaleString("zh-CN")
+    },
+  },
+  { accessorKey: "actions", header: "操作" },
+]
+
+// ── 新建/编辑表单 ──
+const showForm = ref(false)
+const editing = ref<AdminAnnouncement | null>(null)
+const saving = ref(false)
+const formError = ref("")
+const formTitle = ref("")
+const formContent = ref("")
+const formPinned = ref(false)
+const formActive = ref(true)
+
+function openCreate() {
+  editing.value = null
+  formTitle.value = ""
+  formContent.value = ""
+  formPinned.value = false
+  formActive.value = true
+  formError.value = ""
+  showForm.value = true
+}
+
+function openEdit(row: AdminAnnouncement) {
+  editing.value = row
+  formTitle.value = row.title
+  formContent.value = row.content
+  formPinned.value = row.is_pinned
+  formActive.value = row.is_active
+  formError.value = ""
+  showForm.value = true
+}
+
+async function handleSave() {
+  saving.value = true
+  formError.value = ""
+  try {
+    const body = {
+      title: formTitle.value,
+      content: formContent.value,
+      is_pinned: formPinned.value,
+      is_active: formActive.value,
+    }
+    if (editing.value) {
+      await api.put(`/api/v1/admin/announcements/${editing.value.id}`, body)
+    } else {
+      await api.post("/api/v1/admin/announcements", body)
+    }
+    showForm.value = false
+    await load(currentPage.value)
+  } catch (err: unknown) {
+    formError.value = extractApiError(err).message
+  } finally {
+    saving.value = false
+  }
+}
+
+// ── 删除确认 ──
+const deleteTarget = ref<AdminAnnouncement | null>(null)
+const showDeleteConfirm = ref(false)
+const deleting = ref(false)
+
+function confirmDelete(row: AdminAnnouncement) {
+  deleteTarget.value = row
+  formError.value = ""
+  showDeleteConfirm.value = true
+}
+
+async function handleDelete() {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  try {
+    await api.delete(`/api/v1/admin/announcements/${deleteTarget.value.id}`)
+    showDeleteConfirm.value = false
+    await load(currentPage.value)
+  } catch (err: unknown) {
+    formError.value = extractApiError(err).message
+  } finally {
+    deleting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <PageHeader title="公告管理" description="发布系统公告，置顶公告将优先展示在首页轮播">
+      <template #actions>
+        <UButton color="primary" size="sm" @click="openCreate">
+          <UIcon name="i-lucide-plus" class="size-4" />
+          新建公告
+        </UButton>
+      </template>
+    </PageHeader>
+
+    <div v-if="error" class="flex flex-col items-center justify-center gap-2 px-6 py-12 text-sm text-error-text"><span>{{ error }}</span></div>
+    <UTable
+      :columns="columns"
+      :data="items"
+      :loading="loading"
+      :empty="'暂无公告'">
+      <template #actions-cell="{ row }">
+        <div class="flex gap-1.5 justify-center">
+          <UButton color="neutral" variant="outline" class="flex w-9 h-9 border-border text-text-secondary hover:bg-primary-bg hover:text-text" title="编辑" aria-label="编辑" @click="openEdit(row.original)">
+            <UIcon name="i-lucide-pencil" class="size-3.5" />
+          </UButton>
+          <UButton color="neutral" variant="outline" class="flex w-9 h-9 border-border text-text-secondary hover:bg-red-50 hover:text-error-text hover:border-error-text/30" title="删除" aria-label="删除" @click="confirmDelete(row.original)">
+            <UIcon name="i-lucide-trash-2" class="size-3.5" />
+          </UButton>
+        </div>
+      </template>
+    </UTable>
+
+    <PaginationNav
+      v-if="totalPages > 1"
+      :current-page="currentPage"
+      :total-pages="totalPages"
+      class="mt-2"
+      @page-change="onPageChange"
+    />
+  </div>
+
+  <!-- 新建/编辑弹窗 -->
+  <UModal v-model:open="showForm" :title="editing ? '编辑公告' : '新建公告'" :unmount-on-hide="true">
+    <template #body>
+      <div class="flex flex-col gap-3">
+        <div class="flex flex-col gap-1">
+          <label class="text-13px font-semibold text-text">标题 <span class="text-error-text">*</span></label>
+          <input v-model="formTitle" class="px-3 py-2 text-sm border border-border rounded outline-none transition-colors duration-150 focus:border-primary focus:shadow-[0_0_0_2px_rgba(59,130,246,0.1)]" placeholder="公告标题（1–100 字符）" maxlength="100" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label class="text-13px font-semibold text-text">内容（Markdown） <span class="text-error-text">*</span></label>
+          <UTextarea v-model="formContent" :rows="10" maxlength="50000" placeholder="支持 Markdown 语法" />
+        </div>
+        <div class="flex items-center justify-between gap-4 pt-1">
+          <label class="text-13px font-semibold text-text cursor-pointer select-none" for="ann-form-pinned">置顶展示</label>
+          <USwitch v-model="formPinned" id="ann-form-pinned" />
+        </div>
+        <div class="flex items-center justify-between gap-4">
+          <label class="text-13px font-semibold text-text cursor-pointer select-none" for="ann-form-active">立即发布</label>
+          <USwitch v-model="formActive" id="ann-form-active" />
+        </div>
+        <p class="text-12px text-text-muted">关闭「立即发布」后公告将保存为草稿，仅后台可见；发布状态可在编辑时随时切换（即发布/下架）。</p>
+        <p v-if="formError" class="text-error-text text-13px">{{ formError }}</p>
+      </div>
+    </template>
+
+    <template #footer>
+      <UButton color="neutral" variant="ghost" :disabled="saving" @click="showForm = false">取消</UButton>
+      <UButton color="primary" :loading="saving" @click="handleSave">{{ editing ? '保存' : '创建' }}</UButton>
+    </template>
+  </UModal>
+
+  <!-- 删除确认弹窗 -->
+  <UModal v-model:open="showDeleteConfirm" title="删除公告" :unmount-on-hide="true">
+    <template #body>
+      <p>确定要删除公告 <strong>{{ deleteTarget?.title }}</strong> 吗？此操作不可撤销。</p>
+      <p v-if="formError" class="text-error-text text-13px">{{ formError }}</p>
+    </template>
+
+    <template #footer>
+      <UButton color="neutral" variant="ghost" :disabled="deleting" @click="showDeleteConfirm = false">取消</UButton>
+      <UButton color="error" :loading="deleting" @click="handleDelete">删除</UButton>
+    </template>
+  </UModal>
+</template>

--- a/noj-ui/pages/admin/announcements.vue
+++ b/noj-ui/pages/admin/announcements.vue
@@ -123,10 +123,12 @@ async function handleSave() {
 const deleteTarget = ref<AdminAnnouncement | null>(null)
 const showDeleteConfirm = ref(false)
 const deleting = ref(false)
+// 删除错误独立于表单错误，避免两个 modal 间状态串台
+const deleteError = ref("")
 
 function confirmDelete(row: AdminAnnouncement) {
   deleteTarget.value = row
-  formError.value = ""
+  deleteError.value = ""
   showDeleteConfirm.value = true
 }
 
@@ -138,7 +140,7 @@ async function handleDelete() {
     showDeleteConfirm.value = false
     await load(currentPage.value)
   } catch (err: unknown) {
-    formError.value = extractApiError(err).message
+    deleteError.value = extractApiError(err).message
   } finally {
     deleting.value = false
   }
@@ -218,7 +220,7 @@ async function handleDelete() {
   <UModal v-model:open="showDeleteConfirm" title="删除公告" :unmount-on-hide="true">
     <template #body>
       <p>确定要删除公告 <strong>{{ deleteTarget?.title }}</strong> 吗？此操作不可撤销。</p>
-      <p v-if="formError" class="text-error-text text-13px">{{ formError }}</p>
+      <p v-if="deleteError" class="text-error-text text-13px">{{ deleteError }}</p>
     </template>
 
     <template #footer>

--- a/noj-ui/pages/announcements/[id].vue
+++ b/noj-ui/pages/announcements/[id].vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { formatDateTime } from "~/utils/submissionFormat"
+
+interface AnnouncementDetail {
+  id: string
+  title: string
+  content: string
+  is_pinned: boolean
+  created_at: string
+  updated_at: string
+  created_by: string
+}
+
+const route = useRoute()
+const { api } = useApi()
+
+const detail = ref<AnnouncementDetail | null>(null)
+const notFound = ref(false)
+const loading = ref(true)
+
+async function load() {
+  loading.value = true
+  notFound.value = false
+  try {
+    const res = await api.get<AnnouncementDetail>(
+      `/api/v1/announcements/${route.params.id}`,
+      { silent: true },
+    )
+    detail.value = res
+  } catch {
+    // 非 active 或不存在 → 404 占位
+    notFound.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+
+// 详情页标题（浏览器标签）
+useHead(() => ({
+  title: detail.value ? `${detail.value.title} - 公告` : "公告",
+}))
+</script>
+
+<template>
+  <div class="max-w-[900px] mx-auto px-4 py-6 pb-16">
+    <div v-if="loading" class="flex items-center justify-center gap-2 py-16 text-text-muted">
+      <UIcon name="i-lucide-loader-2" class="size-6" />
+      <span>加载中...</span>
+    </div>
+
+    <div v-else-if="notFound || !detail" class="bg-white border border-border rounded-xl p-12 text-center">
+      <UIcon name="i-lucide-megaphone-off" class="size-10 text-text-muted mb-3" />
+      <p class="text-text-muted">公告不存在或已下架</p>
+      <NuxtLink to="/announcements" class="inline-block mt-4 text-sm text-blue-600 hover:underline">
+        返回公告列表
+      </NuxtLink>
+    </div>
+
+    <article v-else class="bg-white border border-border rounded-xl overflow-hidden">
+      <header class="px-6 pt-6 pb-4 border-b border-border">
+        <div class="flex items-center gap-2 mb-2">
+          <span
+            v-if="detail.is_pinned"
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-50 text-amber-700"
+          >
+            <UIcon name="i-lucide-pin" class="size-3" />
+            置顶
+          </span>
+        </div>
+        <h1 class="text-2xl font-bold">{{ detail.title }}</h1>
+        <p class="mt-2 text-13px text-text-muted">发布于 {{ formatDateTime(detail.created_at) }}</p>
+      </header>
+      <div class="px-6 py-6">
+        <MarkdownRenderer :content="detail.content" />
+      </div>
+    </article>
+  </div>
+</template>

--- a/noj-ui/pages/announcements/index.vue
+++ b/noj-ui/pages/announcements/index.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { formatDateTime } from "~/utils/submissionFormat"
+
+interface AnnouncementSummary {
+  id: string
+  title: string
+  excerpt: string
+  is_pinned: boolean
+  created_at: string
+  updated_at: string
+}
+
+interface AnnouncementListData {
+  data: AnnouncementSummary[]
+  meta: {
+    page: number
+    per_page: number
+    total: number
+    total_pages: number
+  }
+}
+
+const { api } = useApi()
+
+const data = ref<AnnouncementListData | null>(null)
+const currentPage = ref(1)
+const perPage = 20
+
+async function load(page = currentPage.value) {
+  try {
+    const res = await api.get<AnnouncementListData>(
+      `/api/v1/announcements?page=${page}&per_page=${perPage}`,
+      { silent: true },
+    )
+    data.value = res
+    currentPage.value = res.meta.page
+  } catch {
+    // silent：保持空态
+  }
+}
+
+onMounted(() => load(1))
+</script>
+
+<template>
+  <div class="max-w-[900px] mx-auto px-4 py-6 pb-16">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-2xl font-bold">公告</h1>
+    </div>
+
+    <div v-if="!data" class="flex items-center justify-center gap-2 py-16 text-text-muted">
+      <UIcon name="i-lucide-loader-2" class="size-6" />
+      <span>加载中...</span>
+    </div>
+
+    <template v-else>
+      <div v-if="data.data.length === 0" class="bg-white border border-border rounded-xl p-8 text-center text-text-muted">
+        暂无公告
+      </div>
+
+      <div v-else class="bg-white border border-border rounded-xl divide-y divide-border overflow-hidden">
+        <NuxtLink
+          v-for="item in data.data"
+          :key="item.id"
+          :to="`/announcements/${item.id}`"
+          class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 px-5 py-4 hover:bg-gray-50 transition-colors"
+        >
+          <div class="flex items-center gap-2 min-w-0 flex-1">
+            <span
+              v-if="item.is_pinned"
+              class="shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-50 text-amber-700"
+            >
+              <UIcon name="i-lucide-pin" class="size-3" />
+              置顶
+            </span>
+            <span class="font-medium text-15px truncate">{{ item.title }}</span>
+          </div>
+          <span v-if="item.excerpt" class="text-13px text-text-muted truncate max-w-[320px] hidden md:block">
+            {{ item.excerpt }}
+          </span>
+          <span class="shrink-0 text-13px text-text-muted">{{ formatDateTime(item.created_at) }}</span>
+        </NuxtLink>
+      </div>
+
+      <PaginationNav
+        v-if="data.meta.total_pages > 1"
+        :current-page="data.meta.page"
+        :total-pages="data.meta.total_pages"
+        class="mt-6"
+        @page-change="load($event)"
+      />
+    </template>
+  </div>
+</template>

--- a/noj-ui/pages/index.vue
+++ b/noj-ui/pages/index.vue
@@ -15,12 +15,31 @@
                     >
                         <Transition name="carousel-fade">
                             <div
+                                v-if="announcements.length > 0"
                                 :key="currentSlide"
                                 class="absolute inset-0 bg-gradient-to-br p-8 lg:p-12 flex flex-col justify-center text-white"
-                                :class="announcements[currentSlide].gradient"
+                                :class="gradientFor(currentSlide)"
                             >
                                 <h2 class="text-2xl lg:text-3xl font-bold mb-3 animate-[slideInUp_0.6s_cubic-bezier(0.16,1,0.3,1)_both]">{{ announcements[currentSlide].title }}</h2>
-                                <p class="text-sm lg:text-base text-white/85 max-w-[480px] leading-relaxed animate-[slideInUp_0.6s_cubic-bezier(0.16,1,0.3,1)_150ms_both]">{{ announcements[currentSlide].description }}</p>
+                                <p class="text-sm lg:text-base text-white/85 max-w-[480px] leading-relaxed animate-[slideInUp_0.6s_cubic-bezier(0.16,1,0.3,1)_150ms_both]">{{ announcements[currentSlide].excerpt }}</p>
+                                <!-- 点击跳转公告详情（整卡可点，按钮层 z-10 在其上不受影响） -->
+                                <NuxtLink
+                                    :to="`/announcements/${announcements[currentSlide].id}`"
+                                    class="absolute inset-0 z-[5]"
+                                    :aria-label="`查看公告：${announcements[currentSlide].title}`"
+                                />
+                                <span class="relative z-[6] mt-4 inline-flex items-center gap-1 text-sm font-medium text-white/90 pointer-events-none animate-[slideInUp_0.6s_cubic-bezier(0.16,1,0.3,1)_300ms_both]">
+                                    查看详情
+                                    <UIcon name="i-lucide-arrow-right" class="size-4" />
+                                </span>
+                            </div>
+                            <!-- 空态：无 active 公告时显示默认欢迎占位 -->
+                            <div
+                                v-else
+                                class="absolute inset-0 bg-gradient-to-br from-blue-600 via-sky-500 to-cyan-400 p-8 lg:p-12 flex flex-col justify-center text-white"
+                            >
+                                <h2 class="text-2xl lg:text-3xl font-bold mb-3 animate-[slideInUp_0.6s_cubic-bezier(0.16,1,0.3,1)_both]">Neuro OJ 正式上线</h2>
+                                <p class="text-sm lg:text-base text-white/85 max-w-[480px] leading-relaxed animate-[slideInUp_0.6s_cubic-bezier(0.16,1,0.3,1)_150ms_both]">面向 LMCC 的在线评测系统现已开放注册，提供高效的代码评测服务和智能化的能力评估。</p>
                             </div>
                         </Transition>
                         <!-- 暂停/继续（WCAG 2.2.2 自动更新内容可暂停） -->
@@ -92,33 +111,62 @@
 </template>
 
 <script setup lang="ts">
+import { useEventSource } from "~/composables/useEventSource"
+
 const { user, isLoggedIn } = useAuth()
 const { api } = useApi()
 
-// ── Announcement Carousel ──
-interface Announcement {
+// ── Announcement Carousel（公告驱动，issue #231）──
+interface CarouselAnnouncement {
+    id: string
     title: string
-    description: string
-    gradient: string
+    excerpt: string
+    is_pinned: boolean
 }
 
-const announcements: Announcement[] = [
-    {
-        title: "Neuro OJ 正式上线",
-        description: "面向 LMCC 的在线评测系统现已开放注册，提供高效的代码评测服务和智能化的能力评估。",
-        gradient: "from-blue-600 via-sky-500 to-cyan-400",
-    },
-    {
-        title: "新题持续更新",
-        description: "题库不断扩充中，涵盖算法、数据结构等各类编程题目，满足不同水平的训练需求。",
-        gradient: "from-purple-600 via-fuchsia-500 to-pink-400",
-    },
-    {
-        title: "社区共建计划",
-        description: "欢迎为 Neuro OJ 贡献题目与代码，共同打造优秀的在线评测社区平台。",
-        gradient: "from-emerald-600 via-teal-500 to-cyan-400",
-    },
+/** 轮播背景渐变预设色板（按下标循环，不依赖公告数据） */
+const GRADIENTS = [
+    "from-blue-600 via-sky-500 to-cyan-400",
+    "from-purple-600 via-fuchsia-500 to-pink-400",
+    "from-emerald-600 via-teal-500 to-cyan-400",
 ]
+
+function gradientFor(i: number): string {
+    return GRADIENTS[i % GRADIENTS.length]
+}
+
+const announcements = ref<CarouselAnnouncement[]>([])
+
+async function fetchAnnouncements() {
+    try {
+        const res = await api.get<{ data: CarouselAnnouncement[] }>(
+            "/api/v1/announcements?per_page=5",
+            { silent: true },
+        )
+        announcements.value = res.data
+        // 数据变化后修正轮播位置并（重新）启动自动轮播
+        if (currentSlide.value >= announcements.value.length) {
+            currentSlide.value = 0
+        }
+        if (announcements.value.length > 0) {
+            stopAuto()
+            startAuto()
+        }
+    } catch {
+        // silent：轮播保持空态占位
+    }
+}
+
+// SSE 实时刷新（端点需登录；未登录用户靠页面加载拉取）
+useEventSource({
+    url: "/api/v1/announcements/events",
+    onEvent: {
+        "announcement:updated": fetchAnnouncements,
+    },
+    fetchFn: fetchAnnouncements,
+    fallbackIntervalMs: 60000,
+    enabled: isLoggedIn,
+})
 
 const currentSlide = ref(0)
 const paused = ref(false)
@@ -126,10 +174,10 @@ let autoTimer: ReturnType<typeof setInterval> | null = null
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 function startAuto() {
-    if (paused.value) return
+    if (paused.value || announcements.value.length === 0) return
     stopAuto()
     autoTimer = setInterval(() => {
-        currentSlide.value = (currentSlide.value + 1) % announcements.length
+        currentSlide.value = (currentSlide.value + 1) % announcements.value.length
     }, 5000)
 }
 
@@ -158,7 +206,7 @@ function resetIdle() {
     idleTimer = setTimeout(startAuto, 60000)
 }
 
-onMounted(startAuto)
+onMounted(fetchAnnouncements)
 onUnmounted(() => {
     stopAuto()
     if (idleTimer) clearTimeout(idleTimer)

--- a/openspec/changes/announcements/.openspec.yaml
+++ b/openspec/changes/announcements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/announcements/design.md
+++ b/openspec/changes/announcements/design.md
@@ -1,0 +1,87 @@
+## Context
+
+公告系统（issue #231）落地前需要定夺的关键点：
+
+1. **数据落点**：独立 `announcements` 表 vs 复用 `systemSettings` 键值（`schema.ts:667`）。验收标准要求「置顶排序生效」+「公开列表分页」+「发布/下架」，KV 形态无法支撑多公告的分页、排序、单条状态管理。
+2. **首页形态**：现有首页左栏「公告轮播」（`pages/index.vue:7-60`）是硬编码 3 条渐变卡片（`index.vue:105-121`，仅 title + description，aria-label="公告轮播"），是天然的公告展示位。
+3. **推送链路**：`lib/event-bus.ts` 已有成熟的 Redis Pub/Sub + 本地 EventEmitter 机制（`Channels` 常量 + `publishEvent` + `onEvent`），`routes/sse.ts` 把 Redis 事件映射为 SSE 事件名（如 `submission:updated`、`queue:changed`、`stats:updated`）；前端 `useEventSource`（`composables/useEventSource.ts`）统一消费 SSE + 30s 轮询 fallback。
+
+用户已拍板两个决策：① 首页轮播改为公告驱动 + 点击看全文；② 包含公开公告列表页 + 详情页。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 独立 `announcements` 表承载公告，置顶优先 + 分页查询，发布/下架状态管理
+- 公开 API + 管理 API（admin CRUD、审计日志），`announcement:manage` 细粒度权限
+- 首页轮播公告驱动（删除硬编码）、公开列表页 + 详情页、管理后台页
+- SSE 全局广播 `announcement:updated`，前端实时刷新（轮询 fallback 兜底）
+
+**Non-Goals:**
+- 不做公告的定时发布/定时下架（本期仅手动发布/下架）
+- 不做公告的阅读统计、已读状态
+- 不做通知中心（铃铛）的公告聚合推送（SSE 横幅刷新已覆盖实时性诉求；社区通知中心保持现状）
+- 不新增公告封面图/富文本字段（content 为 Markdown 文本，渐变背景按轮播下标循环预设色）
+
+## Decisions
+
+### D1: 数据落点 — 独立 announcements 表
+
+`systemSettings` 是 KV 键值（单值 JSON），无法支撑「置顶排序 + 分页 + 单条发布/下架」的验收要求；独立表沿用既有 Drizzle 表风格（text 主键 uuid、ISO 8601 text 时间戳）：
+
+- `id` TEXT PK（uuid）
+- `title` TEXT NOT NULL
+- `content` TEXT NOT NULL（Markdown）
+- `is_pinned` BOOLEAN NOT NULL DEFAULT FALSE
+- `is_active` BOOLEAN NOT NULL DEFAULT TRUE（下架 = false）
+- `created_by` TEXT NOT NULL REFERENCES `users(id)`
+- `created_at` TEXT NOT NULL、`updated_at` TEXT NOT NULL（ISO 8601）
+- 索引：`idx_announcements_active_pinned_created` ON `(is_active, is_pinned, created_at)`（公开列表查询）
+
+### D2: 公开列表排序与分页
+
+- 公开列表仅返回 `is_active=true`；排序 `is_pinned DESC, created_at DESC`（置顶优先，置顶内部与未置顶内部均按最新在前）
+- 分页沿用 `lib/pagination.ts` 的 `parsePagination` / `buildPaginationMeta`（page/per_page，默认 20）
+- 响应 `{ data: Announcement[], meta: { page, per_page, total } }`，列表项不含 `content` 全文（仅标题 + 摘要字段，减载）；详情接口返回全文
+
+### D3: API 契约
+
+公开：
+- `GET /api/v1/announcements`：仅 active，置顶优先 + 分页；列表项字段 `id / title / is_pinned / created_at / updated_at`（+ `excerpt` 摘要，content 截断前 120 字符）
+- `GET /api/v1/announcements/:id`：active 公告详情（含 `content` 全文与 `created_by`）；非 active 返回 404
+
+管理（`routes/admin.ts` 组级 adminMiddleware 下）：
+- `GET /api/v1/admin/announcements`：全量列表（含未发布/已下架），分页 + 可选 `is_active` 筛选
+- `POST /api/v1/admin/announcements`：创建（title、content、is_pinned、is_active），校验非空
+- `PUT /api/v1/admin/announcements/:id`：更新（字段部分更新语义）；发布/下架统一为更新 `is_active`
+- `DELETE /api/v1/admin/announcements/:id`：物理删除
+- 所有写操作记录审计日志（复用 `logAudit`，action `announcement.create / announcement.update / announcement.delete`）
+
+### D4: 权限 — announcement:manage
+
+- `PERMISSION_DEFS`（`types/index.ts:144`）新增 `{ resource: "announcement", action: "manage", description: "管理公告" }`
+- `ADMIN_DEFAULT_PERMISSIONS`（`seed-rbac.ts`）加入该项（admin 角色显式授权 + `admin:full_access` 通配双保险，与 `system:settings` 同模式）
+- admin handler 内 `await assertPermission(c, "announcement:manage")` 细粒度检查（非 admin 且无该权限 → 403）
+
+### D5: SSE 广播
+
+- `Channels`（`lib/event-bus.ts`）新增全局频道 `noj:events:announcements`
+- 服务层创建/更新/删除后 `publishEvent(Channels.announcements, JSON.stringify({ type: "announcement:updated" }))`（fire-and-forget，不阻塞写流程）
+- `routes/sse.ts` 新增监听：`onEvent(Channels.announcements, ...)` → 向全局 SSE 连接推送事件名 `announcement:updated`（与 `queue:changed` 同模式，对所有已连接客户端广播）
+- 前端 `useEventSource` 监听 `announcement:updated` → 重拉公告列表（轮播数据源）；页面加载拉取为 fallback
+
+### D6: UI 形态
+
+- **首页轮播**（`pages/index.vue`）：删除硬编码数组，改为 `GET /api/v1/announcements?per_page=5` 驱动；渲染标题 + 摘要（Markdown 纯文本剥离）；点击跳 `/announcements/[id]`；空态显示默认欢迎占位（保持现状文案）；渐变背景按轮播下标循环 3 个预设色（不新增 DB 字段）；SSE 收到 `announcement:updated` 后重拉
+- **公开列表页** `/announcements`：置顶徽标 + 标题列表 + 分页（复用 `PaginationNav`），行点击进详情
+- **详情页** `/announcements/[id]`：标题 + 发布时间 + 置顶徽标 + Markdown 全文（复用 `MarkdownRenderer`）
+- **管理页** `pages/admin/announcements.vue`：`useAdminList` 分页列表（标题/置顶/发布状态/时间/操作），新建/编辑表单（标题 + Markdown 文本域 + 置顶开关 + 发布状态开关），发布/下架 = 编辑表单切换；`layouts/admin.vue` navGroups「内容与评测」组新增「公告管理」入口
+
+### D7: 内容校验
+
+- `title` 1–100 字符、`content` 1–50000 字符（与社区帖子同量级）；非法输入返回 400
+- 列表摘要：Markdown 源码截断 120 字符（服务端计算，避免前端依赖）
+
+## Risks
+
+- SSE 广播依赖 Redis 可用：事件丢失由页面加载/轮询 fallback 兜底（与既有事件同机制，无新增风险）
+- `is_pinned` 排序无固定 pin 时间字段：置顶公告之间按 `created_at` 排序，若运营需要手动排序可后续加 `pinned_at`（YAGNI，本期不做）

--- a/openspec/changes/announcements/design.md
+++ b/openspec/changes/announcements/design.md
@@ -66,7 +66,8 @@
 
 - `Channels`（`lib/event-bus.ts`）新增全局频道 `noj:events:announcements`
 - 服务层创建/更新/删除后 `publishEvent(Channels.announcements, JSON.stringify({ type: "announcement:updated" }))`（fire-and-forget，不阻塞写流程）
-- `routes/sse.ts` 新增监听：`onEvent(Channels.announcements, ...)` → 向全局 SSE 连接推送事件名 `announcement:updated`（与 `queue:changed` 同模式，对所有已连接客户端广播）
+- 监听注册在**独立 SSE 端点 `GET /api/v1/announcements/events`**（`routes/announcements.ts` 内，位于 `/:id` 参数路由之前），收到事件后以 SSE 事件名 `announcement:updated` 向订阅该端点的客户端推送（与 `queue:changed` 同模式，data 仅作触发通知）
+- **偏离说明（工程妥协）**：原计划在全局 SSE 端点（`routes/sse.ts`）注册监听，但 sse 实例挂载时带全局 `authMiddleware`，会拦截所有挂载在其后的公开路由（见 `app.ts` 挂载注释）。公告 SSE 端点因此注册在公告路由实例内、挂载于 sse 实例之前，行为等价（客户端订阅 `/api/v1/announcements/events` 即可收到广播），spec 文本（`specs/sse-endpoints/spec.md`）已同步此实现
 - 前端 `useEventSource` 监听 `announcement:updated` → 重拉公告列表（轮播数据源）；页面加载拉取为 fallback
 
 ### D6: UI 形态

--- a/openspec/changes/announcements/proposal.md
+++ b/openspec/changes/announcements/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+现状无公告/站内广播能力：admin 页面与路由中均无 announcement 端点，竞赛/社区通知只覆盖自身事件；首页左栏「公告轮播」是硬编码数组（`noj-ui/pages/index.vue:105-121`，3 条写死数据），运营者无法发布维护通知、活动预告。对标 HydroOJ，系统广播是运营者的基础工具（issue #231）。
+
+## What Changes
+
+- **独立 `announcements` 表**：`id` / `title` / `content`（Markdown）/ `is_pinned` / `is_active` / `created_by` / `created_at` / `updated_at`，索引 `(is_active, is_pinned, created_at)` 支撑「置顶优先 + 最新在前」查询（Drizzle 迁移 0035）
+- **公开 API**：`GET /api/v1/announcements`（仅 `is_active=true`，置顶优先 + 分页）、`GET /api/v1/announcements/:id`（详情，非 active 返回 404）
+- **管理 API**：`GET/POST /api/v1/admin/announcements`、`PUT/DELETE /api/v1/admin/announcements/:id`；发布/下架统一为 PUT 更新 `is_active`；全部写操作记录审计日志
+- **RBAC**：`PERMISSION_DEFS` 注册 `announcement:manage`，admin 默认权限含该项（`admin:full_access` 通配放行），handler 内 `assertPermission` 细粒度检查
+- **SSE 广播**：`Channels` 新增全局频道 `noj:events:announcements`，发布/下架/更新后 `publishEvent`；SSE 端点映射 `announcement:updated` 事件，前端 `useEventSource` 监听后重拉（沿用 queue/stats 模式，页面加载拉取为 fallback）
+- **UI**：首页轮播改公告驱动（删除硬编码数组，置顶优先取前 5 条，点击跳详情，空态占位）；新增公开列表页 `/announcements`（置顶标记 + 分页）与详情页 `/announcements/[id]`（Markdown 渲染）；新增管理后台页 `pages/admin/announcements.vue`（复用 `useAdminList`）+ 侧边栏入口
+
+## Capabilities
+
+### New Capabilities
+
+- `announcement-management`: 公告系统完整功能（数据模型、公开 API、管理 API、权限、UI 行为）
+
+### Modified Capabilities
+
+- `database-schema`: 新增 `announcements` 表
+- `sse-endpoints`: 新增 `announcement:updated` 全局事件
+- `admin-authorization`: 新增 `announcement:manage` 权限注册
+
+## Impact
+
+- **noj-core**：`db/schema.ts` + 新迁移、`types/index.ts`（PERMISSION_DEFS）、`services/seed-rbac.ts`（admin 默认权限）、新增 `services/announcements.ts`、新增 `routes/announcements.ts`、`routes/admin.ts`（管理端点）、`routes/sse.ts`（事件映射）、`lib/event-bus.ts`（Channels）、`app.ts`（挂载）
+- **noj-ui**：`pages/index.vue`（轮播公告驱动）、新增 `pages/announcements/index.vue` 与 `pages/announcements/[id].vue`、新增 `pages/admin/announcements.vue`、`layouts/admin.vue`（侧边栏）
+- **测试**：noj-core tests（services/announcements + routes/announcements + admin 权限守卫）、noj-tests E2E（发布→首页可见→下架消失、非 admin 403、置顶排序）
+- **数据库**：一条建表迁移（0035），无数据迁移风险

--- a/openspec/changes/announcements/proposal.md
+++ b/openspec/changes/announcements/proposal.md
@@ -11,6 +11,8 @@
 - **SSE 广播**：`Channels` 新增全局频道 `noj:events:announcements`，发布/下架/更新后 `publishEvent`；SSE 端点映射 `announcement:updated` 事件，前端 `useEventSource` 监听后重拉（沿用 queue/stats 模式，页面加载拉取为 fallback）
 - **UI**：首页轮播改公告驱动（删除硬编码数组，置顶优先取前 5 条，点击跳详情，空态占位）；新增公开列表页 `/announcements`（置顶标记 + 分页）与详情页 `/announcements/[id]`（Markdown 渲染）；新增管理后台页 `pages/admin/announcements.vue`（复用 `useAdminList`）+ 侧边栏入口
 
+> **取舍说明**：issue #231 §3 的「通知中心（铃铛）聚合推送」本期**不做**（design.md Non-Goals 已列明，SSE 横幅刷新已覆盖实时性诉求），留待后续 PR。
+
 ## Capabilities
 
 ### New Capabilities

--- a/openspec/changes/announcements/specs/admin-authorization/spec.md
+++ b/openspec/changes/announcements/specs/admin-authorization/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: 公告管理权限注册
+
+系统 SHALL 在 `PERMISSION_DEFS`（`src/types/index.ts`）注册公告管理权限：
+
+- `announcement:manage`（resource=`announcement`, action=`manage`，description「管理公告」）
+
+`ensurePermissions()`（`seed-rbac.ts`）SHALL 幂等插入该权限（ON CONFLICT DO NOTHING），admin 角色的 `ADMIN_DEFAULT_PERMISSIONS` SHALL 包含该项。`admin:full_access` 通配放行语义 SHALL 适用于该权限（admin 不受收紧影响）。
+
+公告管理端点（`/api/v1/admin/announcements*`）SHALL 在 handler 内调用 `assertPermission(c, "announcement:manage")` 执行细粒度检查，无权限返回 403。
+
+#### Scenario: 权限种子补齐
+
+- **WHEN** 已有数据库上启动并执行 `ensureRbacSeeds()`
+- **THEN** `permissions` 表存在 `announcement:manage` 记录（幂等，不重复）
+
+#### Scenario: admin 隐式拥有公告权限
+
+- **WHEN** 持有 `admin:full_access` 的用户调用公告管理端点
+- **THEN** 权限检查通过（通配放行），无需显式分配 `announcement:manage`
+
+#### Scenario: 无权限用户被拒
+
+- **WHEN** 无 `admin:full_access` 且无 `announcement:manage` 的用户调用公告管理端点
+- **THEN** 系统返回 HTTP 403

--- a/openspec/changes/announcements/specs/announcement-management/spec.md
+++ b/openspec/changes/announcements/specs/announcement-management/spec.md
@@ -1,0 +1,172 @@
+## ADDED Requirements
+
+### Requirement: 公告数据模型
+
+系统 SHALL 提供 `announcements` 表持久化公告，表结构 SHALL 包含：
+
+- `id` TEXT PRIMARY KEY（uuid）
+- `title` TEXT NOT NULL（1–100 字符）
+- `content` TEXT NOT NULL（Markdown，1–50000 字符）
+- `is_pinned` BOOLEAN NOT NULL DEFAULT FALSE
+- `is_active` BOOLEAN NOT NULL DEFAULT TRUE（false = 已下架）
+- `created_by` TEXT NOT NULL REFERENCES `users(id)`
+- `created_at` TEXT NOT NULL（ISO 8601）
+- `updated_at` TEXT NOT NULL（ISO 8601）
+
+表 SHALL 建索引 `(is_active, is_pinned, created_at)` 支撑公开列表查询，通过 Drizzle 迁移（0035）创建。
+
+#### Scenario: 迁移创建公告表
+
+- **WHEN** 执行 `deno task db:migrate`（或启动期自动迁移）
+- **THEN** `announcements` 表创建成功，索引存在，无存量数据
+
+#### Scenario: 创建公告必填校验
+
+- **WHEN** 请求 title 为空或超过 100 字符、content 为空或超过 50000 字符
+- **THEN** 系统返回 HTTP 400，不落库
+
+### Requirement: 公开公告列表 API
+
+系统 SHALL 提供 `GET /api/v1/announcements`，返回**仅 `is_active=true`** 的公告，排序 SHALL 为 `is_pinned DESC, created_at DESC`（置顶优先，同组内最新在前），支持分页（`page` / `per_page`，默认 20，沿用 `lib/pagination.ts`）。
+
+响应 SHALL 为 `{ data: AnnouncementSummary[], meta: { page, per_page, total } }`。列表项 SHALL 包含 `id`、`title`、`is_pinned`、`created_at`、`updated_at` 与 `excerpt`（content Markdown 源码截断 120 字符），**不**包含 `content` 全文。接口无需认证。
+
+#### Scenario: 置顶公告排最前
+
+- **WHEN** 系统存在 1 条置顶公告（较旧）与 1 条未置顶公告（较新）
+- **THEN** 列表第一项为置顶公告（`is_pinned=true`），即使其 `created_at` 更早
+
+#### Scenario: 已下架公告不可见
+
+- **WHEN** 某公告 `is_active=false`（下架）
+- **THEN** 公开列表不包含该公告，且列表 `total` 不统计它
+
+#### Scenario: 分页生效
+
+- **WHEN** 客户端请求 `GET /api/v1/announcements?page=2&per_page=5`
+- **THEN** 返回第 2 页数据，`meta` 中 `page=2`、`per_page=5`、`total` 为 active 公告总数
+
+#### Scenario: 未登录可访问
+
+- **WHEN** 未携带任何认证信息的客户端请求公开列表
+- **THEN** 响应 200 + 数据（公开接口，无需 JWT）
+
+### Requirement: 公开公告详情 API
+
+系统 SHALL 提供 `GET /api/v1/announcements/:id`，返回单个 active 公告的完整信息：`id`、`title`、`content`（Markdown 全文）、`is_pinned`、`created_at`、`updated_at`、`created_by`。非 active 或不存在的公告 SHALL 返回 404。
+
+#### Scenario: 查看已发布公告详情
+
+- **WHEN** 客户端请求某 active 公告的详情
+- **THEN** 响应 200 + 完整字段（含 `content` 全文）
+
+#### Scenario: 已下架公告详情返回 404
+
+- **WHEN** 客户端请求某 `is_active=false` 公告的详情
+- **THEN** 响应 404 Not Found
+
+### Requirement: 管理公告 API
+
+系统 SHALL 提供管理端点（受 `authMiddleware` + `adminMiddleware` 组级保护）：
+
+- `GET /api/v1/admin/announcements`：全量列表（含未发布/已下架），分页，可选 `is_active` 筛选，列表项含 `content` 全文
+- `POST /api/v1/admin/announcements`：创建公告，body `{ title, content, is_pinned?, is_active? }`（缺省 `is_pinned=false`、`is_active=true`）
+- `PUT /api/v1/admin/announcements/:id`：更新公告（部分更新语义）；**发布/下架统一为更新 `is_active`**（下架 = `is_active: false`）
+- `DELETE /api/v1/admin/announcements/:id`：物理删除
+
+所有写操作（创建/更新/删除）SHALL 记录审计日志（action 分别为 `announcement.create` / `announcement.update` / `announcement.delete`，复用既有审计机制）。创建时 `created_by` SHALL 写入当前操作者用户 id。
+
+#### Scenario: 管理员发布公告
+
+- **WHEN** admin 调用 `POST /api/v1/admin/announcements`（合法 body）
+- **THEN** 响应 201 + 创建的公告，`is_active=true`，审计日志新增 `announcement.create` 记录
+
+#### Scenario: 管理员下架公告
+
+- **WHEN** admin 调用 `PUT /api/v1/admin/announcements/:id`，body `{ is_active: false }`
+- **THEN** 更新成功，该公告 `is_active=false`，公开列表不再返回；审计日志新增 `announcement.update` 记录
+
+#### Scenario: 管理员删除公告
+
+- **WHEN** admin 调用 `DELETE /api/v1/admin/announcements/:id`
+- **THEN** 删除成功（204），审计日志新增 `announcement.delete` 记录
+
+#### Scenario: 更新不存在的公告
+
+- **WHEN** admin 调用 `PUT /api/v1/admin/announcements/:id`，id 不存在
+- **THEN** 响应 404 Not Found
+
+### Requirement: 公告管理权限
+
+系统 SHALL 在 `PERMISSION_DEFS` 注册 `announcement:manage`（resource=`announcement`, action=`manage`，description「管理公告」），并在 `seed-rbac.ts` 的 admin 角色默认权限中加入该项（`ensurePermissions()` 幂等插入，ON CONFLICT DO NOTHING）。
+
+管理端点 handler SHALL 调用 `assertPermission(c, "announcement:manage")`：持有 `admin:full_access`（通配放行）或显式拥有该权限的用户放行，其余返回 403。
+
+#### Scenario: admin 管理公告
+
+- **WHEN** 持有 `admin:full_access` 的用户调用管理端点
+- **THEN** 权限检查通过（通配放行），操作正常执行
+
+#### Scenario: 非 admin 写操作被拒
+
+- **WHEN** 普通用户调用 `POST /api/v1/admin/announcements`
+- **THEN** 响应 403 Forbidden（adminMiddleware 或 assertPermission 拦截）
+
+#### Scenario: 权限种子幂等
+
+- **WHEN** 已存在 `announcement:manage` 权限的数据库上再次执行 `ensureRbacSeeds()`
+- **THEN** 不产生重复权限行
+
+### Requirement: 首页公告轮播（UI）
+
+系统 SHALL 将首页（`pages/index.vue`）左栏公告轮播改为公告驱动：删除硬编码公告数组，拉取 `GET /api/v1/announcements?per_page=5` 渲染轮播项（标题 + 摘要），点击轮播项跳转 `/announcements/[id]` 详情页。
+
+- 轮播背景渐变 SHALL 按轮播下标循环使用预设色板（不依赖公告数据）
+- 公告列表为空时 SHALL 显示默认欢迎占位（保留现「正式上线」等静态文案语义）
+- 收到 SSE `announcement:updated` 事件后 SHALL 重新拉取轮播数据
+
+#### Scenario: 首页展示运营公告
+
+- **WHEN** 运营者发布公告（含置顶），任意用户访问首页
+- **THEN** 轮播展示该公告（置顶优先），点击跳转详情页
+
+#### Scenario: 无公告时显示占位
+
+- **WHEN** 系统无任何 active 公告
+- **THEN** 轮播区显示默认欢迎占位文案，不报错
+
+#### Scenario: SSE 触发轮播刷新
+
+- **WHEN** 首页打开期间管理员发布/下架公告（SSE 连接在线）
+- **THEN** 收到 `announcement:updated` 后轮播数据刷新（新公告出现 / 下架公告消失）；SSE 不可用时页面刷新后仍显示最新数据（fallback）
+
+### Requirement: 公开公告页面（UI）
+
+系统 SHALL 提供公开公告列表页 `/announcements` 与详情页 `/announcements/[id]`：
+
+- 列表页 SHALL 展示置顶徽标（`is_pinned`）、标题、发布时间，支持分页（复用 `PaginationNav`），行点击进入详情页
+- 详情页 SHALL 展示标题、发布时间、置顶徽标与 Markdown 全文（复用 `MarkdownRenderer`），使用公开列表/详情 API
+
+#### Scenario: 浏览全部公告
+
+- **WHEN** 任意用户访问 `/announcements`
+- **THEN** 展示 active 公告分页列表，置顶公告带徽标
+
+#### Scenario: 查看公告全文
+
+- **WHEN** 任意用户访问 `/announcements/<id>`（id 为 active 公告）
+- **THEN** 页面渲染 Markdown 全文
+
+### Requirement: 管理后台公告页（UI）
+
+系统 SHALL 提供管理后台公告管理页 `pages/admin/announcements.vue`（`definePageMeta({ layout: "admin", middleware: "admin" })`，与既有 admin 页一致）：
+
+- 列表 SHALL 展示标题、置顶状态、发布状态、创建/更新时间，支持分页（复用 `useAdminList`）
+- 提供新建与编辑表单（标题 + Markdown 文本域 + 置顶开关 + 发布状态开关），保存调用管理 API
+- 支持删除（二次确认）
+- `layouts/admin.vue` 侧边栏 SHALL 新增「公告管理」入口（内容与评测分组）
+
+#### Scenario: 运营者管理公告
+
+- **WHEN** 管理员在后台创建公告并保存
+- **THEN** 列表出现新公告（发布状态按表单开关）；编辑切换发布状态即发布/下架

--- a/openspec/changes/announcements/specs/database-schema/spec.md
+++ b/openspec/changes/announcements/specs/database-schema/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: 公告表（announcements）
+
+系统 SHALL 提供 `announcements` 表：
+
+- `id` TEXT PRIMARY KEY（uuid）
+- `title` TEXT NOT NULL
+- `content` TEXT NOT NULL（Markdown）
+- `is_pinned` BOOLEAN NOT NULL DEFAULT FALSE
+- `is_active` BOOLEAN NOT NULL DEFAULT TRUE
+- `created_by` TEXT NOT NULL REFERENCES `users(id)`
+- `created_at` TEXT NOT NULL、`updated_at` TEXT NOT NULL（ISO 8601）
+
+系统 SHALL 为该表创建索引 `idx_announcements_active_pinned_created` ON `(is_active, is_pinned, created_at)`。表与索引通过 Drizzle 迁移（0035）创建，迁移由 `deno task db:generate` 生成，不可手改 `_journal.json`。
+
+#### Scenario: 迁移建表
+
+- **WHEN** 执行 0035 迁移
+- **THEN** `announcements` 表与索引创建成功
+
+#### Scenario: 级联行为
+
+- **WHEN** 引用 `users.id` 的 `created_by` 用户被删除
+- **THEN** 按既有约束行为处理（`users` 表无级联删除，公告保留，字段为历史记录）

--- a/openspec/changes/announcements/specs/sse-endpoints/spec.md
+++ b/openspec/changes/announcements/specs/sse-endpoints/spec.md
@@ -4,12 +4,14 @@
 
 系统 SHALL 在 `lib/event-bus.ts` 的 `Channels` 常量中新增全局频道 `noj:events:announcements`。公告服务层在创建、更新（含发布/下架）、删除成功后 SHALL 调用 `publishEvent(Channels.announcements, ...)` 广播变更（fire-and-forget，失败仅记日志，不阻塞写流程）。
 
-系统 SHALL 在全局 SSE 端点（`routes/sse.ts`）注册该频道监听：收到事件后以 SSE 事件名 `announcement:updated` 向所有已连接客户端推送（data 仅作触发通知，不含公告完整数据，与 `queue:changed` 同模式）。
+系统 SHALL 提供公告 SSE 端点 `GET /api/v1/announcements/events`（需登录，注册于 `routes/announcements.ts` 内、`/:id` 参数路由之前，公开路由整体挂载于 sse 实例之前）：订阅该端点的客户端收到事件后以 SSE 事件名 `announcement:updated` 推送（data 仅作触发通知，不含公告完整数据，与 `queue:changed` 同模式）。
+
+> **偏离说明（工程妥协）**：原设计在全局 SSE 端点（`routes/sse.ts`）注册监听，但 sse 实例挂载时带全局 `authMiddleware`，会拦截所有挂载在其后的公开路由（见 `app.ts` 挂载注释）。公告 SSE 端点因此注册在公告路由实例内并挂载于 sse 实例之前，行为等价（客户端订阅 `/api/v1/announcements/events` 即可收到广播）。详见 `design.md` D5。
 
 #### Scenario: 发布公告触发广播
 
 - **WHEN** 管理员创建或发布公告
-- **THEN** `noj:events:announcements` 频道收到事件，已连接 SSE 客户端收到 `announcement:updated`
+- **THEN** `noj:events:announcements` 频道收到事件，订阅 `/api/v1/announcements/events` 的 SSE 客户端收到 `announcement:updated`
 
 #### Scenario: 下架公告触发广播
 

--- a/openspec/changes/announcements/specs/sse-endpoints/spec.md
+++ b/openspec/changes/announcements/specs/sse-endpoints/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: 公告变更全局 SSE 事件
+
+系统 SHALL 在 `lib/event-bus.ts` 的 `Channels` 常量中新增全局频道 `noj:events:announcements`。公告服务层在创建、更新（含发布/下架）、删除成功后 SHALL 调用 `publishEvent(Channels.announcements, ...)` 广播变更（fire-and-forget，失败仅记日志，不阻塞写流程）。
+
+系统 SHALL 在全局 SSE 端点（`routes/sse.ts`）注册该频道监听：收到事件后以 SSE 事件名 `announcement:updated` 向所有已连接客户端推送（data 仅作触发通知，不含公告完整数据，与 `queue:changed` 同模式）。
+
+#### Scenario: 发布公告触发广播
+
+- **WHEN** 管理员创建或发布公告
+- **THEN** `noj:events:announcements` 频道收到事件，已连接 SSE 客户端收到 `announcement:updated`
+
+#### Scenario: 下架公告触发广播
+
+- **WHEN** 管理员下架公告（`is_active=false`）
+- **THEN** 已连接 SSE 客户端收到 `announcement:updated`（前端据此刷新轮播/列表）
+
+#### Scenario: Redis 不可用时降级
+
+- **WHEN** Redis 不可用（订阅者未就绪）
+- **THEN** 公告写流程正常完成（publishEvent 跳过），前端通过页面加载/轮询 fallback 获取最新数据

--- a/openspec/changes/announcements/tasks.md
+++ b/openspec/changes/announcements/tasks.md
@@ -1,53 +1,54 @@
 ## 1. 数据模型与迁移（noj-core）
 
-- [ ] 1.1 `db/schema.ts` 新增 `announcements` 表（id/title/content/is_pinned/is_active/created_by/created_at/updated_at + `idx_announcements_active_pinned_created` 索引），沿用既有 text 主键 / ISO 8601 风格
-- [ ] 1.2 `deno task db:generate` 生成 0035 迁移并执行 `deno task db:migrate`（本地 dev 库验证）
+- [x] 1.1 `db/schema.ts` 新增 `announcements` 表（id/title/content/is_pinned/is_active/created_by/created_at/updated_at + `idx_announcements_active_pinned_created` 索引），沿用既有 text 主键 / ISO 8601 风格（已随 b75a62c3 提交）
+- [x] 1.2 `deno task db:generate` 生成 0035 迁移并执行 `deno task db:migrate`（本地 dev 库验证：announcements 表 + 索引 + announcement:manage 权限均已确认）
 
 ## 2. 权限注册（noj-core）
 
-- [ ] 2.1 `types/index.ts` 的 `PERMISSION_DEFS` 新增 `{ resource: "announcement", action: "manage", description: "管理公告" }`
-- [ ] 2.2 `seed-rbac.ts` 的 `ADMIN_DEFAULT_PERMISSIONS` 加入 `{ resource: "announcement", action: "manage" }`
+- [x] 2.1 `types/index.ts` 的 `PERMISSION_DEFS` 新增 `{ resource: "announcement", action: "manage", description: "管理公告" }`
+- [x] 2.2 `seed-rbac.ts` 的 `ADMIN_DEFAULT_PERMISSIONS` 加入 `{ resource: "announcement", action: "manage" }`
+- [x] 2.3 `types/audit-log.ts` `AuditAction`/`AuditDetail` 新增 `announcement.create/update/delete`；`schema.ts` audit CHECK 约束扩展（迁移 0036 由 `db:generate` 生成）
 
 ## 3. 服务层（services/announcements.ts）
 
-- [ ] 3.1 新增 `services/announcements.ts`：类型（AnnouncementSummary / CreateAnnouncementInput / UpdateAnnouncementInput）+ `listPublicAnnouncements(page, perPage)`（仅 active，`is_pinned DESC, created_at DESC`，excerpt 截断 120 字符）+ `getPublicAnnouncement(id)`（非 active 抛 404）
-- [ ] 3.2 `createAnnouncement(c, input)` / `updateAnnouncement(c, id, input)` / `deleteAnnouncement(c, id)` / `listAdminAnnouncements(c, page, perPage, isActive?)`：字段校验（title 1–100、content 1–50000）、`assertPermission(c, "announcement:manage")`、审计日志（`announcement.create/update/delete`）
-- [ ] 3.3 写操作成功后 `publishEvent(Channels.announcements, ...)` 广播变更
+- [x] 3.1 新增 `services/announcements.ts`：类型（AnnouncementSummary / AnnouncementDetail / AdminAnnouncementItem / Create/UpdateAnnouncementInput）+ `listPublicAnnouncements(page, perPage)`（仅 active，`is_pinned DESC, created_at DESC`，excerpt 截断 120 字符）+ `getPublicAnnouncement(id)`（非 active 抛 404）
+- [x] 3.2 `createAnnouncement(input)` / `updateAnnouncement(id, input)` / `deleteAnnouncement(id)` / `listAdminAnnouncements(page, perPage, isActive?)`：字段校验（title 1–100、content 1–50000）、审计日志（`announcement.create/update/delete`）、操作者经 `getRequestContext()` 获取；细粒度权限 `assertPermission(c, "announcement:manage")` 在路由层 handler 内执行（与 community.ts 同模式，服务层不依赖 Hono Context）
+- [x] 3.3 写操作成功后 `publishEvent(Channels.announcements, ...)` 广播变更
 
 ## 4. 路由与 SSE（noj-core）
 
-- [ ] 4.1 新增 `routes/announcements.ts` 公开路由：`GET /`（列表）、`GET /:id`（详情）；`app.ts` 挂载 `/api/v1/announcements`
-- [ ] 4.2 `routes/admin.ts` 追加：`GET/POST /announcements`、`PUT/DELETE /announcements/:id`（handler 内 `assertPermission(c, "announcement:manage")`）
-- [ ] 4.3 `lib/event-bus.ts` `Channels` 新增 `announcements` 全局频道；`routes/sse.ts` 注册监听 → SSE 事件 `announcement:updated`（全局广播，与 `queue:changed` 同模式）
+- [x] 4.1 新增 `routes/announcements.ts` 公开路由：`GET /`（列表）、`GET /:id`（详情）；`app.ts` 挂载 `/api/v1/announcements`（必须在 sse 实例之前注册——sse 全局 authMiddleware 会拦截其后的路由）
+- [x] 4.2 `routes/admin.ts` 追加：`GET/POST /announcements`、`PUT/DELETE /announcements/:id`（handler 内 `assertPermission(c, "announcement:manage")`）
+- [x] 4.3 `lib/event-bus.ts` `Channels` 新增 `announcements` 全局频道；SSE 端点 `GET /api/v1/announcements/events`（注册在 `routes/announcements.ts` 内、`/:id` 之前，单路由挂 authMiddleware）→ SSE 事件 `announcement:updated`（与 `queue:changed` 同模式）
 
 ## 5. core 测试
 
-- [ ] 5.1 `tests/services/`：公告 CRUD（校验 400、权限 403、审计、排序置顶优先、公开列表仅 active、excerpt 截断、非 active 详情 404、分页 meta）
-- [ ] 5.2 `tests/routes/`：公开路由（未登录 200、置顶排序、下架不可见、404）+ admin 路由（非 admin 403、发布/下架/删除全流程、审计日志断言）
-- [ ] 5.3 seed 测试：`ensureRbacSeeds` 后 `announcement:manage` 存在且 admin 角色拥有
+- [x] 5.1 `tests/services/announcements.test.ts`：公告 CRUD（校验 400、审计、排序置顶优先、公开列表仅 active、excerpt 截断、非 active 详情 404、分页 meta）
+- [x] 5.2 `tests/routes/announcements.test.ts`：公开路由（未登录 200、置顶排序、下架不可见、404）+ admin 路由（非 admin 403、发布/下架/删除全流程、分页 meta）
+- [x] 5.3 seed 测试：`ensureRbacSeeds` 后 `announcement:manage` 存在且 admin 角色拥有
 
 ## 6. 前端：首页轮播（noj-ui）
 
-- [ ] 6.1 `pages/index.vue` 删除硬编码 `announcements` 数组，改为 `GET /api/v1/announcements?per_page=5` 驱动（标题 + 摘要，点击跳 `/announcements/[id]`，空态占位，渐变按下标循环预设色板）
-- [ ] 6.2 `useEventSource` 监听 `announcement:updated` → 重拉轮播数据
+- [x] 6.1 `pages/index.vue` 删除硬编码 `announcements` 数组，改为 `GET /api/v1/announcements?per_page=5` 驱动（标题 + 摘要，点击跳 `/announcements/[id]`，空态占位，渐变按下标循环预设色板）
+- [x] 6.2 `useEventSource` 监听 `announcement:updated` → 重拉轮播数据（60s 轮询 fallback，登录用户启用）
 
 ## 7. 前端：公开公告页（noj-ui）
 
-- [ ] 7.1 新增 `pages/announcements/index.vue` 列表页（置顶徽标 + 分页 `PaginationNav`）
-- [ ] 7.2 新增 `pages/announcements/[id].vue` 详情页（`MarkdownRenderer` 渲染全文）
+- [x] 7.1 新增 `pages/announcements/index.vue` 列表页（置顶徽标 + 分页 `PaginationNav`）
+- [x] 7.2 新增 `pages/announcements/[id].vue` 详情页（`MarkdownRenderer` 渲染全文 + 404 占位）
 
 ## 8. 前端：管理后台（noj-ui）
 
-- [ ] 8.1 新增 `pages/admin/announcements.vue`（`useAdminList` 分页列表 + 新建/编辑表单 + 删除二次确认）
-- [ ] 8.2 `layouts/admin.vue` 侧边栏「内容与评测」分组新增「公告管理」入口
+- [x] 8.1 新增 `pages/admin/announcements.vue`（`useAdminList` 分页列表 + 新建/编辑表单 + 删除二次确认）
+- [x] 8.2 `layouts/admin.vue` 侧边栏「内容与评测」分组新增「公告管理」入口
 
 ## 9. 全链路验证
 
-- [ ] 9.1 noj-core：`deno fmt` + `deno lint` + `deno task test` 全量通过
-- [ ] 9.2 noj-ui：`deno fmt` + `deno lint` + `nuxt build` 通过
-- [ ] 9.3 noj-tests E2E 新增公告用例：admin 发布 → 公开列表/首页可见 → 下架消失；非 admin 写 403；置顶排序生效；SSE `announcement:updated` 广播；`run-e2e.sh` 全量跑通
+- [x] 9.1 noj-core：`deno fmt` + `deno lint` + `deno task test` 全量通过（743 passed / 0 failed）
+- [x] 9.2 noj-ui：`deno fmt` + `deno lint` + `nuxt build` 通过
+- [ ] 9.3 noj-tests E2E 新增公告用例（`e2e/28_announcements.test.ts` 已编写：发布→公开可见→下架消失、非 admin 403、置顶排序、SSE 广播），`run-e2e.sh` 全量跑通**待执行**
 
 ## 10. OpenSpec 归档
 
-- [ ] 10.1 `/opsx:archive` 归档变更（目录 `2026-08-08-announcements`）+ `/opsx:sync` 同步主规范
+- [ ] 10.1 `/opsx:archive` 归档变更（目录 `2026-08-08-announcements`）+ `/opsx:sync` 同步主规范（待 9.3 完成）
 - [ ] 10.2 确认 GPG 签名后按项目规范提交（jj，中文 Conventional Commits，scope `core,ui`）

--- a/openspec/changes/announcements/tasks.md
+++ b/openspec/changes/announcements/tasks.md
@@ -1,0 +1,53 @@
+## 1. 数据模型与迁移（noj-core）
+
+- [ ] 1.1 `db/schema.ts` 新增 `announcements` 表（id/title/content/is_pinned/is_active/created_by/created_at/updated_at + `idx_announcements_active_pinned_created` 索引），沿用既有 text 主键 / ISO 8601 风格
+- [ ] 1.2 `deno task db:generate` 生成 0035 迁移并执行 `deno task db:migrate`（本地 dev 库验证）
+
+## 2. 权限注册（noj-core）
+
+- [ ] 2.1 `types/index.ts` 的 `PERMISSION_DEFS` 新增 `{ resource: "announcement", action: "manage", description: "管理公告" }`
+- [ ] 2.2 `seed-rbac.ts` 的 `ADMIN_DEFAULT_PERMISSIONS` 加入 `{ resource: "announcement", action: "manage" }`
+
+## 3. 服务层（services/announcements.ts）
+
+- [ ] 3.1 新增 `services/announcements.ts`：类型（AnnouncementSummary / CreateAnnouncementInput / UpdateAnnouncementInput）+ `listPublicAnnouncements(page, perPage)`（仅 active，`is_pinned DESC, created_at DESC`，excerpt 截断 120 字符）+ `getPublicAnnouncement(id)`（非 active 抛 404）
+- [ ] 3.2 `createAnnouncement(c, input)` / `updateAnnouncement(c, id, input)` / `deleteAnnouncement(c, id)` / `listAdminAnnouncements(c, page, perPage, isActive?)`：字段校验（title 1–100、content 1–50000）、`assertPermission(c, "announcement:manage")`、审计日志（`announcement.create/update/delete`）
+- [ ] 3.3 写操作成功后 `publishEvent(Channels.announcements, ...)` 广播变更
+
+## 4. 路由与 SSE（noj-core）
+
+- [ ] 4.1 新增 `routes/announcements.ts` 公开路由：`GET /`（列表）、`GET /:id`（详情）；`app.ts` 挂载 `/api/v1/announcements`
+- [ ] 4.2 `routes/admin.ts` 追加：`GET/POST /announcements`、`PUT/DELETE /announcements/:id`（handler 内 `assertPermission(c, "announcement:manage")`）
+- [ ] 4.3 `lib/event-bus.ts` `Channels` 新增 `announcements` 全局频道；`routes/sse.ts` 注册监听 → SSE 事件 `announcement:updated`（全局广播，与 `queue:changed` 同模式）
+
+## 5. core 测试
+
+- [ ] 5.1 `tests/services/`：公告 CRUD（校验 400、权限 403、审计、排序置顶优先、公开列表仅 active、excerpt 截断、非 active 详情 404、分页 meta）
+- [ ] 5.2 `tests/routes/`：公开路由（未登录 200、置顶排序、下架不可见、404）+ admin 路由（非 admin 403、发布/下架/删除全流程、审计日志断言）
+- [ ] 5.3 seed 测试：`ensureRbacSeeds` 后 `announcement:manage` 存在且 admin 角色拥有
+
+## 6. 前端：首页轮播（noj-ui）
+
+- [ ] 6.1 `pages/index.vue` 删除硬编码 `announcements` 数组，改为 `GET /api/v1/announcements?per_page=5` 驱动（标题 + 摘要，点击跳 `/announcements/[id]`，空态占位，渐变按下标循环预设色板）
+- [ ] 6.2 `useEventSource` 监听 `announcement:updated` → 重拉轮播数据
+
+## 7. 前端：公开公告页（noj-ui）
+
+- [ ] 7.1 新增 `pages/announcements/index.vue` 列表页（置顶徽标 + 分页 `PaginationNav`）
+- [ ] 7.2 新增 `pages/announcements/[id].vue` 详情页（`MarkdownRenderer` 渲染全文）
+
+## 8. 前端：管理后台（noj-ui）
+
+- [ ] 8.1 新增 `pages/admin/announcements.vue`（`useAdminList` 分页列表 + 新建/编辑表单 + 删除二次确认）
+- [ ] 8.2 `layouts/admin.vue` 侧边栏「内容与评测」分组新增「公告管理」入口
+
+## 9. 全链路验证
+
+- [ ] 9.1 noj-core：`deno fmt` + `deno lint` + `deno task test` 全量通过
+- [ ] 9.2 noj-ui：`deno fmt` + `deno lint` + `nuxt build` 通过
+- [ ] 9.3 noj-tests E2E 新增公告用例：admin 发布 → 公开列表/首页可见 → 下架消失；非 admin 写 403；置顶排序生效；SSE `announcement:updated` 广播；`run-e2e.sh` 全量跑通
+
+## 10. OpenSpec 归档
+
+- [ ] 10.1 `/opsx:archive` 归档变更（目录 `2026-08-08-announcements`）+ `/opsx:sync` 同步主规范
+- [ ] 10.2 确认 GPG 签名后按项目规范提交（jj，中文 Conventional Commits，scope `core,ui`）

--- a/openspec/changes/announcements/tasks.md
+++ b/openspec/changes/announcements/tasks.md
@@ -18,7 +18,7 @@
 ## 4. 路由与 SSE（noj-core）
 
 - [x] 4.1 新增 `routes/announcements.ts` 公开路由：`GET /`（列表）、`GET /:id`（详情）；`app.ts` 挂载 `/api/v1/announcements`（必须在 sse 实例之前注册——sse 全局 authMiddleware 会拦截其后的路由）
-- [x] 4.2 `routes/admin.ts` 追加：`GET/POST /announcements`、`PUT/DELETE /announcements/:id`（handler 内 `assertPermission(c, "announcement:manage")`）
+- [x] 4.2 新增 `routes/admin-announcements.ts` 管理路由：`GET/POST /`、`PUT/DELETE /:id`（独立 router 挂载 `/api/v1/admin/announcements`，仅 authMiddleware + 细粒度 `assertPermission("announcement:manage")` + RequestContext 注入——admin 实例组级 adminMiddleware 仅放行 `admin:full_access` 会拦截细粒度权限持有者，故 admin.ts 组级 use 对公告路径跳过 adminMiddleware；`app.ts` 在 admin 之后挂载）
 - [x] 4.3 `lib/event-bus.ts` `Channels` 新增 `announcements` 全局频道；SSE 端点 `GET /api/v1/announcements/events`（注册在 `routes/announcements.ts` 内、`/:id` 之前，单路由挂 authMiddleware）→ SSE 事件 `announcement:updated`（与 `queue:changed` 同模式）
 
 ## 5. core 测试
@@ -47,6 +47,7 @@
 - [x] 9.1 noj-core：`deno fmt` + `deno lint` + `deno task test` 全量通过（743 passed / 0 failed）
 - [x] 9.2 noj-ui：`deno fmt` + `deno lint` + `nuxt build` 通过
 - [x] 9.3 noj-tests E2E 新增公告用例（`e2e/28_announcements.test.ts`：发布→公开可见→下架消失、非 admin 403、置顶排序、SSE 广播）——已纳入 `.github/workflows/e2e.yml` p3 分组，PR #234 CI 上 4/4 用例通过（Full Pipeline (API E2E) pass）
+- [x] 9.4 评审修复（PR #234 review）：① P0 公告管理端点抽离 adminMiddleware 组级拦截（`routes/admin-announcements.ts` + admin.ts 组级 use 跳过公告路径），core route 测试新增「仅 announcement:manage（无 full_access）用户可管理」+ E2E 用例 5 端到端验证；② P1 SSE 端点 spec 同步（design.md D5 偏离说明 + sse-endpoints spec）；③ P1 E2E 新增首页轮播数据源契约断言（用例 1b：per_page=5 + 字段 + 置顶优先）；④ P2 创建公告必填字段缺失返回 400（`{}` / 仅可选字段）；⑤ P2 proposal.md 补通知中心聚合取舍说明；⑥ P3 管理页 `formError`/`deleteError` 拆分。全量 `deno task test` 744 passed / 0 failed
 
 ## 10. OpenSpec 归档
 

--- a/openspec/changes/announcements/tasks.md
+++ b/openspec/changes/announcements/tasks.md
@@ -46,7 +46,7 @@
 
 - [x] 9.1 noj-core：`deno fmt` + `deno lint` + `deno task test` 全量通过（743 passed / 0 failed）
 - [x] 9.2 noj-ui：`deno fmt` + `deno lint` + `nuxt build` 通过
-- [ ] 9.3 noj-tests E2E 新增公告用例（`e2e/28_announcements.test.ts` 已编写：发布→公开可见→下架消失、非 admin 403、置顶排序、SSE 广播），`run-e2e.sh` 全量跑通**待执行**
+- [x] 9.3 noj-tests E2E 新增公告用例（`e2e/28_announcements.test.ts`：发布→公开可见→下架消失、非 admin 403、置顶排序、SSE 广播）——已纳入 `.github/workflows/e2e.yml` p3 分组，PR #234 CI 上 4/4 用例通过（Full Pipeline (API E2E) pass）
 
 ## 10. OpenSpec 归档
 


### PR DESCRIPTION
## 关联 Issue

Closes #231

## 变更摘要

实现公告系统：新增独立 `announcements` 表承载公告（置顶 + 发布/下架状态），提供公开列表/详情 API 与 admin CRUD（细粒度权限 `announcement:manage` + 审计日志），SSE 全局广播 `announcement:updated` 实时刷新；首页轮播改为公告驱动，新增公开公告列表页/详情页（Markdown 渲染）与后台公告管理页。

## 变更类型

- [x] `feat` 新功能
- [x] `test` 测试
- [x] `ci` CI（`e2e.yml` 分组纳入 `28_announcements.test.ts`）

## 影响范围

- [x] `noj-core` 后端
- [x] `noj-ui` 前端
- [x] 数据库迁移（`drizzle/0036_glorious_nightshade.sql`：audit_logs action CHECK 扩展；`0035` 建表迁移见首个提交）
- [x] 公共 API（`GET /api/v1/announcements[/:id]`、`GET /api/v1/announcements/events`、`/api/v1/admin/announcements*`）
- [x] OpenSpec 规范（`openspec/changes/announcements/` 提案 + tasks.md 进度）

## 验证清单

- [x] `deno fmt` 已运行（noj-core / noj-ui / noj-tests）
- [x] `deno lint` 已运行（core 211 files / ui 38 files 全过）
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）—— 本次无 noj-judge 改动，不适用
- [x] 本地 `deno task test` 通过（743 passed / 0 failed）
- [x] 新功能 / 修复有对应测试（core 新增 14 个：services 7 + routes 7；E2E 用例 `noj-tests/e2e/28_announcements.test.ts`）
- [x] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移（0036；0035 随提案首个提交）
- [x] 提交信息符合 Conventional Commits（`feat(core,ui):` / `feat(core):` / `docs(openspec):` 中文描述）
- [x] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案（`openspec/changes/announcements/`）
- [x] GPG 签名可用（ed25519 密钥，提交均签名）
- [x] **CI 全绿**（PR checks）：Core Quick Check / Core Smoke / Core Test (Unit) / Core Test (DB) / UI (Nuxt) / Judge Sandbox E2E / Full Pipeline (API E2E) / actionlint / Cloudflare Pages 全部 pass；Core Perf / Judge Check / Judge E2E 按路径过滤 skipping（无 judge 改动）

## 截图 / 录屏（可选）

（无——UI 改动为数据驱动轮播与列表页，E2E 已验证行为）

## 补充说明

- **实现说明**：数据模型（`announcements` 表 + 0035 迁移）与 OpenSpec 提案由 `b75a62c3` 提供（已补充描述为 `29fac5f5`）；服务层/路由/SSE/UI/测试为 `3c534660` 实现。
- **SSE 端点位置**：`GET /api/v1/announcements/events` 注册在 `routes/announcements.ts` 内、`/:id` 参数路由之前，且公开路由整体挂载于 `sse` 实例之前（sse 实例的全局 `authMiddleware` 会拦截其后挂载的路由，见 `app.ts` 注释）。
- **权限模型**：`announcement:manage` 注册到 `PERMISSION_DEFS` 并加入 admin 角色默认权限；handler 内 `assertPermission` 细粒度检查（`admin:full_access` 通配放行）。
- **E2E**：`28_announcements.test.ts` 已纳入 `.github/workflows/e2e.yml` p3 分组，CI Full Pipeline 上 4/4 用例通过（发布→可见→下架、403、置顶排序、SSE 广播）。
- **遗留**：`27_objective.test.ts` 未在 e2e.yml 分组中（main 既有遗漏，非本 PR 引入）——建议后续 PR 补入。
- **作者声明**：本 PR 由 AI 编码助手（Reasonix harness，Claude 系列模型）在 hachimi-ak-ioi 的会话中生成——设计经人工评审确认（issue #231 需求 + brainstorming 流程），实现后经人工复核。所有提交均已 GPG 签名。
