### PR TITLE
docs(dev): 记录国内开发环境的镜像与阈值配置

### DIFF
--- a/noj-docs/docs/operators/local-start.md
+++ b/noj-docs/docs/operators/local-start.md
@@ -13,6 +13,8 @@
 - Docker（noj-judge 评测沙箱必需）
 - 系统 `zip` 命令
 
+> 国内网络环境下，请额外配置 Cargo / npm 镜像与超时阈值，详见 [`scripts/dev/README.md` §国内开发环境：镜像与阈值调优](../../scripts/dev/README.md#国内开发环境镜像与阈值调优)。不配置时首次 `start judge` 可能卡住半小时才暴露。
+
 ## 开发期脚本（devtool.sh，不成熟）
 
 ::: danger 部署方式尚未成熟

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -82,6 +82,60 @@ bash scripts/dev/devtool.sh init-env --merge
 
 ---
 
+## 国内开发环境：镜像与阈值调优
+
+国内网络直连 crates.io / npmjs.org 经常出现"几十 KB 文件下载超时"、被 cargo / npm 误判为"传输过慢"。建议配置镜像 + 放宽阈值，否则首次 `start judge` 或 `npm install` 可能跑半小时才察觉是卡死。
+
+### Cargo（noj-judge 编译）
+
+新建 `~/.cargo/config.toml`：
+
+```toml
+# 用 TUNA 镜像替代 crates.io；sparse 协议对小文件响应更稳定
+[source.crates-io]
+replace-with = "tuna"
+
+[source.tuna]
+registry = "sparse+https://mirrors.tuna.tsinghua.edu.cn/crates.io-index/"
+
+[registries.tuna]
+index = "sparse+https://mirrors.tuna.tsinghua.edu.cn/crates.io-index/"
+
+[net]
+# git 协议拉取用系统 git（部分镜像不支持 git protocol）
+git-fetch-with-cli = true
+# 默认 http.timeout=30 / low-speed-limit=10 极易触发"spurious network error"
+http.timeout = 300
+http.low-speed-limit = 1
+```
+
+> 不调 `http.low-speed-limit` 时，cargo 在 TUNA 下会反复打 `warning: spurious network error (3 tries remaining): transfer too slow: failed to transfer more than 10 bytes in 30s`，看起来在下载实际上什么也下不动。
+
+### npm（noj-ui 依赖）
+
+新建 `~/.npmrc`：
+
+```
+registry=https://registry.npmmirror.com
+```
+
+Deno 的 `nodeModulesDir: auto` 会读 `~/.npmrc`；`deno task dev` 首次启动 Nuxt 时仍要数分钟下载 `@iconify-json/lucide` 等大包，属正常现象。
+
+### PATH 持久化（macOS + brew rustup）
+
+brew 安装的 `rustup` formula 不像 `rustup-init` 自动生成 `~/.cargo/bin` shim，需要手动软链并写入 shell rc：
+
+```bash
+mkdir -p ~/.cargo/bin
+for tool in cargo rustc rustup rustfmt cargo-clippy clippy; do
+  ln -sf "$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/$tool" \
+    "$HOME/.cargo/bin/$tool"
+done
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc
+```
+
+---
+
 ## 故障排查
 
 详细 FAQ 见：


### PR DESCRIPTION
## 背景

按 CLAUDE.md §8.4 「标准操作优先使用脚本」梳理时，把首次跑 `devtool.sh start` 在国内网络环境下的三个反复踩坑点沉淀到文档：

1. **cargo 卡在 crates.io / TUNA** —— 默认 `http.timeout=30` + `low-speed-limit=10` 把 TUNA 稀疏索引的小文件响应误判为「传输过慢」，日志里反复刷 `spurious network error (3 tries remaining): transfer too slow`，进程 RSS 涨到 137MB、CPU 0.1% 死锁，要 30+ 分钟才暴露。
2. **deno task dev 启动 Nuxt 慢** —— `@iconify-json/lucide` 等大包从 npmjs.org 直连拉，要数分钟。
3. **brew 装的 rustup 不生成 shim** —— `command -v cargo` 找不到，`devtool install-deps --check-only` 直接报「Rust 未安装」。

## 改动

- `scripts/dev/README.md` 新增「国内开发环境：镜像与阈值调优」一节，包含 `~/.cargo/config.toml` / `~/.npmrc` 完整示例与 macOS brew-rustup 的 PATH 持久化步骤
- `noj-docs/docs/operators/local-start.md` 在「环境要求」段落加一行指向 scripts/dev/README.md 的引导

## 验证

本地实测：

| 配置 | 现象 |
|---|---|
| 不配 | `cargo build` 卡死 6:30 无进展，log 全是 `transfer too slow` 警告 |
| 加镜像 + 调阈值 | `cargo build` 正常下载 + 编译，~4 分钟出 `noj-judge` 二进制 |

## 影响

仅文档，无代码逻辑变更，不需要 CI 跑测试矩阵。