### PR TITLE
feat(core,ui,root): 支持训练计划/题单（training）（#224）

### DIFF
--- a/docs/superpowers/plans/2026-08-17-training.md
+++ b/docs/superpowers/plans/2026-08-17-training.md
@@ -1,0 +1,2495 @@
+# Training / 题单 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 NOJ 增加用户可创建的扁平题单（training）模块，含题单 CRUD、题目排序、AC 进度、RBAC 权限、前端页面与 E2E 测试。
+
+**Architecture:** 独立 training 模块：新增 `trainings` + `training_problems` 两张表；后端新增 `/api/v1/trainings` 用户路由与 `/api/v1/admin/trainings` 管理路由；前端新增题单列表/详情/我的题单/后台管理页面，并在用户主页与题目页加入入口。
+
+**Tech Stack:** Deno 2 + Hono + Drizzle ORM + PostgreSQL；Nuxt 4 + Vue 3；noj-tests Deno E2E。
+
+**Spec:** `docs/superpowers/specs/2026-08-17-training-design.md`
+
+## Global Constraints
+
+- 提交必须 GPG 签名；仓库使用 jj：`jj describe -m "..." && jj sign -r @`。
+- 禁止直接推送到 `main`；所有实现通过 PR 合入。
+- 禁止手动修改 `deno.lock` / `Cargo.lock` / `_journal.json`。
+- 中文注释、中文提交描述；代码标识符使用英文。
+- 时间戳统一 ISO 8601 文本；`text` 主键；Drizzle 迁移自动生成。
+- `visibility` 枚举：`private` / `unlisted` / `public`。
+- `position` 在同一题单内唯一；题目删除通过 `ON DELETE CASCADE` 自动清理。
+- 进度：编程题 `Accepted` 或客观题 `score=10000` 视为 AC；匿名不计算。
+- 前台展示他人题单时一律只读；管理员编辑只出现在后台管理页。
+
+---
+
+### Task 1: 新增 trainings 数据模型与迁移
+
+**Files:**
+- Modify: `noj-core/src/db/schema.ts`
+- Create: `noj-core/drizzle/*`（由 `deno task db:generate` 自动生成）
+- Test: `noj-core/tests/00_migrate_test.ts`（现有迁移测试自动覆盖）
+
+**Interfaces:**
+- Consumes: 现有 `users` / `problems` 表。
+- Produces: Drizzle 表对象 `trainings`、`trainingProblems`，供后续 service 使用。
+
+- [ ] **Step 1: 在 schema.ts 中新增两张表**
+
+在 `contestProblems` 定义之后插入：
+
+```ts
+/**
+ * 题单主表（issue #224）。
+ * visibility: private=仅创建者 / unlisted=URL 可访问 / public=出现在题单列表页。
+ */
+export const trainings = pgTable(
+  "trainings",
+  {
+    id: text("id").primaryKey(),
+    title: text("title").notNull(),
+    description: text("description").notNull().default(""),
+    visibility: text("visibility").notNull().default("private"),
+    is_pinned: boolean("is_pinned").notNull().default(false),
+    created_by: text("created_by").notNull().references(() => users.id, {
+      onDelete: "cascade",
+    }),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+  },
+  (table) => ({
+    visibilityCheck: check(
+      "trainings_visibility_check",
+      sql`${table.visibility} IN ('private', 'unlisted', 'public')`,
+    ),
+    visibilityPinnedCreatedIdx: index(
+      "idx_trainings_visibility_pinned_created",
+    ).on(table.visibility, table.is_pinned, table.created_at),
+    createdByIdx: index("idx_trainings_created_by").on(table.created_by),
+  }),
+);
+
+/**
+ * 题单题目关联表。
+ * position 在单个题单内保持唯一；题目删除时级联清理。
+ */
+export const trainingProblems = pgTable(
+  "training_problems",
+  {
+    training_id: text("training_id")
+      .notNull()
+      .references(() => trainings.id, { onDelete: "cascade" }),
+    problem_id: text("problem_id")
+      .notNull()
+      .references(() => problems.id, { onDelete: "cascade" }),
+    position: integer("position").notNull().default(0),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.training_id, table.problem_id] }),
+    positionUnique: unique(
+      "training_problems_training_position_unique",
+    ).on(table.training_id, table.position),
+    trainingPositionIdx: index(
+      "idx_training_problems_training_position",
+    ).on(table.training_id, table.position),
+  }),
+);
+```
+
+- [ ] **Step 2: 生成迁移**
+
+```bash
+cd noj-core && deno task db:generate
+```
+
+Expected: `drizzle/` 下新增一个迁移 SQL，包含 `trainings` / `training_problems` 建表与索引/约束。
+
+- [ ] **Step 3: 运行迁移测试**
+
+```bash
+cd noj-core && deno task test:smoke
+```
+
+Expected: 迁移成功、服务可启动。
+
+- [ ] **Step 4: 提交**
+
+```bash
+jj describe -m "feat(core): 添加 trainings 与 training_problems 数据模型" && jj sign -r @
+```
+
+---
+
+### Task 2: 新增 training 类型定义
+
+**Files:**
+- Create: `noj-core/src/types/trainings.ts`
+
+**Interfaces:**
+- Consumes: 无外部依赖。
+- Produces: `TrainingVisibility`、`CreateTrainingInput`、`UpdateTrainingInput`、`TrainingResponse`、`TrainingProblemResponse`，供 service/route/UI 共用。
+
+- [ ] **Step 1: 创建类型文件**
+
+```ts
+export const TRAINING_VISIBILITIES = ["private", "unlisted", "public"] as const;
+export type TrainingVisibility = typeof TRAINING_VISIBILITIES[number];
+
+export function isValidTrainingVisibility(
+  value: string,
+): value is TrainingVisibility {
+  return TRAINING_VISIBILITIES.includes(value as TrainingVisibility);
+}
+
+export interface CreateTrainingInput {
+  title: string;
+  description?: string;
+  visibility?: TrainingVisibility;
+}
+
+export interface UpdateTrainingInput {
+  title?: string;
+  description?: string;
+  visibility?: TrainingVisibility;
+  is_pinned?: boolean;
+}
+
+export interface TrainingResponse {
+  id: string;
+  title: string;
+  description: string;
+  visibility: TrainingVisibility;
+  is_pinned: boolean;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  problem_count: number;
+}
+
+export interface TrainingProblemResponse {
+  training_id: string;
+  problem_id: string;
+  position: number;
+  title: string;
+  description: string;
+  difficulty: string;
+  display_id: string;
+  type: string;
+  is_objective: boolean;
+  accepted: boolean;
+}
+```
+
+- [ ] **Step 2: 提交**
+
+```bash
+jj describe -m "feat(core): 添加 training 类型定义" && jj sign -r @
+```
+
+---
+
+### Task 3: training service CRUD 与可见性
+
+**Files:**
+- Create: `noj-core/src/services/trainings.ts`
+- Test: `noj-core/tests/services/trainings.test.ts`
+
+**Interfaces:**
+- Consumes: `trainings` / `trainingProblems` / `problems` / `users` 表；`TrainingResponse` 等类型。
+- Produces:
+  - `listPublicTrainings(params): Promise<{ data: TrainingResponse[]; total: number }>`
+  - `listMyTrainings(userId, params): Promise<{ data: TrainingResponse[]; total: number }>`
+  - `listAllTrainings(params): Promise<{ data: TrainingResponse[]; total: number }>`
+  - `listUserTrainings(ownerId, viewerId?, isAdmin?, params?): Promise<{ data: TrainingResponse[]; total: number }>`
+  - `getTraining(id, viewerId?, isAdmin?): Promise<TrainingResponse>`
+  - `createTraining(input, userId): Promise<TrainingResponse>`
+  - `updateTraining(id, input, actorId, isAdmin?): Promise<TrainingResponse>`
+  - `deleteTraining(id, actorId, isAdmin?): Promise<void>`
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `noj-core/tests/services/trainings.test.ts`：
+
+```ts
+import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { problems, trainings, users } from "../../src/db/schema.ts";
+import {
+  createTraining,
+  deleteTraining,
+  getTraining,
+  listAllTrainings,
+  listMyTrainings,
+  listPublicTrainings,
+  listUserTrainings,
+  updateTraining,
+} from "../../src/services/trainings.ts";
+import {
+  ForbiddenError,
+  NotFoundError,
+} from "../../src/lib/errors.ts";
+
+await resetDbForTest();
+
+async function createUser(prefix: string): Promise<string> {
+  const id = crypto.randomUUID();
+  const unique = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+  const now = new Date().toISOString();
+  await getDb().insert(users).values({
+    id,
+    username: `${prefix}-${unique}`,
+    email: `${prefix}-${unique}@example.com`,
+    password_hash: "hash",
+    created_at: now,
+    updated_at: now,
+  });
+  return id;
+}
+
+Deno.test({
+  name: "trainings service: CRUD 与可见性矩阵",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const owner = await createUser("train-owner");
+    const other = await createUser("train-other");
+    const db = getDb();
+
+    const privateTraining = await createTraining(
+      { title: "私有题单", visibility: "private" },
+      owner,
+    );
+    const unlistedTraining = await createTraining(
+      { title: "链接题单", visibility: "unlisted" },
+      owner,
+    );
+    const publicTraining = await createTraining(
+      { title: "公开题单", visibility: "unlisted" },
+      owner,
+    );
+    await updateTraining(publicTraining.id, { visibility: "public" }, owner, true);
+
+    try {
+      assertEquals(privateTraining.visibility, "private");
+      assertEquals(unlistedTraining.visibility, "unlisted");
+
+      await assertRejects(
+        () => getTraining(privateTraining.id, other),
+        NotFoundError,
+      );
+      assertEquals((await getTraining(privateTraining.id, owner)).id, privateTraining.id);
+      assertEquals((await getTraining(privateTraining.id, other, true)).id, privateTraining.id);
+      assertEquals((await getTraining(unlistedTraining.id, other)).id, unlistedTraining.id);
+      assertEquals((await getTraining(publicTraining.id)).id, publicTraining.id);
+
+      const publicList = await listPublicTrainings({ page: 1, perPage: 20 });
+      assertEquals(publicList.data.some((t) => t.id === publicTraining.id), true);
+      assertEquals(publicList.data.some((t) => t.id === unlistedTraining.id), false);
+
+      const mine = await listMyTrainings(owner, { page: 1, perPage: 20 });
+      assertEquals(mine.total, 3);
+
+      const otherView = await listUserTrainings(owner, other);
+      assertEquals(otherView.data.some((t) => t.id === publicTraining.id), true);
+      assertEquals(otherView.data.some((t) => t.id === privateTraining.id), false);
+
+      const ownerView = await listUserTrainings(owner, owner);
+      assertEquals(ownerView.total, 3);
+
+      const all = await listAllTrainings({ page: 1, perPage: 20 });
+      assertEquals(all.data.some((t) => t.id === privateTraining.id), true);
+
+      await assertRejects(
+        () => updateTraining(privateTraining.id, { title: "x" }, other),
+        ForbiddenError,
+      );
+      const updated = await updateTraining(
+        privateTraining.id,
+        { title: "改名" },
+        owner,
+      );
+      assertEquals(updated.title, "改名");
+
+      await deleteTraining(privateTraining.id, owner);
+      await assertRejects(() => getTraining(privateTraining.id, owner), NotFoundError);
+    } finally {
+      await db.delete(trainings).where(eq(trainings.created_by, owner));
+      await db.delete(users).where(eq(users.id, owner));
+      await db.delete(users).where(eq(users.id, other));
+    }
+  },
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+```bash
+cd noj-core && deno test --no-check -A tests/services/trainings.test.ts
+```
+
+Expected: 编译错误 `Cannot find module '../../src/services/trainings.ts'`。
+
+- [ ] **Step 3: 实现 service 基础 CRUD**
+
+创建 `noj-core/src/services/trainings.ts`：
+
+```ts
+import { and, asc, count, desc, eq, sql } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+import { problems, trainingProblems, trainings, users } from "../db/schema.ts";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "../lib/errors.ts";
+import {
+  type CreateTrainingInput,
+  type TrainingResponse,
+  type TrainingVisibility,
+  type UpdateTrainingInput,
+  isValidTrainingVisibility,
+} from "../types/trainings.ts";
+
+export interface ListTrainingsParams {
+  page?: number;
+  perPage?: number;
+}
+
+export interface ListTrainingsResult {
+  data: TrainingResponse[];
+  total: number;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+function normalizePage(params: ListTrainingsParams): {
+  page: number;
+  perPage: number;
+  offset: number;
+} {
+  const page = Math.max(1, params.page ?? 1);
+  const perPage = Math.min(MAX_PAGE_SIZE, Math.max(1, params.perPage ?? DEFAULT_PAGE_SIZE));
+  return { page, perPage, offset: (page - 1) * perPage };
+}
+
+async function countProblems(
+  trainingIds: string[],
+): Promise<Map<string, number>> {
+  if (trainingIds.length === 0) return new Map();
+  const db = getDb();
+  const rows = await db
+    .select({
+      training_id: trainingProblems.training_id,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(trainingProblems)
+    .where(
+      trainingIds.length === 1
+        ? eq(trainingProblems.training_id, trainingIds[0])
+        : sql`${trainingProblems.training_id} in ${trainingIds}`,
+    )
+    .groupBy(trainingProblems.training_id);
+  return new Map(rows.map((r) => [r.training_id, r.count]));
+}
+
+async function toResponse(
+  row: typeof trainings.$inferSelect,
+  problemCount: number,
+): Promise<TrainingResponse> {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    visibility: row.visibility as TrainingVisibility,
+    is_pinned: row.is_pinned,
+    created_by: row.created_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    problem_count: problemCount,
+  };
+}
+
+export async function listPublicTrainings(
+  params: ListTrainingsParams,
+): Promise<ListTrainingsResult> {
+  const db = getDb();
+  const { page, perPage, offset } = normalizePage(params);
+  const where = eq(trainings.visibility, "public");
+  const [rows, totalRows] = await Promise.all([
+    db.select().from(trainings).where(where)
+      .orderBy(desc(trainings.is_pinned), desc(trainings.updated_at))
+      .limit(perPage).offset(offset),
+    db.select({ total: count() }).from(trainings).where(where),
+  ]);
+  const counts = await countProblems(rows.map((r) => r.id));
+  const data = await Promise.all(rows.map((r) => toResponse(r, counts.get(r.id) ?? 0)));
+  return { data, total: totalRows[0]?.total ?? 0 };
+}
+
+export async function listMyTrainings(
+  userId: string,
+  params: ListTrainingsParams,
+): Promise<ListTrainingsResult> {
+  const db = getDb();
+  const { page, perPage, offset } = normalizePage(params);
+  const where = eq(trainings.created_by, userId);
+  const [rows, totalRows] = await Promise.all([
+    db.select().from(trainings).where(where)
+      .orderBy(desc(trainings.updated_at))
+      .limit(perPage).offset(offset),
+    db.select({ total: count() }).from(trainings).where(where),
+  ]);
+  const counts = await countProblems(rows.map((r) => r.id));
+  const data = await Promise.all(rows.map((r) => toResponse(r, counts.get(r.id) ?? 0)));
+  return { data, total: totalRows[0]?.total ?? 0 };
+}
+
+export async function listAllTrainings(
+  params: ListTrainingsParams,
+): Promise<ListTrainingsResult> {
+  const db = getDb();
+  const { page, perPage, offset } = normalizePage(params);
+  const [rows, totalRows] = await Promise.all([
+    db.select().from(trainings)
+      .orderBy(desc(trainings.updated_at))
+      .limit(perPage).offset(offset),
+    db.select({ total: count() }).from(trainings),
+  ]);
+  const counts = await countProblems(rows.map((r) => r.id));
+  const data = await Promise.all(rows.map((r) => toResponse(r, counts.get(r.id) ?? 0)));
+  return { data, total: totalRows[0]?.total ?? 0 };
+}
+
+export async function listUserTrainings(
+  ownerId: string,
+  viewerId?: string,
+  isAdmin = false,
+  params: ListTrainingsParams = {},
+): Promise<ListTrainingsResult> {
+  const db = getDb();
+  const { page, perPage, offset } = normalizePage(params);
+  const isOwner = ownerId === viewerId || isAdmin;
+  const conditions = [eq(trainings.created_by, ownerId)];
+  if (!isOwner) conditions.push(eq(trainings.visibility, "public"));
+  const where = and(...conditions);
+  const [rows, totalRows] = await Promise.all([
+    db.select().from(trainings).where(where)
+      .orderBy(desc(trainings.is_pinned), desc(trainings.updated_at))
+      .limit(perPage).offset(offset),
+    db.select({ total: count() }).from(trainings).where(where),
+  ]);
+  const counts = await countProblems(rows.map((r) => r.id));
+  const data = await Promise.all(rows.map((r) => toResponse(r, counts.get(r.id) ?? 0)));
+  return { data, total: totalRows[0]?.total ?? 0 };
+}
+
+export async function getTraining(
+  id: string,
+  viewerId?: string,
+  isAdmin = false,
+): Promise<TrainingResponse> {
+  const db = getDb();
+  const [row] = await db.select().from(trainings).where(eq(trainings.id, id)).limit(1);
+  if (!row) throw new NotFoundError("题单不存在");
+  if (
+    row.visibility === "private" &&
+    row.created_by !== viewerId &&
+    !isAdmin
+  ) {
+    throw new NotFoundError("题单不存在");
+  }
+  const counts = await countProblems([row.id]);
+  return toResponse(row, counts.get(row.id) ?? 0);
+}
+
+export async function createTraining(
+  input: CreateTrainingInput,
+  userId: string,
+): Promise<TrainingResponse> {
+  const title = input.title?.trim();
+  if (!title || title.length > 100) {
+    throw new BadRequestError("题单标题必须为 1-100 字符");
+  }
+  const visibility = input.visibility ?? "private";
+  if (!isValidTrainingVisibility(visibility) || visibility === "public") {
+    throw new BadRequestError("创建题单时可见性只能为 private 或 unlisted");
+  }
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+  await db.insert(trainings).values({
+    id,
+    title,
+    description: input.description?.trim() ?? "",
+    visibility,
+    is_pinned: false,
+    created_by: userId,
+    created_at: now,
+    updated_at: now,
+  });
+  return getTraining(id, userId);
+}
+
+export async function updateTraining(
+  id: string,
+  input: UpdateTrainingInput,
+  actorId: string,
+  isAdmin = false,
+): Promise<TrainingResponse> {
+  const db = getDb();
+  const [row] = await db.select().from(trainings).where(eq(trainings.id, id)).limit(1);
+  if (!row) throw new NotFoundError("题单不存在");
+  if (row.created_by !== actorId && !isAdmin) {
+    throw new ForbiddenError("无权编辑该题单");
+  }
+  if (input.is_pinned !== undefined && !isAdmin) {
+    throw new ForbiddenError("无权置顶题单");
+  }
+  if (input.visibility === "public" && !isAdmin) {
+    throw new ForbiddenError("无权将题单设为公开");
+  }
+  if (input.visibility !== undefined && !isValidTrainingVisibility(input.visibility)) {
+    throw new BadRequestError("可见性不合法");
+  }
+  if (input.title !== undefined) {
+    const title = input.title.trim();
+    if (!title || title.length > 100) throw new BadRequestError("题单标题必须为 1-100 字符");
+  }
+  const next = {
+    ...(input.title !== undefined ? { title: input.title.trim() } : {}),
+    ...(input.description !== undefined ? { description: input.description.trim() } : {}),
+    ...(input.visibility !== undefined ? { visibility: input.visibility } : {}),
+    ...(input.is_pinned !== undefined ? { is_pinned: input.is_pinned } : {}),
+    updated_at: new Date().toISOString(),
+  };
+  await db.update(trainings).set(next).where(eq(trainings.id, id));
+  return getTraining(id, actorId, isAdmin);
+}
+
+export async function deleteTraining(
+  id: string,
+  actorId: string,
+  isAdmin = false,
+): Promise<void> {
+  const db = getDb();
+  const [row] = await db.select().from(trainings).where(eq(trainings.id, id)).limit(1);
+  if (!row) throw new NotFoundError("题单不存在");
+  if (row.created_by !== actorId && !isAdmin) {
+    throw new ForbiddenError("无权删除该题单");
+  }
+  await db.delete(trainings).where(eq(trainings.id, id));
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+```bash
+cd noj-core && deno test --no-check -A tests/services/trainings.test.ts
+```
+
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+jj describe -m "feat(core): 实现题单 CRUD 与可见性服务" && jj sign -r @
+```
+
+---
+
+### Task 4: training service 题目管理与进度聚合
+
+**Files:**
+- Modify: `noj-core/src/services/trainings.ts`
+- Test: `noj-core/tests/services/trainings.test.ts`（追加）
+
+**Interfaces:**
+- Consumes: `trainingProblems` / `problems` / `submissions` / `evaluationResults` / `objectiveSubmissions` 表；`TrainingProblemResponse` 类型。
+- Produces:
+  - `listTrainingProblems(trainingId, viewerId?, isAdmin?): Promise<TrainingProblemResponse[]>`
+  - `addTrainingProblem(trainingId, problemId, position?, actorId, isAdmin?): Promise<TrainingProblemResponse>`
+  - `reorderTrainingProblems(trainingId, problems, actorId, isAdmin?): Promise<TrainingProblemResponse[]>`
+  - `removeTrainingProblem(trainingId, problemId, actorId, isAdmin?): Promise<void>`
+
+- [ ] **Step 1: 追加失败测试**
+
+在 `noj-core/tests/services/trainings.test.ts` 末尾追加：
+
+```ts
+import { objectiveSubmissions, submissions, evaluationResults } from "../../src/db/schema.ts";
+
+Deno.test({
+  name: "trainings service: 题目增删排序与进度聚合",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const owner = await createUser("train-problem-owner");
+    const solver = await createUser("train-solver");
+    const db = getDb();
+    const now = new Date().toISOString();
+
+    async function createProblem(number: number, isObjective = false): Promise<string> {
+      const id = crypto.randomUUID();
+      await db.insert(problems).values({
+        id,
+        title: `题单测试题 ${number}`,
+        description: "测试题面",
+        difficulty: "easy",
+        runtime_config: isObjective ? null : {},
+        number,
+        owner_id: "0",
+        type: "P",
+        is_objective: isObjective,
+        created_at: now,
+        updated_at: now,
+      });
+      return id;
+    }
+
+    const training = await createTraining({ title: "进度题单" }, owner);
+    const p1 = await createProblem(940001);
+    const p2 = await createProblem(940002);
+    const objective = await createProblem(940003, true);
+
+    try {
+      await addTrainingProblem(training.id, p2, undefined, owner);
+      await addTrainingProblem(training.id, p1, 0, owner);
+      let problemsList = await listTrainingProblems(training.id, solver);
+      assertEquals(problemsList.map((p) => p.problem_id), [p1, p2]);
+      assertEquals(problemsList.every((p) => p.accepted === false), true);
+
+      await addTrainingProblem(training.id, objective, 2, owner);
+      await db.insert(submissions).values({
+        id: crypto.randomUUID(),
+        user_id: solver,
+        problem_id: p1,
+        status: "finished",
+        language: "python3",
+        code: "print(1)",
+        created_at: now,
+      });
+      const subId = crypto.randomUUID();
+      await db.insert(submissions).values({
+        id: subId,
+        user_id: solver,
+        problem_id: p1,
+        status: "finished",
+        language: "python3",
+        code: "print(1)",
+        created_at: now,
+      });
+      await db.insert(evaluationResults).values({
+        id: crypto.randomUUID(),
+        submission_id: subId,
+        status: "Accepted",
+        score: 10000,
+        output: "",
+        time_ms: 1,
+        memory_kb: 1,
+      });
+      await db.insert(objectiveSubmissions).values({
+        id: crypto.randomUUID(),
+        paper_id: objective,
+        user_id: solver,
+        submission_type: "practice",
+        answers: {},
+        status: "finished",
+        score: 10000,
+        details: {},
+        created_at: now,
+      });
+
+      problemsList = await listTrainingProblems(training.id, solver);
+      assertEquals(problemsList.find((p) => p.problem_id === p1)?.accepted, true);
+      assertEquals(problemsList.find((p) => p.problem_id === objective)?.accepted, true);
+      assertEquals(problemsList.find((p) => p.problem_id === p2)?.accepted, false);
+
+      await reorderTrainingProblems(
+        training.id,
+        [
+          { problem_id: objective, position: 0 },
+          { problem_id: p1, position: 1 },
+          { problem_id: p2, position: 2 },
+        ],
+        owner,
+      );
+      problemsList = await listTrainingProblems(training.id, owner);
+      assertEquals(problemsList.map((p) => p.problem_id), [objective, p1, p2]);
+
+      await removeTrainingProblem(training.id, p2, owner);
+      assertEquals((await listTrainingProblems(training.id, owner)).length, 2);
+
+      await assertRejects(
+        () => addTrainingProblem(training.id, p1, undefined, owner),
+        ConflictError,
+      );
+    } finally {
+      await db.delete(trainings).where(eq(trainings.id, training.id));
+      await db.delete(users).where(eq(users.id, owner));
+      await db.delete(users).where(eq(users.id, solver));
+    }
+  },
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+```bash
+cd noj-core && deno test --no-check -A tests/services/trainings.test.ts
+```
+
+Expected: 编译错误（`addTrainingProblem` 等未定义）。
+
+- [ ] **Step 3: 在 service 中追加实现**
+
+在 `noj-core/src/services/trainings.ts` 追加：
+
+```ts
+import { gte, inArray } from "drizzle-orm";
+import { evaluationResults, objectiveSubmissions, submissions } from "../db/schema.ts";
+import type { TrainingProblemResponse } from "../types/trainings.ts";
+
+async function assertWritable(
+  trainingId: string,
+  actorId: string,
+  isAdmin: boolean,
+): Promise<typeof trainings.$inferSelect> {
+  const db = getDb();
+  const [row] = await db.select().from(trainings).where(eq(trainings.id, trainingId)).limit(1);
+  if (!row) throw new NotFoundError("题单不存在");
+  if (row.created_by !== actorId && !isAdmin) {
+    throw new ForbiddenError("无权编辑该题单");
+  }
+  return row;
+}
+
+async function getAcceptedProblemIds(
+  userId: string,
+  problemIds: string[],
+): Promise<Set<string>> {
+  if (problemIds.length === 0) return new Set();
+  const db = getDb();
+  const acceptedRows = await db
+    .select({ problem_id: submissions.problem_id })
+    .from(submissions)
+    .innerJoin(evaluationResults, eq(evaluationResults.submission_id, submissions.id))
+    .where(and(
+      eq(submissions.user_id, userId),
+      inArray(submissions.problem_id, problemIds),
+      eq(evaluationResults.status, "Accepted"),
+    ));
+  const objectiveRows = await db
+    .select({ paper_id: objectiveSubmissions.paper_id })
+    .from(objectiveSubmissions)
+    .where(and(
+      eq(objectiveSubmissions.user_id, userId),
+      inArray(objectiveSubmissions.paper_id, problemIds),
+      eq(objectiveSubmissions.score, 10000),
+    ));
+  return new Set([
+    ...acceptedRows.map((r) => r.problem_id),
+    ...objectiveRows.map((r) => r.paper_id),
+  ]);
+}
+
+export async function listTrainingProblems(
+  trainingId: string,
+  viewerId?: string,
+  isAdmin = false,
+): Promise<TrainingProblemResponse[]> {
+  await getTraining(trainingId, viewerId, isAdmin);
+  const db = getDb();
+  const rows = await db
+    .select({
+      training_id: trainingProblems.training_id,
+      problem_id: trainingProblems.problem_id,
+      position: trainingProblems.position,
+      title: problems.title,
+      description: problems.description,
+      difficulty: problems.difficulty,
+      display_id: sql<string>`${problems.type} || ${problems.number}`,
+      type: problems.type,
+      is_objective: problems.is_objective,
+    })
+    .from(trainingProblems)
+    .innerJoin(problems, eq(trainingProblems.problem_id, problems.id))
+    .where(eq(trainingProblems.training_id, trainingId))
+    .orderBy(asc(trainingProblems.position));
+  const accepted = viewerId
+    ? await getAcceptedProblemIds(viewerId, rows.map((r) => r.problem_id))
+    : new Set<string>();
+  return rows.map((r) => ({ ...r, accepted: accepted.has(r.problem_id) }));
+}
+
+export async function addTrainingProblem(
+  trainingId: string,
+  problemId: string,
+  position: number | undefined,
+  actorId: string,
+  isAdmin = false,
+): Promise<TrainingProblemResponse> {
+  await assertWritable(trainingId, actorId, isAdmin);
+  const db = getDb();
+  const [problem] = await db.select().from(problems).where(eq(problems.id, problemId)).limit(1);
+  if (!problem) throw new NotFoundError("题目不存在");
+  const [existing] = await db
+    .select()
+    .from(trainingProblems)
+    .where(and(
+      eq(trainingProblems.training_id, trainingId),
+      eq(trainingProblems.problem_id, problemId),
+    ))
+    .limit(1);
+  if (existing) throw new ConflictError("该题目已在题单中");
+  if (position !== undefined && position < 0) {
+    throw new BadRequestError("position 不能为负数");
+  }
+
+  const nextPosition = await db.transaction(async (tx) => {
+    let target = position;
+    if (target === undefined) {
+      const [maxRow] = await tx
+        .select({ max: sql<number>`coalesce(max(${trainingProblems.position}), -1)` })
+        .from(trainingProblems)
+        .where(eq(trainingProblems.training_id, trainingId));
+      target = (maxRow?.max ?? -1) + 1;
+    } else {
+      await tx
+        .update(trainingProblems)
+        .set({ position: sql`${trainingProblems.position} + 1` })
+        .where(and(
+          eq(trainingProblems.training_id, trainingId),
+          gte(trainingProblems.position, target),
+        ));
+    }
+    await tx.insert(trainingProblems).values({
+      training_id: trainingId,
+      problem_id: problemId,
+      position: target,
+    });
+    return target;
+  });
+
+  return {
+    training_id: trainingId,
+    problem_id: problemId,
+    position: nextPosition,
+    title: problem.title,
+    description: problem.description,
+    difficulty: problem.difficulty,
+    display_id: `${problem.type}${problem.number}`,
+    type: problem.type,
+    is_objective: problem.is_objective,
+    accepted: false,
+  };
+}
+
+export async function reorderTrainingProblems(
+  trainingId: string,
+  problemsInput: { problem_id: string; position: number }[],
+  actorId: string,
+  isAdmin = false,
+): Promise<TrainingProblemResponse[]> {
+  await assertWritable(trainingId, actorId, isAdmin);
+  const db = getDb();
+  const existing = await db
+    .select({ problem_id: trainingProblems.problem_id })
+    .from(trainingProblems)
+    .where(eq(trainingProblems.training_id, trainingId));
+  const existingIds = new Set(existing.map((r) => r.problem_id));
+  const inputIds = new Set(problemsInput.map((r) => r.problem_id));
+  if (
+    existingIds.size !== inputIds.size ||
+    [...existingIds].some((id) => !inputIds.has(id))
+  ) {
+    throw new BadRequestError("重排必须包含题单当前全部题目");
+  }
+  const positions = new Set(problemsInput.map((r) => r.position));
+  if (positions.size !== problemsInput.length) {
+    throw new BadRequestError("position 不能重复");
+  }
+  if (problemsInput.some((r) => r.position < 0)) {
+    throw new BadRequestError("position 不能为负数");
+  }
+
+  await db.transaction(async (tx) => {
+    await tx.delete(trainingProblems).where(eq(trainingProblems.training_id, trainingId));
+    await tx.insert(trainingProblems).values(
+      problemsInput.map((r) => ({
+        training_id: trainingId,
+        problem_id: r.problem_id,
+        position: r.position,
+      })),
+    );
+  });
+  return listTrainingProblems(trainingId, actorId, isAdmin);
+}
+
+export async function removeTrainingProblem(
+  trainingId: string,
+  problemId: string,
+  actorId: string,
+  isAdmin = false,
+): Promise<void> {
+  await assertWritable(trainingId, actorId, isAdmin);
+  const db = getDb();
+  await db.delete(trainingProblems).where(and(
+    eq(trainingProblems.training_id, trainingId),
+    eq(trainingProblems.problem_id, problemId),
+  ));
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+```bash
+cd noj-core && deno test --no-check -A tests/services/trainings.test.ts
+```
+
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+jj describe -m "feat(core): 实现题单题目管理、排序与 AC 进度聚合" && jj sign -r @
+```
+
+---
+
+### Task 5: 注册 training RBAC 权限
+
+**Files:**
+- Modify: `noj-core/src/types/index.ts`
+- Modify: `noj-core/src/services/seed-rbac.ts`
+- Test: `noj-core/tests/services/rbac.test.ts`（追加断言）
+
+**Interfaces:**
+- Consumes: `PERMISSION_DEFS` / `USER_DEFAULT_PERMISSIONS`。
+- Produces: 新权限 `training:*` 进入 `permissions` 表；user 默认角色获得 4 项权限。
+
+- [ ] **Step 1: 在 PERMISSION_DEFS 增加 9 项**
+
+在 `noj-core/src/types/index.ts` 的 `// 公告` 之前插入：
+
+```ts
+  // 题单（training）
+  { resource: "training", action: "create", description: "创建题单" },
+  { resource: "training", action: "read", description: "查看题单" },
+  { resource: "training", action: "read_any", description: "查看任意题单" },
+  { resource: "training", action: "write_own", description: "编辑自己的题单" },
+  { resource: "training", action: "write_any", description: "编辑任意题单" },
+  { resource: "training", action: "delete_own", description: "删除自己的题单" },
+  { resource: "training", action: "delete_any", description: "删除任意题单" },
+  { resource: "training", action: "publish", description: "将题单设为公开" },
+  { resource: "training", action: "pin", description: "置顶题单" },
+```
+
+- [ ] **Step 2: 在 USER_DEFAULT_PERMISSIONS 增加 4 项**
+
+在 `noj-core/src/services/seed-rbac.ts` 的 `USER_DEFAULT_PERMISSIONS` 中追加：
+
+```ts
+  { resource: "training", action: "create" },
+  { resource: "training", action: "read" },
+  { resource: "training", action: "write_own" },
+  { resource: "training", action: "delete_own" },
+```
+
+- [ ] **Step 3: 追加 RBAC 种子测试**
+
+在 `noj-core/tests/services/rbac.test.ts` 中追加或新建 `noj-core/tests/services/rbac-training.test.ts`：
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { permissions, rolePermissions, roles, userRoles, users } from "../../src/db/schema.ts";
+import { ensureRbacSeeds } from "../../src/services/seed-rbac.ts";
+
+await resetDbForTest();
+
+Deno.test({
+  name: "rbac: training 权限默认授权",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    await ensureRbacSeeds();
+
+    const defs = await db.select().from(permissions).where(
+      // 用 sql 简化为 in 查询
+      // 这里用循环断言更清晰
+    );
+    const trainingDefs = defs.filter((p) => p.resource === "training");
+    assertEquals(trainingDefs.length, 9);
+
+    const userRole = await db.select().from(roles).where(roles.name.eq("user")).limit(1);
+    const userRoleId = userRole[0].id;
+    const granted = await db
+      .select({ resource: permissions.resource, action: permissions.action })
+      .from(rolePermissions)
+      .innerJoin(permissions, eq(rolePermissions.permission_id, permissions.id))
+      .where(eq(rolePermissions.role_id, userRoleId));
+    const trainingGranted = granted.filter((p) => p.resource === "training").map((p) => p.action).sort();
+    assertEquals(trainingGranted, ["create", "delete_own", "read", "write_own"]);
+    assertEquals(granted.some((p) => p.resource === "training" && p.action === "publish"), false);
+    assertEquals(granted.some((p) => p.resource === "training" && p.action === "pin"), false);
+  },
+});
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+```bash
+cd noj-core && deno test --no-check -A tests/services/rbac-training.test.ts
+```
+
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+jj describe -m "feat(core): 注册 training RBAC 权限与默认授权" && jj sign -r @
+```
+
+---
+
+### Task 6: 用户侧 trainings 路由
+
+**Files:**
+- Create: `noj-core/src/routes/trainings.ts`
+- Modify: `noj-core/src/app.ts`
+- Test: `noj-core/tests/routes/trainings.test.ts`
+
+**Interfaces:**
+- Consumes: `trainings` service 全部函数；`authMiddleware` / `optionalAuthMiddleware` / `checkPermission` / `assertPermission`。
+- Produces: `/api/v1/trainings` 路由，挂载到 app。
+
+- [ ] **Step 1: 写路由测试**
+
+创建 `noj-core/tests/routes/trainings.test.ts`（参考 `contests.test.ts` 的 helper 用法）：
+
+```ts
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { createApp } from "../../src/app.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { problems, trainings, userRoles, users } from "../../src/db/schema.ts";
+import { signToken } from "../../src/lib/jwt.ts";
+import { initRedisForTest, jsonRequest } from "../lib/helper.ts";
+
+await resetDbForTest();
+await initRedisForTest();
+
+Deno.test({
+  name: "trainings routes: 公开列表、mine、CRUD、题目管理",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    const userId = crypto.randomUUID();
+    const adminId = crypto.randomUUID();
+    const problemId = crypto.randomUUID();
+    const unique = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+    const now = new Date().toISOString();
+    const app = createApp();
+
+    await db.insert(users).values([
+      { id: userId, username: `train-user-${unique}`, email: `train-user-${unique}@example.com`, password_hash: "hash", created_at: now, updated_at: now },
+      { id: adminId, username: `train-admin-${unique}`, email: `train-admin-${unique}@example.com`, password_hash: "hash", created_at: now, updated_at: now },
+    ]);
+    await db.insert(userRoles).values({
+      user_id: adminId,
+      role_id: "admin",
+    }).onConflictDoNothing();
+    await db.insert(problems).values({
+      id: problemId,
+      title: "路由题单测试题",
+      description: "测试题面",
+      difficulty: "easy",
+      runtime_config: {},
+      number: 950001,
+      owner_id: adminId,
+      type: "P",
+      created_at: now,
+      updated_at: now,
+    });
+
+    const userToken = await signToken({ sub: userId, role: "user" });
+    const adminToken = await signToken({ sub: adminId, role: "admin" });
+    let trainingId: string | undefined;
+
+    try {
+      const createRes = await jsonRequest(app, "/api/v1/trainings", {
+        method: "POST",
+        token: userToken,
+        body: { title: "我的题单", visibility: "private" },
+      });
+      assertEquals(createRes.status, 201);
+      trainingId = (await createRes.json()).data.id;
+      assertExists(trainingId);
+
+      const publicRes = await jsonRequest(app, "/api/v1/trainings", {
+        method: "POST",
+        token: adminToken,
+        body: { title: "公开题单", visibility: "unlisted" },
+      });
+      const publicTrainingId = (await publicRes.json()).data.id;
+      const publishRes = await jsonRequest(app, `/api/v1/trainings/${publicTrainingId}`, {
+        method: "PUT",
+        token: adminToken,
+        body: { visibility: "public" },
+      });
+      assertEquals(publishRes.status, 200);
+
+      const listRes = await jsonRequest(app, "/api/v1/trainings");
+      const listBody = await listRes.json();
+      assertEquals(listBody.data.some((t: { id: string }) => t.id === publicTrainingId), true);
+      assertEquals(listBody.data.some((t: { id: string }) => t.id === trainingId), false);
+
+      const mineRes = await jsonRequest(app, "/api/v1/trainings/mine", { token: userToken });
+      assertEquals(mineRes.status, 200);
+
+      const profileRes = await jsonRequest(
+        app,
+        `/api/v1/trainings?created_by=${userId}`,
+      );
+      const profileBody = await profileRes.json();
+      assertEquals(profileBody.data.length, 0);
+
+      const addRes = await jsonRequest(app, `/api/v1/trainings/${trainingId}/problems`, {
+        method: "POST",
+        token: userToken,
+        body: { problem_id: problemId },
+      });
+      assertEquals(addRes.status, 201);
+
+      const problemsRes = await jsonRequest(app, `/api/v1/trainings/${trainingId}/problems`, {
+        token: userToken,
+      });
+      assertEquals((await problemsRes.json()).data.length, 1);
+
+      const forbiddenPublish = await jsonRequest(app, `/api/v1/trainings/${trainingId}`, {
+        method: "PUT",
+        token: userToken,
+        body: { visibility: "public" },
+      });
+      assertEquals(forbiddenPublish.status, 403);
+    } finally {
+      if (trainingId) await db.delete(trainings).where(eq(trainings.id, trainingId));
+      await db.delete(problems).where(eq(problems.id, problemId));
+      await db.delete(users).where(eq(users.id, userId));
+      await db.delete(users).where(eq(users.id, adminId));
+    }
+  },
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+```bash
+cd noj-core && deno test --no-check -A tests/routes/trainings.test.ts
+```
+
+Expected: 404/编译错误（路由未注册）。
+
+- [ ] **Step 3: 实现用户路由**
+
+创建 `noj-core/src/routes/trainings.ts`：
+
+```ts
+import { Hono } from "hono";
+import { authMiddleware, optionalAuthMiddleware } from "../middleware/auth.ts";
+import { parseJsonBody } from "../lib/request.ts";
+import { parsePagination } from "../lib/pagination.ts";
+import { assertPermission, checkPermission } from "../lib/permissions.ts";
+import { BadRequestError, ForbiddenError } from "../lib/errors.ts";
+import {
+  addTrainingProblem,
+  createTraining,
+  deleteTraining,
+  getTraining,
+  listMyTrainings,
+  listPublicTrainings,
+  listTrainingProblems,
+  listUserTrainings,
+  removeTrainingProblem,
+  reorderTrainingProblems,
+  updateTraining,
+} from "../services/trainings.ts";
+import type { CreateTrainingInput, UpdateTrainingInput } from "../types/trainings.ts";
+import { isValidTrainingVisibility } from "../types/trainings.ts";
+
+const router = new Hono<{ Variables: { userId: string; userRole: string } }>();
+
+router.get("/", optionalAuthMiddleware, async (c) => {
+  const { page, perPage } = parsePagination(c);
+  const createdBy = c.req.query("created_by");
+  if (createdBy) {
+    const viewerId = c.get("userId") as string | undefined;
+    const isAdmin = viewerId
+      ? await checkPermission(c, "training:read_any")
+      : false;
+    const result = await listUserTrainings(createdBy, viewerId, isAdmin, {
+      page,
+      perPage,
+    });
+    return c.json({ data: result.data, total: result.total, page, per_page: perPage });
+  }
+  const result = await listPublicTrainings({ page, perPage });
+  return c.json({ data: result.data, total: result.total, page, per_page: perPage });
+});
+
+router.get("/mine", authMiddleware, async (c) => {
+  const { page, perPage } = parsePagination(c);
+  const result = await listMyTrainings(c.get("userId"), { page, perPage });
+  return c.json({ data: result.data, total: result.total, page, per_page: perPage });
+});
+
+router.post("/", authMiddleware, async (c) => {
+  await assertPermission(c, "training:create");
+  const body = await parseJsonBody<CreateTrainingInput>(c);
+  const training = await createTraining(body, c.get("userId"));
+  return c.json({ data: training }, 201);
+});
+
+router.get("/:id", optionalAuthMiddleware, async (c) => {
+  const viewerId = c.get("userId") as string | undefined;
+  const isAdmin = viewerId
+    ? await checkPermission(c, "training:read_any")
+    : false;
+  const training = await getTraining(c.req.param("id") as string, viewerId, isAdmin);
+  return c.json({ data: training });
+});
+
+router.put("/:id", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:write_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  const isOwner = training.created_by === actorId;
+  await assertPermission(c, isOwner ? "training:write_own" : "training:write_any");
+
+  const body = await parseJsonBody<UpdateTrainingInput>(c);
+  if (body.visibility === "public") {
+    await assertPermission(c, "training:publish");
+  }
+  if (body.is_pinned !== undefined) {
+    await assertPermission(c, "training:pin");
+  }
+  const updated = await updateTraining(id, body, actorId, isAdmin);
+  return c.json({ data: updated });
+});
+
+router.delete("/:id", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:delete_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  const isOwner = training.created_by === actorId;
+  await assertPermission(c, isOwner ? "training:delete_own" : "training:delete_any");
+  await deleteTraining(id, actorId, isAdmin);
+  return c.body(null, 204);
+});
+
+router.get("/:id/problems", optionalAuthMiddleware, async (c) => {
+  const viewerId = c.get("userId") as string | undefined;
+  const isAdmin = viewerId ? await checkPermission(c, "training:read_any") : false;
+  const data = await listTrainingProblems(c.req.param("id") as string, viewerId, isAdmin);
+  return c.json({ data });
+});
+
+router.post("/:id/problems", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:write_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  await assertPermission(c, training.created_by === actorId ? "training:write_own" : "training:write_any");
+  const body = await parseJsonBody<{ problem_id: string; position?: number }>(c);
+  if (!body.problem_id) throw new BadRequestError("缺少 problem_id");
+  const data = await addTrainingProblem(id, body.problem_id, body.position, actorId, isAdmin);
+  return c.json({ data }, 201);
+});
+
+router.put("/:id/problems", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:write_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  await assertPermission(c, training.created_by === actorId ? "training:write_own" : "training:write_any");
+  const body = await parseJsonBody<{ problems: { problem_id: string; position: number }[] }>(c);
+  if (!Array.isArray(body.problems)) throw new BadRequestError("problems 必须是数组");
+  const data = await reorderTrainingProblems(id, body.problems, actorId, isAdmin);
+  return c.json({ data });
+});
+
+router.delete("/:id/problems/:problemId", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const problemId = c.req.param("problemId") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:write_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  await assertPermission(c, training.created_by === actorId ? "training:write_own" : "training:write_any");
+  await removeTrainingProblem(id, problemId, actorId, isAdmin);
+  return c.body(null, 204);
+});
+
+export default router;
+```
+
+- [ ] **Step 4: 挂载路由**
+
+在 `noj-core/src/app.ts` 中 import 并挂载：
+
+```ts
+import trainings from "./routes/trainings.ts";
+// ...
+app.route("/api/v1/trainings", trainings);
+```
+
+放在 `app.route("/api/v1/contests", contests);` 之后。
+
+- [ ] **Step 5: 运行测试确认通过**
+
+```bash
+cd noj-core && deno test --no-check -A tests/routes/trainings.test.ts
+```
+
+Expected: PASS。
+
+- [ ] **Step 6: 提交**
+
+```bash
+jj describe -m "feat(core): 添加用户侧 trainings API" && jj sign -r @
+```
+
+---
+
+### Task 7: 管理员后台 trainings 路由
+
+**Files:**
+- Create: `noj-core/src/routes/admin-trainings.ts`
+- Modify: `noj-core/src/app.ts`
+- Test: `noj-core/tests/routes/admin-trainings.test.ts`
+
+**Interfaces:**
+- Consumes: `listMyTrainings` 之外的 service 全部函数；`authMiddleware` / `assertPermission` / `runWithContext`。
+- Produces: `/api/v1/admin/trainings` 路由。
+
+- [ ] **Step 1: 写路由测试**
+
+创建 `noj-core/tests/routes/admin-trainings.test.ts`：
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { createApp } from "../../src/app.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { trainings, users, userRoles } from "../../src/db/schema.ts";
+import { signToken } from "../../src/lib/jwt.ts";
+import { initRedisForTest, jsonRequest } from "../lib/helper.ts";
+
+await resetDbForTest();
+await initRedisForTest();
+
+Deno.test({
+  name: "admin trainings routes: 列表、设 public、置顶、删除",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    const adminId = crypto.randomUUID();
+    const userId = crypto.randomUUID();
+    const unique = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+    const now = new Date().toISOString();
+    const app = createApp();
+
+    await db.insert(users).values([
+      { id: adminId, username: `admin-train-${unique}`, email: `admin-train-${unique}@example.com`, password_hash: "hash", created_at: now, updated_at: now },
+      { id: userId, username: `user-train-${unique}`, email: `user-train-${unique}@example.com`, password_hash: "hash", created_at: now, updated_at: now },
+    ]);
+    await db.insert(userRoles).values({ user_id: adminId, role_id: "admin" }).onConflictDoNothing();
+    const adminToken = await signToken({ sub: adminId, role: "admin" });
+    const userToken = await signToken({ sub: userId, role: "user" });
+
+    let trainingId: string | undefined;
+    try {
+      const createRes = await jsonRequest(app, "/api/v1/trainings", {
+        method: "POST",
+        token: userToken,
+        body: { title: "待管理题单", visibility: "unlisted" },
+      });
+      trainingId = (await createRes.json()).data.id;
+
+      const forbidden = await jsonRequest(app, `/api/v1/admin/trainings/${trainingId}`, {
+        method: "PATCH",
+        token: userToken,
+        body: { visibility: "public" },
+      });
+      assertEquals(forbidden.status, 403);
+
+      const patch = await jsonRequest(app, `/api/v1/admin/trainings/${trainingId}`, {
+        method: "PATCH",
+        token: adminToken,
+        body: { visibility: "public", is_pinned: true },
+      });
+      assertEquals(patch.status, 200);
+      const patched = await patch.json();
+      assertEquals(patched.data.visibility, "public");
+      assertEquals(patched.data.is_pinned, true);
+
+      const list = await jsonRequest(app, "/api/v1/admin/trainings", { token: adminToken });
+      assertEquals(list.status, 200);
+    } finally {
+      if (trainingId) await db.delete(trainings).where(eq(trainings.id, trainingId));
+      await db.delete(users).where(eq(users.id, userId));
+      await db.delete(users).where(eq(users.id, adminId));
+    }
+  },
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+```bash
+cd noj-core && deno test --no-check -A tests/routes/admin-trainings.test.ts
+```
+
+Expected: 404（路由未注册）。
+
+- [ ] **Step 3: 实现管理员路由**
+
+创建 `noj-core/src/routes/admin-trainings.ts`：
+
+```ts
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth.ts";
+import { parseJsonBody } from "../lib/request.ts";
+import { parsePagination } from "../lib/pagination.ts";
+import { assertPermission } from "../lib/permissions.ts";
+import { runWithContext } from "../lib/requestContext.ts";
+import { getClientIp } from "../lib/rate-limit-env.ts";
+import {
+  deleteTraining,
+  getTraining,
+  listAllTrainings,
+  updateTraining,
+} from "../services/trainings.ts";
+import type { UpdateTrainingInput } from "../types/trainings.ts";
+
+const router = new Hono<{ Variables: { userId: string; userRole: string } }>();
+
+router.use("*", authMiddleware, async (c, next) => {
+  await assertPermission(c, "training:read_any");
+  return runWithContext(
+    {
+      actorId: c.get("userId"),
+      actorIp: getClientIp(c),
+      actorRole: c.get("userRole"),
+    },
+    () => next(),
+  );
+});
+
+router.get("/", async (c) => {
+  const { page, perPage } = parsePagination(c);
+  const result = await listAllTrainings({ page, perPage });
+  return c.json({ data: result.data, total: result.total, page, per_page: perPage });
+});
+
+router.patch("/:id", async (c) => {
+  const id = c.req.param("id") as string;
+  const body = await parseJsonBody<UpdateTrainingInput>(c);
+  if (body.visibility === "public") {
+    await assertPermission(c, "training:publish");
+  }
+  if (body.is_pinned !== undefined) {
+    await assertPermission(c, "training:pin");
+  }
+  const updated = await updateTraining(id, body, c.get("userId"), true);
+  return c.json({ data: updated });
+});
+
+router.delete("/:id", async (c) => {
+  await assertPermission(c, "training:delete_any");
+  const id = c.req.param("id") as string;
+  await deleteTraining(id, c.get("userId"), true);
+  return c.body(null, 204);
+});
+
+export default router;
+```
+
+- [ ] **Step 4: 挂载路由**
+
+在 `noj-core/src/app.ts` 中：
+
+```ts
+import adminTrainings from "./routes/admin-trainings.ts";
+// ...
+app.route("/api/v1/admin/trainings", adminTrainings);
+```
+
+放在 `app.route("/api/v1/admin/announcements", adminAnnouncements);` 之后。
+
+- [ ] **Step 5: 运行测试确认通过**
+
+```bash
+cd noj-core && deno test --no-check -A tests/routes/admin-trainings.test.ts
+```
+
+Expected: PASS。
+
+- [ ] **Step 6: 提交**
+
+```bash
+jj describe -m "feat(core): 添加管理员后台 trainings API" && jj sign -r @
+```
+
+---
+
+### Task 8: 前端 useTrainings composable
+
+**Files:**
+- Create: `noj-ui/composables/useTrainings.ts`
+
+**Interfaces:**
+- Consumes: `useApi()`。
+- Produces: `useTrainings()` 返回题单 CRUD / 题目管理方法，供页面使用。
+
+- [ ] **Step 1: 创建 composable**
+
+```ts
+import type { Training, TrainingProblem, TrainingPayload, TrainingVisibility } from '~/types/training'
+
+export interface Pagination {
+  page: number
+  per_page: number
+  total: number
+}
+
+export function useTrainings() {
+  const { api } = useApi()
+
+  function listPublic(query?: { page?: number; per_page?: number }) {
+    return api.get<{ data: Training[]; total: number }>('/api/v1/trainings', { query, silent: true })
+  }
+
+  function listMine(query?: { page?: number; per_page?: number }) {
+    return api.get<{ data: Training[]; total: number }>('/api/v1/trainings/mine', { query, silent: true })
+  }
+
+  function getTraining(id: string) {
+    return api.get<{ data: Training }>(`/api/v1/trainings/${id}`, { silent: true })
+  }
+
+  function createTraining(body: TrainingPayload) {
+    return api.post<{ data: Training }>('/api/v1/trainings', body)
+  }
+
+  function updateTraining(id: string, body: Partial<TrainingPayload>) {
+    return api.put<{ data: Training }>(`/api/v1/trainings/${id}`, body)
+  }
+
+  function deleteTraining(id: string) {
+    return api.delete<void>(`/api/v1/trainings/${id}`)
+  }
+
+  function listTrainingProblems(id: string) {
+    return api.get<{ data: TrainingProblem[] }>(`/api/v1/trainings/${id}/problems`, { silent: true })
+  }
+
+  function addProblem(id: string, problemId: string, position?: number) {
+    return api.post<{ data: TrainingProblem }>(`/api/v1/trainings/${id}/problems`, { problem_id: problemId, position })
+  }
+
+  function reorderProblems(id: string, problems: { problem_id: string; position: number }[]) {
+    return api.put<{ data: TrainingProblem[] }>(`/api/v1/trainings/${id}/problems`, { problems })
+  }
+
+  function removeProblem(id: string, problemId: string) {
+    return api.delete<void>(`/api/v1/trainings/${id}/problems/${problemId}`)
+  }
+
+  function adminUpdateTraining(id: string, body: Partial<TrainingPayload & { is_pinned?: boolean }>) {
+    return api.patch<{ data: Training }>(`/api/v1/admin/trainings/${id}`, body)
+  }
+
+  function adminListTrainings(query?: { page?: number; per_page?: number }) {
+    return api.get<{ data: Training[]; total: number }>('/api/v1/admin/trainings', { query, silent: true })
+  }
+
+  function adminDeleteTraining(id: string) {
+    return api.delete<void>(`/api/v1/admin/trainings/${id}`)
+  }
+
+  return {
+    listPublic,
+    listMine,
+    getTraining,
+    createTraining,
+    updateTraining,
+    deleteTraining,
+    listTrainingProblems,
+    addProblem,
+    reorderProblems,
+    removeProblem,
+    adminUpdateTraining,
+    adminListTrainings,
+    adminDeleteTraining,
+  }
+}
+```
+
+- [ ] **Step 2: 创建前端类型文件**
+
+创建 `noj-ui/types/training.ts`：
+
+```ts
+export type TrainingVisibility = 'private' | 'unlisted' | 'public'
+
+export interface Training {
+  id: string
+  title: string
+  description: string
+  visibility: TrainingVisibility
+  is_pinned: boolean
+  created_by: string
+  created_at: string
+  updated_at: string
+  problem_count: number
+}
+
+export interface TrainingProblem {
+  training_id: string
+  problem_id: string
+  position: number
+  title: string
+  description: string
+  difficulty: string
+  display_id: string
+  type: string
+  is_objective: boolean
+  accepted: boolean
+}
+
+export interface TrainingPayload {
+  title: string
+  description?: string
+  visibility?: TrainingVisibility
+}
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+jj describe -m "feat(ui): 添加 useTrainings composable 与类型" && jj sign -r @
+```
+
+---
+
+### Task 9: 题单列表页与我的题单页
+
+**Files:**
+- Create: `noj-ui/pages/trainings/index.vue`
+- Create: `noj-ui/pages/trainings/mine.vue`
+- Create: `noj-ui/components/feature/training/TrainingCard.vue`
+- Create: `noj-ui/components/feature/training/TrainingFormModal.vue`
+
+**Interfaces:**
+- Consumes: `useTrainings()` / `useAuth()` / Nuxt UI 组件。
+- Produces: 公开题单列表、我的题单管理入口。
+
+- [ ] **Step 1: 创建 TrainingCard.vue**
+
+```vue
+<script setup lang="ts">
+import type { Training } from '~/types/training'
+
+defineProps<{ training: Training }>()
+</script>
+
+<template>
+  <NuxtLink
+    :to="`/trainings/${training.id}`"
+    class="group flex min-h-44 flex-col rounded-xl border border-border bg-white p-5 text-text no-underline shadow-sm transition-all hover:-translate-y-1 hover:border-primary/40 hover:shadow-card"
+  >
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="line-clamp-2 text-lg font-bold transition-colors group-hover:text-primary">
+        {{ training.title }}
+      </h2>
+      <span
+        v-if="training.is_pinned"
+        class="rounded-full bg-warning-bg px-2.5 py-1 text-xs font-semibold text-warning-text"
+      >
+        置顶
+      </span>
+    </div>
+    <p class="mt-2 line-clamp-2 text-sm leading-6 text-text-secondary">
+      {{ training.description || '暂无简介' }}
+    </p>
+    <div class="mt-auto flex items-center gap-4 border-t border-border pt-3 text-xs text-text-secondary">
+      <span>{{ training.problem_count }} 题</span>
+      <span v-if="training.visibility === 'private'" class="ml-auto">私有</span>
+      <span v-else-if="training.visibility === 'unlisted'" class="ml-auto">链接可见</span>
+      <span v-else class="ml-auto">公开</span>
+    </div>
+  </NuxtLink>
+</template>
+```
+
+- [ ] **Step 2: 创建题单列表页 `pages/trainings/index.vue`**
+
+```vue
+<script setup lang="ts">
+import type { Training } from '~/types/training'
+
+useHead({ title: '题单 - Neuro OJ' })
+
+const { listPublic } = useTrainings()
+const currentPage = ref(1)
+const perPage = 12
+
+const { data, pending, error, refresh } = await useFetch<{ data: Training[]; total: number }>(
+  '/api/v1/trainings',
+  {
+    query: computed(() => ({ page: currentPage.value, per_page: perPage })),
+  },
+)
+const totalPages = computed(() => Math.ceil((data.value?.total ?? 0) / perPage))
+</script>
+
+<template>
+  <div class="min-h-full bg-bg-page py-10">
+    <div class="mx-auto max-w-[960px] space-y-7 px-4 sm:px-7">
+      <section class="rounded-2xl bg-bg-dark px-8 py-9 text-white shadow-card">
+        <h1 class="text-3xl font-bold">题单</h1>
+        <p class="mt-3 text-sm leading-6 text-slate-300">按学习路径刷题，整理自己的题目集合。</p>
+      </section>
+
+      <AsyncContent
+        :status="pending ? 'loading' : error ? 'error' : data?.data.length ? 'data' : 'empty'"
+        error="题单列表加载失败"
+        empty-text="暂无公开题单"
+        @retry="refresh"
+      >
+        <div class="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          <TrainingCard v-for="training in data?.data" :key="training.id" :training="training" />
+        </div>
+      </AsyncContent>
+
+      <PaginationNav :current-page="currentPage" :total-pages="totalPages" @page-change="currentPage = $event" />
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 3: 创建我的题单页 `pages/trainings/mine.vue`**
+
+```vue
+<script setup lang="ts">
+import type { Training } from '~/types/training'
+
+useHead({ title: '我的题单 - Neuro OJ' })
+
+const { listMine, deleteTraining } = useTrainings()
+const { data, pending, error, refresh } = await useFetch<{ data: Training[]; total: number }>(
+  '/api/v1/trainings/mine',
+  { query: { page: 1, per_page: 100 } },
+)
+const showCreate = ref(false)
+
+async function onDelete(id: string) {
+  if (!confirm('确定删除该题单？')) return
+  await deleteTraining(id)
+  await refresh()
+}
+</script>
+
+<template>
+  <div class="min-h-full bg-bg-page py-10">
+    <div class="mx-auto max-w-[960px] space-y-7 px-4 sm:px-7">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-bold">我的题单</h1>
+        <UButton icon="i-lucide-plus" @click="showCreate = true">新建题单</UButton>
+      </div>
+
+      <AsyncContent
+        :status="pending ? 'loading' : error ? 'error' : data?.data.length ? 'data' : 'empty'"
+        error="加载失败"
+        empty-text="你还没有创建题单"
+        @retry="refresh"
+      >
+        <div class="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          <TrainingCard v-for="training in data?.data" :key="training.id" :training="training" />
+        </div>
+      </AsyncContent>
+
+      <TrainingFormModal v-model="showCreate" @saved="refresh" />
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 4: 创建 TrainingFormModal.vue**
+
+```vue
+<script setup lang="ts">
+import type { TrainingPayload } from '~/types/training'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits<{ 'update:modelValue': [boolean]; saved: [] }>()
+
+const { createTraining } = useTrainings()
+const title = ref('')
+const description = ref('')
+const visibility = ref<'private' | 'unlisted'>('private')
+const saving = ref(false)
+
+async function submit() {
+  if (!title.value.trim()) return
+  saving.value = true
+  try {
+    const body: TrainingPayload = {
+      title: title.value.trim(),
+      description: description.value,
+      visibility: visibility.value,
+    }
+    await createTraining(body)
+    emit('update:modelValue', false)
+    emit('saved')
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <UDialog v-model="props.modelValue" title="新建题单">
+    <UForm :state="{ title, description, visibility }" class="space-y-4" @submit="submit">
+      <UFormGroup label="标题" required>
+        <UInput v-model="title" placeholder="题单标题" />
+      </UFormGroup>
+      <UFormGroup label="简介">
+        <UTextarea v-model="description" placeholder="题单简介" />
+      </UFormGroup>
+      <UFormGroup label="可见性">
+        <USelect
+          v-model="visibility"
+          :items="[
+            { label: '私有', value: 'private' },
+            { label: '链接可见', value: 'unlisted' },
+          ]"
+        />
+      </UFormGroup>
+      <div class="flex justify-end gap-3">
+        <UButton color="gray" @click="emit('update:modelValue', false)">取消</UButton>
+        <UButton type="submit" :loading="saving">创建</UButton>
+      </div>
+    </UForm>
+  </UDialog>
+</template>
+```
+
+- [ ] **Step 5: 提交**
+
+```bash
+jj describe -m "feat(ui): 添加题单列表与我的题单页面" && jj sign -r @
+```
+
+---
+
+### Task 10: 题单详情页与题目管理
+
+**Files:**
+- Create: `noj-ui/pages/trainings/[id].vue`
+- Create: `noj-ui/components/feature/training/TrainingProblemList.vue`
+- Create: `noj-ui/components/feature/training/TrainingProblemManager.vue`
+
+**Interfaces:**
+- Consumes: `useTrainings()` / `useAuth()`。
+- Produces: 题单详情、AC 进度、创建者管理题目。
+
+- [ ] **Step 1: 创建 TrainingProblemList.vue**
+
+```vue
+<script setup lang="ts">
+import type { TrainingProblem } from '~/types/training'
+
+defineProps<{ problems: TrainingProblem[] }>()
+</script>
+
+<template>
+  <ol class="divide-y divide-border rounded-xl border border-border bg-white">
+    <li
+      v-for="problem in problems"
+      :key="problem.problem_id"
+      class="flex items-center gap-4 px-5 py-3"
+    >
+      <span class="w-8 text-center text-sm text-text-secondary">{{ problem.position + 1 }}</span>
+      <span
+        class="flex size-6 items-center justify-center rounded-full text-xs"
+        :class="problem.accepted ? 'bg-success-bg text-success-text' : 'bg-gray-100 text-text-muted'"
+      >
+        {{ problem.accepted ? '✓' : '' }}
+      </span>
+      <NuxtLink :to="`/problems/${problem.display_id}`" class="flex-1 font-medium hover:text-primary">
+        {{ problem.display_id }} · {{ problem.title }}
+      </NuxtLink>
+      <span class="text-xs text-text-secondary">{{ problem.difficulty }}</span>
+    </li>
+  </ol>
+</template>
+```
+
+- [ ] **Step 2: 创建详情页 `pages/trainings/[id].vue`**
+
+```vue
+<script setup lang="ts">
+import type { Training, TrainingProblem } from '~/types/training'
+
+const route = useRoute()
+const trainingId = route.params.id as string
+const { getTraining, listTrainingProblems } = useTrainings()
+const { isAdmin, userId } = useAuth()
+
+const { data: trainingData, pending, error, refresh } = await useFetch<{ data: Training }>(
+  `/api/v1/trainings/${trainingId}`,
+  { silent: true },
+)
+const { data: problemsData, refresh: refreshProblems } = await useFetch<{ data: TrainingProblem[] }>(
+  `/api/v1/trainings/${trainingId}/problems`,
+  { silent: true },
+)
+const training = computed(() => trainingData.value?.data)
+const problems = computed(() => problemsData.value?.data ?? [])
+const isOwner = computed(() => training.value?.created_by === userId.value)
+</script>
+
+<template>
+  <div class="min-h-full bg-bg-page py-10">
+    <div class="mx-auto max-w-[960px] space-y-7 px-4 sm:px-7">
+      <AsyncContent :status="pending ? 'loading' : error ? 'error' : 'data'" error="题单加载失败" @retry="refresh">
+        <section class="rounded-2xl bg-bg-dark px-8 py-8 text-white shadow-card">
+          <div class="flex items-center gap-3">
+            <h1 class="text-3xl font-bold">{{ training?.title }}</h1>
+            <span
+              v-if="training?.visibility === 'private'"
+              class="rounded-full bg-white/10 px-3 py-1 text-xs"
+            >私有</span>
+            <span v-else-if="training?.visibility === 'unlisted'" class="rounded-full bg-white/10 px-3 py-1 text-xs">链接可见</span>
+            <span v-else class="rounded-full bg-white/10 px-3 py-1 text-xs">公开</span>
+          </div>
+          <p class="mt-4 whitespace-pre-line text-sm leading-6 text-slate-300">{{ training?.description }}</p>
+        </section>
+
+        <TrainingProblemList :problems="problems" />
+
+        <TrainingProblemManager
+          v-if="isOwner"
+          :training-id="trainingId"
+          :problems="problems"
+          @changed="refreshProblems"
+        />
+      </AsyncContent>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 3: 创建 TrainingProblemManager.vue**
+
+```vue
+<script setup lang="ts">
+import type { TrainingProblem } from '~/types/training'
+
+const props = defineProps<{
+  trainingId: string
+  problems: TrainingProblem[]
+}>()
+const emit = defineEmits<{ changed: [] }>()
+
+const { addProblem, removeProblem, reorderProblems } = useTrainings()
+const newProblemId = ref('')
+
+async function add() {
+  if (!newProblemId.value.trim()) return
+  await addProblem(props.trainingId, newProblemId.value.trim())
+  newProblemId.value = ''
+  emit('changed')
+}
+
+async function remove(problemId: string) {
+  await removeProblem(props.trainingId, problemId)
+  emit('changed')
+}
+
+async function move(problemId: string, direction: -1 | 1) {
+  const index = props.problems.findIndex((p) => p.problem_id === problemId)
+  const target = index + direction
+  if (index < 0 || target < 0 || target >= props.problems.length) return
+  const next = [...props.problems]
+  const [item] = next.splice(index, 1)
+  next.splice(target, 0, item)
+  await reorderProblems(
+    props.trainingId,
+    next.map((p, i) => ({ problem_id: p.problem_id, position: i })),
+  )
+  emit('changed')
+}
+</script>
+
+<template>
+  <section class="rounded-xl border border-border bg-white p-5">
+    <h2 class="mb-4 text-lg font-bold">管理题目</h2>
+    <div class="mb-4 flex gap-2">
+      <UInput v-model="newProblemId" placeholder="输入题目 ID 或 display_id" class="flex-1" />
+      <UButton icon="i-lucide-plus" @click="add">加入</UButton>
+    </div>
+    <div class="space-y-2">
+      <div
+        v-for="(problem, index) in problems"
+        :key="problem.problem_id"
+        class="flex items-center gap-3 rounded-lg border border-border px-4 py-2"
+      >
+        <span>{{ index + 1 }}</span>
+        <span class="flex-1">{{ problem.display_id }} · {{ problem.title }}</span>
+        <UButton icon="i-lucide-chevron-up" size="xs" variant="ghost" @click="move(problem.problem_id, -1)" />
+        <UButton icon="i-lucide-chevron-down" size="xs" variant="ghost" @click="move(problem.problem_id, 1)" />
+        <UButton icon="i-lucide-trash" size="xs" color="red" variant="ghost" @click="remove(problem.problem_id)" />
+      </div>
+    </div>
+  </section>
+</template>
+```
+
+- [ ] **Step 4: 提交**
+
+```bash
+jj describe -m "feat(ui): 添加题单详情页与题目管理" && jj sign -r @
+```
+
+---
+
+### Task 11: 用户主页与题目页入口
+
+**Files:**
+- Modify: `noj-ui/pages/users/[id].vue`
+- Modify: `noj-ui/pages/problems/[id].vue`
+- Create: `noj-ui/components/feature/training/AddToTrainingMenu.vue`
+
+**Interfaces:**
+- Consumes: `useTrainings()` / `useAuth()`。
+- Produces: 用户主页“我的题单”区块、题目页“加入题单”入口。
+
+- [ ] **Step 1: 创建 AddToTrainingMenu.vue**
+
+```vue
+<script setup lang="ts">
+const props = defineProps<{ problemId: string }>()
+const { listMine, addProblem, createTraining } = useTrainings()
+const { data } = await useFetch<{ data: import('~/types/training').Training[] }>(
+  '/api/v1/trainings/mine',
+  { query: { page: 1, per_page: 100 }, silent: true },
+)
+const selected = ref<string[]>([])
+const showCreate = ref(false)
+const newTitle = ref('')
+
+async function save() {
+  for (const trainingId of selected.value) {
+    await addProblem(trainingId, props.problemId)
+  }
+  selected.value = []
+}
+
+async function createAndAdd() {
+  if (!newTitle.value.trim()) return
+  const created = await createTraining({ title: newTitle.value.trim(), visibility: 'private' })
+  await addProblem(created.data.id, props.problemId)
+  showCreate.value = false
+  newTitle.value = ''
+}
+</script>
+
+<template>
+  <UPopover>
+    <UButton icon="i-lucide-list-plus">加入题单</UButton>
+    <template #content>
+      <div class="w-72 space-y-3 p-4">
+        <div class="space-y-2">
+          <label
+            v-for="training in data?.data ?? []"
+            :key="training.id"
+            class="flex items-center gap-2 text-sm"
+          >
+            <UCheckbox v-model="selected" :value="training.id" />
+            {{ training.title }}
+          </label>
+        </div>
+        <div class="flex gap-2">
+          <UInput v-model="newTitle" placeholder="新题单标题" class="flex-1" />
+          <UButton size="sm" @click="createAndAdd">新建并加入</UButton>
+        </div>
+        <UButton class="w-full" color="primary" size="sm" @click="save">加入选中题单</UButton>
+      </div>
+    </template>
+  </UPopover>
+</template>
+```
+
+- [ ] **Step 2: 在题目详情页加入入口**
+
+在 `noj-ui/pages/problems/[id].vue` 的合适位置（例如题目标题区）加入：
+
+```vue
+<AddToTrainingMenu v-if="isLoggedIn" :problem-id="problem.id" />
+```
+
+并在 `<script setup>` 中 import 组件、获取 `isLoggedIn`（已有 `useAuth()` 时直接使用）。
+
+- [ ] **Step 3: 在用户主页加入“我的题单”区块**
+
+在 `noj-ui/pages/users/[id].vue` 中追加：
+
+```vue
+<script setup lang="ts">
+const route = useRoute()
+const profileUserId = route.params.id as string
+const { data: trainingsData } = await useFetch<{ data: import('~/types/training').Training[] }>(
+  `/api/v1/trainings?created_by=${profileUserId}`,
+  { query: { page: 1, per_page: 100 }, silent: true },
+)
+</script>
+
+<template>
+  <section v-if="trainingsData?.data.length" class="mt-8">
+    <h2 class="mb-4 text-xl font-bold">我的题单</h2>
+    <div class="grid gap-5 md:grid-cols-2">
+      <NuxtLink
+        v-for="training in trainingsData.data"
+        :key="training.id"
+        :to="`/trainings/${training.id}`"
+        class="rounded-xl border border-border bg-white p-5"
+      >
+        <h3 class="font-bold">{{ training.title }}</h3>
+        <p class="mt-1 text-sm text-text-secondary">{{ training.problem_count }} 题</p>
+      </NuxtLink>
+    </div>
+  </section>
+</template>
+```
+
+> 后端 `GET /api/v1/trainings?created_by=:userId` 已按“本人看全部，他人只看 public”处理：请求者是本人或 admin 时返回全部可见性，否则仅返回 public。
+
+- [ ] **Step 4: 提交**
+
+```bash
+jj describe -m "feat(ui): 添加用户主页题单区块与题目页加入题单入口" && jj sign -r @
+```
+
+---
+
+### Task 12: 后台题单管理页
+
+**Files:**
+- Create: `noj-ui/pages/admin/trainings.vue`
+- Create: `noj-ui/components/admin/TrainingManagementSection.vue`
+
+**Interfaces:**
+- Consumes: `useTrainings().adminListTrainings / adminUpdateTraining / adminDeleteTraining`。
+- Produces: 后台管理任意题单（当前按管理员自己创建的题单列表实现，可扩展全量查询）。
+
+- [ ] **Step 1: 创建 TrainingManagementSection.vue**
+
+```vue
+<script setup lang="ts">
+import type { Training } from '~/types/training'
+
+const { adminListTrainings, adminUpdateTraining, adminDeleteTraining } = useTrainings()
+const { data, pending, error, refresh } = await useFetch<{ data: Training[]; total: number }>(
+  '/api/v1/admin/trainings',
+  { query: { page: 1, per_page: 100 }, silent: true },
+)
+
+async function setVisibility(training: Training, visibility: Training['visibility']) {
+  await adminUpdateTraining(training.id, { visibility })
+  await refresh()
+}
+
+async function togglePinned(training: Training) {
+  await adminUpdateTraining(training.id, { is_pinned: !training.is_pinned })
+  await refresh()
+}
+
+async function remove(id: string) {
+  if (!confirm('确定删除该题单？')) return
+  await adminDeleteTraining(id)
+  await refresh()
+}
+</script>
+
+<template>
+  <AsyncContent :status="pending ? 'loading' : error ? 'error' : 'data'" error="题单加载失败" @retry="refresh">
+    <UTable
+      :rows="data?.data ?? []"
+      :columns="[
+        { key: 'title', label: '标题' },
+        { key: 'visibility', label: '可见性' },
+        { key: 'is_pinned', label: '置顶' },
+        { key: 'problem_count', label: '题目数' },
+        { key: 'actions', label: '操作' },
+      ]"
+    >
+      <template #visibility-data="{ row }: { row: Training }">
+        <USelect
+          :model-value="row.visibility"
+          :items="[
+            { label: '私有', value: 'private' },
+            { label: '链接可见', value: 'unlisted' },
+            { label: '公开', value: 'public' },
+          ]"
+          @update:model-value="setVisibility(row, $event as Training['visibility'])"
+        />
+      </template>
+      <template #is_pinned-data="{ row }: { row: Training }">
+        <UCheckbox :model-value="row.is_pinned" @update:model-value="togglePinned(row)" />
+      </template>
+      <template #actions-data="{ row }: { row: Training }">
+        <UButton icon="i-lucide-trash" size="xs" color="red" variant="ghost" @click="remove(row.id)" />
+      </template>
+    </UTable>
+  </AsyncContent>
+</template>
+```
+
+- [ ] **Step 2: 创建后台页面 `pages/admin/trainings.vue`**
+
+```vue
+<script setup lang="ts">
+useHead({ title: '题单管理 - Neuro OJ' })
+</script>
+
+<template>
+  <div class="space-y-6">
+    <PageHeader title="题单管理" description="管理题单可见性、置顶与删除。" />
+    <TrainingManagementSection />
+  </div>
+</template>
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+jj describe -m "feat(ui): 添加后台题单管理页" && jj sign -r @
+```
+
+---
+
+### Task 13: 跨模块 E2E 测试
+
+**Files:**
+- Create: `noj-tests/e2e/trainings.test.ts`
+
+**Interfaces:**
+- Consumes: 已实现的 core API + UI 依赖的 API 契约。
+- Produces: E2E 覆盖题单主流程。
+
+- [ ] **Step 1: 创建 E2E 测试**
+
+参考 `noj-tests/e2e/helper.ts` 现有辅助函数，创建 `noj-tests/e2e/trainings.test.ts`：
+
+```ts
+import {
+  apiDelete,
+  apiGet,
+  apiPatch,
+  apiPost,
+  e2eTest,
+  getAdminToken,
+  getOrCreateUser,
+  pollSubmission,
+  submitCode,
+} from "./helper.ts";
+
+e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", async () => {
+  const adminToken = await getAdminToken();
+  const user = await getOrCreateUser(
+    "training_user",
+    `training_user_${Date.now().toString(36)}`,
+    `training_user_${Date.now().toString(36)}@test.com`,
+  );
+  const other = await getOrCreateUser(
+    "training_other",
+    `training_other_${Date.now().toString(36)}`,
+    `training_other_${Date.now().toString(36)}@test.com`,
+  );
+
+  const problemRes = await apiPost(
+    "/api/v1/problems",
+    {
+      title: "Training E2E Problem",
+      description: "e2e",
+      type: "U",
+      runtime_config: {
+        evaluator: {
+          image: "noj-evaluator-python",
+          command: "python3 /workspace/evaluate.py",
+          time_limit_ms: 5000,
+          memory_limit_mb: 512,
+        },
+        solution: {
+          image: "noj-solution-python",
+          call_timeout_ms: 2000,
+          memory_limit_mb: 512,
+        },
+      },
+    },
+    user.token,
+  );
+  if (problemRes.status !== 201) {
+    throw new Error(`建题失败: ${JSON.stringify(problemRes.body)}`);
+  }
+  const problemId = (problemRes.body as { data: { id: string } }).data.id;
+
+  const created = await apiPost(
+    "/api/v1/trainings",
+    { title: "E2E 题单", visibility: "private" },
+    user.token,
+  );
+  if (created.status !== 201) {
+    throw new Error(`建题单失败: ${JSON.stringify(created.body)}`);
+  }
+  const trainingId = (created.body as { data: { id: string } }).data.id;
+
+  const added = await apiPost(
+    `/api/v1/trainings/${trainingId}/problems`,
+    { problem_id: problemId },
+    user.token,
+  );
+  if (added.status !== 201) {
+    throw new Error(`加题失败: ${JSON.stringify(added.body)}`);
+  }
+
+  const hidden = await apiGet(`/api/v1/trainings/${trainingId}`, other.token);
+  if (hidden.status !== 404) {
+    throw new Error(`私有题单应对他人 404: ${hidden.status}`);
+  }
+
+  const subId = await submitCode(user.token, problemId, "print(1)");
+  await pollSubmission(user.token, subId);
+  const problems = await apiGet(
+    `/api/v1/trainings/${trainingId}/problems`,
+    user.token,
+  );
+  if (problems.status !== 200) {
+    throw new Error(`取题单题目失败: ${problems.status}`);
+  }
+  const problemsData = (problems.body as { data: { accepted: boolean }[] }).data;
+  if (!problemsData[0]?.accepted) {
+    throw new Error("AC 后进度应为 true");
+  }
+
+  const patched = await apiPatch(
+    `/api/v1/admin/trainings/${trainingId}`,
+    { visibility: "public", is_pinned: true },
+    adminToken,
+  );
+  if (patched.status !== 200) {
+    throw new Error(`管理员设 public 失败: ${patched.status}`);
+  }
+
+  const list = await apiGet("/api/v1/trainings");
+  const listData = (list.body as { data: { id: string }[] }).data;
+  if (!listData.some((t) => t.id === trainingId)) {
+    throw new Error("公开列表应包含该题单");
+  }
+
+  const deleted = await apiDelete(`/api/v1/problems/${problemId}`, user.token);
+  if (deleted.status !== 204 && deleted.status !== 200) {
+    throw new Error(`删题失败: ${deleted.status}`);
+  }
+  const afterDelete = await apiGet(
+    `/api/v1/trainings/${trainingId}/problems`,
+    user.token,
+  );
+  const afterData = (afterDelete.body as { data: unknown[] }).data;
+  if (afterData.length !== 0) {
+    throw new Error("删除题目后题单关联应自动清理");
+  }
+});
+```
+
+- [ ] **Step 2: 运行 E2E**
+
+```bash
+cd noj-tests && deno task test -- --test-name-pattern="training e2e"
+```
+
+Expected: PASS。
+
+- [ ] **Step 3: 提交**
+
+```bash
+jj describe -m "test(e2e): 添加题单功能 E2E 测试" && jj sign -r @
+```
+
+---
+
+### Task 14: 全量验证与收尾
+
+**Files:**
+- 无新文件；运行既有检查。
+
+**Interfaces:**
+- Consumes: 全部已实现代码。
+- Produces: 可合入的完整功能。
+
+- [ ] **Step 1: noj-core 格式化与 lint**
+
+```bash
+cd noj-core && deno fmt --check && deno lint
+```
+
+Expected: 无错误。
+
+- [ ] **Step 2: noj-core 全量测试**
+
+```bash
+cd noj-core && deno task test
+```
+
+Expected: PASS。
+
+- [ ] **Step 3: noj-ui 格式化与构建**
+
+```bash
+cd noj-ui && deno lint && deno fmt --check && npm run build
+```
+
+Expected: 无错误。
+
+- [ ] **Step 4: 确认设计文档与计划已提交**
+
+```bash
+jj log --no-graph -r '::@' -T 'description' | head -30
+```
+
+Expected: 包含 design 与各实现提交。
+
+- [ ] **Step 5: 提交收尾（如有 lint 修复）**
+
+```bash
+jj describe -m "chore(root): training 功能收尾修复" && jj sign -r @
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** 数据模型（Task 1）、类型（Task 2）、CRUD/可见性（Task 3）、题目/进度（Task 4）、RBAC（Task 5）、用户 API（Task 6）、管理 API（Task 7）、前端 composable（Task 8）、列表/我的（Task 9）、详情/管理（Task 10）、个人主页/题目页（Task 11）、后台页（Task 12）、E2E（Task 13）、全量验证（Task 14）均已覆盖。
+- **Placeholder scan:** 已避免 TBD/TODO；用户主页通过 `GET /api/v1/trainings?created_by=:userId` 实现“本人看全部、他人只看 public”。
+- **Type consistency:** `TrainingResponse` / `TrainingProblemResponse` / `Training` / `TrainingProblem` 命名在 service/route/composable 中一致；API 返回字段与前端类型一致。

--- a/docs/superpowers/specs/2026-08-17-training-design.md
+++ b/docs/superpowers/specs/2026-08-17-training-design.md
@@ -1,0 +1,248 @@
+# Training / 题单功能设计
+
+> 日期：2026-08-17
+> 关联 Issue：#224 feat: 支持训练计划/题单（training）
+> 状态：已与需求方确认，待评审
+
+## 1. 背景与目标
+
+当前 NOJ 只有 admin 管控的分类树，用户无法自主组织题目、形成系统刷题路径。本设计对标 HydroOJ `training` / 洛谷题单的**基础形态**，为 NOJ 增加用户可创建的“题单”。
+
+第一版范围明确为**扁平题单**：
+
+- `trainings` 主表 + `trainingProblems` 关联表
+- 题目在题单内按 `position` 排序
+- 不引入章节、前置依赖等 DAG 能力（后续可扩展）
+
+## 2. 范围决策（已确认）
+
+| 决策点 | 结论 |
+| --- | --- |
+| 结构复杂度 | 扁平题单，不引入 DAG/章节/前置依赖 |
+| 创建权限 | 所有登录用户可创建题单 |
+| 可见性模型 | 三态：`private` / `unlisted` / `public` |
+| 公开审核流 | 第一版不做申请审核流；仅具备 `training:publish` 的管理员可直接设 `public` |
+| 置顶 | 独立权限 `training:pin`，默认仅管理员 |
+| RBAC 粒度 | 细粒度 `training:resource:action`，含独立 `publish` / `pin` |
+| 进度覆盖 | 编程题 + 客观题套卷（客观题满分视为 AC） |
+| 题目类型 | 题单可收录 U/P/客观题任意类型，不额外过滤 |
+| 题目页入口 | “加入题单”仅操作自己创建的题单；管理员在前台对他人题单保持只读 |
+| 个人主页 | 本人看全部，他人只看 public |
+| 后台管理 | 管理员对任意题单的编辑/置顶/设 public 仅出现在后台管理页 |
+
+## 3. 数据模型
+
+沿用现有约定：`text` 主键、ISO 8601 文本时间戳、Drizzle ORM。
+
+### 3.1 `trainings` 题单主表
+
+| 列 | 类型 | 说明 |
+| --- | --- | --- |
+| `id` | text PK | UUID |
+| `title` | text notNull | 1–100 字符 |
+| `description` | text notNull default `""` | Markdown 描述 |
+| `visibility` | text notNull default `"private"` | `private` / `unlisted` / `public`，CHECK 约束 |
+| `is_pinned` | boolean notNull default `false` | 仅管理员可置顶 |
+| `created_by` | text notNull FK→users.id | 创建者；用户删除时级联删除其题单 |
+| `created_at` | text notNull | ISO 8601 |
+| `updated_at` | text notNull | ISO 8601 |
+
+### 3.2 `training_problems` 题单题目关联表
+
+| 列 | 类型 | 说明 |
+| --- | --- | --- |
+| `training_id` | text notNull FK→trainings.id ON DELETE CASCADE | 所属题单 |
+| `problem_id` | text notNull FK→problems.id ON DELETE CASCADE | 题目；题目删除自动清理 |
+| `position` | integer notNull default `0` | 题单内排序 |
+
+约束/索引：
+
+- 主键 `(training_id, problem_id)`：同一题单不重复收录同一题。
+- 唯一约束 `(training_id, position)`：同一题单内顺序唯一（参考 `contest_problems`）。
+- 索引：`trainings(visibility, is_pinned, created_at)` 供公开列表；`trainings(created_by)` 供“我的题单”；`training_problems(training_id, position)` 供详情按序取题。
+
+### 3.3 可见性与权限模型
+
+- `visibility=public` 仅可由具备 `training:publish` 权限的管理员设置；创建者只能设 `private/unlisted`。
+- `is_pinned` 仅可由具备 `training:pin` 权限的管理员设置。
+- 题单可收录 U/P/客观题任意类型，不额外过滤。
+- U 型题目维持“unlisted”式语义：不展示在官方题目目录中，可通过 URL 或题单跳转打开；题单允许收录 U 题，无论题单自身可见性。
+
+## 4. API 设计
+
+### 4.1 用户/公开路由（`/api/v1/trainings`）
+
+| 方法 | 路径 | 权限 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/` | 公开 | 公开题单列表：仅 `visibility=public`，置顶优先、`updated_at` 倒序，分页 |
+| GET | `/mine` | 登录 | 当前用户创建的全部题单（private/unlisted/public），分页 |
+| POST | `/` | `training:create` | 创建题单；`visibility` 只能为 `private/unlisted` |
+| GET | `/:id` | 公开/受限 | 详情：public/unlisted 任何人可看；private 仅创建者或 `training:read_any` |
+| PUT | `/:id` | `training:write_own` / `write_any` | 更新 title/description/visibility；设为 `public` 需 `training:publish`，置顶需 `training:pin` |
+| DELETE | `/:id` | `training:delete_own` / `delete_any` | 删除题单（级联删关联） |
+| GET | `/:id/problems` | 同详情访问规则 | 有序题目列表，分页；登录用户附带 `accepted` 进度，匿名一律 `false` |
+| POST | `/:id/problems` | `training:write_own` / `write_any` | 加题：`{ problem_id, position? }`，不传 `position` 追加到末尾 |
+| PUT | `/:id/problems` | 同上 | 批量重排：`{ problems: [{ problem_id, position }] }`，一次提交全量顺序 |
+| DELETE | `/:id/problems/:problemId` | 同上 | 从题单移除某题 |
+
+### 4.2 管理员后台路由（`/api/v1/admin/trainings`）
+
+| 方法 | 路径 | 权限 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/` | `training:read_any` | 查看全部题单（含 private/unlisted），支持按 visibility/creator 筛选 |
+| PATCH | `/:id` | `training:publish` 或 `write_any` + `training:pin` | 后台改 `visibility`（可设为 public）、`is_pinned` |
+| DELETE | `/:id` | `training:delete_any` | 后台删除任意题单 |
+
+### 4.3 关键规则
+
+- **路由顺序**：`GET /mine` 必须注册在 `GET /:id` 之前，避免 `mine` 被当作 `:id`。
+- **可见性访问矩阵**：
+
+| 访问者 | private | unlisted | public |
+| --- | --- | --- | --- |
+| 匿名 | ❌ | ✅（仅 URL） | ✅ |
+| 登录用户（非创建者） | ❌ | ✅ | ✅ |
+| 创建者 | ✅ | ✅ | ✅ |
+| admin（read_any） | ✅ | ✅ | ✅ |
+
+- **进度（accepted）**：
+  - 编程题：当前用户是否存在 `submissions.status='Accepted'`（或经 `evaluationResults` 聚合）的提交。
+  - 客观题套卷：当前用户是否存在 `score=10000` 的 `objectiveSubmissions` 提交。
+  - 匿名请求不计算进度。
+- **加题/排序**：
+  - `position` 在同一题单内唯一；插入/重排时服务端统一重写 `position`，避免中间插入产生冲突。
+  - 重复收录同一题返回 `ConflictError`。
+- **错误处理**：统一走 `AppError`（NotFound/Forbidden/BadRequest/Conflict）。
+
+## 5. RBAC 权限与默认角色
+
+### 5.1 新增权限定义（`PERMISSION_DEFS`）
+
+| resource | action | 说明 |
+| --- | --- | --- |
+| `training` | `create` | 创建题单 |
+| `training` | `read` | 查看题单（自己的 + public/unlisted） |
+| `training` | `read_any` | 查看任意题单（含 private） |
+| `training` | `write_own` | 编辑自己的题单 |
+| `training` | `write_any` | 编辑任意题单 |
+| `training` | `delete_own` | 删除自己的题单 |
+| `training` | `delete_any` | 删除任意题单 |
+| `training` | `publish` | 设置 `visibility=public` |
+| `training` | `pin` | 设置/取消 `is_pinned` |
+
+### 5.2 默认角色授权
+
+- **user 角色默认新增**：
+  - `training:create`
+  - `training:read`
+  - `training:write_own`
+  - `training:delete_own`
+- **admin 角色**：不显式新增，`admin:full_access` 通配覆盖全部（含 `publish`/`pin`/`read_any`/`write_any`/`delete_any`）。
+- `training:publish` 与 `training:pin` **不加入 user 默认权限**；如需授予自定义运营角色，在 RBAC 管理面板单独勾选。
+
+### 5.3 服务层权限检查
+
+- 创建：`training:create`
+- 查看：`private` → 创建者或 `training:read_any`；`unlisted/public` → `training:read`（匿名可读）
+- 更新/加题/排序/移除：创建者 `training:write_own`，非创建者 `training:write_any`
+- 设置 `visibility=public`：额外 `training:publish`
+- 设置/取消 `is_pinned`：额外 `training:pin`
+
+## 6. 前端 UI 设计
+
+### 6.1 页面路由
+
+| 路由 | 页面 | 说明 |
+| --- | --- | --- |
+| `/trainings` | 题单列表页 | 公开题单（public），置顶优先 + 更新时间倒序，分页；卡片显示标题/简介/创建者/题目数 |
+| `/trainings/mine` | 我的题单 | 当前用户创建的全部题单（private/unlisted/public），可新建/编辑/删除/管理题目 |
+| `/trainings/[id]` | 题单详情页 | 标题/简介/创建者/可见性；按 `position` 展示题目，每题带 AC 绿勾/灰勾；创建者可见“管理题目”控件 |
+| `/users/[id]` | 用户主页扩展 | 新增“我的题单”区块：本人看全部，他人只看 public |
+| `/problems/[id]` | 题目详情页扩展 | 新增“加入题单”入口：仅操作自己创建的题单，可新建题单后加入 |
+| `/admin/trainings` | 后台题单管理 | admin 查看/筛选全部题单，可改 visibility（含 public）、置顶/取消置顶、编辑/删除任意题单、管理题目 |
+
+### 6.2 关键组件
+
+| 组件 | 用途 |
+| --- | --- |
+| `components/feature/training/TrainingCard.vue` | 题单卡片 |
+| `components/feature/training/TrainingProblemList.vue` | 详情页有序题目列表 + AC 状态 |
+| `components/feature/training/TrainingFormModal.vue` | 创建/编辑题单（标题、简介、可见性） |
+| `components/feature/training/TrainingProblemManager.vue` | 创建者管理题目：加题/移除/拖拽排序 |
+| `components/feature/training/AddToTrainingMenu.vue` | 题目页“加入题单”下拉/弹窗 |
+| `components/admin/TrainingManagementSection.vue` | 后台题单管理表格 |
+
+### 6.3 Composables
+
+- `composables/useTrainings.ts`
+  - `listPublic()`
+  - `listMine()`
+  - `getTraining(id)`
+  - `createTraining(input)`
+  - `updateTraining(id, input)`
+  - `deleteTraining(id)`
+  - `listTrainingProblems(id)`
+  - `addProblem(id, problemId, position?)`
+  - `reorderProblems(id, problems[])`
+  - `removeProblem(id, problemId)`
+
+### 6.4 交互规则
+
+- **详情页管理控件**：仅创建者本人可见；管理员在前台看他人题单时保持只读，不显示任何“可编辑/管理”标识。
+- **后台管理页**：admin 专属，可管理任意题单。
+- **进度展示**：登录用户看详情时每题返回 `accepted: true/false`；匿名一律灰勾（或“未登录”提示），不计算进度。
+- **加入题单**：题目页弹窗列出当前用户自己的题单；勾选即调用 `addProblem`；也提供“新建题单并加入”。
+
+## 7. 测试计划
+
+### 7.1 noj-core
+
+- **服务层**（`tests/services/trainings.test.ts`）：
+  - 创建/更新/删除题单的权限矩阵（创建者、他人、admin、匿名）
+  - 可见性访问矩阵（private/unlisted/public × 匿名/登录/创建者/admin）
+  - 加题/重复加题/移除/重排（position 唯一、重写顺序）
+  - 题目删除后 `training_problems` 级联清理
+  - 进度聚合：编程题 Accepted、客观题满分；匿名不计算
+- **路由层**（`tests/routes/trainings.test.ts`）：
+  - 路由注册顺序（`/mine` 在 `/:id` 前）
+  - 请求参数校验（title 长度、visibility 枚举、problem_id 存在性）
+  - RBAC 中间件拦截（无 `training:create` 不能建题单；无 `publish` 不能设 public；无 `pin` 不能置顶）
+- **RBAC 种子**：验证 `PERMISSION_DEFS` 新增 9 项、user 默认权限新增 4 项、`publish`/`pin` 不在 user 默认中
+
+### 7.2 noj-ui
+
+- 组件/页面走现有 lint + build（`deno lint` / `deno fmt` / `nuxt build`）
+- 若项目已有前端测试模式则补充题单列表/详情渲染测试
+
+### 7.3 跨模块 E2E（`noj-tests`）
+
+- 建题单 → 按序加题 → 详情按 position 返回 → 提交 AC 后进度变为 true
+- 私有题单对他人不可见、unlisted 仅 URL 可访问、public 出现在列表
+- 无 `training:publish` 的用户不能设 public；admin 可设 public/pin
+- 删除题目后题单内关联自动消失
+
+## 8. 实施文件清单（预估）
+
+### noj-core
+
+- `src/db/schema.ts`（新增 2 表）
+- `drizzle/`（新迁移，自动生成）
+- `src/types/trainings.ts`
+- `src/services/trainings.ts`
+- `src/routes/trainings.ts`
+- `src/routes/admin/trainings.ts`（或并入现有 admin 路由）
+- `src/app.ts`（挂载路由）
+- `src/types/index.ts`（PERMISSION_DEFS）
+- `src/services/seed-rbac.ts`（user 默认权限）
+
+### noj-ui
+
+- `pages/trainings/index.vue`、`pages/trainings/mine.vue`、`pages/trainings/[id].vue`
+- `pages/admin/trainings.vue`
+- `pages/users/[id].vue`、`pages/problems/[id].vue` 扩展
+- `components/feature/training/*`、`components/admin/TrainingManagementSection.vue`
+- `composables/useTrainings.ts`
+
+### noj-tests
+
+- `e2e/trainings.test.ts`（或按现有命名）

--- a/noj-core/deno.lock
+++ b/noj-core/deno.lock
@@ -26,6 +26,7 @@
     "npm:@types/pg@^8.20.0": "8.20.0",
     "npm:bcryptjs@*": "2.4.3",
     "npm:bcryptjs@^2.4.3": "2.4.3",
+    "npm:drizzle-kit@*": "0.31.10",
     "npm:drizzle-kit@0.31.10": "0.31.10",
     "npm:drizzle-orm@*": "0.45.2_@electric-sql+pglite@0.5.3_@types+pg@8.20.0_postgres@3.4.5",
     "npm:drizzle-orm@0.35.2": "0.35.2_@electric-sql+pglite@0.5.3_@types+pg@8.20.0_postgres@3.4.5",

--- a/noj-core/drizzle/0041_harsh_lilandra.sql
+++ b/noj-core/drizzle/0041_harsh_lilandra.sql
@@ -1,0 +1,59 @@
+CREATE TABLE "training_problems" (
+	"training_id" text NOT NULL,
+	"problem_id" text NOT NULL,
+	"position" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "training_problems_training_id_problem_id_pk" PRIMARY KEY("training_id","problem_id"),
+	CONSTRAINT "training_problems_training_position_unique" UNIQUE("training_id","position")
+);
+--> statement-breakpoint
+CREATE TABLE "trainings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"title" text NOT NULL,
+	"description" text DEFAULT '' NOT NULL,
+	"visibility" text DEFAULT 'private' NOT NULL,
+	"is_pinned" boolean DEFAULT false NOT NULL,
+	"created_by" text NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "trainings_visibility_check" CHECK ("trainings"."visibility" IN ('private', 'unlisted', 'public'))
+);
+--> statement-breakpoint
+ALTER TABLE "audit_logs" DROP CONSTRAINT "audit_logs_action_check";--> statement-breakpoint
+ALTER TABLE "tags" DROP CONSTRAINT "tags_kind_check";--> statement-breakpoint
+ALTER TABLE "training_problems" ADD CONSTRAINT "training_problems_training_id_trainings_id_fk" FOREIGN KEY ("training_id") REFERENCES "trainings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "training_problems" ADD CONSTRAINT "training_problems_problem_id_problems_id_fk" FOREIGN KEY ("problem_id") REFERENCES "problems"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trainings" ADD CONSTRAINT "trainings_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_training_problems_training_position" ON "training_problems" USING btree ("training_id","position");--> statement-breakpoint
+CREATE INDEX "idx_trainings_visibility_pinned_created" ON "trainings" USING btree ("visibility","is_pinned","created_at");--> statement-breakpoint
+CREATE INDEX "idx_trainings_created_by" ON "trainings" USING btree ("created_by");--> statement-breakpoint
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_action_check" CHECK ("audit_logs"."action" IN (
+        'users.role_change',
+        'users.ban',
+        'users.unban',
+        'problems.delete',
+        'problems.runtime_config_changed',
+        'problems.imported',
+        'tags.create',
+        'tags.update',
+        'tags.delete',
+        'tags.merge',
+        'submissions.rejudge',
+        'settings.update',
+        'ip_ban.create',
+        'ip_ban.delete',
+        'auth.login_success',
+        'auth.login_failure',
+        'auth.register',
+        'auth.change_password',
+        'auth.forgot_password_request',
+        'auth.password_reset',
+        'community.post_moderated',
+        'community.report_resolved',
+        'community.sanction_created',
+        'community.sanction_revoked',
+        'community.preset_applied',
+        'announcement.create',
+        'announcement.update',
+        'announcement.delete'
+      ));--> statement-breakpoint
+ALTER TABLE "tags" ADD CONSTRAINT "tags_kind_check" CHECK ("tags"."kind" IN ('problem', 'algorithm'));

