### PR TITLE
test(root): 放宽 E2E 提交轮询超时至 90s 并补充诊断信息

### DIFF
--- a/noj-tests/e2e/06_pipeline.test.ts
+++ b/noj-tests/e2e/06_pipeline.test.ts
@@ -65,7 +65,7 @@ e2eTest("[e2e/pipeline] 3/8 TLE", async () => {
       PROBLEM_ID,
       CODE_SAMPLES.timeLimitExceeded,
     );
-    const result = await pollSubmission(token, id, 10, 2000);
+    const result = await pollSubmission(token, id);
     if (result.verdict !== "TimeLimitExceeded") {
       throw new Error("期望 TLE, 实际 " + result.verdict);
     }
@@ -114,7 +114,7 @@ e2eTest("[e2e/pipeline] 6/8 Memory Limit Exceeded", async () => {
       PROBLEM_ID,
       CODE_SAMPLES.memoryLimitExceeded,
     );
-    const result = await pollSubmission(token, id, 15, 2000);
+    const result = await pollSubmission(token, id);
     if (
       result.verdict !== "MemoryLimitExceeded" &&
       result.verdict !== "RuntimeError"
@@ -131,7 +131,7 @@ e2eTest("[e2e/pipeline] 7/8 Runtime Error", async () => {
       PROBLEM_ID,
       CODE_SAMPLES.runtimeError,
     );
-    const result = await pollSubmission(token, id, 15, 2000);
+    const result = await pollSubmission(token, id);
     if (result.verdict !== "RuntimeError") {
       throw new Error("期望 RuntimeError, 实际 " + result.verdict);
     }
@@ -144,7 +144,7 @@ e2eTest("[e2e/pipeline] 8/8 Syntax Error", async () => {
       PROBLEM_ID,
       CODE_SAMPLES.syntaxError,
     );
-    const result = await pollSubmission(token, id, 15, 2000);
+    const result = await pollSubmission(token, id);
     if (
       result.verdict !== "CompileError" && result.verdict !== "RuntimeError"
     ) {

--- a/noj-tests/e2e/14_rejudge.test.ts
+++ b/noj-tests/e2e/14_rejudge.test.ts
@@ -98,7 +98,7 @@ e2eTest("[e2e/rejudge] 5.1 管理员单条重测完成提交", async () => {
     console.log("  ✓ 重测已发起: " + (body.message || ""));
 
     // 等待重测完成
-    const result = await pollSubmission(adminToken, submissionId, 15, 2000);
+    const result = await pollSubmission(adminToken, submissionId);
     if (result.verdict !== "Accepted") {
       throw new Error("重测结果期望 Accepted, 实际 " + result.verdict);
     }

--- a/noj-tests/e2e/helper.ts
+++ b/noj-tests/e2e/helper.ts
@@ -346,22 +346,33 @@ export async function submitCode(
 
 /**
  * 轮询 submission 直到完成或超时。
+ *
+ * 默认阈值 90s（45 次 × 2s）：CI 上多组 E2E 并行提交真实评测时，
+ * judge 队列排队 + 容器启动开销叠加，原 30s 阈值会误判为超时。
+ * 超时错误会附带最后一次观测到的 status / HTTP 码，便于区分
+ * 「评测排队未完成」与「接口异常」。
  */
 export async function pollSubmission(
   token: string,
   submissionId: string,
-  maxRetries = 15,
+  maxRetries = 45,
   intervalMs = 2000,
 ): Promise<{ status: string; verdict: string; score: number }> {
+  // 记录最后一次观测状态，用于超时时给出可诊断的错误信息
+  let lastStatus = "(未取得)";
+  let lastHttpStatus = 0;
+
   for (let i = 0; i < maxRetries; i++) {
     const res = await apiGet(
       `/api/v1/submissions/${submissionId}`,
       token,
     );
+    lastHttpStatus = res.status;
 
     if (res.status === 200) {
       const data = (res.body as { data: Record<string, unknown> }).data;
       const subStatus = data.status as string;
+      lastStatus = subStatus;
 
       if (subStatus === "finished") {
         // API 返回 data.result.status / data.result.score（见 getSubmission）
@@ -373,8 +384,10 @@ export async function pollSubmission(
     }
     await new Promise((r) => setTimeout(r, intervalMs));
   }
+  const timeoutMs = maxRetries * intervalMs;
+  const detail = `status=${lastStatus}, HTTP=${lastHttpStatus}`;
   throw new Error(
-    `Submission ${submissionId} 超时（${maxRetries * intervalMs}ms 未完成）`,
+    `Submission ${submissionId} 超时（${timeoutMs}ms 未完成），最后状态 ${detail}`,
   );
 }
 


### PR DESCRIPTION
## 背景

main 分支上 [`#239` 合并后的 E2E run 31608692694](https://github.com/Neuro-OJ/neuro-oj/actions/runs/31608692694) 失败，但同一分支的 PR run 全绿，CI / Lint Workflows 也均通过 —— 属于典型 flaky。

## 根因

三处失败全部级联自 `noj-tests/e2e/helper.ts` 的 `pollSubmission` **30s 轮询超时**：

| 分组 | 结果 | 首个错误 |
|---|---|---|
| rejudge | 52 passed / 2 failed | `Setup`：`Submission 08e69512 超时（30000ms 未完成）` |
| contest | 64 passed / 3 failed | `步骤 2`：`Submission 09fef33a 超时（30000ms 未完成）` |

级联关系：

- **rejudge**：Setup 超时 → `5.1` 报「重测响应缺少 submission_id」，但响应里 submission_id 实际存在（`{"submission_id":"08e69512-..."}`），是 Setup 挂掉后变量未赋值导致的误导性报错。
- **contest**：步骤 2 提交未评完 → `3` 封榜排名、`4` 解封最终 AC 因榜单无数据连带失败。

日志中 `dual_container_judge` 的 3 条 FAILED 是并行分组交错输出的视觉噪声，不计入最终统计。

超时而非逻辑缺陷的依据：同一份代码 PR 上通过、main 上失败，且同期 network-capability / import-bundle / call_timeout 都在并行提交真实评测（`call_timeout` 单用例自身就要 14s），judge 队列排队叠加容器启动开销后 30s 阈值过紧。

## 改动

- `pollSubmission` 默认 `maxRetries` 15 → 45（30s → **90s**）
- 超时错误附带最后观测到的 `status` 与 HTTP 码，便于区分「评测排队未完成」与「接口异常」，避免再出现 rejudge 5.1 那种误导性报错
- 统一显式传入旧默认值（`15, 2000` / `10, 2000`）的 6 处调用点改用默认值，否则它们仍卡在 30s/20s

`23_network_capability.test.ts` 的 `40, 3000`（120s）是有意的更长阈值，保持不变。

## 影响

仅测试辅助代码，不涉及生产逻辑。超时阈值是上限而非固定等待，正常评测路径耗时不变，不会拖长 CI。