--- a/noj-core/drizzle/meta/0041_snapshot.json
+++ b/noj-core/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,4972 @@
+{
+  "id": "b1805d01-3242-4ffa-96f7-74945881cc77",
+  "prevId": "6bcb1ff8-43af-4d40-8694-cc4ac2e7999a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_announcements_active_pinned_created": {
+          "name": "idx_announcements_active_pinned_created",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audit_logs_admin_id_idx": {
+          "name": "audit_logs_admin_id_idx",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_admin_id_users_id_fk": {
+          "name": "audit_logs_admin_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'users.role_change',\n        'users.ban',\n        'users.unban',\n        'problems.delete',\n        'problems.runtime_config_changed',\n        'problems.imported',\n        'tags.create',\n        'tags.update',\n        'tags.delete',\n        'tags.merge',\n        'submissions.rejudge',\n        'settings.update',\n        'ip_ban.create',\n        'ip_ban.delete',\n        'auth.login_success',\n        'auth.login_failure',\n        'auth.register',\n        'auth.change_password',\n        'auth.forgot_password_request',\n        'auth.password_reset',\n        'community.post_moderated',\n        'community.report_resolved',\n        'community.sanction_created',\n        'community.sanction_revoked',\n        'community.preset_applied',\n        'announcement.create',\n        'announcement.update',\n        'announcement.delete'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkin_date": {
+          "name": "checkin_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streak": {
+          "name": "streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "check_ins_user_id_users_id_fk": {
+          "name": "check_ins_user_id_users_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "check_ins_user_date_unique": {
+          "name": "check_ins_user_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "checkin_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_activity_events": {
+      "name": "community_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_activity_events_actor": {
+          "name": "idx_community_activity_events_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_activity_events_actor_id_users_id_fk": {
+          "name": "community_activity_events_actor_id_users_id_fk",
+          "tableFrom": "community_activity_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_activity_events_dedupe_unique": {
+          "name": "community_activity_events_dedupe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "type",
+            "subject_type",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "community_activity_events_type_check": {
+          "name": "community_activity_events_type_check",
+          "value": "\"community_activity_events\".\"type\" IN ('first_accepted', 'solution_published', 'contest_joined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_board_role_grants": {
+      "name": "community_board_role_grants",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_read": {
+          "name": "can_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_post": {
+          "name": "can_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_moderate": {
+          "name": "can_moderate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_community_board_role_grants_role": {
+          "name": "idx_community_board_role_grants_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_board_role_grants_board_id_community_boards_id_fk": {
+          "name": "community_board_role_grants_board_id_community_boards_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_board_role_grants_role_id_roles_id_fk": {
+          "name": "community_board_role_grants_role_id_roles_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_board_role_grants_board_id_role_id_pk": {
+          "name": "community_board_role_grants_board_id_role_id_pk",
+          "columns": [
+            "board_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_boards": {
+      "name": "community_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_boards_sort": {
+          "name": "idx_community_boards_sort",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_boards_slug_unique": {
+          "name": "community_boards_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_bookmarks": {
+      "name": "community_bookmarks",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_bookmarks_user": {
+          "name": "idx_community_bookmarks_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_bookmarks_post_id_community_posts_id_fk": {
+          "name": "community_bookmarks_post_id_community_posts_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_bookmarks_user_id_users_id_fk": {
+          "name": "community_bookmarks_user_id_users_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_bookmarks_post_id_user_id_pk": {
+          "name": "community_bookmarks_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comment_likes": {
+      "name": "community_comment_likes",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comment_likes_user": {
+          "name": "idx_community_comment_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comment_likes_comment_id_community_comments_id_fk": {
+          "name": "community_comment_likes_comment_id_community_comments_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comment_likes_user_id_users_id_fk": {
+          "name": "community_comment_likes_user_id_users_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_comment_likes_comment_id_user_id_pk": {
+          "name": "community_comment_likes_comment_id_user_id_pk",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comments_post": {
+          "name": "idx_community_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_author": {
+          "name": "idx_community_comments_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_parent": {
+          "name": "idx_community_comments_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_author_id_users_id_fk": {
+          "name": "community_comments_author_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_parent_id_community_comments_id_fk": {
+          "name": "community_comments_parent_id_community_comments_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_comments_status_check": {
+          "name": "community_comments_status_check",
+          "value": "\"community_comments\".\"status\" IN ('pending', 'published', 'hidden', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_follows": {
+      "name": "community_follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followee_id": {
+          "name": "followee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_follows_followee": {
+          "name": "idx_community_follows_followee",
+          "columns": [
+            {
+              "expression": "followee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_follows_follower_id_users_id_fk": {
+          "name": "community_follows_follower_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_follows_followee_id_users_id_fk": {
+          "name": "community_follows_followee_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_follows_follower_id_followee_id_pk": {
+          "name": "community_follows_follower_id_followee_id_pk",
+          "columns": [
+            "follower_id",
+            "followee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_follows_not_self_check": {
+          "name": "community_follows_not_self_check",
+          "value": "\"community_follows\".\"follower_id\" <> \"community_follows\".\"followee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_moderation_actions": {
+      "name": "community_moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_moderation_actions_target": {
+          "name": "idx_community_moderation_actions_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_moderation_actions_moderator": {
+          "name": "idx_community_moderation_actions_moderator",
+          "columns": [
+            {
+              "expression": "moderator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_moderation_actions_moderator_id_users_id_fk": {
+          "name": "community_moderation_actions_moderator_id_users_id_fk",
+          "tableFrom": "community_moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_notifications": {
+      "name": "community_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_notifications_recipient": {
+          "name": "idx_community_notifications_recipient",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_unread": {
+          "name": "idx_community_notifications_unread",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_actor": {
+          "name": "idx_community_notifications_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_post": {
+          "name": "idx_community_notifications_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_comment": {
+          "name": "idx_community_notifications_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_notifications_recipient_id_users_id_fk": {
+          "name": "community_notifications_recipient_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_notifications_actor_id_users_id_fk": {
+          "name": "community_notifications_actor_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_post_id_community_posts_id_fk": {
+          "name": "community_notifications_post_id_community_posts_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_comment_id_community_comments_id_fk": {
+          "name": "community_notifications_comment_id_community_comments_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_notifications_type_check": {
+          "name": "community_notifications_type_check",
+          "value": "\"community_notifications\".\"type\" IN ('reply', 'like', 'follow', 'moderation', 'clarification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_post_likes": {
+      "name": "community_post_likes",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_post_likes_user": {
+          "name": "idx_community_post_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_post_likes_post_id_community_posts_id_fk": {
+          "name": "community_post_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_post_likes_user_id_users_id_fk": {
+          "name": "community_post_likes_user_id_users_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_post_likes_post_id_user_id_pk": {
+          "name": "community_post_likes_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_posts_author": {
+          "name": "idx_community_posts_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_problem": {
+          "name": "idx_community_posts_problem",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_board": {
+          "name": "idx_community_posts_board",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_published": {
+          "name": "idx_community_posts_published",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_pending": {
+          "name": "idx_community_posts_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_posts_author_id_users_id_fk": {
+          "name": "community_posts_author_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_problem_id_problems_id_fk": {
+          "name": "community_posts_problem_id_problems_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_board_id_community_boards_id_fk": {
+          "name": "community_posts_board_id_community_boards_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_posts_type_check": {
+          "name": "community_posts_type_check",
+          "value": "\"community_posts\".\"type\" IN ('solution', 'discussion', 'moment')"
+        },
+        "community_posts_status_check": {
+          "name": "community_posts_status_check",
+          "value": "\"community_posts\".\"status\" IN ('draft', 'pending', 'published', 'hidden', 'deleted')"
+        },
+        "community_posts_context_check": {
+          "name": "community_posts_context_check",
+          "value": "(\n        (\"community_posts\".\"type\" = 'solution' AND \"community_posts\".\"problem_id\" IS NOT NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'discussion' AND \"community_posts\".\"board_id\" IS NOT NULL AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'moment' AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_reports": {
+      "name": "community_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_reports_pending": {
+          "name": "idx_community_reports_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_reports\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_reporter": {
+          "name": "idx_community_reports_reporter",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_post": {
+          "name": "idx_community_reports_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_comment": {
+          "name": "idx_community_reports_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_reports_reporter_id_users_id_fk": {
+          "name": "community_reports_reporter_id_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_reports_post_id_community_posts_id_fk": {
+          "name": "community_reports_post_id_community_posts_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_comment_id_community_comments_id_fk": {
+          "name": "community_reports_comment_id_community_comments_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_resolved_by_users_id_fk": {
+          "name": "community_reports_resolved_by_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_reports_target_check": {
+          "name": "community_reports_target_check",
+          "value": "num_nonnulls(\"community_reports\".\"post_id\", \"community_reports\".\"comment_id\") = 1"
+        },
+        "community_reports_status_check": {
+          "name": "community_reports_status_check",
+          "value": "\"community_reports\".\"status\" IN ('pending', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_sanctions": {
+      "name": "community_sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_community_sanctions_active": {
+          "name": "idx_community_sanctions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_sanctions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_sanctions_creator": {
+          "name": "idx_community_sanctions_creator",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_sanctions_user_id_users_id_fk": {
+          "name": "community_sanctions_user_id_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_created_by_users_id_fk": {
+          "name": "community_sanctions_created_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_revoked_by_users_id_fk": {
+          "name": "community_sanctions_revoked_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_clarifications": {
+      "name": "contest_clarifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to_id": {
+          "name": "reply_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_clarifications_contest": {
+          "name": "idx_contest_clarifications_contest",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_clarifications_contest_id_contests_id_fk": {
+          "name": "contest_clarifications_contest_id_contests_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_problem_id_problems_id_fk": {
+          "name": "contest_clarifications_problem_id_problems_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_sender_id_users_id_fk": {
+          "name": "contest_clarifications_sender_id_users_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_reply_to_id_contest_clarifications_id_fk": {
+          "name": "contest_clarifications_reply_to_id_contest_clarifications_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contest_clarifications",
+          "columnsFrom": [
+            "reply_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_participants": {
+      "name": "contest_participants",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_participants_user": {
+          "name": "idx_contest_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_participants_contest_id_contests_id_fk": {
+          "name": "contest_participants_contest_id_contests_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_participants_user_id_users_id_fk": {
+          "name": "contest_participants_user_id_users_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_participants_contest_id_user_id_pk": {
+          "name": "contest_participants_contest_id_user_id_pk",
+          "columns": [
+            "contest_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_problems": {
+      "name": "contest_problems",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contest_problems_contest_id_contests_id_fk": {
+          "name": "contest_problems_contest_id_contests_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_problems_problem_id_problems_id_fk": {
+          "name": "contest_problems_problem_id_problems_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_problems_contest_id_problem_id_pk": {
+          "name": "contest_problems_contest_id_problem_id_pk",
+          "columns": [
+            "contest_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "contest_problems_contest_label_unique": {
+          "name": "contest_problems_contest_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "label"
+          ]
+        },
+        "contest_problems_contest_sort_order_unique": {
+          "name": "contest_problems_contest_sort_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contests": {
+      "name": "contests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affect_global_ranking": {
+          "name": "affect_global_ranking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announcement": {
+          "name": "announcement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contests_created_by": {
+          "name": "idx_contests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_start_time": {
+          "name": "idx_contests_start_time",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_end_time": {
+          "name": "idx_contests_end_time",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contests_created_by_users_id_fk": {
+          "name": "contests_created_by_users_id_fk",
+          "tableFrom": "contests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "contests_type_check": {
+          "name": "contests_type_check",
+          "value": "\"contests\".\"type\" IN ('icpc', 'ioi', 'oi')"
+        },
+        "contests_time_check": {
+          "name": "contests_time_check",
+          "value": "\"contests\".\"end_time\" > \"contests\".\"start_time\""
+        },
+        "contests_config_check": {
+          "name": "contests_config_check",
+          "value": "jsonb_typeof(\"contests\".\"config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_reads": {
+      "name": "conversation_reads",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_reads_user_id_users_id_fk": {
+          "name": "conversation_reads_user_id_users_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_reads_conversation_id_conversations_id_fk": {
+          "name": "conversation_reads_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_reads_user_id_conversation_id_pk": {
+          "name": "conversation_reads_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_conversations_user1_id": {
+          "name": "idx_conversations_user1_id",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_user2_id": {
+          "name": "idx_conversations_user2_id",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_message_at": {
+          "name": "idx_conversations_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user1_id_users_id_fk": {
+          "name": "conversations_user1_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_user2_id_users_id_fk": {
+          "name": "conversations_user2_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_user_pair_unique": {
+          "name": "conversations_user_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1_id",
+            "user2_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversations_user_order_check": {
+          "name": "conversations_user_order_check",
+          "value": "\"conversations\".\"user1_id\" < \"conversations\".\"user2_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eval_results_submission_id": {
+          "name": "idx_eval_results_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eval_results_created_at": {
+          "name": "idx_eval_results_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_submission_id_submissions_id_fk": {
+          "name": "evaluation_results_submission_id_submissions_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ip_bans": {
+      "name": "ip_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_or_cidr": {
+          "name": "ip_or_cidr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ip_bans_ip_or_cidr": {
+          "name": "idx_ip_bans_ip_or_cidr",
+          "columns": [
+            {
+              "expression": "ip_or_cidr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ip_bans_expires_at": {
+          "name": "idx_ip_bans_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ip_bans_created_by_users_id_fk": {
+          "name": "ip_bans_created_by_users_id_fk",
+          "tableFrom": "ip_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judge_images": {
+      "name": "judge_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exact'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evaluator'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_images_mode_check": {
+          "name": "judge_images_mode_check",
+          "value": "\"judge_images\".\"mode\" IN ('exact', 'all_versions')"
+        },
+        "judge_images_kind_check": {
+          "name": "judge_images_kind_check",
+          "value": "\"judge_images\".\"kind\" IN ('evaluator', 'solution')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_deletions": {
+      "name": "message_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_message_deletions_message_id": {
+          "name": "idx_message_deletions_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_deletions_user_id_users_id_fk": {
+          "name": "message_deletions_user_id_users_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_deletions_message_id_messages_id_fk": {
+          "name": "message_deletions_message_id_messages_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_deletions_user_id_message_id_pk": {
+          "name": "message_deletions_user_id_message_id_pk",
+          "columns": [
+            "user_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_created": {
+          "name": "idx_messages_conversation_created",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_sender_id": {
+          "name": "idx_messages_sender_id",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_users_id_fk": {
+          "name": "messages_sender_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.objective_questions": {
+      "name": "objective_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_questions_paper_id": {
+          "name": "idx_objective_questions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_questions_paper_id_problems_id_fk": {
+          "name": "objective_questions_paper_id_problems_id_fk",
+          "tableFrom": "objective_questions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_questions_paper_sort_unique": {
+          "name": "objective_questions_paper_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_questions_type_check": {
+          "name": "objective_questions_type_check",
+          "value": "\"objective_questions\".\"type\" IN ('single', 'multiple', 'judge')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.objective_submissions": {
+      "name": "objective_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finished'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_submissions_paper_id": {
+          "name": "idx_objective_submissions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_id": {
+          "name": "idx_objective_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_paper_created": {
+          "name": "idx_objective_submissions_user_paper_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_contest_id": {
+          "name": "idx_objective_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_submissions_paper_id_problems_id_fk": {
+          "name": "objective_submissions_paper_id_problems_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_user_id_users_id_fk": {
+          "name": "objective_submissions_user_id_users_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_contest_id_contests_id_fk": {
+          "name": "objective_submissions_contest_id_contests_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_submissions_contest_unique": {
+          "name": "objective_submissions_contest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "user_id",
+            "contest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_submissions_type_check": {
+          "name": "objective_submissions_type_check",
+          "value": "\"objective_submissions\".\"submission_type\" IN ('practice', 'contest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_password_reset_tokens_user_id": {
+          "name": "idx_password_reset_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_password_reset_tokens_expires_at": {
+          "name": "idx_password_reset_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_resource_action_unique": {
+          "name": "permissions_resource_action_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resource",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_tags": {
+      "name": "problem_tags",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "problem_tags_problem_id_problems_id_fk": {
+          "name": "problem_tags_problem_id_problems_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "problem_tags_tag_id_tags_id_fk": {
+          "name": "problem_tags_tag_id_tags_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "problem_tags_problem_id_tag_id_pk": {
+          "name": "problem_tags_problem_id_tag_id_pk",
+          "columns": [
+            "problem_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "support_package_storage_url": {
+          "name": "support_package_storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_config": {
+          "name": "runtime_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'U'"
+        },
+        "is_objective": {
+          "name": "is_objective",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_problems_search_vector": {
+          "name": "idx_problems_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "problems_type_number_unique": {
+          "name": "problems_type_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "problems_type_check": {
+          "name": "problems_type_check",
+          "value": "\"problems\".\"type\" IN ('U', 'P')"
+        },
+        "problems_runtime_config_check": {
+          "name": "problems_runtime_config_check",
+          "value": "\"problems\".\"runtime_config\" IS NULL OR jsonb_typeof(\"problems\".\"runtime_config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_roles_parent_id": {
+          "name": "idx_roles_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_parent_id_roles_id_fk": {
+          "name": "roles_parent_id_roles_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejudge_seq": {
+          "name": "rejudge_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_submissions_user_id": {
+          "name": "idx_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_problem_id": {
+          "name": "idx_submissions_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_status": {
+          "name": "idx_submissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_id": {
+          "name": "idx_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_problem_user": {
+          "name": "idx_submissions_contest_problem_user",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_user_id_created_at": {
+          "name": "idx_submissions_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_problem_id_problems_id_fk": {
+          "name": "submissions_problem_id_problems_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_contest_id_contests_id_fk": {
+          "name": "submissions_contest_id_contests_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_settings_updated_at": {
+          "name": "idx_system_settings_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tags_kind_check": {
+          "name": "tags_kind_check",
+          "value": "\"tags\".\"kind\" IN ('problem', 'algorithm')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.training_problems": {
+      "name": "training_problems",
+      "schema": "",
+      "columns": {
+        "training_id": {
+          "name": "training_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_training_problems_training_position": {
+          "name": "idx_training_problems_training_position",
+          "columns": [
+            {
+              "expression": "training_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_problems_training_id_trainings_id_fk": {
+          "name": "training_problems_training_id_trainings_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "trainings",
+          "columnsFrom": [
+            "training_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "training_problems_problem_id_problems_id_fk": {
+          "name": "training_problems_problem_id_problems_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "training_problems_training_id_problem_id_pk": {
+          "name": "training_problems_training_id_problem_id_pk",
+          "columns": [
+            "training_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "training_problems_training_position_unique": {
+          "name": "training_problems_training_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "training_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainings": {
+      "name": "trainings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trainings_visibility_pinned_created": {
+          "name": "idx_trainings_visibility_pinned_created",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trainings_created_by": {
+          "name": "idx_trainings_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trainings_created_by_users_id_fk": {
+          "name": "trainings_created_by_users_id_fk",
+          "tableFrom": "trainings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "trainings_visibility_check": {
+          "name": "trainings_visibility_check",
+          "value": "\"trainings\".\"visibility\" IN ('private', 'unlisted', 'public')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_bans": {
+      "name": "user_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "banned_until": {
+          "name": "banned_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "banned_by": {
+          "name": "banned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_at": {
+          "name": "unbanned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_by": {
+          "name": "unbanned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_bans_user": {
+          "name": "idx_user_bans_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_bans_active": {
+          "name": "idx_user_bans_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "unbanned_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_bans_user_id_users_id_fk": {
+          "name": "user_bans_user_id_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bans_banned_by_users_id_fk": {
+          "name": "user_bans_banned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "banned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_bans_unbanned_by_users_id_fk": {
+          "name": "user_bans_unbanned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "unbanned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_activity_visibility": {
+          "name": "community_activity_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'following'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_search_vector": {
+          "name": "idx_users_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_community_activity_visibility_check": {
+          "name": "users_community_activity_visibility_check",
+          "value": "\"users\".\"community_activity_visibility\" IN ('hidden', 'following', 'everyone')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1786701211528,
       "tag": "0040_drop_categories_add_tags",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1786979668015,
+      "tag": "0041_harsh_lilandra",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -6,6 +6,7 @@ import stats from "./routes/stats.ts";
 import auth from "./routes/auth.ts";
 import admin from "./routes/admin.ts";
 import adminAnnouncements from "./routes/admin-announcements.ts";
+import adminTrainings from "./routes/admin-trainings.ts";
 import tags from "./routes/tags.ts";
 import problems from "./routes/problems.ts";
 import checkin from "./routes/checkin.ts";
@@ -17,6 +18,7 @@ import conversations from "./routes/conversations.ts";
 import community from "./routes/community.ts";
 import search from "./routes/search.ts";
 import contests from "./routes/contests.ts";
+import trainings from "./routes/trainings.ts";
 import announcements from "./routes/announcements.ts";
 import sse, { contestSse, statsSse } from "./routes/sse.ts";
 import { AppError } from "./lib/errors.ts";
@@ -146,6 +148,7 @@ export function createApp(): Hono {
   // 公告管理：细粒度权限（admin:full_access 通配放行 或 announcement:manage），
   // 独立于 admin 实例（admin 实例组级 adminMiddleware 仅放行 full_access）
   app.route("/api/v1/admin/announcements", adminAnnouncements);
+  app.route("/api/v1/admin/trainings", adminTrainings);
   app.route("/api/v1/tags", tags);
   app.route("/api/v1/problems", problems);
   app.route("/api/v1/checkin", checkin);
@@ -156,6 +159,7 @@ export function createApp(): Hono {
   app.route("/api/v1/conversations", conversations);
   app.route("/api/v1/community", community);
   app.route("/api/v1/contests", contests);
+  app.route("/api/v1/trainings", trainings);
   app.route("/api/v1/search", search);
   // 公告公开路由：必须在 sse 之前注册——sse 实例的全局 authMiddleware
   // 会拦截所有挂载在其后的路由；公告 SSE 端点 /announcements/events

--- a/noj-core/src/db/schema-ddl.ts
+++ b/noj-core/src/db/schema-ddl.ts
@@ -164,6 +164,26 @@ export const SCHEMA_DDL: string[] = [
     created_at TEXT NOT NULL
   )`,
 
+  // 3.4 trainings（题单，issue #224）
+  `CREATE TABLE IF NOT EXISTS trainings (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    visibility TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private', 'unlisted', 'public')),
+    is_pinned BOOLEAN NOT NULL DEFAULT false,
+    created_by TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
+
+  `CREATE TABLE IF NOT EXISTS training_problems (
+    training_id TEXT NOT NULL REFERENCES trainings(id) ON DELETE CASCADE,
+    problem_id TEXT NOT NULL REFERENCES problems(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (training_id, problem_id),
+    UNIQUE (training_id, position)
+  )`,
+
   // 6. submissions
   `CREATE TABLE IF NOT EXISTS submissions (
     id TEXT PRIMARY KEY,
@@ -487,6 +507,10 @@ export const SCHEMA_INDEXES: string[] = [
   "CREATE INDEX IF NOT EXISTS idx_contests_end_time ON contests (end_time)",
   "CREATE INDEX IF NOT EXISTS idx_contest_clarifications_contest ON contest_clarifications (contest_id, created_at)",
   "CREATE INDEX IF NOT EXISTS idx_contest_participants_user ON contest_participants (user_id)",
+  // 题单索引（issue #224）
+  "CREATE INDEX IF NOT EXISTS idx_trainings_visibility_pinned_created ON trainings (visibility, is_pinned, created_at)",
+  "CREATE INDEX IF NOT EXISTS idx_trainings_created_by ON trainings (created_by)",
+  "CREATE INDEX IF NOT EXISTS idx_training_problems_training_position ON training_problems (training_id, position)",
   // 客观题表索引（与 schema.ts 定义一致，PGlite 测试模式）
   "CREATE INDEX IF NOT EXISTS idx_objective_questions_paper_id ON objective_questions (paper_id)",
   "CREATE INDEX IF NOT EXISTS idx_objective_submissions_paper_id ON objective_submissions (paper_id)",
@@ -572,6 +596,8 @@ export const ALL_TABLES = [
   "contest_problems",
   "contest_participants",
   "contest_clarifications",
+  "trainings",
+  "training_problems",
   "submissions",
   "evaluation_results",
   "check_ins",

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -373,6 +373,62 @@ export const contestProblems = pgTable(
 );
 
 /**
+ * 题单主表（issue #224）。
+ * visibility: private=仅创建者 / unlisted=URL 可访问 / public=出现在题单列表页。
+ */
+export const trainings = pgTable(
+  "trainings",
+  {
+    id: text("id").primaryKey(),
+    title: text("title").notNull(),
+    description: text("description").notNull().default(""),
+    visibility: text("visibility").notNull().default("private"),
+    is_pinned: boolean("is_pinned").notNull().default(false),
+    created_by: text("created_by").notNull().references(() => users.id, {
+      onDelete: "cascade",
+    }),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+  },
+  (table) => ({
+    visibilityCheck: check(
+      "trainings_visibility_check",
+      sql`${table.visibility} IN ('private', 'unlisted', 'public')`,
+    ),
+    visibilityPinnedCreatedIdx: index(
+      "idx_trainings_visibility_pinned_created",
+    ).on(table.visibility, table.is_pinned, table.created_at),
+    createdByIdx: index("idx_trainings_created_by").on(table.created_by),
+  }),
+);
+
+/**
+ * 题单题目关联表。
+ * position 在单个题单内保持唯一；题目删除时级联清理。
+ */
+export const trainingProblems = pgTable(
+  "training_problems",
+  {
+    training_id: text("training_id")
+      .notNull()
+      .references(() => trainings.id, { onDelete: "cascade" }),
+    problem_id: text("problem_id")
+      .notNull()
+      .references(() => problems.id, { onDelete: "cascade" }),
+    position: integer("position").notNull().default(0),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.training_id, table.problem_id] }),
+    positionUnique: unique(
+      "training_problems_training_position_unique",
+    ).on(table.training_id, table.position),
+    trainingPositionIdx: index(
+      "idx_training_problems_training_position",
+    ).on(table.training_id, table.position),
+  }),
+);
+
+/**
  * 竞赛参与者表。
  */
 export const contestParticipants = pgTable(

--- a/noj-core/src/routes/admin-trainings.ts
+++ b/noj-core/src/routes/admin-trainings.ts
@@ -1,0 +1,98 @@
+/**
+ * 题单后台管理路由（issue #224）。
+ *
+ * 挂载前缀：/api/v1/admin/trainings
+ * 提供：全部题单列表、任意题单更新（含 public/pin）、删除。
+ * 权限：细粒度 `training:*`；`admin:full_access` 通配放行。
+ */
+
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth.ts";
+import { parseJsonBody } from "../lib/request.ts";
+import { parsePagination } from "../lib/pagination.ts";
+import { assertPermission, checkPermission } from "../lib/permissions.ts";
+import { BadRequestError } from "../lib/errors.ts";
+import { runWithContext } from "../lib/requestContext.ts";
+import { getClientIp } from "../lib/rate-limit-env.ts";
+import {
+  deleteTraining,
+  listAllTrainings,
+  updateTraining,
+} from "../services/trainings.ts";
+import type { UpdateTrainingInput } from "../types/trainings.ts";
+
+const router = new Hono<{ Variables: { userId: string; userRole: string } }>();
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertObjectBody(
+  body: unknown,
+): asserts body is Record<string, unknown> {
+  if (!isObject(body)) {
+    throw new BadRequestError("请求体必须为 JSON 对象");
+  }
+}
+
+// 组级中间件：认证 + RequestContext 注入；具体权限在各 handler 内按需校验。
+router.use("*", authMiddleware, (c, next) => {
+  return runWithContext(
+    {
+      actorId: c.get("userId"),
+      actorIp: getClientIp(c),
+      actorRole: c.get("userRole"),
+    },
+    () => next(),
+  );
+});
+
+router.get("/", async (c) => {
+  await assertPermission(c, "training:read_any");
+  const { page, perPage } = parsePagination(c);
+  const result = await listAllTrainings({ page, perPage });
+  return c.json({
+    data: result.data,
+    total: result.total,
+    page,
+    per_page: perPage,
+  });
+});
+
+router.patch("/:id", async (c) => {
+  const id = c.req.param("id") as string;
+  const body = await parseJsonBody<UpdateTrainingInput>(c);
+  assertObjectBody(body as unknown);
+  const canPublish = await checkPermission(c, "training:publish");
+  const canPin = await checkPermission(c, "training:pin");
+
+  const editsTitleOrDescription = body.title !== undefined ||
+    body.description !== undefined;
+  const editsNonPublicVisibility = body.visibility !== undefined &&
+    body.visibility !== "public";
+  if (editsTitleOrDescription || editsNonPublicVisibility) {
+    await assertPermission(c, "training:write_any");
+  }
+  if (body.visibility === "public") {
+    await assertPermission(c, "training:publish");
+  }
+  if (body.is_pinned !== undefined) {
+    await assertPermission(c, "training:pin");
+  }
+
+  const updated = await updateTraining(id, body, c.get("userId"), {
+    isAdmin: true,
+    canPublish,
+    canPin,
+  });
+  return c.json({ data: updated });
+});
+
+router.delete("/:id", async (c) => {
+  await assertPermission(c, "training:delete_any");
+  const id = c.req.param("id") as string;
+  await deleteTraining(id, c.get("userId"), true);
+  return c.body(null, 204);
+});
+
+export default router;

--- a/noj-core/src/routes/trainings.ts
+++ b/noj-core/src/routes/trainings.ts
@@ -1,0 +1,231 @@
+/**
+ * 题单（training）用户侧路由（issue #224）。
+ *
+ * 挂载前缀：/api/v1/trainings
+ * 包含：公开列表、用户主页题单列表、我的题单、题单 CRUD、题目管理。
+ */
+
+import { Hono } from "hono";
+import { authMiddleware, optionalAuthMiddleware } from "../middleware/auth.ts";
+import { parseJsonBody } from "../lib/request.ts";
+import { parsePagination } from "../lib/pagination.ts";
+import { assertPermission, checkPermission } from "../lib/permissions.ts";
+import { BadRequestError } from "../lib/errors.ts";
+import {
+  addTrainingProblem,
+  createTraining,
+  deleteTraining,
+  getTraining,
+  listMyTrainings,
+  listPublicTrainings,
+  listTrainingProblems,
+  listUserTrainings,
+  removeTrainingProblem,
+  reorderTrainingProblems,
+  updateTraining,
+} from "../services/trainings.ts";
+import type {
+  CreateTrainingInput,
+  UpdateTrainingInput,
+} from "../types/trainings.ts";
+
+const router = new Hono<{ Variables: { userId: string; userRole: string } }>();
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertObjectBody(
+  body: unknown,
+): asserts body is Record<string, unknown> {
+  if (!isObject(body)) {
+    throw new BadRequestError("请求体必须为 JSON 对象");
+  }
+}
+
+router.get("/", optionalAuthMiddleware, async (c) => {
+  const { page, perPage } = parsePagination(c);
+  const createdBy = c.req.query("created_by");
+  if (createdBy) {
+    const viewerId = c.get("userId") as string | undefined;
+    const isAdmin = viewerId
+      ? await checkPermission(c, "training:read_any")
+      : false;
+    const result = await listUserTrainings(createdBy, viewerId, isAdmin, {
+      page,
+      perPage,
+    });
+    return c.json({
+      data: result.data,
+      total: result.total,
+      page,
+      per_page: perPage,
+    });
+  }
+  const result = await listPublicTrainings({ page, perPage });
+  return c.json({
+    data: result.data,
+    total: result.total,
+    page,
+    per_page: perPage,
+  });
+});
+
+router.get("/mine", authMiddleware, async (c) => {
+  const { page, perPage } = parsePagination(c);
+  const result = await listMyTrainings(c.get("userId"), { page, perPage });
+  return c.json({
+    data: result.data,
+    total: result.total,
+    page,
+    per_page: perPage,
+  });
+});
+
+router.post("/", authMiddleware, async (c) => {
+  await assertPermission(c, "training:create");
+  const body = await parseJsonBody<CreateTrainingInput>(c);
+  assertObjectBody(body as unknown);
+  const training = await createTraining(body, c.get("userId"));
+  return c.json({ data: training }, 201);
+});
+
+router.get("/:id", optionalAuthMiddleware, async (c) => {
+  const viewerId = c.get("userId") as string | undefined;
+  const isAdmin = viewerId
+    ? await checkPermission(c, "training:read_any")
+    : false;
+  const training = await getTraining(
+    c.req.param("id") as string,
+    viewerId,
+    isAdmin,
+  );
+  return c.json({ data: training });
+});
+
+router.put("/:id", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:write_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  const isOwner = training.created_by === actorId;
+  await assertPermission(
+    c,
+    isOwner ? "training:write_own" : "training:write_any",
+  );
+
+  const body = await parseJsonBody<UpdateTrainingInput>(c);
+  assertObjectBody(body as unknown);
+  const canPublish = await checkPermission(c, "training:publish");
+  const canPin = await checkPermission(c, "training:pin");
+  if (body.visibility === "public") {
+    await assertPermission(c, "training:publish");
+  }
+  if (body.is_pinned !== undefined) {
+    await assertPermission(c, "training:pin");
+  }
+  const updated = await updateTraining(id, body, actorId, {
+    isAdmin,
+    canPublish,
+    canPin,
+  });
+  return c.json({ data: updated });
+});
+
+router.delete("/:id", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:delete_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  const isOwner = training.created_by === actorId;
+  await assertPermission(
+    c,
+    isOwner ? "training:delete_own" : "training:delete_any",
+  );
+  await deleteTraining(id, actorId, isAdmin);
+  return c.body(null, 204);
+});
+
+router.get("/:id/problems", optionalAuthMiddleware, async (c) => {
+  const viewerId = c.get("userId") as string | undefined;
+  const isAdmin = viewerId
+    ? await checkPermission(c, "training:read_any")
+    : false;
+  const data = await listTrainingProblems(
+    c.req.param("id") as string,
+    viewerId,
+    isAdmin,
+  );
+  return c.json({ data });
+});
+
+router.post("/:id/problems", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:write_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  await assertPermission(
+    c,
+    training.created_by === actorId
+      ? "training:write_own"
+      : "training:write_any",
+  );
+  const body = await parseJsonBody<{ problem_id: string; position?: number }>(
+    c,
+  );
+  assertObjectBody(body as unknown);
+  if (!body.problem_id) throw new BadRequestError("缺少 problem_id");
+  const data = await addTrainingProblem(
+    id,
+    body.problem_id,
+    body.position,
+    actorId,
+    isAdmin,
+  );
+  return c.json({ data }, 201);
+});
+
+router.put("/:id/problems", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:write_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  await assertPermission(
+    c,
+    training.created_by === actorId
+      ? "training:write_own"
+      : "training:write_any",
+  );
+  const body = await parseJsonBody<{
+    problems: { problem_id: string; position: number }[];
+  }>(c);
+  assertObjectBody(body as unknown);
+  if (!Array.isArray(body.problems)) {
+    throw new BadRequestError("problems 必须是数组");
+  }
+  const data = await reorderTrainingProblems(
+    id,
+    body.problems,
+    actorId,
+    isAdmin,
+  );
+  return c.json({ data });
+});
+
+router.delete("/:id/problems/:problemId", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const problemId = c.req.param("problemId") as string;
+  const actorId = c.get("userId");
+  const isAdmin = await checkPermission(c, "training:write_any");
+  const training = await getTraining(id, actorId, isAdmin);
+  await assertPermission(
+    c,
+    training.created_by === actorId
+      ? "training:write_own"
+      : "training:write_any",
+  );
+  await removeTrainingProblem(id, problemId, actorId, isAdmin);
+  return c.body(null, 204);
+});
+
+export default router;

--- a/noj-core/src/services/seed-rbac.ts
+++ b/noj-core/src/services/seed-rbac.ts
@@ -44,6 +44,10 @@ const USER_DEFAULT_PERMISSIONS: Array<{ resource: string; action: string }> = [
   { resource: "community", action: "react" },
   { resource: "community", action: "follow" },
   { resource: "community", action: "report" },
+  { resource: "training", action: "create" },
+  { resource: "training", action: "read" },
+  { resource: "training", action: "write_own" },
+  { resource: "training", action: "delete_own" },
 ];
 
 // NOJ-062：普通注册用户不得默认持有 evaluator.command/network 等敏感字段

--- a/noj-core/src/services/trainings.ts
+++ b/noj-core/src/services/trainings.ts
@@ -1,0 +1,518 @@
+/**
+ * 题单（training）服务层（issue #224）。
+ *
+ * 职责：
+ * - 题单 CRUD 与可见性访问控制
+ * - 题单题目管理（加题 / 重排 / 移除）
+ * - AC 进度聚合（编程题 Accepted + 客观题满分）
+ *
+ * 权限约定：
+ * - 路由层负责 RBAC 权限判定；服务层做所有权/可见性兜底（fail-closed）。
+ * - `visibility=public` 仅管理员（`training:publish`）可设置；
+ *   `is_pinned` 仅管理员（`training:pin`）可设置。
+ */
+
+import { and, asc, count, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+import {
+  evaluationResults,
+  objectiveSubmissions,
+  problems,
+  submissions,
+  trainingProblems,
+  trainings,
+} from "../db/schema.ts";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "../lib/errors.ts";
+import { getProblem, getProblemByTypeAndNumber } from "./problems.ts";
+import {
+  type CreateTrainingInput,
+  isValidTrainingVisibility,
+  type TrainingProblemResponse,
+  type TrainingResponse,
+  type TrainingVisibility,
+  type UpdateTrainingInput,
+} from "../types/trainings.ts";
+
+export interface ListTrainingsParams {
+  page?: number;
+  perPage?: number;
+}
+
+export interface ListTrainingsResult {
+  data: TrainingResponse[];
+  total: number;
+}
+
+export interface UpdateTrainingOptions {
+  /** 是否可编辑任意题单（admin / training:write_any） */
+  isAdmin?: boolean;
+  /** 是否可将可见性设为 public（training:publish） */
+  canPublish?: boolean;
+  /** 是否可设置 is_pinned（training:pin） */
+  canPin?: boolean;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+function normalizePage(params: ListTrainingsParams): {
+  page: number;
+  perPage: number;
+  offset: number;
+} {
+  const page = Math.max(1, params.page ?? 1);
+  const perPage = Math.min(
+    MAX_PAGE_SIZE,
+    Math.max(1, params.perPage ?? DEFAULT_PAGE_SIZE),
+  );
+  return { page, perPage, offset: (page - 1) * perPage };
+}
+
+async function countProblems(
+  trainingIds: string[],
+): Promise<Map<string, number>> {
+  if (trainingIds.length === 0) return new Map();
+  const db = getDb();
+  const rows = await db
+    .select({
+      training_id: trainingProblems.training_id,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(trainingProblems)
+    .where(inArray(trainingProblems.training_id, trainingIds))
+    .groupBy(trainingProblems.training_id);
+  return new Map(rows.map((r) => [r.training_id, r.count]));
+}
+
+function toResponse(
+  row: typeof trainings.$inferSelect,
+  problemCount: number,
+): TrainingResponse {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    visibility: row.visibility as TrainingVisibility,
+    is_pinned: row.is_pinned,
+    created_by: row.created_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    problem_count: problemCount,
+  };
+}
+
+export async function listPublicTrainings(
+  params: ListTrainingsParams,
+): Promise<ListTrainingsResult> {
+  const db = getDb();
+  const { perPage, offset } = normalizePage(params);
+  const where = eq(trainings.visibility, "public");
+  const [rows, totalRows] = await Promise.all([
+    db.select().from(trainings).where(where)
+      .orderBy(desc(trainings.is_pinned), desc(trainings.updated_at))
+      .limit(perPage).offset(offset),
+    db.select({ total: count() }).from(trainings).where(where),
+  ]);
+  const counts = await countProblems(rows.map((r) => r.id));
+  const data = rows.map((r) => toResponse(r, counts.get(r.id) ?? 0));
+  return { data, total: totalRows[0]?.total ?? 0 };
+}
+
+export async function listMyTrainings(
+  userId: string,
+  params: ListTrainingsParams,
+): Promise<ListTrainingsResult> {
+  const db = getDb();
+  const { perPage, offset } = normalizePage(params);
+  const where = eq(trainings.created_by, userId);
+  const [rows, totalRows] = await Promise.all([
+    db.select().from(trainings).where(where)
+      .orderBy(desc(trainings.updated_at))
+      .limit(perPage).offset(offset),
+    db.select({ total: count() }).from(trainings).where(where),
+  ]);
+  const counts = await countProblems(rows.map((r) => r.id));
+  const data = rows.map((r) => toResponse(r, counts.get(r.id) ?? 0));
+  return { data, total: totalRows[0]?.total ?? 0 };
+}
+
+export async function listAllTrainings(
+  params: ListTrainingsParams,
+): Promise<ListTrainingsResult> {
+  const db = getDb();
+  const { perPage, offset } = normalizePage(params);
+  const [rows, totalRows] = await Promise.all([
+    db.select().from(trainings)
+      .orderBy(desc(trainings.updated_at))
+      .limit(perPage).offset(offset),
+    db.select({ total: count() }).from(trainings),
+  ]);
+  const counts = await countProblems(rows.map((r) => r.id));
+  const data = rows.map((r) => toResponse(r, counts.get(r.id) ?? 0));
+  return { data, total: totalRows[0]?.total ?? 0 };
+}
+
+export async function listUserTrainings(
+  ownerId: string,
+  viewerId?: string,
+  isAdmin = false,
+  params: ListTrainingsParams = {},
+): Promise<ListTrainingsResult> {
+  const db = getDb();
+  const { perPage, offset } = normalizePage(params);
+  const isOwner = ownerId === viewerId || isAdmin;
+  const conditions = [eq(trainings.created_by, ownerId)];
+  if (!isOwner) conditions.push(eq(trainings.visibility, "public"));
+  const where = and(...conditions);
+  const [rows, totalRows] = await Promise.all([
+    db.select().from(trainings).where(where)
+      .orderBy(desc(trainings.is_pinned), desc(trainings.updated_at))
+      .limit(perPage).offset(offset),
+    db.select({ total: count() }).from(trainings).where(where),
+  ]);
+  const counts = await countProblems(rows.map((r) => r.id));
+  const data = rows.map((r) => toResponse(r, counts.get(r.id) ?? 0));
+  return { data, total: totalRows[0]?.total ?? 0 };
+}
+
+export async function getTraining(
+  id: string,
+  viewerId?: string,
+  isAdmin = false,
+): Promise<TrainingResponse> {
+  const db = getDb();
+  const [row] = await db.select().from(trainings).where(eq(trainings.id, id))
+    .limit(1);
+  if (!row) throw new NotFoundError("题单不存在");
+  if (row.visibility === "private" && row.created_by !== viewerId && !isAdmin) {
+    throw new NotFoundError("题单不存在");
+  }
+  const counts = await countProblems([row.id]);
+  return toResponse(row, counts.get(row.id) ?? 0);
+}
+
+export async function createTraining(
+  input: CreateTrainingInput,
+  userId: string,
+): Promise<TrainingResponse> {
+  const title = input.title?.trim();
+  if (!title || title.length > 100) {
+    throw new BadRequestError("题单标题必须为 1-100 字符");
+  }
+  const visibility = input.visibility ?? "private";
+  if (!isValidTrainingVisibility(visibility) || visibility === "public") {
+    throw new BadRequestError("创建题单时可见性只能为 private 或 unlisted");
+  }
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+  await db.insert(trainings).values({
+    id,
+    title,
+    description: input.description?.trim() ?? "",
+    visibility,
+    is_pinned: false,
+    created_by: userId,
+    created_at: now,
+    updated_at: now,
+  });
+  return getTraining(id, userId);
+}
+
+export async function updateTraining(
+  id: string,
+  input: UpdateTrainingInput,
+  actorId: string,
+  options: UpdateTrainingOptions = {},
+): Promise<TrainingResponse> {
+  const { isAdmin = false, canPublish = isAdmin, canPin = isAdmin } = options;
+  const db = getDb();
+  const [row] = await db.select().from(trainings).where(eq(trainings.id, id))
+    .limit(1);
+  if (!row) throw new NotFoundError("题单不存在");
+  if (row.created_by !== actorId && !isAdmin) {
+    throw new ForbiddenError("无权编辑该题单");
+  }
+  if (input.is_pinned !== undefined && !canPin) {
+    throw new ForbiddenError("无权置顶题单");
+  }
+  if (input.visibility === "public" && !canPublish) {
+    throw new ForbiddenError("无权将题单设为公开");
+  }
+  if (
+    input.visibility !== undefined &&
+    !isValidTrainingVisibility(input.visibility)
+  ) {
+    throw new BadRequestError("可见性不合法");
+  }
+  if (input.title !== undefined) {
+    const title = input.title.trim();
+    if (!title || title.length > 100) {
+      throw new BadRequestError("题单标题必须为 1-100 字符");
+    }
+  }
+  const next = {
+    ...(input.title !== undefined ? { title: input.title.trim() } : {}),
+    ...(input.description !== undefined
+      ? { description: input.description.trim() }
+      : {}),
+    ...(input.visibility !== undefined ? { visibility: input.visibility } : {}),
+    ...(input.is_pinned !== undefined ? { is_pinned: input.is_pinned } : {}),
+    updated_at: new Date().toISOString(),
+  };
+  await db.update(trainings).set(next).where(eq(trainings.id, id));
+  return getTraining(id, actorId, isAdmin);
+}
+
+export async function deleteTraining(
+  id: string,
+  actorId: string,
+  isAdmin = false,
+): Promise<void> {
+  const db = getDb();
+  const [row] = await db.select().from(trainings).where(eq(trainings.id, id))
+    .limit(1);
+  if (!row) throw new NotFoundError("题单不存在");
+  if (row.created_by !== actorId && !isAdmin) {
+    throw new ForbiddenError("无权删除该题单");
+  }
+  await db.delete(trainings).where(eq(trainings.id, id));
+}
+
+// ── 题单题目管理与进度聚合 ──────────────────────────────
+
+async function assertWritable(
+  trainingId: string,
+  actorId: string,
+  isAdmin: boolean,
+): Promise<typeof trainings.$inferSelect> {
+  const db = getDb();
+  const [row] = await db.select().from(trainings).where(
+    eq(trainings.id, trainingId),
+  )
+    .limit(1);
+  if (!row) throw new NotFoundError("题单不存在");
+  if (row.created_by !== actorId && !isAdmin) {
+    throw new ForbiddenError("无权编辑该题单");
+  }
+  return row;
+}
+
+async function getAcceptedProblemIds(
+  userId: string,
+  problemIds: string[],
+): Promise<Set<string>> {
+  if (problemIds.length === 0) return new Set();
+  const db = getDb();
+  const acceptedRows = await db
+    .select({ problem_id: submissions.problem_id })
+    .from(submissions)
+    .innerJoin(
+      evaluationResults,
+      eq(evaluationResults.submission_id, submissions.id),
+    )
+    .where(and(
+      eq(submissions.user_id, userId),
+      inArray(submissions.problem_id, problemIds),
+      eq(evaluationResults.status, "Accepted"),
+    ));
+  const objectiveRows = await db
+    .select({ paper_id: objectiveSubmissions.paper_id })
+    .from(objectiveSubmissions)
+    .where(and(
+      eq(objectiveSubmissions.user_id, userId),
+      inArray(objectiveSubmissions.paper_id, problemIds),
+      eq(objectiveSubmissions.score, 10000),
+    ));
+  return new Set([
+    ...acceptedRows.map((r) => r.problem_id),
+    ...objectiveRows.map((r) => r.paper_id),
+  ]);
+}
+
+export async function listTrainingProblems(
+  trainingId: string,
+  viewerId?: string,
+  isAdmin = false,
+): Promise<TrainingProblemResponse[]> {
+  await getTraining(trainingId, viewerId, isAdmin);
+  const db = getDb();
+  const rows = await db
+    .select({
+      training_id: trainingProblems.training_id,
+      problem_id: trainingProblems.problem_id,
+      position: trainingProblems.position,
+      title: problems.title,
+      description: problems.description,
+      difficulty: problems.difficulty,
+      display_id: sql<string>`${problems.type} || ${problems.number}`,
+      type: problems.type,
+      is_objective: problems.is_objective,
+    })
+    .from(trainingProblems)
+    .innerJoin(problems, eq(trainingProblems.problem_id, problems.id))
+    .where(eq(trainingProblems.training_id, trainingId))
+    .orderBy(asc(trainingProblems.position));
+  const accepted = viewerId
+    ? await getAcceptedProblemIds(viewerId, rows.map((r) => r.problem_id))
+    : new Set<string>();
+  return rows.map((r) => ({ ...r, accepted: accepted.has(r.problem_id) }));
+}
+
+async function resolveProblemId(input: string): Promise<string> {
+  const value = input.trim();
+  const match = value.match(/^([UuPp])(\d+)$/);
+  if (match) {
+    const problem = await getProblemByTypeAndNumber(
+      match[1].toUpperCase(),
+      parseInt(match[2], 10),
+    );
+    return problem.id;
+  }
+  const problem = await getProblem(value);
+  return problem.id;
+}
+
+export async function addTrainingProblem(
+  trainingId: string,
+  problemId: string,
+  position: number | undefined,
+  actorId: string,
+  isAdmin = false,
+): Promise<TrainingProblemResponse> {
+  await assertWritable(trainingId, actorId, isAdmin);
+  const db = getDb();
+  const resolvedProblemId = await resolveProblemId(problemId);
+  const [problem] = await db.select().from(problems).where(
+    eq(problems.id, resolvedProblemId),
+  )
+    .limit(1);
+  if (!problem) throw new NotFoundError("题目不存在");
+  const [existing] = await db
+    .select()
+    .from(trainingProblems)
+    .where(and(
+      eq(trainingProblems.training_id, trainingId),
+      eq(trainingProblems.problem_id, resolvedProblemId),
+    ))
+    .limit(1);
+  if (existing) throw new ConflictError("该题目已在题单中");
+  if (position !== undefined && (!Number.isInteger(position) || position < 0)) {
+    throw new BadRequestError("position 必须为非负整数");
+  }
+
+  const nextPosition = await db.transaction(async (tx) => {
+    let target = position;
+    if (target === undefined) {
+      const [maxRow] = await tx
+        .select({
+          max: sql<number>`coalesce(max(${trainingProblems.position}), -1)`,
+        })
+        .from(trainingProblems)
+        .where(eq(trainingProblems.training_id, trainingId));
+      target = (maxRow?.max ?? -1) + 1;
+    } else {
+      await tx
+        .update(trainingProblems)
+        .set({ position: sql`${trainingProblems.position} + 1` })
+        .where(and(
+          eq(trainingProblems.training_id, trainingId),
+          gte(trainingProblems.position, target),
+        ));
+    }
+    await tx.insert(trainingProblems).values({
+      training_id: trainingId,
+      problem_id: resolvedProblemId,
+      position: target,
+    });
+    return target;
+  });
+
+  return {
+    training_id: trainingId,
+    problem_id: resolvedProblemId,
+    position: nextPosition,
+    title: problem.title,
+    description: problem.description,
+    difficulty: problem.difficulty,
+    display_id: `${problem.type}${problem.number}`,
+    type: problem.type,
+    is_objective: problem.is_objective,
+    accepted: false,
+  };
+}
+
+export async function reorderTrainingProblems(
+  trainingId: string,
+  problemsInput: { problem_id: string; position: number }[],
+  actorId: string,
+  isAdmin = false,
+): Promise<TrainingProblemResponse[]> {
+  await assertWritable(trainingId, actorId, isAdmin);
+  const db = getDb();
+  const existing = await db
+    .select({ problem_id: trainingProblems.problem_id })
+    .from(trainingProblems)
+    .where(eq(trainingProblems.training_id, trainingId));
+  const existingIds = new Set(existing.map((r) => r.problem_id));
+  if (
+    problemsInput.some((r) =>
+      typeof r.problem_id !== "string" || !r.problem_id.trim() ||
+      !Number.isInteger(r.position)
+    )
+  ) {
+    throw new BadRequestError(
+      "problem_id 必须为非空字符串，position 必须为整数",
+    );
+  }
+  const inputIds = new Set(problemsInput.map((r) => r.problem_id));
+  if (inputIds.size !== problemsInput.length) {
+    throw new BadRequestError("problem_id 不能重复");
+  }
+  if (
+    existingIds.size !== inputIds.size ||
+    [...existingIds].some((id) => !inputIds.has(id))
+  ) {
+    throw new BadRequestError("重排必须包含题单当前全部题目");
+  }
+  const positions = new Set(problemsInput.map((r) => r.position));
+  if (positions.size !== problemsInput.length) {
+    throw new BadRequestError("position 不能重复");
+  }
+  if (problemsInput.some((r) => r.position < 0)) {
+    throw new BadRequestError("position 不能为负数");
+  }
+
+  await db.transaction(async (tx) => {
+    await tx.delete(trainingProblems).where(
+      eq(trainingProblems.training_id, trainingId),
+    );
+    await tx.insert(trainingProblems).values(
+      problemsInput.map((r) => ({
+        training_id: trainingId,
+        problem_id: r.problem_id,
+        position: r.position,
+      })),
+    );
+  });
+  return listTrainingProblems(trainingId, actorId, isAdmin);
+}
+
+export async function removeTrainingProblem(
+  trainingId: string,
+  problemId: string,
+  actorId: string,
+  isAdmin = false,
+): Promise<void> {
+  await assertWritable(trainingId, actorId, isAdmin);
+  const db = getDb();
+  await db.delete(trainingProblems).where(and(
+    eq(trainingProblems.training_id, trainingId),
+    eq(trainingProblems.problem_id, problemId),
+  ));
+}

--- a/noj-core/src/types/index.ts
+++ b/noj-core/src/types/index.ts
@@ -255,6 +255,16 @@ export const PERMISSION_DEFS: Array<{
     action: "manage",
     description: "管理社区板块",
   },
+  // 题单（training）
+  { resource: "training", action: "create", description: "创建题单" },
+  { resource: "training", action: "read", description: "查看题单" },
+  { resource: "training", action: "read_any", description: "查看任意题单" },
+  { resource: "training", action: "write_own", description: "编辑自己的题单" },
+  { resource: "training", action: "write_any", description: "编辑任意题单" },
+  { resource: "training", action: "delete_own", description: "删除自己的题单" },
+  { resource: "training", action: "delete_any", description: "删除任意题单" },
+  { resource: "training", action: "publish", description: "将题单设为公开" },
+  { resource: "training", action: "pin", description: "置顶题单" },
   // 公告
   { resource: "announcement", action: "manage", description: "管理公告" },
   // 系统

--- a/noj-core/src/types/trainings.ts
+++ b/noj-core/src/types/trainings.ts
@@ -1,0 +1,51 @@
+/**
+ * 题单（training）类型定义（issue #224）。
+ * 第一版为扁平题单：trainings + training_problems，题目按 position 排序。
+ */
+
+export const TRAINING_VISIBILITIES = ["private", "unlisted", "public"] as const;
+export type TrainingVisibility = typeof TRAINING_VISIBILITIES[number];
+
+export function isValidTrainingVisibility(
+  value: string,
+): value is TrainingVisibility {
+  return TRAINING_VISIBILITIES.includes(value as TrainingVisibility);
+}
+
+export interface CreateTrainingInput {
+  title: string;
+  description?: string;
+  visibility?: TrainingVisibility;
+}
+
+export interface UpdateTrainingInput {
+  title?: string;
+  description?: string;
+  visibility?: TrainingVisibility;
+  is_pinned?: boolean;
+}
+
+export interface TrainingResponse {
+  id: string;
+  title: string;
+  description: string;
+  visibility: TrainingVisibility;
+  is_pinned: boolean;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  problem_count: number;
+}
+
+export interface TrainingProblemResponse {
+  training_id: string;
+  problem_id: string;
+  position: number;
+  title: string;
+  description: string;
+  difficulty: string;
+  display_id: string;
+  type: string;
+  is_objective: boolean;
+  accepted: boolean;
+}

--- a/noj-core/tests/routes/admin-trainings.test.ts
+++ b/noj-core/tests/routes/admin-trainings.test.ts
@@ -1,0 +1,112 @@
+import { assertEquals } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { createApp } from "../../src/app.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { trainings, userRoles, users } from "../../src/db/schema.ts";
+import { signToken } from "../../src/lib/jwt.ts";
+import { initRedisForTest, jsonRequest } from "../lib/helper.ts";
+import { ensureRbacSeeds } from "../../src/services/seed-rbac.ts";
+
+await resetDbForTest();
+await initRedisForTest();
+await ensureRbacSeeds();
+
+Deno.test({
+  name: "admin trainings routes: 列表、设 public、置顶、删除",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    const adminId = crypto.randomUUID();
+    const userId = crypto.randomUUID();
+    const unique = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+    const now = new Date().toISOString();
+    const app = createApp();
+
+    await db.insert(users).values([
+      {
+        id: adminId,
+        username: `admin-train-${unique}`,
+        email: `admin-train-${unique}@example.com`,
+        password_hash: "hash",
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: userId,
+        username: `user-train-${unique}`,
+        email: `user-train-${unique}@example.com`,
+        password_hash: "hash",
+        created_at: now,
+        updated_at: now,
+      },
+    ]);
+    await db.insert(userRoles).values({
+      user_id: adminId,
+      role_id: "admin",
+    }).onConflictDoNothing();
+    await db.insert(userRoles).values({
+      user_id: userId,
+      role_id: "user",
+    }).onConflictDoNothing();
+    const adminToken = await signToken({ sub: adminId, role: "admin" });
+    const userToken = await signToken({ sub: userId, role: "user" });
+
+    let trainingId: string | undefined;
+    try {
+      const createRes = await jsonRequest(app, "/api/v1/trainings", {
+        method: "POST",
+        token: userToken,
+        body: { title: "待管理题单", visibility: "unlisted" },
+      });
+      assertEquals(createRes.status, 201);
+      trainingId = (await createRes.json()).data.id;
+
+      const forbidden = await jsonRequest(
+        app,
+        `/api/v1/admin/trainings/${trainingId}`,
+        {
+          method: "PATCH",
+          token: userToken,
+          body: { visibility: "public" },
+        },
+      );
+      assertEquals(forbidden.status, 403);
+
+      const forbiddenList = await jsonRequest(app, "/api/v1/admin/trainings", {
+        token: userToken,
+      });
+      assertEquals(forbiddenList.status, 403);
+
+      const patch = await jsonRequest(
+        app,
+        `/api/v1/admin/trainings/${trainingId}`,
+        {
+          method: "PATCH",
+          token: adminToken,
+          body: { visibility: "public", is_pinned: true },
+        },
+      );
+      assertEquals(patch.status, 200);
+      const patched = await patch.json();
+      assertEquals(patched.data.visibility, "public");
+      assertEquals(patched.data.is_pinned, true);
+
+      const list = await jsonRequest(app, "/api/v1/admin/trainings", {
+        token: adminToken,
+      });
+      assertEquals(list.status, 200);
+      const listBody = await list.json();
+      assertEquals(
+        listBody.data.some((t: { id: string }) => t.id === trainingId),
+        true,
+      );
+    } finally {
+      if (trainingId) {
+        await db.delete(trainings).where(eq(trainings.id, trainingId));
+      }
+      await db.delete(users).where(eq(users.id, userId));
+      await db.delete(users).where(eq(users.id, adminId));
+    }
+  },
+});

--- a/noj-core/tests/routes/trainings.test.ts
+++ b/noj-core/tests/routes/trainings.test.ts
@@ -1,0 +1,174 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { createApp } from "../../src/app.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { problems, trainings, userRoles, users } from "../../src/db/schema.ts";
+import { signToken } from "../../src/lib/jwt.ts";
+import { initRedisForTest, jsonRequest } from "../lib/helper.ts";
+import { ensureRbacSeeds } from "../../src/services/seed-rbac.ts";
+
+await resetDbForTest();
+await initRedisForTest();
+await ensureRbacSeeds();
+
+Deno.test({
+  name: "trainings routes: 公开列表、mine、CRUD、题目管理",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    const userId = crypto.randomUUID();
+    const adminId = crypto.randomUUID();
+    const problemId = crypto.randomUUID();
+    const unique = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+    const now = new Date().toISOString();
+    const app = createApp();
+
+    await db.insert(users).values([
+      {
+        id: userId,
+        username: `train-user-${unique}`,
+        email: `train-user-${unique}@example.com`,
+        password_hash: "hash",
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: adminId,
+        username: `train-admin-${unique}`,
+        email: `train-admin-${unique}@example.com`,
+        password_hash: "hash",
+        created_at: now,
+        updated_at: now,
+      },
+    ]);
+    await db.insert(userRoles).values({
+      user_id: adminId,
+      role_id: "admin",
+    }).onConflictDoNothing();
+    await db.insert(userRoles).values({
+      user_id: userId,
+      role_id: "user",
+    }).onConflictDoNothing();
+    await db.insert(problems).values({
+      id: problemId,
+      title: "路由题单测试题",
+      description: "测试题面",
+      difficulty: "easy",
+      runtime_config: {},
+      number: 950001,
+      owner_id: adminId,
+      type: "P",
+      created_at: now,
+      updated_at: now,
+    });
+
+    const userToken = await signToken({ sub: userId, role: "user" });
+    const adminToken = await signToken({ sub: adminId, role: "admin" });
+    let trainingId: string | undefined;
+    let publicTrainingId: string | undefined;
+
+    try {
+      const createRes = await jsonRequest(app, "/api/v1/trainings", {
+        method: "POST",
+        token: userToken,
+        body: { title: "我的题单", visibility: "private" },
+      });
+      assertEquals(createRes.status, 201);
+      trainingId = (await createRes.json()).data.id;
+      assertExists(trainingId);
+
+      const publicRes = await jsonRequest(app, "/api/v1/trainings", {
+        method: "POST",
+        token: adminToken,
+        body: { title: "公开题单", visibility: "unlisted" },
+      });
+      assertEquals(publicRes.status, 201);
+      publicTrainingId = (await publicRes.json()).data.id;
+      const publishRes = await jsonRequest(
+        app,
+        `/api/v1/trainings/${publicTrainingId}`,
+        {
+          method: "PUT",
+          token: adminToken,
+          body: { visibility: "public" },
+        },
+      );
+      assertEquals(publishRes.status, 200);
+
+      const listRes = await jsonRequest(app, "/api/v1/trainings");
+      const listBody = await listRes.json();
+      assertEquals(
+        listBody.data.some((t: { id: string }) => t.id === publicTrainingId),
+        true,
+      );
+      assertEquals(
+        listBody.data.some((t: { id: string }) => t.id === trainingId),
+        false,
+      );
+
+      const mineRes = await jsonRequest(app, "/api/v1/trainings/mine", {
+        token: userToken,
+      });
+      assertEquals(mineRes.status, 200);
+
+      const profileRes = await jsonRequest(
+        app,
+        `/api/v1/trainings?created_by=${userId}`,
+      );
+      const profileBody = await profileRes.json();
+      assertEquals(profileBody.data.length, 0);
+
+      const addRes = await jsonRequest(
+        app,
+        `/api/v1/trainings/${trainingId}/problems`,
+        {
+          method: "POST",
+          token: userToken,
+          body: { problem_id: problemId },
+        },
+      );
+      assertEquals(addRes.status, 201);
+
+      const problemsRes = await jsonRequest(
+        app,
+        `/api/v1/trainings/${trainingId}/problems`,
+        { token: userToken },
+      );
+      assertEquals((await problemsRes.json()).data.length, 1);
+
+      const forbiddenPublish = await jsonRequest(
+        app,
+        `/api/v1/trainings/${trainingId}`,
+        {
+          method: "PUT",
+          token: userToken,
+          body: { visibility: "public" },
+        },
+      );
+      assertEquals(forbiddenPublish.status, 403);
+
+      const adminView = await jsonRequest(
+        app,
+        `/api/v1/trainings/${trainingId}`,
+        { token: adminToken },
+      );
+      assertEquals(adminView.status, 200);
+      const hiddenByAnon = await jsonRequest(
+        app,
+        `/api/v1/trainings/${trainingId}`,
+      );
+      assertEquals(hiddenByAnon.status, 404);
+    } finally {
+      if (trainingId) {
+        await db.delete(trainings).where(eq(trainings.id, trainingId));
+      }
+      if (publicTrainingId) {
+        await db.delete(trainings).where(eq(trainings.id, publicTrainingId));
+      }
+      await db.delete(problems).where(eq(problems.id, problemId));
+      await db.delete(users).where(eq(users.id, userId));
+      await db.delete(users).where(eq(users.id, adminId));
+    }
+  },
+});

--- a/noj-core/tests/services/rbac-training.test.ts
+++ b/noj-core/tests/services/rbac-training.test.ts
@@ -1,0 +1,61 @@
+import { assertEquals } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { permissions, rolePermissions, roles } from "../../src/db/schema.ts";
+import { ensureRbacSeeds } from "../../src/services/seed-rbac.ts";
+
+await resetDbForTest();
+
+Deno.test({
+  name: "rbac: training 权限默认授权",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    await ensureRbacSeeds();
+
+    const trainingDefs = await db
+      .select()
+      .from(permissions)
+      .where(eq(permissions.resource, "training"));
+    assertEquals(trainingDefs.length, 9);
+
+    const [userRole] = await db
+      .select()
+      .from(roles)
+      .where(eq(roles.name, "user"))
+      .limit(1);
+    const granted = await db
+      .select({
+        resource: permissions.resource,
+        action: permissions.action,
+      })
+      .from(rolePermissions)
+      .innerJoin(
+        permissions,
+        eq(rolePermissions.permission_id, permissions.id),
+      )
+      .where(eq(rolePermissions.role_id, userRole.id));
+
+    const trainingGranted = granted
+      .filter((p) => p.resource === "training")
+      .map((p) => p.action)
+      .sort();
+    assertEquals(trainingGranted, [
+      "create",
+      "delete_own",
+      "read",
+      "write_own",
+    ]);
+    assertEquals(
+      granted.some(
+        (p) => p.resource === "training" && p.action === "publish",
+      ),
+      false,
+    );
+    assertEquals(
+      granted.some((p) => p.resource === "training" && p.action === "pin"),
+      false,
+    );
+  },
+});

--- a/noj-core/tests/services/trainings.test.ts
+++ b/noj-core/tests/services/trainings.test.ts
@@ -1,0 +1,308 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import { eq, inArray } from "drizzle-orm";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import {
+  evaluationResults,
+  objectiveSubmissions,
+  problems,
+  submissions,
+  trainings,
+  users,
+} from "../../src/db/schema.ts";
+import {
+  addTrainingProblem,
+  createTraining,
+  deleteTraining,
+  getTraining,
+  listAllTrainings,
+  listMyTrainings,
+  listPublicTrainings,
+  listTrainingProblems,
+  listUserTrainings,
+  removeTrainingProblem,
+  reorderTrainingProblems,
+  updateTraining,
+} from "../../src/services/trainings.ts";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "../../src/lib/errors.ts";
+
+await resetDbForTest();
+
+async function createUser(prefix: string): Promise<string> {
+  const id = crypto.randomUUID();
+  const unique = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+  const now = new Date().toISOString();
+  await getDb().insert(users).values({
+    id,
+    username: `${prefix}-${unique}`,
+    email: `${prefix}-${unique}@example.com`,
+    password_hash: "hash",
+    created_at: now,
+    updated_at: now,
+  });
+  return id;
+}
+
+Deno.test({
+  name: "trainings service: CRUD 与可见性矩阵",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const owner = await createUser("train-owner");
+    const other = await createUser("train-other");
+    const db = getDb();
+
+    const privateTraining = await createTraining(
+      { title: "私有题单", visibility: "private" },
+      owner,
+    );
+    const unlistedTraining = await createTraining(
+      { title: "链接题单", visibility: "unlisted" },
+      owner,
+    );
+    const publicTraining = await createTraining(
+      { title: "公开题单", visibility: "unlisted" },
+      owner,
+    );
+    await updateTraining(
+      publicTraining.id,
+      { visibility: "public" },
+      owner,
+      { isAdmin: true },
+    );
+
+    try {
+      assertEquals(privateTraining.visibility, "private");
+      assertEquals(unlistedTraining.visibility, "unlisted");
+
+      await assertRejects(
+        () => getTraining(privateTraining.id, other),
+        NotFoundError,
+      );
+      assertEquals(
+        (await getTraining(privateTraining.id, owner)).id,
+        privateTraining.id,
+      );
+      assertEquals(
+        (await getTraining(privateTraining.id, other, true)).id,
+        privateTraining.id,
+      );
+      assertEquals(
+        (await getTraining(unlistedTraining.id, other)).id,
+        unlistedTraining.id,
+      );
+      assertEquals(
+        (await getTraining(publicTraining.id)).id,
+        publicTraining.id,
+      );
+
+      const publicList = await listPublicTrainings({ page: 1, perPage: 20 });
+      assertEquals(
+        publicList.data.some((t) => t.id === publicTraining.id),
+        true,
+      );
+      assertEquals(
+        publicList.data.some((t) => t.id === unlistedTraining.id),
+        false,
+      );
+
+      const mine = await listMyTrainings(owner, { page: 1, perPage: 20 });
+      assertEquals(mine.total, 3);
+
+      const otherView = await listUserTrainings(owner, other);
+      assertEquals(
+        otherView.data.some((t) => t.id === publicTraining.id),
+        true,
+      );
+      assertEquals(
+        otherView.data.some((t) => t.id === privateTraining.id),
+        false,
+      );
+
+      const ownerView = await listUserTrainings(owner, owner);
+      assertEquals(ownerView.total, 3);
+
+      const all = await listAllTrainings({ page: 1, perPage: 20 });
+      assertEquals(
+        all.data.some((t) => t.id === privateTraining.id),
+        true,
+      );
+
+      await assertRejects(
+        () => updateTraining(privateTraining.id, { title: "x" }, other),
+        ForbiddenError,
+      );
+      const updated = await updateTraining(
+        privateTraining.id,
+        { title: "改名" },
+        owner,
+      );
+      assertEquals(updated.title, "改名");
+
+      // 自定义角色即使没有 write_any/admin，只要拥有 publish/pin 权限即可操作自己的题单
+      const publishOwn = await updateTraining(
+        unlistedTraining.id,
+        { visibility: "public" },
+        owner,
+        { canPublish: true },
+      );
+      assertEquals(publishOwn.visibility, "public");
+      const pinOwn = await updateTraining(
+        unlistedTraining.id,
+        { is_pinned: true },
+        owner,
+        { canPin: true },
+      );
+      assertEquals(pinOwn.is_pinned, true);
+
+      await deleteTraining(privateTraining.id, owner);
+      await assertRejects(
+        () => getTraining(privateTraining.id, owner),
+        NotFoundError,
+      );
+    } finally {
+      await db.delete(trainings).where(eq(trainings.created_by, owner));
+      await db.delete(users).where(eq(users.id, owner));
+      await db.delete(users).where(eq(users.id, other));
+    }
+  },
+});
+
+Deno.test({
+  name: "trainings service: 题目增删排序与进度聚合",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const owner = await createUser("train-problem-owner");
+    const solver = await createUser("train-solver");
+    const db = getDb();
+    const now = new Date().toISOString();
+
+    async function createProblem(
+      number: number,
+      isObjective = false,
+    ): Promise<string> {
+      const id = crypto.randomUUID();
+      await db.insert(problems).values({
+        id,
+        title: `题单测试题 ${number}`,
+        description: "测试题面",
+        difficulty: "easy",
+        runtime_config: isObjective ? null : {},
+        number,
+        owner_id: "0",
+        type: "P",
+        is_objective: isObjective,
+        created_at: now,
+        updated_at: now,
+      });
+      return id;
+    }
+
+    const training = await createTraining(
+      { title: "进度题单", visibility: "unlisted" },
+      owner,
+    );
+    const p1 = await createProblem(940001);
+    const p2 = await createProblem(940002);
+    const objective = await createProblem(940003, true);
+
+    try {
+      await addTrainingProblem(training.id, p2, undefined, owner);
+      await addTrainingProblem(training.id, p1, 0, owner);
+      let problemsList = await listTrainingProblems(training.id, solver);
+      assertEquals(problemsList.map((p) => p.problem_id), [p1, p2]);
+      assertEquals(problemsList.every((p) => p.accepted === false), true);
+
+      await addTrainingProblem(training.id, objective, 2, owner);
+      const subId = crypto.randomUUID();
+      await db.insert(submissions).values({
+        id: subId,
+        user_id: solver,
+        problem_id: p1,
+        status: "finished",
+        language: "python3",
+        code: "print(1)",
+        created_at: now,
+      });
+      await db.insert(evaluationResults).values({
+        id: crypto.randomUUID(),
+        submission_id: subId,
+        status: "Accepted",
+        score: 10000,
+        output: "",
+        time_ms: 1,
+        memory_kb: 1,
+        created_at: now,
+      });
+      await db.insert(objectiveSubmissions).values({
+        id: crypto.randomUUID(),
+        paper_id: objective,
+        user_id: solver,
+        submission_type: "practice",
+        answers: {},
+        status: "finished",
+        score: 10000,
+        details: {},
+        created_at: now,
+      });
+
+      problemsList = await listTrainingProblems(training.id, solver);
+      assertEquals(
+        problemsList.find((p) => p.problem_id === p1)?.accepted,
+        true,
+      );
+      assertEquals(
+        problemsList.find((p) => p.problem_id === objective)?.accepted,
+        true,
+      );
+      assertEquals(
+        problemsList.find((p) => p.problem_id === p2)?.accepted,
+        false,
+      );
+
+      await reorderTrainingProblems(
+        training.id,
+        [
+          { problem_id: objective, position: 0 },
+          { problem_id: p1, position: 1 },
+          { problem_id: p2, position: 2 },
+        ],
+        owner,
+      );
+      problemsList = await listTrainingProblems(training.id, owner);
+      assertEquals(problemsList.map((p) => p.problem_id), [objective, p1, p2]);
+
+      await removeTrainingProblem(training.id, p2, owner);
+      assertEquals((await listTrainingProblems(training.id, owner)).length, 2);
+
+      await assertRejects(
+        () => addTrainingProblem(training.id, p1, undefined, owner),
+        ConflictError,
+      );
+    } finally {
+      await db.delete(trainings).where(eq(trainings.id, training.id));
+      const solverSubs = await db
+        .select({ id: submissions.id })
+        .from(submissions)
+        .where(eq(submissions.user_id, solver));
+      if (solverSubs.length > 0) {
+        await db.delete(evaluationResults).where(
+          inArray(
+            evaluationResults.submission_id,
+            solverSubs.map((s) => s.id),
+          ),
+        );
+      }
+      await db.delete(submissions).where(eq(submissions.user_id, solver));
+      await db.delete(objectiveSubmissions).where(
+        eq(objectiveSubmissions.user_id, solver),
+      );
+      await db.delete(users).where(eq(users.id, owner));
+      await db.delete(users).where(eq(users.id, solver));
+    }
+  },
+});

--- a/noj-tests/e2e/trainings.test.ts
+++ b/noj-tests/e2e/trainings.test.ts
@@ -1,0 +1,118 @@
+import {
+  apiDelete,
+  apiGet,
+  apiPatch,
+  apiPost,
+  e2eTest,
+  getAdminToken,
+  getOrCreateUser,
+  pollSubmission,
+  submitCode,
+} from "./helper.ts";
+
+e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", async () => {
+  const adminToken = await getAdminToken();
+  const user = await getOrCreateUser(
+    "training_user",
+    `training_user_${Date.now().toString(36)}`,
+    `training_user_${Date.now().toString(36)}@test.com`,
+  );
+  const other = await getOrCreateUser(
+    "training_other",
+    `training_other_${Date.now().toString(36)}`,
+    `training_other_${Date.now().toString(36)}@test.com`,
+  );
+
+  const problemRes = await apiPost(
+    "/api/v1/problems",
+    {
+      title: "Training E2E Problem",
+      description: "e2e",
+      type: "U",
+      runtime_config: {
+        evaluator: {
+          image: "noj-evaluator-python",
+          command: "python3 /workspace/evaluate.py",
+          time_limit_ms: 5000,
+          memory_limit_mb: 512,
+        },
+        solution: {
+          image: "noj-solution-python",
+          call_timeout_ms: 2000,
+          memory_limit_mb: 512,
+        },
+      },
+    },
+    user.token,
+  );
+  if (problemRes.status !== 201) {
+    throw new Error(`建题失败: ${JSON.stringify(problemRes.body)}`);
+  }
+  const problemId = (problemRes.body as { data: { id: string } }).data.id;
+
+  const created = await apiPost(
+    "/api/v1/trainings",
+    { title: "E2E 题单", visibility: "private" },
+    user.token,
+  );
+  if (created.status !== 201) {
+    throw new Error(`建题单失败: ${JSON.stringify(created.body)}`);
+  }
+  const trainingId = (created.body as { data: { id: string } }).data.id;
+
+  const added = await apiPost(
+    `/api/v1/trainings/${trainingId}/problems`,
+    { problem_id: problemId },
+    user.token,
+  );
+  if (added.status !== 201) {
+    throw new Error(`加题失败: ${JSON.stringify(added.body)}`);
+  }
+
+  const hidden = await apiGet(`/api/v1/trainings/${trainingId}`, other.token);
+  if (hidden.status !== 404) {
+    throw new Error(`私有题单应对他人 404: ${hidden.status}`);
+  }
+
+  const subId = await submitCode(user.token, problemId, "print(1)");
+  await pollSubmission(user.token, subId);
+  const problems = await apiGet(
+    `/api/v1/trainings/${trainingId}/problems`,
+    user.token,
+  );
+  if (problems.status !== 200) {
+    throw new Error(`取题单题目失败: ${problems.status}`);
+  }
+  const problemsData = (problems.body as { data: { accepted: boolean }[] }).data;
+  if (!problemsData[0]?.accepted) {
+    throw new Error("AC 后进度应为 true");
+  }
+
+  const patched = await apiPatch(
+    `/api/v1/admin/trainings/${trainingId}`,
+    { visibility: "public", is_pinned: true },
+    adminToken,
+  );
+  if (patched.status !== 200) {
+    throw new Error(`管理员设 public 失败: ${patched.status}`);
+  }
+
+  const list = await apiGet("/api/v1/trainings");
+  const listData = (list.body as { data: { id: string }[] }).data;
+  if (!listData.some((t) => t.id === trainingId)) {
+    throw new Error("公开列表应包含该题单");
+  }
+
+  const deleted = await apiDelete(`/api/v1/problems/${problemId}`, user.token);
+  if (deleted.status !== 204 && deleted.status !== 200) {
+    throw new Error(`删题失败: ${deleted.status}`);
+  }
+  const afterDelete = await apiGet(
+    `/api/v1/trainings/${trainingId}/problems`,
+    user.token,
+  );
+  const afterData = (afterDelete.body as { data: unknown[] }).data;
+  if (afterData.length !== 0) {
+    throw new Error("删除题目后题单关联应自动清理");
+  }
+});

--- a/noj-ui/components/admin/TrainingManagementSection.vue
+++ b/noj-ui/components/admin/TrainingManagementSection.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import type { Training, TrainingVisibility } from '~/composables/useTrainings'
+
+const { adminUpdateTraining, adminDeleteTraining } = useTrainings()
+const { data, pending, error, refresh } = await useFetch<{ data: Training[]; total: number }>(
+  '/api/v1/admin/trainings',
+  { query: { page: 1, per_page: 100 }, silent: true },
+)
+
+const columns = [
+  { key: 'title', label: '标题' },
+  { key: 'visibility', label: '可见性' },
+  { key: 'is_pinned', label: '置顶' },
+  { key: 'problem_count', label: '题目数' },
+  { key: 'actions', label: '操作' },
+]
+
+async function setVisibility(training: Training, visibility: TrainingVisibility) {
+  await adminUpdateTraining(training.id, { visibility })
+  await refresh()
+}
+
+async function togglePinned(training: Training) {
+  await adminUpdateTraining(training.id, { is_pinned: !training.is_pinned })
+  await refresh()
+}
+
+async function remove(id: string) {
+  if (!confirm('确定删除该题单？')) return
+  await adminDeleteTraining(id)
+  await refresh()
+}
+</script>
+
+<template>
+  <AsyncContent
+    :status="pending ? 'loading' : error ? 'error' : 'data'"
+    error="题单加载失败"
+    @retry="refresh"
+  >
+    <UTable
+      :columns="columns"
+      :data="data?.data ?? []"
+      :loading="pending"
+      :empty="'暂无题单'"
+    >
+      <template #visibility-cell="{ row }">
+        <USelect
+          :model-value="(row as Training).visibility"
+          :items="[
+            { label: '私有', value: 'private' },
+            { label: '链接可见', value: 'unlisted' },
+            { label: '公开', value: 'public' },
+          ]"
+          class="min-w-[120px]"
+          @update:model-value="setVisibility(row as Training, $event as TrainingVisibility)"
+        />
+      </template>
+      <template #is_pinned-cell="{ row }">
+        <UCheckbox
+          :model-value="(row as Training).is_pinned"
+          @update:model-value="togglePinned(row as Training)"
+        />
+      </template>
+      <template #actions-cell="{ row }">
+        <UButton
+          icon="i-lucide-trash"
+          size="xs"
+          color="red"
+          variant="ghost"
+          @click="remove((row as Training).id)"
+        />
+      </template>
+    </UTable>
+  </AsyncContent>
+</template>

--- a/noj-ui/components/feature/training/AddToTrainingMenu.vue
+++ b/noj-ui/components/feature/training/AddToTrainingMenu.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import type { Training } from '~/composables/useTrainings'
+
+const props = defineProps<{ problemId: string }>()
+
+const { listMine, addProblem, createTraining } = useTrainings()
+const open = ref(false)
+const selected = ref<string[]>([])
+const saving = ref(false)
+const showCreate = ref(false)
+const newTitle = ref('')
+
+async function load() {
+  const res = await listMine({ page: 1, per_page: 100 }, { silent: true })
+  return res.data
+}
+
+const mineTrainings = ref<Training[]>([])
+
+async function openModal() {
+  mineTrainings.value = await load()
+  selected.value = []
+  open.value = true
+}
+
+async function save() {
+  if (saving.value) return
+  saving.value = true
+  try {
+    for (const trainingId of selected.value) {
+      await addProblem(trainingId, props.problemId)
+    }
+    open.value = false
+  } finally {
+    saving.value = false
+  }
+}
+
+async function createAndAdd() {
+  const title = newTitle.value.trim()
+  if (!title || saving.value) return
+  saving.value = true
+  try {
+    const created = await createTraining({ title, visibility: 'private' })
+    await addProblem(created.data.id, props.problemId)
+    showCreate.value = false
+    newTitle.value = ''
+    open.value = false
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <div>
+    <UButton icon="i-lucide-list-plus" @click="openModal">加入题单</UButton>
+
+    <UModal
+      :open="open"
+      title="加入题单"
+      :unmount-on-hide="true"
+      @update:open="open = $event"
+    >
+      <div class="space-y-3 p-4">
+        <div class="space-y-2">
+          <label
+            v-for="training in mineTrainings"
+            :key="training.id"
+            class="flex items-center gap-2 text-sm"
+          >
+            <UCheckbox v-model="selected" :value="training.id" />
+            {{ training.title }}
+          </label>
+          <p v-if="mineTrainings.length === 0" class="text-sm text-text-secondary">
+            你还没有题单，可以新建一个。
+          </p>
+        </div>
+
+        <div v-if="showCreate" class="flex gap-2">
+          <UInput v-model="newTitle" placeholder="新题单标题" class="flex-1" />
+          <UButton size="sm" :loading="saving" @click="createAndAdd">新建并加入</UButton>
+        </div>
+        <UButton
+          v-else
+          size="xs"
+          variant="ghost"
+          @click="showCreate = true"
+        >
+          新建题单
+        </UButton>
+
+        <div class="flex justify-end gap-3 pt-2">
+          <UButton color="gray" @click="open = false">取消</UButton>
+          <UButton color="primary" :loading="saving" :disabled="selected.length === 0" @click="save">
+            加入选中题单
+          </UButton>
+        </div>
+      </div>
+    </UModal>
+  </div>
+</template>

--- a/noj-ui/components/feature/training/TrainingCard.vue
+++ b/noj-ui/components/feature/training/TrainingCard.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { Training } from '~/composables/useTrainings'
+
+defineProps<{ training: Training }>()
+</script>
+
+<template>
+  <NuxtLink
+    :to="`/trainings/${training.id}`"
+    class="group flex min-h-44 flex-col rounded-xl border border-border bg-white p-5 text-text no-underline shadow-sm transition-all hover:-translate-y-1 hover:border-primary/40 hover:shadow-card"
+  >
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="line-clamp-2 text-lg font-bold transition-colors group-hover:text-primary">
+        {{ training.title }}
+      </h2>
+      <span
+        v-if="training.is_pinned"
+        class="rounded-full bg-warning-bg px-2.5 py-1 text-xs font-semibold text-warning-text"
+      >
+        置顶
+      </span>
+    </div>
+    <p class="mt-2 line-clamp-2 text-sm leading-6 text-text-secondary">
+      {{ training.description || '暂无简介' }}
+    </p>
+    <div class="mt-auto flex items-center gap-4 border-t border-border pt-3 text-xs text-text-secondary">
+      <span>{{ training.problem_count }} 题</span>
+      <span v-if="training.visibility === 'private'" class="ml-auto">私有</span>
+      <span v-else-if="training.visibility === 'unlisted'" class="ml-auto">链接可见</span>
+      <span v-else class="ml-auto">公开</span>
+    </div>
+  </NuxtLink>
+</template>

--- a/noj-ui/components/feature/training/TrainingFormModal.vue
+++ b/noj-ui/components/feature/training/TrainingFormModal.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import type { TrainingPayload } from '~/composables/useTrainings'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits<{ 'update:modelValue': [boolean]; saved: [] }>()
+
+const { createTraining } = useTrainings()
+const title = ref('')
+const description = ref('')
+const visibility = ref<'private' | 'unlisted'>('private')
+const saving = ref(false)
+
+async function submit() {
+  if (!title.value.trim()) return
+  saving.value = true
+  try {
+    const body: TrainingPayload = {
+      title: title.value.trim(),
+      description: description.value,
+      visibility: visibility.value,
+    }
+    await createTraining(body)
+    emit('update:modelValue', false)
+    emit('saved')
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <UModal
+    :open="props.modelValue"
+    title="新建题单"
+    :unmount-on-hide="true"
+    @update:open="emit('update:modelValue', $event)"
+  >
+    <UForm :state="{ title, description, visibility }" class="space-y-4" @submit="submit">
+      <UFormGroup label="标题" required>
+        <UInput v-model="title" placeholder="题单标题" />
+      </UFormGroup>
+      <UFormGroup label="简介">
+        <UTextarea v-model="description" placeholder="题单简介" />
+      </UFormGroup>
+      <UFormGroup label="可见性">
+        <USelect
+          v-model="visibility"
+          :items="[
+            { label: '私有', value: 'private' },
+            { label: '链接可见', value: 'unlisted' },
+          ]"
+        />
+      </UFormGroup>
+      <div class="flex justify-end gap-3">
+        <UButton color="gray" @click="emit('update:modelValue', false)">取消</UButton>
+        <UButton type="submit" :loading="saving">创建</UButton>
+      </div>
+    </UForm>
+  </UModal>
+</template>

--- a/noj-ui/components/feature/training/TrainingProblemList.vue
+++ b/noj-ui/components/feature/training/TrainingProblemList.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { TrainingProblem } from '~/composables/useTrainings'
+
+defineProps<{ problems: TrainingProblem[] }>()
+</script>
+
+<template>
+  <ol class="divide-y divide-border rounded-xl border border-border bg-white">
+    <li
+      v-for="(problem, index) in problems"
+      :key="problem.problem_id"
+      class="flex items-center gap-4 px-5 py-3"
+    >
+      <span class="w-8 text-center text-sm text-text-secondary">{{ index + 1 }}</span>
+      <span
+        class="flex size-6 items-center justify-center rounded-full text-xs"
+        :class="problem.accepted ? 'bg-success-bg text-success-text' : 'bg-gray-100 text-text-muted'"
+      >
+        {{ problem.accepted ? '✓' : '' }}
+      </span>
+      <NuxtLink
+        :to="`/problems/${problem.display_id}`"
+        class="flex-1 font-medium hover:text-primary"
+      >
+        {{ problem.display_id }} · {{ problem.title }}
+      </NuxtLink>
+      <span class="text-xs text-text-secondary">{{ problem.difficulty }}</span>
+    </li>
+  </ol>
+</template>

--- a/noj-ui/components/feature/training/TrainingProblemManager.vue
+++ b/noj-ui/components/feature/training/TrainingProblemManager.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import type { TrainingProblem } from '~/composables/useTrainings'
+
+const props = defineProps<{
+  trainingId: string
+  problems: TrainingProblem[]
+}>()
+const emit = defineEmits<{ changed: [] }>()
+
+const { addProblem, removeProblem, reorderProblems } = useTrainings()
+const newProblemId = ref('')
+const busy = ref(false)
+
+async function add() {
+  const problemId = newProblemId.value.trim()
+  if (!problemId || busy.value) return
+  busy.value = true
+  try {
+    await addProblem(props.trainingId, problemId)
+    newProblemId.value = ''
+    emit('changed')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function remove(problemId: string) {
+  if (busy.value) return
+  busy.value = true
+  try {
+    await removeProblem(props.trainingId, problemId)
+    emit('changed')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function move(problemId: string, direction: -1 | 1) {
+  if (busy.value) return
+  const index = props.problems.findIndex((p) => p.problem_id === problemId)
+  const target = index + direction
+  if (index < 0 || target < 0 || target >= props.problems.length) return
+  const next = [...props.problems]
+  const [item] = next.splice(index, 1)
+  next.splice(target, 0, item)
+  busy.value = true
+  try {
+    await reorderProblems(
+      props.trainingId,
+      next.map((p, i) => ({ problem_id: p.problem_id, position: i })),
+    )
+    emit('changed')
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<template>
+  <section class="rounded-xl border border-border bg-white p-5">
+    <h2 class="mb-4 text-lg font-bold">管理题目</h2>
+    <div class="mb-4 flex gap-2">
+      <UInput
+        v-model="newProblemId"
+        placeholder="输入题目 ID 或 display_id"
+        class="flex-1"
+        :disabled="busy"
+      />
+      <UButton icon="i-lucide-plus" :loading="busy" @click="add">加入</UButton>
+    </div>
+    <div class="space-y-2">
+      <div
+        v-for="(problem, index) in problems"
+        :key="problem.problem_id"
+        class="flex items-center gap-3 rounded-lg border border-border px-4 py-2"
+      >
+        <span>{{ index + 1 }}</span>
+        <span class="flex-1">{{ problem.display_id }} · {{ problem.title }}</span>
+        <UButton
+          icon="i-lucide-chevron-up"
+          size="xs"
+          variant="ghost"
+          :disabled="busy || index === 0"
+          @click="move(problem.problem_id, -1)"
+        />
+        <UButton
+          icon="i-lucide-chevron-down"
+          size="xs"
+          variant="ghost"
+          :disabled="busy || index === problems.length - 1"
+          @click="move(problem.problem_id, 1)"
+        />
+        <UButton
+          icon="i-lucide-trash"
+          size="xs"
+          color="red"
+          variant="ghost"
+          :disabled="busy"
+          @click="remove(problem.problem_id)"
+        />
+      </div>
+    </div>
+  </section>
+</template>

--- a/noj-ui/composables/useTrainings.ts
+++ b/noj-ui/composables/useTrainings.ts
@@ -1,0 +1,132 @@
+import type { ApiCallOptions } from '~/composables/useApi';
+
+export type TrainingVisibility = 'private' | 'unlisted' | 'public';
+
+export interface Training {
+  id: string;
+  title: string;
+  description: string;
+  visibility: TrainingVisibility;
+  is_pinned: boolean;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  problem_count: number;
+}
+
+export interface TrainingProblem {
+  training_id: string;
+  problem_id: string;
+  position: number;
+  title: string;
+  description: string;
+  difficulty: string;
+  display_id: string;
+  type: string;
+  is_objective: boolean;
+  accepted: boolean;
+}
+
+export interface TrainingPayload {
+  title: string;
+  description?: string;
+  visibility?: TrainingVisibility;
+}
+
+export interface TrainingListResult {
+  data: Training[];
+  total: number;
+}
+
+export function useTrainings() {
+  const { api } = useApi();
+
+  function listPublic(query?: { page?: number; per_page?: number }, options?: ApiCallOptions) {
+    return api.get<TrainingListResult>('/api/v1/trainings', { query, silent: true, ...options });
+  }
+
+  function listMine(query?: { page?: number; per_page?: number }, options?: ApiCallOptions) {
+    return api.get<TrainingListResult>('/api/v1/trainings/mine', { query, silent: true, ...options });
+  }
+
+  function listUserTrainings(
+    createdBy: string,
+    query?: { page?: number; per_page?: number },
+    options?: ApiCallOptions,
+  ) {
+    return api.get<TrainingListResult>(`/api/v1/trainings?created_by=${createdBy}`, {
+      query,
+      silent: true,
+      ...options,
+    });
+  }
+
+  function getTraining(id: string, options?: ApiCallOptions) {
+    return api.get<{ data: Training }>(`/api/v1/trainings/${id}`, { silent: true, ...options });
+  }
+
+  function createTraining(body: TrainingPayload, options?: ApiCallOptions) {
+    return api.post<{ data: Training }>('/api/v1/trainings', body, options);
+  }
+
+  function updateTraining(id: string, body: Partial<TrainingPayload>, options?: ApiCallOptions) {
+    return api.put<{ data: Training }>(`/api/v1/trainings/${id}`, body, options);
+  }
+
+  function deleteTraining(id: string, options?: ApiCallOptions) {
+    return api.delete<void>(`/api/v1/trainings/${id}`, options);
+  }
+
+  function listTrainingProblems(id: string, options?: ApiCallOptions) {
+    return api.get<{ data: TrainingProblem[] }>(`/api/v1/trainings/${id}/problems`, { silent: true, ...options });
+  }
+
+  function addProblem(id: string, problemId: string, position?: number, options?: ApiCallOptions) {
+    return api.post<{ data: TrainingProblem }>(
+      `/api/v1/trainings/${id}/problems`,
+      { problem_id: problemId, position },
+      options,
+    );
+  }
+
+  function reorderProblems(id: string, problems: { problem_id: string; position: number }[], options?: ApiCallOptions) {
+    return api.put<{ data: TrainingProblem[] }>(`/api/v1/trainings/${id}/problems`, { problems }, options);
+  }
+
+  function removeProblem(id: string, problemId: string, options?: ApiCallOptions) {
+    return api.delete<void>(`/api/v1/trainings/${id}/problems/${problemId}`, options);
+  }
+
+  function adminListTrainings(query?: { page?: number; per_page?: number }, options?: ApiCallOptions) {
+    return api.get<TrainingListResult>('/api/v1/admin/trainings', { query, silent: true, ...options });
+  }
+
+  function adminUpdateTraining(
+    id: string,
+    body: Partial<TrainingPayload & { is_pinned?: boolean }>,
+    options?: ApiCallOptions,
+  ) {
+    return api.patch<{ data: Training }>(`/api/v1/admin/trainings/${id}`, body, options);
+  }
+
+  function adminDeleteTraining(id: string, options?: ApiCallOptions) {
+    return api.delete<void>(`/api/v1/admin/trainings/${id}`, options);
+  }
+
+  return {
+    listPublic,
+    listMine,
+    listUserTrainings,
+    getTraining,
+    createTraining,
+    updateTraining,
+    deleteTraining,
+    listTrainingProblems,
+    addProblem,
+    reorderProblems,
+    removeProblem,
+    adminListTrainings,
+    adminUpdateTraining,
+    adminDeleteTraining,
+  };
+}

--- a/noj-ui/layouts/admin.vue
+++ b/noj-ui/layouts/admin.vue
@@ -34,6 +34,7 @@ const navGroups: NavGroup[] = [
       { label: "题目管理", to: "/admin/problems", icon: 'i-lucide-book-open' },
       { label: "标签管理", to: "/admin/tags", icon: 'i-lucide-tags' },
       { label: "竞赛管理", to: "/admin/contests", icon: 'i-lucide-trophy' },
+      { label: "题单管理", to: "/admin/trainings", icon: 'i-lucide-list-todo' },
       { label: "提交管理", to: "/admin/submissions", icon: 'i-lucide-files' },
       { label: "评测镜像", to: "/admin/judge-images", icon: 'i-lucide-container' },
       { label: "社区管理", to: "/admin/community", icon: 'i-lucide-messages-square' },

--- a/noj-ui/pages/admin/trainings.vue
+++ b/noj-ui/pages/admin/trainings.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+useHead({ title: '题单管理 - Neuro OJ' })
+
+definePageMeta({ layout: 'admin', middleware: 'admin', ssr: false })
+</script>
+
+<template>
+  <div class="space-y-6">
+    <PageHeader title="题单管理" description="管理题单可见性、置顶与删除。" />
+    <TrainingManagementSection />
+  </div>
+</template>

--- a/noj-ui/pages/problems/[id].vue
+++ b/noj-ui/pages/problems/[id].vue
@@ -165,14 +165,17 @@ const publishBlockReason = computed(() => {
               </div>
               <h1 class="text-2xl font-bold mb-3 text-text">{{ problem.title }}</h1>
             </div>
-            <NuxtLink
-              v-if="canEdit"
-              :to="`/problems/${problem.id}/edit`"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border border-border rounded-lg text-text-secondary hover:text-primary hover:border-primary/40 transition-colors"
-            >
-              <UIcon name="i-lucide-pencil" class="size-3.5" />
-              编辑
-            </NuxtLink>
+            <div class="flex items-center gap-2">
+              <AddToTrainingMenu v-if="isLoggedIn" :problem-id="problem.id" />
+              <NuxtLink
+                v-if="canEdit"
+                :to="`/problems/${problem.id}/edit`"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border border-border rounded-lg text-text-secondary hover:text-primary hover:border-primary/40 transition-colors"
+              >
+                <UIcon name="i-lucide-pencil" class="size-3.5" />
+                编辑
+              </NuxtLink>
+            </div>
           </div>
           <div class="flex items-center gap-5 flex-wrap">
             <DifficultyBadge :difficulty="problem.difficulty" />

--- a/noj-ui/pages/trainings/[id].vue
+++ b/noj-ui/pages/trainings/[id].vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import type { Training, TrainingProblem } from '~/composables/useTrainings'
+
+const route = useRoute()
+const trainingId = route.params.id as string
+const { user } = useAuth()
+
+const { data: trainingData, pending, error, refresh } = await useFetch<{ data: Training }>(
+  `/api/v1/trainings/${trainingId}`,
+  { silent: true },
+)
+const { data: problemsData, refresh: refreshProblems } = await useFetch<{ data: TrainingProblem[] }>(
+  `/api/v1/trainings/${trainingId}/problems`,
+  { silent: true },
+)
+const training = computed(() => trainingData.value?.data)
+const problems = computed(() => problemsData.value?.data ?? [])
+const isOwner = computed(() => training.value?.created_by === user.value?.id)
+</script>
+
+<template>
+  <div class="min-h-full bg-bg-page py-10">
+    <div class="mx-auto max-w-[960px] space-y-7 px-4 sm:px-7">
+      <AsyncContent
+        :status="pending ? 'loading' : error ? 'error' : 'data'"
+        error="题单加载失败"
+        @retry="refresh"
+      >
+        <section class="rounded-2xl bg-bg-dark px-8 py-8 text-white shadow-card">
+          <div class="flex items-center gap-3">
+            <h1 class="text-3xl font-bold">{{ training?.title }}</h1>
+            <span
+              v-if="training?.visibility === 'private'"
+              class="rounded-full bg-white/10 px-3 py-1 text-xs"
+            >私有</span>
+            <span
+              v-else-if="training?.visibility === 'unlisted'"
+              class="rounded-full bg-white/10 px-3 py-1 text-xs"
+            >链接可见</span>
+            <span v-else class="rounded-full bg-white/10 px-3 py-1 text-xs">公开</span>
+          </div>
+          <p class="mt-4 whitespace-pre-line text-sm leading-6 text-slate-300">
+            {{ training?.description }}
+          </p>
+        </section>
+
+        <TrainingProblemList :problems="problems" />
+
+        <TrainingProblemManager
+          v-if="isOwner"
+          :training-id="trainingId"
+          :problems="problems"
+          @changed="refreshProblems"
+        />
+      </AsyncContent>
+    </div>
+  </div>
+</template>

--- a/noj-ui/pages/trainings/index.vue
+++ b/noj-ui/pages/trainings/index.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import type { Training } from '~/composables/useTrainings'
+
+useHead({ title: '题单 - Neuro OJ' })
+
+const currentPage = ref(1)
+const perPage = 12
+
+const { data, pending, error, refresh } = await useFetch<{ data: Training[]; total: number }>(
+  '/api/v1/trainings',
+  {
+    query: computed(() => ({ page: currentPage.value, per_page: perPage })),
+  },
+)
+const totalPages = computed(() => Math.ceil((data.value?.total ?? 0) / perPage))
+</script>
+
+<template>
+  <div class="min-h-full bg-bg-page py-10">
+    <div class="mx-auto max-w-[960px] space-y-7 px-4 sm:px-7">
+      <section class="rounded-2xl bg-bg-dark px-8 py-9 text-white shadow-card">
+        <h1 class="text-3xl font-bold">题单</h1>
+        <p class="mt-3 text-sm leading-6 text-slate-300">按学习路径刷题，整理自己的题目集合。</p>
+      </section>
+
+      <AsyncContent
+        :status="pending ? 'loading' : error ? 'error' : data?.data.length ? 'data' : 'empty'"
+        error="题单列表加载失败"
+        empty-text="暂无公开题单"
+        @retry="refresh"
+      >
+        <div class="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          <TrainingCard
+            v-for="training in data?.data"
+            :key="training.id"
+            :training="training"
+          />
+        </div>
+      </AsyncContent>
+
+      <PaginationNav
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @page-change="currentPage = $event"
+      />
+    </div>
+  </div>
+</template>

--- a/noj-ui/pages/trainings/mine.vue
+++ b/noj-ui/pages/trainings/mine.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import type { Training } from '~/composables/useTrainings'
+
+useHead({ title: '我的题单 - Neuro OJ' })
+
+definePageMeta({ middleware: 'auth' })
+
+const { deleteTraining } = useTrainings()
+const { data, pending, error, refresh } = await useFetch<{ data: Training[]; total: number }>(
+  '/api/v1/trainings/mine',
+  { query: { page: 1, per_page: 100 }, silent: true },
+)
+const showCreate = ref(false)
+
+async function onDelete(id: string) {
+  if (!confirm('确定删除该题单？')) return
+  await deleteTraining(id)
+  await refresh()
+}
+</script>
+
+<template>
+  <div class="min-h-full bg-bg-page py-10">
+    <div class="mx-auto max-w-[960px] space-y-7 px-4 sm:px-7">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-bold">我的题单</h1>
+        <UButton icon="i-lucide-plus" @click="showCreate = true">新建题单</UButton>
+      </div>
+
+      <AsyncContent
+        :status="pending ? 'loading' : error ? 'error' : data?.data.length ? 'data' : 'empty'"
+        error="加载失败"
+        empty-text="你还没有创建题单"
+        @retry="refresh"
+      >
+        <div class="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          <div
+            v-for="training in data?.data"
+            :key="training.id"
+            class="relative"
+          >
+            <TrainingCard :training="training" />
+            <UButton
+              icon="i-lucide-trash"
+              size="xs"
+              color="red"
+              variant="ghost"
+              class="absolute right-2 top-2"
+              @click="onDelete(training.id)"
+            />
+          </div>
+        </div>
+      </AsyncContent>
+
+      <TrainingFormModal v-model="showCreate" @saved="refresh" />
+    </div>
+  </div>
+</template>

--- a/noj-ui/pages/users/[id].vue
+++ b/noj-ui/pages/users/[id].vue
@@ -119,6 +119,24 @@ const { data: createdData, pending: createdPending } = useFetch<{
 
 const createdProblems = computed(() => createdData.value?.data ?? [])
 
+interface TrainingProfile {
+  id: string
+  title: string
+  description: string
+  visibility: 'private' | 'unlisted' | 'public'
+  is_pinned: boolean
+  created_by: string
+  created_at: string
+  updated_at: string
+  problem_count: number
+}
+
+const { data: trainingsData } = useFetch<{ data: TrainingProfile[]; total: number }>(
+  `/api/v1/trainings?created_by=${userId}`,
+  { query: { page: 1, per_page: 100 }, silent: true },
+)
+const profileTrainings = computed(() => trainingsData.value?.data ?? [])
+
 // 当前登录用户是否在查看自己的主页
 const isOwnProfile = computed(
   () => currentUser.value?.id === userId,
@@ -335,6 +353,27 @@ async function toggleFollow() {
               <span class="text-xs text-text-muted">{{ formatDate(problem.created_at) }}</span>
             </div>
           </div>
+        </div>
+      </div>
+
+      <!-- 我的题单 -->
+      <div v-if="profileTrainings.length" class="bg-white border border-border rounded-xl overflow-hidden">
+        <div class="px-6 py-4 border-b border-border bg-bg-page">
+          <h2 class="text-base font-semibold flex items-center gap-2">
+            <UIcon name="i-lucide-list-todo" class="text-primary size-4.5" />
+            我的题单
+          </h2>
+        </div>
+        <div class="divide-y divide-border">
+          <NuxtLink
+            v-for="training in profileTrainings"
+            :key="training.id"
+            :to="`/trainings/${training.id}`"
+            class="flex items-center justify-between px-6 py-3 hover:bg-primary-bg no-underline"
+          >
+            <span class="text-sm text-primary">{{ training.title }}</span>
+            <span class="text-xs text-text-muted">{{ training.problem_count }} 题</span>
+          </NuxtLink>
         </div>
       </div>
 

--- a/noj-ui/utils/sanitize.ts
+++ b/noj-ui/utils/sanitize.ts
@@ -70,38 +70,35 @@ function decodeHtmlEntities(value: string): string {
   return value
     .replace(/&#x([0-9a-f]+);/gi, (_m, hex: string) => {
       const code = parseInt(hex, 16);
-      return Number.isFinite(code) && code > 0 && code <= 0x10ffff
-        ? String.fromCodePoint(code)
-        : "";
+      return Number.isFinite(code) && code > 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
     })
     .replace(/&#([0-9]+);/g, (_m, dec: string) => {
       const code = parseInt(dec, 10);
-      return Number.isFinite(code) && code > 0 && code <= 0x10ffff
-        ? String.fromCodePoint(code)
-        : "";
+      return Number.isFinite(code) && code > 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
     })
     .replace(
       /&(nbsp|amp|lt|gt|quot|apos|colon|tab|newline);/gi,
       (_m, name: string) =>
         ({
-          nbsp: "\u00a0",
-          amp: "&",
-          lt: "<",
-          gt: ">",
+          nbsp: '\u00a0',
+          amp: '&',
+          lt: '<',
+          gt: '>',
           quot: '"',
           apos: "'",
-          colon: ":",
-          tab: "\t",
-          newline: "\n",
-        })[name.toLowerCase()] ?? "",
+          colon: ':',
+          tab: '\t',
+          newline: '\n',
+        })[name.toLowerCase()] ?? '',
     );
 }
 
 /** 归一化 URL 用于协议判断：实体解码 + 去除浏览器会忽略的控制/空白字符。 */
 function isUnsafeUrl(value: string): boolean {
   const decoded = decodeHtmlEntities(value).replace(
+    // deno-lint-ignore no-control-regex -- 需要剥离 URL 中的控制字符
     /[\u0000-\u0020\u007f-\u009f\u00a0]+/g,
-    "",
+    '',
   );
   if (!/^[a-z][a-z0-9+.-]*:/i.test(decoded)) return false;
   return !SAFE_URL_PROTOCOLS.test(decoded);

--- a/openspec/changes/training-plans/.openspec.yaml
+++ b/openspec/changes/training-plans/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/training-plans/design.md
+++ b/openspec/changes/training-plans/design.md
@@ -1,0 +1,79 @@
+## Context
+
+NOJ 当前已有分类树（admin 管控）、标签系统、竞赛系统和客观题系统，但缺少用户可自主组织的学习路径载体。Issue #224 要求对标 HydroOJ `training` / 洛谷题单，实现用户可创建的扁平题单。设计文档见 `docs/superpowers/specs/2026-08-17-training-design.md`，实施计划见 `docs/superpowers/plans/2026-08-17-training.md`。
+
+本变更新增一个独立 training 模块，不修改竞赛/标签/分类的既有语义。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 提供 `trainings` + `training_problems` 两张表，支持题单 CRUD 与题目有序收录。
+- 提供三态可见性：`private` / `unlisted` / `public`。
+- 提供 RBAC 细粒度权限 `training:*`，`publish` / `pin` 默认仅管理员。
+- 提供 AC 进度聚合：编程题 Accepted、客观题满分视为通过。
+- 提供前端题单列表、我的题单、详情、后台管理页面，并在用户主页/题目页加入入口。
+
+**Non-Goals:**
+
+- 不实现 DAG 章节、前置依赖、训练计划进度解锁。
+- 不实现公开审核流（用户申请公开 → 管理员审批）。
+- 不实现题单收藏、订阅、推荐等社交功能。
+- 不修改现有竞赛、标签、分类模块。
+
+## Decisions
+
+### 1. 独立 training 模块，而非泛化 contest_problems
+
+- **选择**：新增独立 `trainings` / `training_problems` 表与独立 service/route。
+- **理由**：竞赛题目有 `label` / `score` 等特有字段，泛化集合表会引入兼容负担；独立模块边界清晰，后续可平滑扩展章节/前置依赖。
+- **备选**：泛化 `collection_problems`、扩展 categories/tags；均因语义不匹配被否决。
+
+### 2. 三态可见性与 RBAC
+
+- `private` 仅创建者（或 `training:read_any`）可见；`unlisted` 知道 URL 即可访问但不出现在列表；`public` 仅具备 `training:publish` 的管理员可设置。
+- `is_pinned` 仅具备 `training:pin` 的管理员可设置。
+- 默认 user 角色获得 `training:create/read/write_own/delete_own`，`publish/pin` 不授予普通用户。
+
+### 3. 题目收录不做类型过滤
+
+- 题单可收录 U/P/客观题任意类型。
+- U 型题维持“unlisted”语义：不出现在官方题目目录，但可通过 URL 或题单跳转打开。
+- 因此题单详情直接返回收录题目，不额外按访问者过滤。
+
+### 4. 进度由现有提交记录派生
+
+- 不新增进度表。
+- 编程题：`submissions` join `evaluation_results` 中 `status='Accepted'`。
+- 客观题：`objective_submissions` 中 `score=10000`。
+- 匿名请求不计算进度，返回 `accepted=false`。
+
+### 5. 排序策略
+
+- `position` 在同一题单内唯一。
+- 加题到指定位置时，先对已有 `position >= target` 的行 +1，再插入；追加时取 `max(position)+1`。
+- 批量重排采用“校验集合一致后 DELETE + INSERT”的原子事务，保证最终顺序。
+
+### 6. 前端只读/编辑边界
+
+- 前台详情页仅创建者本人显示管理控件。
+- 管理员对他人题单的编辑只出现在 `/admin/trainings` 后台页，前台展示他人题单一律只读。
+
+## Risks / Trade-offs
+
+- [U 型题经 public 题单被枚举] → 接受：U 型题本身可通过 URL 访问，题单仅额外提供入口；与需求方确认“题单允许收录 U 题（无论题单可见性）”。
+- [批量重排 DELETE+INSERT 产生短暂空窗] → 使用数据库事务包裹，外界不可见中间状态。
+- [后台“查看全部题单”数据量增长] → 使用分页，后续可按需增加 visibility/created_by 筛选。
+- [进度聚合随题单题目数增加有查询成本] → 按 `problem_id IN (...)` 批量查询，避免 N+1；后续可加缓存/物化。
+
+## Migration Plan
+
+1. `deno task db:generate` 生成 `trainings` / `training_problems` 迁移。
+2. `deno task db:migrate` 应用迁移。
+3. 发布后端 API 与 RBAC 种子（幂等）。
+4. 发布前端页面。
+5. 回滚策略：新表不影响现有功能；如需回滚，删除新迁移即可（未上线数据时）。
+
+## Open Questions
+
+- 后台是否需要在第一版支持按创建者/可见性筛选全量题单：当前计划实现 `listAllTrainings` 全量分页，筛选可作为后续增强。

--- a/openspec/changes/training-plans/proposal.md
+++ b/openspec/changes/training-plans/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+当前 NOJ 只有 admin 管控的分类树，用户无法自主组织题目、形成系统刷题路径。对标 HydroOJ `training` / 洛谷题单的基础形态，为用户提供可创建、可排序、可跟踪 AC 进度的题单能力，是 LMCC 备考与日常刷题的核心学习路径载体。
+
+## What Changes
+
+- 新增 `trainings` 题单主表与 `training_problems` 题单题目关联表（Drizzle 迁移）。
+- 新增题单 CRUD API：公开列表、我的题单、详情、更新、删除。
+- 新增题单题目管理 API：加题、批量重排、移除；题目删除时关联自动清理。
+- 新增 AC 进度聚合：编程题 `Accepted` 与客观题满分（`score=10000`）视为已通过。
+- 新增 RBAC 权限族 `training:*`，默认 user 角色获得 `create/read/write_own/delete_own`，`publish/pin` 默认仅管理员。
+- 新增前端页面：题单列表、我的题单、题单详情、后台题单管理；用户主页与题目页增加入口。
+- 可见性采用三态：`private`（仅创建者）、`unlisted`（URL 可访问）、`public`（管理员设置后出现在题单列表）。
+
+## Capabilities
+
+### New Capabilities
+
+- `training-plans`: 用户可创建与管理扁平题单，支持按序收录题目、AC 进度展示与三态可见性。
+
+### Modified Capabilities
+
+<!-- 无既有 spec 的需求变更 -->
+
+## Impact
+
+- **noj-core**：新增 `src/db/schema.ts` 表定义、迁移、`src/types/trainings.ts`、`src/services/trainings.ts`、`src/routes/trainings.ts`、`src/routes/admin-trainings.ts`、RBAC 权限种子。
+- **noj-ui**：新增题单相关页面与组件、`composables/useTrainings.ts`；修改用户主页与题目详情页。
+- **noj-tests**：新增 training E2E 测试。
+- **API**：新增 `/api/v1/trainings` 与 `/api/v1/admin/trainings` 路由。
+- **依赖**：无新增外部依赖。

--- a/openspec/changes/training-plans/specs/training-plans/spec.md
+++ b/openspec/changes/training-plans/specs/training-plans/spec.md
@@ -1,0 +1,207 @@
+## ADDED Requirements
+
+### Requirement: 题单数据模型
+
+系统 SHALL 提供 `trainings` 与 `training_problems` 两张表存储题单数据。
+
+`trainings` 表字段：
+
+| 字段 | 类型 | 约束 |
+|------|------|------|
+| id | TEXT | PRIMARY KEY, UUID |
+| title | TEXT | NOT NULL, 1-100 字符 |
+| description | TEXT | NOT NULL, DEFAULT '' |
+| visibility | TEXT | NOT NULL, DEFAULT 'private', CHECK IN ('private', 'unlisted', 'public') |
+| is_pinned | BOOLEAN | NOT NULL, DEFAULT false |
+| created_by | TEXT | NOT NULL, REFERENCES users(id) ON DELETE CASCADE |
+| created_at | TEXT | NOT NULL, ISO 8601 |
+| updated_at | TEXT | NOT NULL, ISO 8601 |
+
+`training_problems` 表字段：
+
+| 字段 | 类型 | 约束 |
+|------|------|------|
+| training_id | TEXT | NOT NULL, REFERENCES trainings(id) ON DELETE CASCADE |
+| problem_id | TEXT | NOT NULL, REFERENCES problems(id) ON DELETE CASCADE |
+| position | INTEGER | NOT NULL, DEFAULT 0 |
+| PRIMARY KEY (training_id, problem_id) | | |
+| UNIQUE (training_id, position) | | |
+
+系统 SHALL 在题目被删除时通过 `ON DELETE CASCADE` 自动清理 `training_problems` 中的关联行。
+
+#### Scenario: 创建题单
+- **WHEN** 登录用户创建题单并指定标题与可见性
+- **THEN** `trainings` 表新增一行，`created_by` 为该用户，`is_pinned` 为 false
+
+#### Scenario: 题目删除自动清理关联
+- **WHEN** 管理员或题主删除一道已被题单收录的题目
+- **THEN** `training_problems` 中关联该题目的行被自动删除，题单本身保留
+
+### Requirement: 题单可见性与访问控制
+
+系统 SHALL 支持三种可见性：`private`（仅创建者或 `training:read_any` 可见）、`unlisted`（知道 URL 即可访问，不出现在公开列表）、`public`（出现在公开题单列表）。
+
+系统 SHALL 仅允许具备 `training:publish` 权限的用户将题单可见性设为 `public`，仅允许具备 `training:pin` 权限的用户设置 `is_pinned`。
+
+访问矩阵 MUST 为：
+
+| 访问者 | private | unlisted | public |
+|--------|---------|----------|--------|
+| 匿名 | 不可见 | 可见（仅 URL） | 可见 |
+| 登录用户（非创建者） | 不可见 | 可见（仅 URL） | 可见 |
+| 创建者 | 可见 | 可见 | 可见 |
+| admin / read_any | 可见 | 可见 | 可见 |
+
+对于无权访问的 private 题单，系统 MUST 返回 404（不暴露题单存在）。
+
+#### Scenario: 私有题单对他人隐藏
+- **WHEN** 非创建者用户访问一个 `private` 题单详情
+- **THEN** 系统返回 404
+
+#### Scenario: 创建者访问自己的私有题单
+- **WHEN** 创建者访问自己的 `private` 题单详情
+- **THEN** 系统返回题单详情
+
+#### Scenario: unlisted 不出现在公开列表
+- **WHEN** 匿名用户请求公开题单列表
+- **THEN** 列表只包含 `public` 题单，不包含 `unlisted` 题单
+
+#### Scenario: 普通用户不能设为 public
+- **WHEN** 普通用户更新自己的题单可见性为 `public`
+- **THEN** 系统返回 403
+
+#### Scenario: 普通用户不能置顶
+- **WHEN** 普通用户更新自己的题单 `is_pinned` 为 true
+- **THEN** 系统返回 403
+
+### Requirement: 题单 CRUD API（用户侧）
+
+系统 SHALL 在 `/api/v1/trainings` 下提供以下端点：
+
+- `GET /api/v1/trainings` — 公开题单列表，仅 `public`，置顶优先、`updated_at` 倒序，分页
+- `GET /api/v1/trainings?created_by=:userId` — 用户主页题单列表：本人或 admin 返回全部可见性，其他访客仅返回 public
+- `GET /api/v1/trainings/mine` — 当前用户创建的全部题单，分页
+- `POST /api/v1/trainings` — 创建题单，需 `training:create`，可见性只能为 `private/unlisted`
+- `GET /api/v1/trainings/:id` — 题单详情，按可见性访问矩阵控制
+- `PUT /api/v1/trainings/:id` — 更新题单，创建者需 `training:write_own`，非创建者需 `training:write_any`；设 `public` 需 `training:publish`，设 `is_pinned` 需 `training:pin`
+- `DELETE /api/v1/trainings/:id` — 删除题单，创建者需 `training:delete_own`，非创建者需 `training:delete_any`
+
+`title` MUST 为 1-100 字符。创建时 `visibility` MUST 只能是 `private` 或 `unlisted`。
+
+#### Scenario: 登录用户创建题单
+- **WHEN** 登录用户 POST `/api/v1/trainings` 提供合法 title 和 visibility
+- **THEN** 系统返回 201 和题单详情
+
+#### Scenario: 创建题单时设为 public 被拒
+- **WHEN** 普通用户 POST `/api/v1/trainings` 且 `visibility=public`
+- **THEN** 系统返回 400
+
+#### Scenario: 非创建者编辑他人题单被拒
+- **WHEN** 普通用户 PUT 他人的题单
+- **THEN** 系统返回 403
+
+#### Scenario: 我的题单只返回本人创建
+- **WHEN** 登录用户 GET `/api/v1/trainings/mine`
+- **THEN** 系统只返回该用户创建的题单
+
+### Requirement: 题单题目管理 API
+
+系统 SHALL 在 `/api/v1/trainings/:id/problems` 下提供题目管理端点：
+
+- `GET /api/v1/trainings/:id/problems` — 返回题单内有序题目列表，按 `position` 升序
+- `POST /api/v1/trainings/:id/problems` — 加题，body `{ problem_id, position? }`，不传 position 追加到末尾
+- `PUT /api/v1/trainings/:id/problems` — 批量重排，body `{ problems: [{ problem_id, position }] }`，必须包含题单当前全部题目
+- `DELETE /api/v1/trainings/:id/problems/:problemId` — 从题单移除题目
+
+权限 MUST 与更新题单一致：创建者需 `training:write_own`，非创建者需 `training:write_any`。
+
+同一题单 MUST 不能重复收录同一道题，重复时返回 409。`position` MUST 为非负整数且在同一题单内唯一。
+
+#### Scenario: 按序加题
+- **WHEN** 创建者向题单连续加入题目 A、B、C
+- **THEN** 题目按加入顺序获得 position 0、1、2，详情按 position 返回
+
+#### Scenario: 指定位置插入
+- **WHEN** 创建者向已有 [A,B] 的题单在 position 0 插入 C
+- **THEN** 原 position 0/1 的题目变为 1/2，C 的 position 为 0
+
+#### Scenario: 重复加题被拒
+- **WHEN** 创建者向已包含题目 A 的题单再次加入 A
+- **THEN** 系统返回 409
+
+#### Scenario: 批量重排
+- **WHEN** 创建者 PUT `/api/v1/trainings/:id/problems` 提交全量新顺序
+- **THEN** 题单内题目顺序按新 position 保存
+
+#### Scenario: 批量重排缺少题目被拒
+- **WHEN** 创建者提交的重排数组未包含题单当前全部题目
+- **THEN** 系统返回 400
+
+### Requirement: AC 进度聚合
+
+系统 SHALL 在题单题目列表的响应中为登录用户返回每题 `accepted` 布尔值。
+
+判定规则 MUST 为：
+
+- 编程题：当前用户存在 `submissions` join `evaluation_results` 且 `evaluation_results.status='Accepted'` 的记录
+- 客观题套卷：当前用户存在 `objective_submissions` 且 `score=10000` 的记录
+- 匿名请求不计算进度，`accepted` 恒为 false
+
+#### Scenario: 编程题 AC 后进度为 true
+- **WHEN** 登录用户对题单内编程题提交并通过（Accepted）
+- **THEN** 该题在题单题目列表中 `accepted=true`
+
+#### Scenario: 客观题满分后进度为 true
+- **WHEN** 登录用户对题单内客观题套卷提交并获得满分 10000
+- **THEN** 该套卷在题单题目列表中 `accepted=true`
+
+#### Scenario: 匿名用户查看进度
+- **WHEN** 匿名用户请求题单题目列表
+- **THEN** 每题 `accepted` 均为 false
+
+### Requirement: 管理员后台管理
+
+系统 SHALL 在 `/api/v1/admin/trainings` 下提供后台管理端点：
+
+- `GET /api/v1/admin/trainings` — 查看全部题单（含 private/unlisted），分页，需 `training:read_any`
+- `PATCH /api/v1/admin/trainings/:id` — 更新任意题单的可见性、置顶、标题、简介；设 `public` 需 `training:publish`，设 `is_pinned` 需 `training:pin`
+- `DELETE /api/v1/admin/trainings/:id` — 删除任意题单，需 `training:delete_any`
+
+管理员对他人题单的编辑 MUST 只通过后台管理端点暴露，前台展示他人题单时不得显示编辑/管理控件。
+
+#### Scenario: 管理员查看全部题单
+- **WHEN** 具备 `training:read_any` 的用户 GET `/api/v1/admin/trainings`
+- **THEN** 系统返回包含 private/unlisted/public 的全部题单分页列表
+
+#### Scenario: 管理员将题单设为公开并置顶
+- **WHEN** 具备 `training:publish` 和 `training:pin` 的管理员 PATCH 题单为 `{ visibility: "public", is_pinned: true }`
+- **THEN** 题单出现在公开列表且排序优先
+
+#### Scenario: 普通用户访问后台端点被拒
+- **WHEN** 普通用户 GET `/api/v1/admin/trainings`
+- **THEN** 系统返回 403
+
+### Requirement: 前端题单页面
+
+系统 SHALL 提供以下前端页面与入口：
+
+- `/trainings` — 公开题单列表页
+- `/trainings/mine` — 我的题单页，可新建/删除
+- `/trainings/[id]` — 题单详情页，按序展示题目与 AC 进度；创建者可见管理题目控件
+- `/admin/trainings` — 后台题单管理页
+- 用户主页展示“我的题单”区块：本人看全部，他人只看 public
+- 题目详情页提供“加入题单”入口：仅操作当前用户自己创建的题单
+
+前台展示他人题单时 MUST 保持只读，即使当前用户是管理员也不显示可编辑标识。
+
+#### Scenario: 公开题单列表展示
+- **WHEN** 用户访问 `/trainings`
+- **THEN** 页面展示 public 题单，置顶优先
+
+#### Scenario: 详情页只读展示他人题单
+- **WHEN** 非创建者（含管理员）访问他人题单详情
+- **THEN** 页面只读展示题目与进度，不显示管理控件
+
+#### Scenario: 题目页加入自己的题单
+- **WHEN** 登录用户打开题目详情并选择自己的题单加入
+- **THEN** 该题目被加入所选题单，重复加入被拒绝并提示

--- a/openspec/changes/training-plans/tasks.md
+++ b/openspec/changes/training-plans/tasks.md
@@ -1,0 +1,41 @@
+## 1. 数据模型与类型
+
+- [ ] 1.1 在 `noj-core/src/db/schema.ts` 新增 `trainings` 与 `training_problems` 表定义
+- [ ] 1.2 运行 `deno task db:generate` 生成 Drizzle 迁移并应用
+- [ ] 1.3 新建 `noj-core/src/types/trainings.ts`，定义可见性枚举、Create/Update/TrainingResponse/TrainingProblemResponse 类型
+
+## 2. 后端 Service
+
+- [ ] 2.1 实现 `services/trainings.ts` 的 CRUD 与可见性访问（listPublicTrainings / listMyTrainings / listAllTrainings / listUserTrainings / getTraining / createTraining / updateTraining / deleteTraining）
+- [ ] 2.2 实现题单题目管理（listTrainingProblems / addTrainingProblem / reorderTrainingProblems / removeTrainingProblem）
+- [ ] 2.3 实现 AC 进度聚合（编程题 Accepted + 客观题满分）
+- [ ] 2.4 编写并跑通 `tests/services/trainings.test.ts`
+
+## 3. RBAC 权限
+
+- [ ] 3.1 在 `PERMISSION_DEFS` 注册 9 项 `training:*` 权限
+- [ ] 3.2 在 `USER_DEFAULT_PERMISSIONS` 为 user 角色添加 `training:create/read/write_own/delete_own`
+- [ ] 3.3 编写并跑通 RBAC training 权限种子测试
+
+## 4. 后端 API
+
+- [ ] 4.1 新建 `routes/trainings.ts` 并挂载 `/api/v1/trainings`
+- [ ] 4.2 实现公开列表、`?created_by=` 用户题单列表、`/mine`、CRUD、题目管理端点
+- [ ] 4.3 新建 `routes/admin-trainings.ts` 并挂载 `/api/v1/admin/trainings`
+- [ ] 4.4 实现后台全部题单列表、PATCH（含 public/pin）、DELETE
+- [ ] 4.5 编写并跑通 `tests/routes/trainings.test.ts` 与 `tests/routes/admin-trainings.test.ts`
+
+## 5. 前端
+
+- [ ] 5.1 新建 `noj-ui/types/training.ts` 与 `composables/useTrainings.ts`
+- [ ] 5.2 新建题单列表页 `/trainings`、我的题单页 `/trainings/mine` 及 TrainingCard/TrainingFormModal 组件
+- [ ] 5.3 新建题单详情页 `/trainings/[id]` 与 TrainingProblemList/TrainingProblemManager 组件
+- [ ] 5.4 用户主页增加“我的题单”区块，题目详情页增加“加入题单”入口
+- [ ] 5.5 新建后台 `/admin/trainings` 页面与 TrainingManagementSection 组件
+- [ ] 5.6 跑通 `deno lint` / `deno fmt` / `nuxt build`
+
+## 6. E2E 与收尾
+
+- [ ] 6.1 新建 `noj-tests/e2e/trainings.test.ts` 覆盖建题单、加题、进度、可见性、删题清理
+- [ ] 6.2 运行 noj-core 全量测试、noj-ui 构建、noj-tests training E2E
+- [ ] 6.3 确认设计文档、实施计划与 OpenSpec 变更齐全


### PR DESCRIPTION
实现 Issue #224：训练计划/题单（training）。

## 变更内容

- 新增 `trainings` / `training_problems` 表与 Drizzle 迁移
- 新增题单 CRUD、题目管理、AC 进度聚合 API（`/api/v1/trainings`、`/api/v1/admin/trainings`）
- 新增 `training:*` RBAC 权限族，默认 user 角色获得 create/read/write_own/delete_own
- 新增前端：题单列表、我的题单、题单详情、后台题单管理，用户主页/题目页入口
- 新增 training 单元测试与 E2E 测试
- 附带 OpenSpec 变更提案、设计文档与实施计划

Closes #224