### PR TITLE
feat(core,ui,root): 支持代码自测（#221）

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -301,7 +301,9 @@ jobs:
             e2e/27_objective.test.ts \
             e2e/28_announcements.test.ts \
             e2e/28_clarifications.test.ts \
-            e2e/29_avatar.test.ts &
+            e2e/29_avatar.test.ts \
+            e2e/30_self_test.test.ts \
+            e2e/trainings.test.ts &
           p3=$!
           fail=0
           wait "$p1" || fail=1

--- a/noj-core/drizzle/0042_tough_saracen.sql
+++ b/noj-core/drizzle/0042_tough_saracen.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "self_tests" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"problem_id" text NOT NULL,
+	"language" text NOT NULL,
+	"code" text NOT NULL,
+	"file_name" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"score" integer DEFAULT 0 NOT NULL,
+	"output" text DEFAULT '' NOT NULL,
+	"details" text DEFAULT '{}' NOT NULL,
+	"time_ms" integer,
+	"memory_kb" integer,
+	"judge_started_at" text,
+	"judge_finished_at" text,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "self_tests" ADD CONSTRAINT "self_tests_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "self_tests" ADD CONSTRAINT "self_tests_problem_id_problems_id_fk" FOREIGN KEY ("problem_id") REFERENCES "problems"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_self_tests_user_id" ON "self_tests" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_self_tests_problem_id" ON "self_tests" USING btree ("problem_id");--> statement-breakpoint
+CREATE INDEX "idx_self_tests_created_at" ON "self_tests" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "idx_self_tests_user_id_created_at" ON "self_tests" USING btree ("user_id","created_at");

--- a/noj-core/drizzle/0043_goofy_hellfire_club.sql
+++ b/noj-core/drizzle/0043_goofy_hellfire_club.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "self_tests" ADD COLUMN "result_status" text;

--- a/noj-core/drizzle/0044_nervous_franklin_richards.sql
+++ b/noj-core/drizzle/0044_nervous_franklin_richards.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "idx_self_tests_status_created_at" ON "self_tests" USING btree ("status","created_at");--> statement-breakpoint
+ALTER TABLE "self_tests" ADD CONSTRAINT "self_tests_status_check" CHECK ("self_tests"."status" IN ('pending', 'judging', 'finished', 'error'));

--- a/noj-core/drizzle/meta/0042_snapshot.json
+++ b/noj-core/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,5173 @@
+{
+  "id": "78207ff5-4850-4209-a536-c56c89a5019c",
+  "prevId": "b1805d01-3242-4ffa-96f7-74945881cc77",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_announcements_active_pinned_created": {
+          "name": "idx_announcements_active_pinned_created",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audit_logs_admin_id_idx": {
+          "name": "audit_logs_admin_id_idx",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_admin_id_users_id_fk": {
+          "name": "audit_logs_admin_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'users.role_change',\n        'users.ban',\n        'users.unban',\n        'problems.delete',\n        'problems.runtime_config_changed',\n        'problems.imported',\n        'tags.create',\n        'tags.update',\n        'tags.delete',\n        'tags.merge',\n        'submissions.rejudge',\n        'settings.update',\n        'ip_ban.create',\n        'ip_ban.delete',\n        'auth.login_success',\n        'auth.login_failure',\n        'auth.register',\n        'auth.change_password',\n        'auth.forgot_password_request',\n        'auth.password_reset',\n        'community.post_moderated',\n        'community.report_resolved',\n        'community.sanction_created',\n        'community.sanction_revoked',\n        'community.preset_applied',\n        'announcement.create',\n        'announcement.update',\n        'announcement.delete'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkin_date": {
+          "name": "checkin_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streak": {
+          "name": "streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "check_ins_user_id_users_id_fk": {
+          "name": "check_ins_user_id_users_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "check_ins_user_date_unique": {
+          "name": "check_ins_user_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "checkin_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_activity_events": {
+      "name": "community_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_activity_events_actor": {
+          "name": "idx_community_activity_events_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_activity_events_actor_id_users_id_fk": {
+          "name": "community_activity_events_actor_id_users_id_fk",
+          "tableFrom": "community_activity_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_activity_events_dedupe_unique": {
+          "name": "community_activity_events_dedupe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "type",
+            "subject_type",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "community_activity_events_type_check": {
+          "name": "community_activity_events_type_check",
+          "value": "\"community_activity_events\".\"type\" IN ('first_accepted', 'solution_published', 'contest_joined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_board_role_grants": {
+      "name": "community_board_role_grants",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_read": {
+          "name": "can_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_post": {
+          "name": "can_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_moderate": {
+          "name": "can_moderate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_community_board_role_grants_role": {
+          "name": "idx_community_board_role_grants_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_board_role_grants_board_id_community_boards_id_fk": {
+          "name": "community_board_role_grants_board_id_community_boards_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_board_role_grants_role_id_roles_id_fk": {
+          "name": "community_board_role_grants_role_id_roles_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_board_role_grants_board_id_role_id_pk": {
+          "name": "community_board_role_grants_board_id_role_id_pk",
+          "columns": [
+            "board_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_boards": {
+      "name": "community_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_boards_sort": {
+          "name": "idx_community_boards_sort",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_boards_slug_unique": {
+          "name": "community_boards_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_bookmarks": {
+      "name": "community_bookmarks",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_bookmarks_user": {
+          "name": "idx_community_bookmarks_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_bookmarks_post_id_community_posts_id_fk": {
+          "name": "community_bookmarks_post_id_community_posts_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_bookmarks_user_id_users_id_fk": {
+          "name": "community_bookmarks_user_id_users_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_bookmarks_post_id_user_id_pk": {
+          "name": "community_bookmarks_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comment_likes": {
+      "name": "community_comment_likes",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comment_likes_user": {
+          "name": "idx_community_comment_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comment_likes_comment_id_community_comments_id_fk": {
+          "name": "community_comment_likes_comment_id_community_comments_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comment_likes_user_id_users_id_fk": {
+          "name": "community_comment_likes_user_id_users_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_comment_likes_comment_id_user_id_pk": {
+          "name": "community_comment_likes_comment_id_user_id_pk",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comments_post": {
+          "name": "idx_community_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_author": {
+          "name": "idx_community_comments_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_parent": {
+          "name": "idx_community_comments_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_author_id_users_id_fk": {
+          "name": "community_comments_author_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_parent_id_community_comments_id_fk": {
+          "name": "community_comments_parent_id_community_comments_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_comments_status_check": {
+          "name": "community_comments_status_check",
+          "value": "\"community_comments\".\"status\" IN ('pending', 'published', 'hidden', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_follows": {
+      "name": "community_follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followee_id": {
+          "name": "followee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_follows_followee": {
+          "name": "idx_community_follows_followee",
+          "columns": [
+            {
+              "expression": "followee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_follows_follower_id_users_id_fk": {
+          "name": "community_follows_follower_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_follows_followee_id_users_id_fk": {
+          "name": "community_follows_followee_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_follows_follower_id_followee_id_pk": {
+          "name": "community_follows_follower_id_followee_id_pk",
+          "columns": [
+            "follower_id",
+            "followee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_follows_not_self_check": {
+          "name": "community_follows_not_self_check",
+          "value": "\"community_follows\".\"follower_id\" <> \"community_follows\".\"followee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_moderation_actions": {
+      "name": "community_moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_moderation_actions_target": {
+          "name": "idx_community_moderation_actions_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_moderation_actions_moderator": {
+          "name": "idx_community_moderation_actions_moderator",
+          "columns": [
+            {
+              "expression": "moderator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_moderation_actions_moderator_id_users_id_fk": {
+          "name": "community_moderation_actions_moderator_id_users_id_fk",
+          "tableFrom": "community_moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_notifications": {
+      "name": "community_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_notifications_recipient": {
+          "name": "idx_community_notifications_recipient",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_unread": {
+          "name": "idx_community_notifications_unread",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_actor": {
+          "name": "idx_community_notifications_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_post": {
+          "name": "idx_community_notifications_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_comment": {
+          "name": "idx_community_notifications_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_notifications_recipient_id_users_id_fk": {
+          "name": "community_notifications_recipient_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_notifications_actor_id_users_id_fk": {
+          "name": "community_notifications_actor_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_post_id_community_posts_id_fk": {
+          "name": "community_notifications_post_id_community_posts_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_comment_id_community_comments_id_fk": {
+          "name": "community_notifications_comment_id_community_comments_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_notifications_type_check": {
+          "name": "community_notifications_type_check",
+          "value": "\"community_notifications\".\"type\" IN ('reply', 'like', 'follow', 'moderation', 'clarification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_post_likes": {
+      "name": "community_post_likes",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_post_likes_user": {
+          "name": "idx_community_post_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_post_likes_post_id_community_posts_id_fk": {
+          "name": "community_post_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_post_likes_user_id_users_id_fk": {
+          "name": "community_post_likes_user_id_users_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_post_likes_post_id_user_id_pk": {
+          "name": "community_post_likes_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_posts_author": {
+          "name": "idx_community_posts_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_problem": {
+          "name": "idx_community_posts_problem",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_board": {
+          "name": "idx_community_posts_board",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_published": {
+          "name": "idx_community_posts_published",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_pending": {
+          "name": "idx_community_posts_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_posts_author_id_users_id_fk": {
+          "name": "community_posts_author_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_problem_id_problems_id_fk": {
+          "name": "community_posts_problem_id_problems_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_board_id_community_boards_id_fk": {
+          "name": "community_posts_board_id_community_boards_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_posts_type_check": {
+          "name": "community_posts_type_check",
+          "value": "\"community_posts\".\"type\" IN ('solution', 'discussion', 'moment')"
+        },
+        "community_posts_status_check": {
+          "name": "community_posts_status_check",
+          "value": "\"community_posts\".\"status\" IN ('draft', 'pending', 'published', 'hidden', 'deleted')"
+        },
+        "community_posts_context_check": {
+          "name": "community_posts_context_check",
+          "value": "(\n        (\"community_posts\".\"type\" = 'solution' AND \"community_posts\".\"problem_id\" IS NOT NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'discussion' AND \"community_posts\".\"board_id\" IS NOT NULL AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'moment' AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_reports": {
+      "name": "community_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_reports_pending": {
+          "name": "idx_community_reports_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_reports\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_reporter": {
+          "name": "idx_community_reports_reporter",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_post": {
+          "name": "idx_community_reports_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_comment": {
+          "name": "idx_community_reports_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_reports_reporter_id_users_id_fk": {
+          "name": "community_reports_reporter_id_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_reports_post_id_community_posts_id_fk": {
+          "name": "community_reports_post_id_community_posts_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_comment_id_community_comments_id_fk": {
+          "name": "community_reports_comment_id_community_comments_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_resolved_by_users_id_fk": {
+          "name": "community_reports_resolved_by_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_reports_target_check": {
+          "name": "community_reports_target_check",
+          "value": "num_nonnulls(\"community_reports\".\"post_id\", \"community_reports\".\"comment_id\") = 1"
+        },
+        "community_reports_status_check": {
+          "name": "community_reports_status_check",
+          "value": "\"community_reports\".\"status\" IN ('pending', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_sanctions": {
+      "name": "community_sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_community_sanctions_active": {
+          "name": "idx_community_sanctions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_sanctions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_sanctions_creator": {
+          "name": "idx_community_sanctions_creator",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_sanctions_user_id_users_id_fk": {
+          "name": "community_sanctions_user_id_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_created_by_users_id_fk": {
+          "name": "community_sanctions_created_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_revoked_by_users_id_fk": {
+          "name": "community_sanctions_revoked_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_clarifications": {
+      "name": "contest_clarifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to_id": {
+          "name": "reply_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_clarifications_contest": {
+          "name": "idx_contest_clarifications_contest",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_clarifications_contest_id_contests_id_fk": {
+          "name": "contest_clarifications_contest_id_contests_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_problem_id_problems_id_fk": {
+          "name": "contest_clarifications_problem_id_problems_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_sender_id_users_id_fk": {
+          "name": "contest_clarifications_sender_id_users_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_reply_to_id_contest_clarifications_id_fk": {
+          "name": "contest_clarifications_reply_to_id_contest_clarifications_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contest_clarifications",
+          "columnsFrom": [
+            "reply_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_participants": {
+      "name": "contest_participants",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_participants_user": {
+          "name": "idx_contest_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_participants_contest_id_contests_id_fk": {
+          "name": "contest_participants_contest_id_contests_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_participants_user_id_users_id_fk": {
+          "name": "contest_participants_user_id_users_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_participants_contest_id_user_id_pk": {
+          "name": "contest_participants_contest_id_user_id_pk",
+          "columns": [
+            "contest_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_problems": {
+      "name": "contest_problems",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contest_problems_contest_id_contests_id_fk": {
+          "name": "contest_problems_contest_id_contests_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_problems_problem_id_problems_id_fk": {
+          "name": "contest_problems_problem_id_problems_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_problems_contest_id_problem_id_pk": {
+          "name": "contest_problems_contest_id_problem_id_pk",
+          "columns": [
+            "contest_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "contest_problems_contest_label_unique": {
+          "name": "contest_problems_contest_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "label"
+          ]
+        },
+        "contest_problems_contest_sort_order_unique": {
+          "name": "contest_problems_contest_sort_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contests": {
+      "name": "contests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affect_global_ranking": {
+          "name": "affect_global_ranking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announcement": {
+          "name": "announcement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contests_created_by": {
+          "name": "idx_contests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_start_time": {
+          "name": "idx_contests_start_time",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_end_time": {
+          "name": "idx_contests_end_time",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contests_created_by_users_id_fk": {
+          "name": "contests_created_by_users_id_fk",
+          "tableFrom": "contests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "contests_type_check": {
+          "name": "contests_type_check",
+          "value": "\"contests\".\"type\" IN ('icpc', 'ioi', 'oi')"
+        },
+        "contests_time_check": {
+          "name": "contests_time_check",
+          "value": "\"contests\".\"end_time\" > \"contests\".\"start_time\""
+        },
+        "contests_config_check": {
+          "name": "contests_config_check",
+          "value": "jsonb_typeof(\"contests\".\"config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_reads": {
+      "name": "conversation_reads",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_reads_user_id_users_id_fk": {
+          "name": "conversation_reads_user_id_users_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_reads_conversation_id_conversations_id_fk": {
+          "name": "conversation_reads_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_reads_user_id_conversation_id_pk": {
+          "name": "conversation_reads_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_conversations_user1_id": {
+          "name": "idx_conversations_user1_id",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_user2_id": {
+          "name": "idx_conversations_user2_id",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_message_at": {
+          "name": "idx_conversations_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user1_id_users_id_fk": {
+          "name": "conversations_user1_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_user2_id_users_id_fk": {
+          "name": "conversations_user2_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_user_pair_unique": {
+          "name": "conversations_user_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1_id",
+            "user2_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversations_user_order_check": {
+          "name": "conversations_user_order_check",
+          "value": "\"conversations\".\"user1_id\" < \"conversations\".\"user2_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eval_results_submission_id": {
+          "name": "idx_eval_results_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eval_results_created_at": {
+          "name": "idx_eval_results_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_submission_id_submissions_id_fk": {
+          "name": "evaluation_results_submission_id_submissions_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ip_bans": {
+      "name": "ip_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_or_cidr": {
+          "name": "ip_or_cidr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ip_bans_ip_or_cidr": {
+          "name": "idx_ip_bans_ip_or_cidr",
+          "columns": [
+            {
+              "expression": "ip_or_cidr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ip_bans_expires_at": {
+          "name": "idx_ip_bans_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ip_bans_created_by_users_id_fk": {
+          "name": "ip_bans_created_by_users_id_fk",
+          "tableFrom": "ip_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judge_images": {
+      "name": "judge_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exact'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evaluator'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_images_mode_check": {
+          "name": "judge_images_mode_check",
+          "value": "\"judge_images\".\"mode\" IN ('exact', 'all_versions')"
+        },
+        "judge_images_kind_check": {
+          "name": "judge_images_kind_check",
+          "value": "\"judge_images\".\"kind\" IN ('evaluator', 'solution')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_deletions": {
+      "name": "message_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_message_deletions_message_id": {
+          "name": "idx_message_deletions_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_deletions_user_id_users_id_fk": {
+          "name": "message_deletions_user_id_users_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_deletions_message_id_messages_id_fk": {
+          "name": "message_deletions_message_id_messages_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_deletions_user_id_message_id_pk": {
+          "name": "message_deletions_user_id_message_id_pk",
+          "columns": [
+            "user_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_created": {
+          "name": "idx_messages_conversation_created",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_sender_id": {
+          "name": "idx_messages_sender_id",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_users_id_fk": {
+          "name": "messages_sender_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.objective_questions": {
+      "name": "objective_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_questions_paper_id": {
+          "name": "idx_objective_questions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_questions_paper_id_problems_id_fk": {
+          "name": "objective_questions_paper_id_problems_id_fk",
+          "tableFrom": "objective_questions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_questions_paper_sort_unique": {
+          "name": "objective_questions_paper_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_questions_type_check": {
+          "name": "objective_questions_type_check",
+          "value": "\"objective_questions\".\"type\" IN ('single', 'multiple', 'judge')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.objective_submissions": {
+      "name": "objective_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finished'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_submissions_paper_id": {
+          "name": "idx_objective_submissions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_id": {
+          "name": "idx_objective_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_paper_created": {
+          "name": "idx_objective_submissions_user_paper_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_contest_id": {
+          "name": "idx_objective_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_submissions_paper_id_problems_id_fk": {
+          "name": "objective_submissions_paper_id_problems_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_user_id_users_id_fk": {
+          "name": "objective_submissions_user_id_users_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_contest_id_contests_id_fk": {
+          "name": "objective_submissions_contest_id_contests_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_submissions_contest_unique": {
+          "name": "objective_submissions_contest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "user_id",
+            "contest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_submissions_type_check": {
+          "name": "objective_submissions_type_check",
+          "value": "\"objective_submissions\".\"submission_type\" IN ('practice', 'contest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_password_reset_tokens_user_id": {
+          "name": "idx_password_reset_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_password_reset_tokens_expires_at": {
+          "name": "idx_password_reset_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_resource_action_unique": {
+          "name": "permissions_resource_action_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resource",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_tags": {
+      "name": "problem_tags",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "problem_tags_problem_id_problems_id_fk": {
+          "name": "problem_tags_problem_id_problems_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "problem_tags_tag_id_tags_id_fk": {
+          "name": "problem_tags_tag_id_tags_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "problem_tags_problem_id_tag_id_pk": {
+          "name": "problem_tags_problem_id_tag_id_pk",
+          "columns": [
+            "problem_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "support_package_storage_url": {
+          "name": "support_package_storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_config": {
+          "name": "runtime_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'U'"
+        },
+        "is_objective": {
+          "name": "is_objective",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_problems_search_vector": {
+          "name": "idx_problems_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "problems_type_number_unique": {
+          "name": "problems_type_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "problems_type_check": {
+          "name": "problems_type_check",
+          "value": "\"problems\".\"type\" IN ('U', 'P')"
+        },
+        "problems_runtime_config_check": {
+          "name": "problems_runtime_config_check",
+          "value": "\"problems\".\"runtime_config\" IS NULL OR jsonb_typeof(\"problems\".\"runtime_config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_roles_parent_id": {
+          "name": "idx_roles_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_parent_id_roles_id_fk": {
+          "name": "roles_parent_id_roles_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.self_tests": {
+      "name": "self_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_self_tests_user_id": {
+          "name": "idx_self_tests_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_problem_id": {
+          "name": "idx_self_tests_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_created_at": {
+          "name": "idx_self_tests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_user_id_created_at": {
+          "name": "idx_self_tests_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "self_tests_user_id_users_id_fk": {
+          "name": "self_tests_user_id_users_id_fk",
+          "tableFrom": "self_tests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "self_tests_problem_id_problems_id_fk": {
+          "name": "self_tests_problem_id_problems_id_fk",
+          "tableFrom": "self_tests",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejudge_seq": {
+          "name": "rejudge_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_submissions_user_id": {
+          "name": "idx_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_problem_id": {
+          "name": "idx_submissions_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_status": {
+          "name": "idx_submissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_id": {
+          "name": "idx_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_problem_user": {
+          "name": "idx_submissions_contest_problem_user",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_user_id_created_at": {
+          "name": "idx_submissions_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_problem_id_problems_id_fk": {
+          "name": "submissions_problem_id_problems_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_contest_id_contests_id_fk": {
+          "name": "submissions_contest_id_contests_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_settings_updated_at": {
+          "name": "idx_system_settings_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tags_kind_check": {
+          "name": "tags_kind_check",
+          "value": "\"tags\".\"kind\" IN ('problem', 'algorithm')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.training_problems": {
+      "name": "training_problems",
+      "schema": "",
+      "columns": {
+        "training_id": {
+          "name": "training_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_training_problems_training_position": {
+          "name": "idx_training_problems_training_position",
+          "columns": [
+            {
+              "expression": "training_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_problems_training_id_trainings_id_fk": {
+          "name": "training_problems_training_id_trainings_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "trainings",
+          "columnsFrom": [
+            "training_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "training_problems_problem_id_problems_id_fk": {
+          "name": "training_problems_problem_id_problems_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "training_problems_training_id_problem_id_pk": {
+          "name": "training_problems_training_id_problem_id_pk",
+          "columns": [
+            "training_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "training_problems_training_position_unique": {
+          "name": "training_problems_training_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "training_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainings": {
+      "name": "trainings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trainings_visibility_pinned_created": {
+          "name": "idx_trainings_visibility_pinned_created",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trainings_created_by": {
+          "name": "idx_trainings_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trainings_created_by_users_id_fk": {
+          "name": "trainings_created_by_users_id_fk",
+          "tableFrom": "trainings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "trainings_visibility_check": {
+          "name": "trainings_visibility_check",
+          "value": "\"trainings\".\"visibility\" IN ('private', 'unlisted', 'public')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_bans": {
+      "name": "user_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "banned_until": {
+          "name": "banned_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "banned_by": {
+          "name": "banned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_at": {
+          "name": "unbanned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_by": {
+          "name": "unbanned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_bans_user": {
+          "name": "idx_user_bans_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_bans_active": {
+          "name": "idx_user_bans_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "unbanned_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_bans_user_id_users_id_fk": {
+          "name": "user_bans_user_id_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bans_banned_by_users_id_fk": {
+          "name": "user_bans_banned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "banned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_bans_unbanned_by_users_id_fk": {
+          "name": "user_bans_unbanned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "unbanned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_activity_visibility": {
+          "name": "community_activity_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'following'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_search_vector": {
+          "name": "idx_users_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_community_activity_visibility_check": {
+          "name": "users_community_activity_visibility_check",
+          "value": "\"users\".\"community_activity_visibility\" IN ('hidden', 'following', 'everyone')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/noj-core/drizzle/meta/0043_snapshot.json
+++ b/noj-core/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,5179 @@
+{
+  "id": "f047f4a7-70a5-4d95-9fed-876184c292b1",
+  "prevId": "78207ff5-4850-4209-a536-c56c89a5019c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_announcements_active_pinned_created": {
+          "name": "idx_announcements_active_pinned_created",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audit_logs_admin_id_idx": {
+          "name": "audit_logs_admin_id_idx",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_admin_id_users_id_fk": {
+          "name": "audit_logs_admin_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'users.role_change',\n        'users.ban',\n        'users.unban',\n        'problems.delete',\n        'problems.runtime_config_changed',\n        'problems.imported',\n        'tags.create',\n        'tags.update',\n        'tags.delete',\n        'tags.merge',\n        'submissions.rejudge',\n        'settings.update',\n        'ip_ban.create',\n        'ip_ban.delete',\n        'auth.login_success',\n        'auth.login_failure',\n        'auth.register',\n        'auth.change_password',\n        'auth.forgot_password_request',\n        'auth.password_reset',\n        'community.post_moderated',\n        'community.report_resolved',\n        'community.sanction_created',\n        'community.sanction_revoked',\n        'community.preset_applied',\n        'announcement.create',\n        'announcement.update',\n        'announcement.delete'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkin_date": {
+          "name": "checkin_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streak": {
+          "name": "streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "check_ins_user_id_users_id_fk": {
+          "name": "check_ins_user_id_users_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "check_ins_user_date_unique": {
+          "name": "check_ins_user_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "checkin_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_activity_events": {
+      "name": "community_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_activity_events_actor": {
+          "name": "idx_community_activity_events_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_activity_events_actor_id_users_id_fk": {
+          "name": "community_activity_events_actor_id_users_id_fk",
+          "tableFrom": "community_activity_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_activity_events_dedupe_unique": {
+          "name": "community_activity_events_dedupe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "type",
+            "subject_type",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "community_activity_events_type_check": {
+          "name": "community_activity_events_type_check",
+          "value": "\"community_activity_events\".\"type\" IN ('first_accepted', 'solution_published', 'contest_joined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_board_role_grants": {
+      "name": "community_board_role_grants",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_read": {
+          "name": "can_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_post": {
+          "name": "can_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_moderate": {
+          "name": "can_moderate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_community_board_role_grants_role": {
+          "name": "idx_community_board_role_grants_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_board_role_grants_board_id_community_boards_id_fk": {
+          "name": "community_board_role_grants_board_id_community_boards_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_board_role_grants_role_id_roles_id_fk": {
+          "name": "community_board_role_grants_role_id_roles_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_board_role_grants_board_id_role_id_pk": {
+          "name": "community_board_role_grants_board_id_role_id_pk",
+          "columns": [
+            "board_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_boards": {
+      "name": "community_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_boards_sort": {
+          "name": "idx_community_boards_sort",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_boards_slug_unique": {
+          "name": "community_boards_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_bookmarks": {
+      "name": "community_bookmarks",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_bookmarks_user": {
+          "name": "idx_community_bookmarks_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_bookmarks_post_id_community_posts_id_fk": {
+          "name": "community_bookmarks_post_id_community_posts_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_bookmarks_user_id_users_id_fk": {
+          "name": "community_bookmarks_user_id_users_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_bookmarks_post_id_user_id_pk": {
+          "name": "community_bookmarks_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comment_likes": {
+      "name": "community_comment_likes",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comment_likes_user": {
+          "name": "idx_community_comment_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comment_likes_comment_id_community_comments_id_fk": {
+          "name": "community_comment_likes_comment_id_community_comments_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comment_likes_user_id_users_id_fk": {
+          "name": "community_comment_likes_user_id_users_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_comment_likes_comment_id_user_id_pk": {
+          "name": "community_comment_likes_comment_id_user_id_pk",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comments_post": {
+          "name": "idx_community_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_author": {
+          "name": "idx_community_comments_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_parent": {
+          "name": "idx_community_comments_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_author_id_users_id_fk": {
+          "name": "community_comments_author_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_parent_id_community_comments_id_fk": {
+          "name": "community_comments_parent_id_community_comments_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_comments_status_check": {
+          "name": "community_comments_status_check",
+          "value": "\"community_comments\".\"status\" IN ('pending', 'published', 'hidden', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_follows": {
+      "name": "community_follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followee_id": {
+          "name": "followee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_follows_followee": {
+          "name": "idx_community_follows_followee",
+          "columns": [
+            {
+              "expression": "followee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_follows_follower_id_users_id_fk": {
+          "name": "community_follows_follower_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_follows_followee_id_users_id_fk": {
+          "name": "community_follows_followee_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_follows_follower_id_followee_id_pk": {
+          "name": "community_follows_follower_id_followee_id_pk",
+          "columns": [
+            "follower_id",
+            "followee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_follows_not_self_check": {
+          "name": "community_follows_not_self_check",
+          "value": "\"community_follows\".\"follower_id\" <> \"community_follows\".\"followee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_moderation_actions": {
+      "name": "community_moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_moderation_actions_target": {
+          "name": "idx_community_moderation_actions_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_moderation_actions_moderator": {
+          "name": "idx_community_moderation_actions_moderator",
+          "columns": [
+            {
+              "expression": "moderator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_moderation_actions_moderator_id_users_id_fk": {
+          "name": "community_moderation_actions_moderator_id_users_id_fk",
+          "tableFrom": "community_moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_notifications": {
+      "name": "community_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_notifications_recipient": {
+          "name": "idx_community_notifications_recipient",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_unread": {
+          "name": "idx_community_notifications_unread",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_actor": {
+          "name": "idx_community_notifications_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_post": {
+          "name": "idx_community_notifications_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_comment": {
+          "name": "idx_community_notifications_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_notifications_recipient_id_users_id_fk": {
+          "name": "community_notifications_recipient_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_notifications_actor_id_users_id_fk": {
+          "name": "community_notifications_actor_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_post_id_community_posts_id_fk": {
+          "name": "community_notifications_post_id_community_posts_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_comment_id_community_comments_id_fk": {
+          "name": "community_notifications_comment_id_community_comments_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_notifications_type_check": {
+          "name": "community_notifications_type_check",
+          "value": "\"community_notifications\".\"type\" IN ('reply', 'like', 'follow', 'moderation', 'clarification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_post_likes": {
+      "name": "community_post_likes",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_post_likes_user": {
+          "name": "idx_community_post_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_post_likes_post_id_community_posts_id_fk": {
+          "name": "community_post_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_post_likes_user_id_users_id_fk": {
+          "name": "community_post_likes_user_id_users_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_post_likes_post_id_user_id_pk": {
+          "name": "community_post_likes_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_posts_author": {
+          "name": "idx_community_posts_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_problem": {
+          "name": "idx_community_posts_problem",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_board": {
+          "name": "idx_community_posts_board",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_published": {
+          "name": "idx_community_posts_published",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_pending": {
+          "name": "idx_community_posts_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_posts_author_id_users_id_fk": {
+          "name": "community_posts_author_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_problem_id_problems_id_fk": {
+          "name": "community_posts_problem_id_problems_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_board_id_community_boards_id_fk": {
+          "name": "community_posts_board_id_community_boards_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_posts_type_check": {
+          "name": "community_posts_type_check",
+          "value": "\"community_posts\".\"type\" IN ('solution', 'discussion', 'moment')"
+        },
+        "community_posts_status_check": {
+          "name": "community_posts_status_check",
+          "value": "\"community_posts\".\"status\" IN ('draft', 'pending', 'published', 'hidden', 'deleted')"
+        },
+        "community_posts_context_check": {
+          "name": "community_posts_context_check",
+          "value": "(\n        (\"community_posts\".\"type\" = 'solution' AND \"community_posts\".\"problem_id\" IS NOT NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'discussion' AND \"community_posts\".\"board_id\" IS NOT NULL AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'moment' AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_reports": {
+      "name": "community_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_reports_pending": {
+          "name": "idx_community_reports_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_reports\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_reporter": {
+          "name": "idx_community_reports_reporter",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_post": {
+          "name": "idx_community_reports_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_comment": {
+          "name": "idx_community_reports_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_reports_reporter_id_users_id_fk": {
+          "name": "community_reports_reporter_id_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_reports_post_id_community_posts_id_fk": {
+          "name": "community_reports_post_id_community_posts_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_comment_id_community_comments_id_fk": {
+          "name": "community_reports_comment_id_community_comments_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_resolved_by_users_id_fk": {
+          "name": "community_reports_resolved_by_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_reports_target_check": {
+          "name": "community_reports_target_check",
+          "value": "num_nonnulls(\"community_reports\".\"post_id\", \"community_reports\".\"comment_id\") = 1"
+        },
+        "community_reports_status_check": {
+          "name": "community_reports_status_check",
+          "value": "\"community_reports\".\"status\" IN ('pending', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_sanctions": {
+      "name": "community_sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_community_sanctions_active": {
+          "name": "idx_community_sanctions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_sanctions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_sanctions_creator": {
+          "name": "idx_community_sanctions_creator",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_sanctions_user_id_users_id_fk": {
+          "name": "community_sanctions_user_id_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_created_by_users_id_fk": {
+          "name": "community_sanctions_created_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_revoked_by_users_id_fk": {
+          "name": "community_sanctions_revoked_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_clarifications": {
+      "name": "contest_clarifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to_id": {
+          "name": "reply_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_clarifications_contest": {
+          "name": "idx_contest_clarifications_contest",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_clarifications_contest_id_contests_id_fk": {
+          "name": "contest_clarifications_contest_id_contests_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_problem_id_problems_id_fk": {
+          "name": "contest_clarifications_problem_id_problems_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_sender_id_users_id_fk": {
+          "name": "contest_clarifications_sender_id_users_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_reply_to_id_contest_clarifications_id_fk": {
+          "name": "contest_clarifications_reply_to_id_contest_clarifications_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contest_clarifications",
+          "columnsFrom": [
+            "reply_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_participants": {
+      "name": "contest_participants",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_participants_user": {
+          "name": "idx_contest_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_participants_contest_id_contests_id_fk": {
+          "name": "contest_participants_contest_id_contests_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_participants_user_id_users_id_fk": {
+          "name": "contest_participants_user_id_users_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_participants_contest_id_user_id_pk": {
+          "name": "contest_participants_contest_id_user_id_pk",
+          "columns": [
+            "contest_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_problems": {
+      "name": "contest_problems",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contest_problems_contest_id_contests_id_fk": {
+          "name": "contest_problems_contest_id_contests_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_problems_problem_id_problems_id_fk": {
+          "name": "contest_problems_problem_id_problems_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_problems_contest_id_problem_id_pk": {
+          "name": "contest_problems_contest_id_problem_id_pk",
+          "columns": [
+            "contest_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "contest_problems_contest_label_unique": {
+          "name": "contest_problems_contest_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "label"
+          ]
+        },
+        "contest_problems_contest_sort_order_unique": {
+          "name": "contest_problems_contest_sort_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contests": {
+      "name": "contests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affect_global_ranking": {
+          "name": "affect_global_ranking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announcement": {
+          "name": "announcement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contests_created_by": {
+          "name": "idx_contests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_start_time": {
+          "name": "idx_contests_start_time",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_end_time": {
+          "name": "idx_contests_end_time",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contests_created_by_users_id_fk": {
+          "name": "contests_created_by_users_id_fk",
+          "tableFrom": "contests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "contests_type_check": {
+          "name": "contests_type_check",
+          "value": "\"contests\".\"type\" IN ('icpc', 'ioi', 'oi')"
+        },
+        "contests_time_check": {
+          "name": "contests_time_check",
+          "value": "\"contests\".\"end_time\" > \"contests\".\"start_time\""
+        },
+        "contests_config_check": {
+          "name": "contests_config_check",
+          "value": "jsonb_typeof(\"contests\".\"config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_reads": {
+      "name": "conversation_reads",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_reads_user_id_users_id_fk": {
+          "name": "conversation_reads_user_id_users_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_reads_conversation_id_conversations_id_fk": {
+          "name": "conversation_reads_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_reads_user_id_conversation_id_pk": {
+          "name": "conversation_reads_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_conversations_user1_id": {
+          "name": "idx_conversations_user1_id",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_user2_id": {
+          "name": "idx_conversations_user2_id",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_message_at": {
+          "name": "idx_conversations_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user1_id_users_id_fk": {
+          "name": "conversations_user1_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_user2_id_users_id_fk": {
+          "name": "conversations_user2_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_user_pair_unique": {
+          "name": "conversations_user_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1_id",
+            "user2_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversations_user_order_check": {
+          "name": "conversations_user_order_check",
+          "value": "\"conversations\".\"user1_id\" < \"conversations\".\"user2_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eval_results_submission_id": {
+          "name": "idx_eval_results_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eval_results_created_at": {
+          "name": "idx_eval_results_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_submission_id_submissions_id_fk": {
+          "name": "evaluation_results_submission_id_submissions_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ip_bans": {
+      "name": "ip_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_or_cidr": {
+          "name": "ip_or_cidr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ip_bans_ip_or_cidr": {
+          "name": "idx_ip_bans_ip_or_cidr",
+          "columns": [
+            {
+              "expression": "ip_or_cidr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ip_bans_expires_at": {
+          "name": "idx_ip_bans_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ip_bans_created_by_users_id_fk": {
+          "name": "ip_bans_created_by_users_id_fk",
+          "tableFrom": "ip_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judge_images": {
+      "name": "judge_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exact'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evaluator'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_images_mode_check": {
+          "name": "judge_images_mode_check",
+          "value": "\"judge_images\".\"mode\" IN ('exact', 'all_versions')"
+        },
+        "judge_images_kind_check": {
+          "name": "judge_images_kind_check",
+          "value": "\"judge_images\".\"kind\" IN ('evaluator', 'solution')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_deletions": {
+      "name": "message_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_message_deletions_message_id": {
+          "name": "idx_message_deletions_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_deletions_user_id_users_id_fk": {
+          "name": "message_deletions_user_id_users_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_deletions_message_id_messages_id_fk": {
+          "name": "message_deletions_message_id_messages_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_deletions_user_id_message_id_pk": {
+          "name": "message_deletions_user_id_message_id_pk",
+          "columns": [
+            "user_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_created": {
+          "name": "idx_messages_conversation_created",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_sender_id": {
+          "name": "idx_messages_sender_id",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_users_id_fk": {
+          "name": "messages_sender_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.objective_questions": {
+      "name": "objective_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_questions_paper_id": {
+          "name": "idx_objective_questions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_questions_paper_id_problems_id_fk": {
+          "name": "objective_questions_paper_id_problems_id_fk",
+          "tableFrom": "objective_questions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_questions_paper_sort_unique": {
+          "name": "objective_questions_paper_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_questions_type_check": {
+          "name": "objective_questions_type_check",
+          "value": "\"objective_questions\".\"type\" IN ('single', 'multiple', 'judge')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.objective_submissions": {
+      "name": "objective_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finished'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_submissions_paper_id": {
+          "name": "idx_objective_submissions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_id": {
+          "name": "idx_objective_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_paper_created": {
+          "name": "idx_objective_submissions_user_paper_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_contest_id": {
+          "name": "idx_objective_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_submissions_paper_id_problems_id_fk": {
+          "name": "objective_submissions_paper_id_problems_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_user_id_users_id_fk": {
+          "name": "objective_submissions_user_id_users_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_contest_id_contests_id_fk": {
+          "name": "objective_submissions_contest_id_contests_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_submissions_contest_unique": {
+          "name": "objective_submissions_contest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "user_id",
+            "contest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_submissions_type_check": {
+          "name": "objective_submissions_type_check",
+          "value": "\"objective_submissions\".\"submission_type\" IN ('practice', 'contest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_password_reset_tokens_user_id": {
+          "name": "idx_password_reset_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_password_reset_tokens_expires_at": {
+          "name": "idx_password_reset_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_resource_action_unique": {
+          "name": "permissions_resource_action_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resource",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_tags": {
+      "name": "problem_tags",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "problem_tags_problem_id_problems_id_fk": {
+          "name": "problem_tags_problem_id_problems_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "problem_tags_tag_id_tags_id_fk": {
+          "name": "problem_tags_tag_id_tags_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "problem_tags_problem_id_tag_id_pk": {
+          "name": "problem_tags_problem_id_tag_id_pk",
+          "columns": [
+            "problem_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "support_package_storage_url": {
+          "name": "support_package_storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_config": {
+          "name": "runtime_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'U'"
+        },
+        "is_objective": {
+          "name": "is_objective",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_problems_search_vector": {
+          "name": "idx_problems_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "problems_type_number_unique": {
+          "name": "problems_type_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "problems_type_check": {
+          "name": "problems_type_check",
+          "value": "\"problems\".\"type\" IN ('U', 'P')"
+        },
+        "problems_runtime_config_check": {
+          "name": "problems_runtime_config_check",
+          "value": "\"problems\".\"runtime_config\" IS NULL OR jsonb_typeof(\"problems\".\"runtime_config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_roles_parent_id": {
+          "name": "idx_roles_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_parent_id_roles_id_fk": {
+          "name": "roles_parent_id_roles_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.self_tests": {
+      "name": "self_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_self_tests_user_id": {
+          "name": "idx_self_tests_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_problem_id": {
+          "name": "idx_self_tests_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_created_at": {
+          "name": "idx_self_tests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_user_id_created_at": {
+          "name": "idx_self_tests_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "self_tests_user_id_users_id_fk": {
+          "name": "self_tests_user_id_users_id_fk",
+          "tableFrom": "self_tests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "self_tests_problem_id_problems_id_fk": {
+          "name": "self_tests_problem_id_problems_id_fk",
+          "tableFrom": "self_tests",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejudge_seq": {
+          "name": "rejudge_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_submissions_user_id": {
+          "name": "idx_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_problem_id": {
+          "name": "idx_submissions_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_status": {
+          "name": "idx_submissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_id": {
+          "name": "idx_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_problem_user": {
+          "name": "idx_submissions_contest_problem_user",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_user_id_created_at": {
+          "name": "idx_submissions_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_problem_id_problems_id_fk": {
+          "name": "submissions_problem_id_problems_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_contest_id_contests_id_fk": {
+          "name": "submissions_contest_id_contests_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_settings_updated_at": {
+          "name": "idx_system_settings_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tags_kind_check": {
+          "name": "tags_kind_check",
+          "value": "\"tags\".\"kind\" IN ('problem', 'algorithm')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.training_problems": {
+      "name": "training_problems",
+      "schema": "",
+      "columns": {
+        "training_id": {
+          "name": "training_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_training_problems_training_position": {
+          "name": "idx_training_problems_training_position",
+          "columns": [
+            {
+              "expression": "training_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_problems_training_id_trainings_id_fk": {
+          "name": "training_problems_training_id_trainings_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "trainings",
+          "columnsFrom": [
+            "training_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "training_problems_problem_id_problems_id_fk": {
+          "name": "training_problems_problem_id_problems_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "training_problems_training_id_problem_id_pk": {
+          "name": "training_problems_training_id_problem_id_pk",
+          "columns": [
+            "training_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "training_problems_training_position_unique": {
+          "name": "training_problems_training_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "training_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainings": {
+      "name": "trainings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trainings_visibility_pinned_created": {
+          "name": "idx_trainings_visibility_pinned_created",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trainings_created_by": {
+          "name": "idx_trainings_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trainings_created_by_users_id_fk": {
+          "name": "trainings_created_by_users_id_fk",
+          "tableFrom": "trainings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "trainings_visibility_check": {
+          "name": "trainings_visibility_check",
+          "value": "\"trainings\".\"visibility\" IN ('private', 'unlisted', 'public')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_bans": {
+      "name": "user_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "banned_until": {
+          "name": "banned_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "banned_by": {
+          "name": "banned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_at": {
+          "name": "unbanned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_by": {
+          "name": "unbanned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_bans_user": {
+          "name": "idx_user_bans_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_bans_active": {
+          "name": "idx_user_bans_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "unbanned_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_bans_user_id_users_id_fk": {
+          "name": "user_bans_user_id_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bans_banned_by_users_id_fk": {
+          "name": "user_bans_banned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "banned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_bans_unbanned_by_users_id_fk": {
+          "name": "user_bans_unbanned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "unbanned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_activity_visibility": {
+          "name": "community_activity_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'following'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_search_vector": {
+          "name": "idx_users_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_community_activity_visibility_check": {
+          "name": "users_community_activity_visibility_check",
+          "value": "\"users\".\"community_activity_visibility\" IN ('hidden', 'following', 'everyone')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/noj-core/drizzle/meta/0044_snapshot.json
+++ b/noj-core/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,5205 @@
+{
+  "id": "170a58b4-221f-46f1-bd02-def79519a183",
+  "prevId": "f047f4a7-70a5-4d95-9fed-876184c292b1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_announcements_active_pinned_created": {
+          "name": "idx_announcements_active_pinned_created",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audit_logs_admin_id_idx": {
+          "name": "audit_logs_admin_id_idx",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_admin_id_users_id_fk": {
+          "name": "audit_logs_admin_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'users.role_change',\n        'users.ban',\n        'users.unban',\n        'problems.delete',\n        'problems.runtime_config_changed',\n        'problems.imported',\n        'tags.create',\n        'tags.update',\n        'tags.delete',\n        'tags.merge',\n        'submissions.rejudge',\n        'settings.update',\n        'ip_ban.create',\n        'ip_ban.delete',\n        'auth.login_success',\n        'auth.login_failure',\n        'auth.register',\n        'auth.change_password',\n        'auth.forgot_password_request',\n        'auth.password_reset',\n        'community.post_moderated',\n        'community.report_resolved',\n        'community.sanction_created',\n        'community.sanction_revoked',\n        'community.preset_applied',\n        'announcement.create',\n        'announcement.update',\n        'announcement.delete'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkin_date": {
+          "name": "checkin_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streak": {
+          "name": "streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "check_ins_user_id_users_id_fk": {
+          "name": "check_ins_user_id_users_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "check_ins_user_date_unique": {
+          "name": "check_ins_user_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "checkin_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_activity_events": {
+      "name": "community_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_activity_events_actor": {
+          "name": "idx_community_activity_events_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_activity_events_actor_id_users_id_fk": {
+          "name": "community_activity_events_actor_id_users_id_fk",
+          "tableFrom": "community_activity_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_activity_events_dedupe_unique": {
+          "name": "community_activity_events_dedupe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "type",
+            "subject_type",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "community_activity_events_type_check": {
+          "name": "community_activity_events_type_check",
+          "value": "\"community_activity_events\".\"type\" IN ('first_accepted', 'solution_published', 'contest_joined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_board_role_grants": {
+      "name": "community_board_role_grants",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_read": {
+          "name": "can_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_post": {
+          "name": "can_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_moderate": {
+          "name": "can_moderate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_community_board_role_grants_role": {
+          "name": "idx_community_board_role_grants_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_board_role_grants_board_id_community_boards_id_fk": {
+          "name": "community_board_role_grants_board_id_community_boards_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_board_role_grants_role_id_roles_id_fk": {
+          "name": "community_board_role_grants_role_id_roles_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_board_role_grants_board_id_role_id_pk": {
+          "name": "community_board_role_grants_board_id_role_id_pk",
+          "columns": [
+            "board_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_boards": {
+      "name": "community_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_boards_sort": {
+          "name": "idx_community_boards_sort",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_boards_slug_unique": {
+          "name": "community_boards_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_bookmarks": {
+      "name": "community_bookmarks",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_bookmarks_user": {
+          "name": "idx_community_bookmarks_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_bookmarks_post_id_community_posts_id_fk": {
+          "name": "community_bookmarks_post_id_community_posts_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_bookmarks_user_id_users_id_fk": {
+          "name": "community_bookmarks_user_id_users_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_bookmarks_post_id_user_id_pk": {
+          "name": "community_bookmarks_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comment_likes": {
+      "name": "community_comment_likes",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comment_likes_user": {
+          "name": "idx_community_comment_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comment_likes_comment_id_community_comments_id_fk": {
+          "name": "community_comment_likes_comment_id_community_comments_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comment_likes_user_id_users_id_fk": {
+          "name": "community_comment_likes_user_id_users_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_comment_likes_comment_id_user_id_pk": {
+          "name": "community_comment_likes_comment_id_user_id_pk",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comments_post": {
+          "name": "idx_community_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_author": {
+          "name": "idx_community_comments_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_parent": {
+          "name": "idx_community_comments_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_author_id_users_id_fk": {
+          "name": "community_comments_author_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_parent_id_community_comments_id_fk": {
+          "name": "community_comments_parent_id_community_comments_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_comments_status_check": {
+          "name": "community_comments_status_check",
+          "value": "\"community_comments\".\"status\" IN ('pending', 'published', 'hidden', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_follows": {
+      "name": "community_follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followee_id": {
+          "name": "followee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_follows_followee": {
+          "name": "idx_community_follows_followee",
+          "columns": [
+            {
+              "expression": "followee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_follows_follower_id_users_id_fk": {
+          "name": "community_follows_follower_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_follows_followee_id_users_id_fk": {
+          "name": "community_follows_followee_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_follows_follower_id_followee_id_pk": {
+          "name": "community_follows_follower_id_followee_id_pk",
+          "columns": [
+            "follower_id",
+            "followee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_follows_not_self_check": {
+          "name": "community_follows_not_self_check",
+          "value": "\"community_follows\".\"follower_id\" <> \"community_follows\".\"followee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_moderation_actions": {
+      "name": "community_moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_moderation_actions_target": {
+          "name": "idx_community_moderation_actions_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_moderation_actions_moderator": {
+          "name": "idx_community_moderation_actions_moderator",
+          "columns": [
+            {
+              "expression": "moderator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_moderation_actions_moderator_id_users_id_fk": {
+          "name": "community_moderation_actions_moderator_id_users_id_fk",
+          "tableFrom": "community_moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_notifications": {
+      "name": "community_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_notifications_recipient": {
+          "name": "idx_community_notifications_recipient",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_unread": {
+          "name": "idx_community_notifications_unread",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_actor": {
+          "name": "idx_community_notifications_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_post": {
+          "name": "idx_community_notifications_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_comment": {
+          "name": "idx_community_notifications_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_notifications_recipient_id_users_id_fk": {
+          "name": "community_notifications_recipient_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_notifications_actor_id_users_id_fk": {
+          "name": "community_notifications_actor_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_post_id_community_posts_id_fk": {
+          "name": "community_notifications_post_id_community_posts_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_comment_id_community_comments_id_fk": {
+          "name": "community_notifications_comment_id_community_comments_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_notifications_type_check": {
+          "name": "community_notifications_type_check",
+          "value": "\"community_notifications\".\"type\" IN ('reply', 'like', 'follow', 'moderation', 'clarification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_post_likes": {
+      "name": "community_post_likes",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_post_likes_user": {
+          "name": "idx_community_post_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_post_likes_post_id_community_posts_id_fk": {
+          "name": "community_post_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_post_likes_user_id_users_id_fk": {
+          "name": "community_post_likes_user_id_users_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_post_likes_post_id_user_id_pk": {
+          "name": "community_post_likes_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_posts_author": {
+          "name": "idx_community_posts_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_problem": {
+          "name": "idx_community_posts_problem",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_board": {
+          "name": "idx_community_posts_board",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_published": {
+          "name": "idx_community_posts_published",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_pending": {
+          "name": "idx_community_posts_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_posts_author_id_users_id_fk": {
+          "name": "community_posts_author_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_problem_id_problems_id_fk": {
+          "name": "community_posts_problem_id_problems_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_board_id_community_boards_id_fk": {
+          "name": "community_posts_board_id_community_boards_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_posts_type_check": {
+          "name": "community_posts_type_check",
+          "value": "\"community_posts\".\"type\" IN ('solution', 'discussion', 'moment')"
+        },
+        "community_posts_status_check": {
+          "name": "community_posts_status_check",
+          "value": "\"community_posts\".\"status\" IN ('draft', 'pending', 'published', 'hidden', 'deleted')"
+        },
+        "community_posts_context_check": {
+          "name": "community_posts_context_check",
+          "value": "(\n        (\"community_posts\".\"type\" = 'solution' AND \"community_posts\".\"problem_id\" IS NOT NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'discussion' AND \"community_posts\".\"board_id\" IS NOT NULL AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'moment' AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_reports": {
+      "name": "community_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_reports_pending": {
+          "name": "idx_community_reports_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_reports\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_reporter": {
+          "name": "idx_community_reports_reporter",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_post": {
+          "name": "idx_community_reports_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_comment": {
+          "name": "idx_community_reports_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_reports_reporter_id_users_id_fk": {
+          "name": "community_reports_reporter_id_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_reports_post_id_community_posts_id_fk": {
+          "name": "community_reports_post_id_community_posts_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_comment_id_community_comments_id_fk": {
+          "name": "community_reports_comment_id_community_comments_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_resolved_by_users_id_fk": {
+          "name": "community_reports_resolved_by_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_reports_target_check": {
+          "name": "community_reports_target_check",
+          "value": "num_nonnulls(\"community_reports\".\"post_id\", \"community_reports\".\"comment_id\") = 1"
+        },
+        "community_reports_status_check": {
+          "name": "community_reports_status_check",
+          "value": "\"community_reports\".\"status\" IN ('pending', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_sanctions": {
+      "name": "community_sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_community_sanctions_active": {
+          "name": "idx_community_sanctions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_sanctions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_sanctions_creator": {
+          "name": "idx_community_sanctions_creator",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_sanctions_user_id_users_id_fk": {
+          "name": "community_sanctions_user_id_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_created_by_users_id_fk": {
+          "name": "community_sanctions_created_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_revoked_by_users_id_fk": {
+          "name": "community_sanctions_revoked_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_clarifications": {
+      "name": "contest_clarifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to_id": {
+          "name": "reply_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_clarifications_contest": {
+          "name": "idx_contest_clarifications_contest",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_clarifications_contest_id_contests_id_fk": {
+          "name": "contest_clarifications_contest_id_contests_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_problem_id_problems_id_fk": {
+          "name": "contest_clarifications_problem_id_problems_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_sender_id_users_id_fk": {
+          "name": "contest_clarifications_sender_id_users_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_reply_to_id_contest_clarifications_id_fk": {
+          "name": "contest_clarifications_reply_to_id_contest_clarifications_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contest_clarifications",
+          "columnsFrom": [
+            "reply_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_participants": {
+      "name": "contest_participants",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_participants_user": {
+          "name": "idx_contest_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_participants_contest_id_contests_id_fk": {
+          "name": "contest_participants_contest_id_contests_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_participants_user_id_users_id_fk": {
+          "name": "contest_participants_user_id_users_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_participants_contest_id_user_id_pk": {
+          "name": "contest_participants_contest_id_user_id_pk",
+          "columns": [
+            "contest_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_problems": {
+      "name": "contest_problems",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contest_problems_contest_id_contests_id_fk": {
+          "name": "contest_problems_contest_id_contests_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_problems_problem_id_problems_id_fk": {
+          "name": "contest_problems_problem_id_problems_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_problems_contest_id_problem_id_pk": {
+          "name": "contest_problems_contest_id_problem_id_pk",
+          "columns": [
+            "contest_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "contest_problems_contest_label_unique": {
+          "name": "contest_problems_contest_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "label"
+          ]
+        },
+        "contest_problems_contest_sort_order_unique": {
+          "name": "contest_problems_contest_sort_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contests": {
+      "name": "contests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affect_global_ranking": {
+          "name": "affect_global_ranking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announcement": {
+          "name": "announcement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contests_created_by": {
+          "name": "idx_contests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_start_time": {
+          "name": "idx_contests_start_time",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_end_time": {
+          "name": "idx_contests_end_time",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contests_created_by_users_id_fk": {
+          "name": "contests_created_by_users_id_fk",
+          "tableFrom": "contests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "contests_type_check": {
+          "name": "contests_type_check",
+          "value": "\"contests\".\"type\" IN ('icpc', 'ioi', 'oi')"
+        },
+        "contests_time_check": {
+          "name": "contests_time_check",
+          "value": "\"contests\".\"end_time\" > \"contests\".\"start_time\""
+        },
+        "contests_config_check": {
+          "name": "contests_config_check",
+          "value": "jsonb_typeof(\"contests\".\"config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_reads": {
+      "name": "conversation_reads",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_reads_user_id_users_id_fk": {
+          "name": "conversation_reads_user_id_users_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_reads_conversation_id_conversations_id_fk": {
+          "name": "conversation_reads_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_reads_user_id_conversation_id_pk": {
+          "name": "conversation_reads_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_conversations_user1_id": {
+          "name": "idx_conversations_user1_id",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_user2_id": {
+          "name": "idx_conversations_user2_id",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_message_at": {
+          "name": "idx_conversations_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user1_id_users_id_fk": {
+          "name": "conversations_user1_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_user2_id_users_id_fk": {
+          "name": "conversations_user2_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_user_pair_unique": {
+          "name": "conversations_user_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1_id",
+            "user2_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversations_user_order_check": {
+          "name": "conversations_user_order_check",
+          "value": "\"conversations\".\"user1_id\" < \"conversations\".\"user2_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eval_results_submission_id": {
+          "name": "idx_eval_results_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eval_results_created_at": {
+          "name": "idx_eval_results_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_submission_id_submissions_id_fk": {
+          "name": "evaluation_results_submission_id_submissions_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ip_bans": {
+      "name": "ip_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_or_cidr": {
+          "name": "ip_or_cidr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ip_bans_ip_or_cidr": {
+          "name": "idx_ip_bans_ip_or_cidr",
+          "columns": [
+            {
+              "expression": "ip_or_cidr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ip_bans_expires_at": {
+          "name": "idx_ip_bans_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ip_bans_created_by_users_id_fk": {
+          "name": "ip_bans_created_by_users_id_fk",
+          "tableFrom": "ip_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judge_images": {
+      "name": "judge_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exact'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evaluator'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_images_mode_check": {
+          "name": "judge_images_mode_check",
+          "value": "\"judge_images\".\"mode\" IN ('exact', 'all_versions')"
+        },
+        "judge_images_kind_check": {
+          "name": "judge_images_kind_check",
+          "value": "\"judge_images\".\"kind\" IN ('evaluator', 'solution')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_deletions": {
+      "name": "message_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_message_deletions_message_id": {
+          "name": "idx_message_deletions_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_deletions_user_id_users_id_fk": {
+          "name": "message_deletions_user_id_users_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_deletions_message_id_messages_id_fk": {
+          "name": "message_deletions_message_id_messages_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_deletions_user_id_message_id_pk": {
+          "name": "message_deletions_user_id_message_id_pk",
+          "columns": [
+            "user_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_created": {
+          "name": "idx_messages_conversation_created",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_sender_id": {
+          "name": "idx_messages_sender_id",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_users_id_fk": {
+          "name": "messages_sender_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.objective_questions": {
+      "name": "objective_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_questions_paper_id": {
+          "name": "idx_objective_questions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_questions_paper_id_problems_id_fk": {
+          "name": "objective_questions_paper_id_problems_id_fk",
+          "tableFrom": "objective_questions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_questions_paper_sort_unique": {
+          "name": "objective_questions_paper_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_questions_type_check": {
+          "name": "objective_questions_type_check",
+          "value": "\"objective_questions\".\"type\" IN ('single', 'multiple', 'judge')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.objective_submissions": {
+      "name": "objective_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finished'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_submissions_paper_id": {
+          "name": "idx_objective_submissions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_id": {
+          "name": "idx_objective_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_paper_created": {
+          "name": "idx_objective_submissions_user_paper_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_contest_id": {
+          "name": "idx_objective_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_submissions_paper_id_problems_id_fk": {
+          "name": "objective_submissions_paper_id_problems_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_user_id_users_id_fk": {
+          "name": "objective_submissions_user_id_users_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_contest_id_contests_id_fk": {
+          "name": "objective_submissions_contest_id_contests_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_submissions_contest_unique": {
+          "name": "objective_submissions_contest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "user_id",
+            "contest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_submissions_type_check": {
+          "name": "objective_submissions_type_check",
+          "value": "\"objective_submissions\".\"submission_type\" IN ('practice', 'contest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_password_reset_tokens_user_id": {
+          "name": "idx_password_reset_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_password_reset_tokens_expires_at": {
+          "name": "idx_password_reset_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_resource_action_unique": {
+          "name": "permissions_resource_action_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resource",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_tags": {
+      "name": "problem_tags",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "problem_tags_problem_id_problems_id_fk": {
+          "name": "problem_tags_problem_id_problems_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "problem_tags_tag_id_tags_id_fk": {
+          "name": "problem_tags_tag_id_tags_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "problem_tags_problem_id_tag_id_pk": {
+          "name": "problem_tags_problem_id_tag_id_pk",
+          "columns": [
+            "problem_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "support_package_storage_url": {
+          "name": "support_package_storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_config": {
+          "name": "runtime_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'U'"
+        },
+        "is_objective": {
+          "name": "is_objective",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_problems_search_vector": {
+          "name": "idx_problems_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "problems_type_number_unique": {
+          "name": "problems_type_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "problems_type_check": {
+          "name": "problems_type_check",
+          "value": "\"problems\".\"type\" IN ('U', 'P')"
+        },
+        "problems_runtime_config_check": {
+          "name": "problems_runtime_config_check",
+          "value": "\"problems\".\"runtime_config\" IS NULL OR jsonb_typeof(\"problems\".\"runtime_config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_roles_parent_id": {
+          "name": "idx_roles_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_parent_id_roles_id_fk": {
+          "name": "roles_parent_id_roles_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.self_tests": {
+      "name": "self_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_self_tests_user_id": {
+          "name": "idx_self_tests_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_problem_id": {
+          "name": "idx_self_tests_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_created_at": {
+          "name": "idx_self_tests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_user_id_created_at": {
+          "name": "idx_self_tests_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_status_created_at": {
+          "name": "idx_self_tests_status_created_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "self_tests_user_id_users_id_fk": {
+          "name": "self_tests_user_id_users_id_fk",
+          "tableFrom": "self_tests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "self_tests_problem_id_problems_id_fk": {
+          "name": "self_tests_problem_id_problems_id_fk",
+          "tableFrom": "self_tests",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "self_tests_status_check": {
+          "name": "self_tests_status_check",
+          "value": "\"self_tests\".\"status\" IN ('pending', 'judging', 'finished', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejudge_seq": {
+          "name": "rejudge_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_submissions_user_id": {
+          "name": "idx_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_problem_id": {
+          "name": "idx_submissions_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_status": {
+          "name": "idx_submissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_id": {
+          "name": "idx_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_problem_user": {
+          "name": "idx_submissions_contest_problem_user",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_user_id_created_at": {
+          "name": "idx_submissions_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_problem_id_problems_id_fk": {
+          "name": "submissions_problem_id_problems_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_contest_id_contests_id_fk": {
+          "name": "submissions_contest_id_contests_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_settings_updated_at": {
+          "name": "idx_system_settings_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tags_kind_check": {
+          "name": "tags_kind_check",
+          "value": "\"tags\".\"kind\" IN ('problem', 'algorithm')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.training_problems": {
+      "name": "training_problems",
+      "schema": "",
+      "columns": {
+        "training_id": {
+          "name": "training_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_training_problems_training_position": {
+          "name": "idx_training_problems_training_position",
+          "columns": [
+            {
+              "expression": "training_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_problems_training_id_trainings_id_fk": {
+          "name": "training_problems_training_id_trainings_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "trainings",
+          "columnsFrom": [
+            "training_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "training_problems_problem_id_problems_id_fk": {
+          "name": "training_problems_problem_id_problems_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "training_problems_training_id_problem_id_pk": {
+          "name": "training_problems_training_id_problem_id_pk",
+          "columns": [
+            "training_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "training_problems_training_position_unique": {
+          "name": "training_problems_training_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "training_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainings": {
+      "name": "trainings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trainings_visibility_pinned_created": {
+          "name": "idx_trainings_visibility_pinned_created",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trainings_created_by": {
+          "name": "idx_trainings_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trainings_created_by_users_id_fk": {
+          "name": "trainings_created_by_users_id_fk",
+          "tableFrom": "trainings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "trainings_visibility_check": {
+          "name": "trainings_visibility_check",
+          "value": "\"trainings\".\"visibility\" IN ('private', 'unlisted', 'public')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_bans": {
+      "name": "user_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "banned_until": {
+          "name": "banned_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "banned_by": {
+          "name": "banned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_at": {
+          "name": "unbanned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_by": {
+          "name": "unbanned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_bans_user": {
+          "name": "idx_user_bans_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_bans_active": {
+          "name": "idx_user_bans_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "unbanned_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_bans_user_id_users_id_fk": {
+          "name": "user_bans_user_id_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bans_banned_by_users_id_fk": {
+          "name": "user_bans_banned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "banned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_bans_unbanned_by_users_id_fk": {
+          "name": "user_bans_unbanned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "unbanned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_activity_visibility": {
+          "name": "community_activity_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'following'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_search_vector": {
+          "name": "idx_users_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_community_activity_visibility_check": {
+          "name": "users_community_activity_visibility_check",
+          "value": "\"users\".\"community_activity_visibility\" IN ('hidden', 'following', 'everyone')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -295,6 +295,20 @@
       "when": 1786979668015,
       "tag": "0041_harsh_lilandra",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1787064737751,
+      "tag": "0042_tough_saracen",
+      "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1787065084218,
+      "tag": "0043_goofy_hellfire_club",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1787065084218,
       "tag": "0043_goofy_hellfire_club",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1787125953031,
+      "tag": "0044_nervous_franklin_richards",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -12,6 +12,7 @@ import problems from "./routes/problems.ts";
 import checkin from "./routes/checkin.ts";
 import queue from "./routes/queue.ts";
 import submissions from "./routes/submissions.ts";
+import selfTests from "./routes/self-tests.ts";
 import users from "./routes/users.ts";
 import rankings from "./routes/rankings.ts";
 import conversations from "./routes/conversations.ts";
@@ -154,6 +155,7 @@ export function createApp(): Hono {
   app.route("/api/v1/checkin", checkin);
   app.route("/api/v1/queue", queue);
   app.route("/api/v1/submissions", submissions);
+  app.route("/api/v1", selfTests);
   app.route("/api/v1/users", users);
   app.route("/api/v1/rankings", rankings);
   app.route("/api/v1/conversations", conversations);

--- a/noj-core/src/db/schema-ddl.ts
+++ b/noj-core/src/db/schema-ddl.ts
@@ -213,6 +213,26 @@ export const SCHEMA_DDL: string[] = [
     created_at TEXT NOT NULL
   )`,
 
+  // 7.1 self_tests（issue #221）
+  `CREATE TABLE IF NOT EXISTS self_tests (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id),
+    problem_id TEXT NOT NULL REFERENCES problems(id),
+    language TEXT NOT NULL,
+    code TEXT NOT NULL,
+    file_name TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    result_status TEXT,
+    score INTEGER NOT NULL DEFAULT 0,
+    output TEXT NOT NULL DEFAULT '',
+    details TEXT NOT NULL DEFAULT '{}',
+    time_ms INTEGER,
+    memory_kb INTEGER,
+    judge_started_at TEXT,
+    judge_finished_at TEXT,
+    created_at TEXT NOT NULL
+  )`,
+
   // 8. check_ins
   `CREATE TABLE IF NOT EXISTS check_ins (
     id TEXT PRIMARY KEY,
@@ -521,6 +541,10 @@ export const SCHEMA_INDEXES: string[] = [
   "CREATE INDEX IF NOT EXISTS idx_objective_submissions_contest_id ON objective_submissions (contest_id)",
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_eval_results_submission_id ON evaluation_results (submission_id)",
   "CREATE INDEX IF NOT EXISTS idx_eval_results_created_at ON evaluation_results (created_at)",
+  "CREATE INDEX IF NOT EXISTS idx_self_tests_user_id ON self_tests (user_id)",
+  "CREATE INDEX IF NOT EXISTS idx_self_tests_problem_id ON self_tests (problem_id)",
+  "CREATE INDEX IF NOT EXISTS idx_self_tests_created_at ON self_tests (created_at)",
+  "CREATE INDEX IF NOT EXISTS idx_self_tests_user_id_created_at ON self_tests (user_id, created_at)",
   "CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens (user_id)",
   "CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expires_at ON password_reset_tokens (expires_at)",
   "CREATE INDEX IF NOT EXISTS idx_conversations_user1_id ON conversations (user1_id)",

--- a/noj-core/src/db/schema-ddl.ts
+++ b/noj-core/src/db/schema-ddl.ts
@@ -221,7 +221,8 @@ export const SCHEMA_DDL: string[] = [
     language TEXT NOT NULL,
     code TEXT NOT NULL,
     file_name TEXT,
-    status TEXT NOT NULL DEFAULT 'pending',
+    status TEXT NOT NULL DEFAULT 'pending'
+      CHECK (status IN ('pending', 'judging', 'finished', 'error')),
     result_status TEXT,
     score INTEGER NOT NULL DEFAULT 0,
     output TEXT NOT NULL DEFAULT '',
@@ -545,6 +546,7 @@ export const SCHEMA_INDEXES: string[] = [
   "CREATE INDEX IF NOT EXISTS idx_self_tests_problem_id ON self_tests (problem_id)",
   "CREATE INDEX IF NOT EXISTS idx_self_tests_created_at ON self_tests (created_at)",
   "CREATE INDEX IF NOT EXISTS idx_self_tests_user_id_created_at ON self_tests (user_id, created_at)",
+  "CREATE INDEX IF NOT EXISTS idx_self_tests_status_created_at ON self_tests (status, created_at)",
   "CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens (user_id)",
   "CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expires_at ON password_reset_tokens (expires_at)",
   "CREATE INDEX IF NOT EXISTS idx_conversations_user1_id ON conversations (user1_id)",

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -14,6 +14,7 @@ import {
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import type { SubmissionStatus } from "../types/index.ts";
+import type { SelfTestStatus } from "../types/self-tests.ts";
 import { ROOT_USER_ID } from "../lib/constants.ts";
 
 /**
@@ -555,6 +556,48 @@ export const evaluationResults = pgTable(
     ),
     // created_at 索引：评测结果按时间分页与归档（issue 64 评论 §6.4）
     created_at_idx: index("idx_eval_results_created_at").on(table.created_at),
+  }),
+);
+
+/**
+ * 自测记录表（issue #221）。
+ * 与正式提交完全隔离，不参与统计/榜单/AC 活动。
+ */
+export const selfTests = pgTable(
+  "self_tests",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    problem_id: text("problem_id")
+      .notNull()
+      .references(() => problems.id),
+    language: text("language").notNull(),
+    code: text("code").notNull(),
+    file_name: text("file_name"),
+    status: text("status").$type<SelfTestStatus>().notNull().default(
+      "pending",
+    ),
+    /** 评测结果状态（如 Accepted / WrongAnswer），终态时由 JudgeResult 写入。 */
+    result_status: text("result_status"),
+    score: integer("score").notNull().default(0),
+    output: text("output").notNull().default(""),
+    details: text("details").notNull().default("{}"),
+    time_ms: integer("time_ms"),
+    memory_kb: integer("memory_kb"),
+    judge_started_at: text("judge_started_at"),
+    judge_finished_at: text("judge_finished_at"),
+    created_at: text("created_at").notNull(),
+  },
+  (table) => ({
+    user_idx: index("idx_self_tests_user_id").on(table.user_id),
+    problem_idx: index("idx_self_tests_problem_id").on(table.problem_id),
+    created_at_idx: index("idx_self_tests_created_at").on(table.created_at),
+    user_created_idx: index("idx_self_tests_user_id_created_at").on(
+      table.user_id,
+      table.created_at,
+    ),
   }),
 );
 

--- a/noj-core/src/db/schema.ts
+++ b/noj-core/src/db/schema.ts
@@ -598,6 +598,14 @@ export const selfTests = pgTable(
       table.user_id,
       table.created_at,
     ),
+    status_created_idx: index("idx_self_tests_status_created_at").on(
+      table.status,
+      table.created_at,
+    ),
+    statusCheck: check(
+      "self_tests_status_check",
+      sql`${table.status} IN ('pending', 'judging', 'finished', 'error')`,
+    ),
   }),
 );
 

--- a/noj-core/src/lib/hardening-rate-limit.ts
+++ b/noj-core/src/lib/hardening-rate-limit.ts
@@ -44,6 +44,16 @@ export const SUBMISSION_USER_LIMIT: RateLimitConfig = {
   max: 120,
 };
 
+export const SELF_TEST_IP_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 30,
+};
+
+export const SELF_TEST_USER_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 4,
+};
+
 function normalizeLimitKey(value: string): string {
   return value.trim().toLowerCase().slice(0, 128);
 }
@@ -114,5 +124,20 @@ export async function enforceSubmissionRateLimit(
   await enforceRateLimit(
     `submission:user:${userId}`,
     SUBMISSION_USER_LIMIT,
+  );
+}
+
+/** 自测创建：IP + 用户双维度，阈值比正式提交更严格（默认每用户 60s 4 次）。 */
+export async function enforceSelfTestRateLimit(
+  c: Context,
+  userId: string,
+): Promise<void> {
+  await enforceRateLimit(
+    `self-test:ip:${getClientIp(c)}`,
+    SELF_TEST_IP_LIMIT,
+  );
+  await enforceRateLimit(
+    `self-test:user:${userId}`,
+    SELF_TEST_USER_LIMIT,
   );
 }

--- a/noj-core/src/lib/problem-resolve.ts
+++ b/noj-core/src/lib/problem-resolve.ts
@@ -1,0 +1,39 @@
+/**
+ * 题目双索引解析工具。
+ *
+ * 支持 UUID、display_id（如 P1001 / U42）、纯数字 ID（兼容旧 seed 数据）以及
+ * 任意非标准 ID 格式。供 problems 路由与自测路由共用。
+ */
+
+import {
+  getProblem,
+  getProblemByTypeAndNumber,
+} from "../services/problems-list.ts";
+
+/**
+ * 双索引查找题目。
+ * 先通过正则判断 id 格式，避免每次 display_id 请求都先多一次 UUID 查询。
+ * 对于不匹配任何已知格式的 ID，fallback 到 `getProblem(id)` 直接查找。
+ */
+export function resolveProblem(id: string) {
+  // UUID / 纯数字（兼容旧 seed 数据 1001/1002/1003 等）：直接按 id 精确查找
+  if (
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      id,
+    ) ||
+    /^\d+$/.test(id)
+  ) {
+    return getProblem(id);
+  }
+
+  // display_id 格式：解析 "P1001" / "U42" → (type, number)
+  const match = id.match(/^([UuPp])(\d+)$/);
+  if (match) {
+    const type = match[1].toUpperCase();
+    const number = parseInt(match[2], 10);
+    return getProblemByTypeAndNumber(type, number);
+  }
+
+  // fallback：尝试直接按 id 查找（兼容非标准 ID 格式）
+  return getProblem(id);
+}

--- a/noj-core/src/mq/consumer.ts
+++ b/noj-core/src/mq/consumer.ts
@@ -1,7 +1,9 @@
 import { createConsumer, requestConsumerShutdown } from "./base-consumer.ts";
 import { saveEvaluationResult } from "../services/submissions.ts";
+import { saveSelfTestResult } from "../services/self-tests.ts";
 import { logger, logJudgeResultReceived } from "../lib/logging.ts";
 import { Channels, publishEvent } from "../lib/event-bus.ts";
+import { SELF_TEST_ID_PREFIX } from "../types/self-tests.ts";
 import type { JudgeResult } from "../types/index.ts";
 
 /**
@@ -16,7 +18,7 @@ export const RESULT_QUEUE = "noj:judge:results";
  */
 export const consumerAlive = { value: false };
 
-async function handleResultMessage(
+export async function handleResultMessage(
   data: Record<string, unknown>,
 ): Promise<void> {
   const judgeResult = data as unknown as JudgeResult;
@@ -32,9 +34,13 @@ async function handleResultMessage(
     judgeResult.score,
   );
 
+  const isSelfTest = judgeResult.submission_id.startsWith(SELF_TEST_ID_PREFIX);
+
   // NOJ-074：写库失败必须向上抛出让消费者重投，
   // 不再吞掉错误导致提交永久停留在 judging。
-  const applied = await saveEvaluationResult(judgeResult);
+  const applied = isSelfTest
+    ? await saveSelfTestResult(judgeResult)
+    : await saveEvaluationResult(judgeResult);
   if (!applied) {
     logger.info("评测结果为重复/过时消息，已幂等忽略", {
       submission_id: judgeResult.submission_id,
@@ -45,17 +51,20 @@ async function handleResultMessage(
 
   logger.info("评测结果已持久化", {
     submission_id: judgeResult.submission_id,
+    kind: isSelfTest ? "self_test" : "submission",
   });
 
   // 发布事件到 Redis Pub/Sub（fire-and-forget，不阻塞）
   // 事件仅作触发通知，前端收到后主动通过 REST 接口拉取全量数据
-  publishEvent(
-    Channels.submission(judgeResult.submission_id),
-    JSON.stringify({
-      type: "submission:updated",
-      id: judgeResult.submission_id,
-    }),
-  );
+  if (!isSelfTest) {
+    publishEvent(
+      Channels.submission(judgeResult.submission_id),
+      JSON.stringify({
+        type: "submission:updated",
+        id: judgeResult.submission_id,
+      }),
+    );
+  }
   publishEvent(
     Channels.queue,
     JSON.stringify({ type: "queue:changed" }),

--- a/noj-core/src/mq/sweeper.ts
+++ b/noj-core/src/mq/sweeper.ts
@@ -118,6 +118,100 @@ async function sweepProcessingQueue(
   }
 }
 
+interface PendingRecoveryRow {
+  id: string;
+  language: string;
+  code: string;
+  file_name: string | null;
+  rejudge_seq?: number;
+  problem_id: string;
+  runtime_config: unknown;
+  support_package_storage_url: string | null;
+  judge_started_at?: string | null;
+}
+
+interface PendingRecoveryActions<T extends PendingRecoveryRow> {
+  /** 日志字段名：提交用 submission_id，自测用 self_test_id。 */
+  idKey: "submission_id" | "self_test_id";
+  /** 日志展示名。 */
+  label: "提交" | "自测";
+  /** 缺少 runtime_config 时的处理（自行记录日志并收尾）。 */
+  onMissingRuntimeConfig(row: T): void | Promise<void>;
+  /** 入队成功后更新行状态（可保留原始 judge_started_at）。 */
+  onEnqueued(row: T): void | Promise<void>;
+  /** 永久入队失败（消息超限等）时标记 error。 */
+  onPermanentError(row: T, err: unknown): void | Promise<void>;
+}
+
+/**
+ * 恢复 pending 记录通用流程：构建 JudgeTask → 入队 → 更新状态。
+ * 正式提交与自测共用同一套恢复逻辑，仅保留各自的表更新/日志差异。
+ */
+async function recoverPendingRows<T extends PendingRecoveryRow>(
+  rows: T[],
+  actions: PendingRecoveryActions<T>,
+): Promise<void> {
+  for (const row of rows) {
+    const runtimeConfig = row.runtime_config as RuntimeConfig | null;
+    if (!runtimeConfig) {
+      await actions.onMissingRuntimeConfig(row);
+      continue;
+    }
+
+    let download_url: string | undefined;
+    if (row.support_package_storage_url) {
+      try {
+        const storage = await getStorageProvider();
+        download_url = await storage.downloadUrl(
+          row.support_package_storage_url,
+        );
+      } catch (err) {
+        logger.error("pending 恢复获取支持包失败，将以无支持包任务继续", {
+          [actions.idKey]: row.id,
+          err,
+        });
+      }
+    }
+
+    const task: JudgeTask = {
+      submission_id: row.id,
+      problem_id: row.problem_id,
+      runtime_config: runtimeConfig,
+      download_url,
+      language: row.language,
+      code: row.code,
+      file_name: row.file_name ??
+        (LANGUAGE_EXT_MAP[row.language] || "main.txt"),
+      ...(row.rejudge_seq !== undefined
+        ? { rejudge_seq: row.rejudge_seq }
+        : {}),
+    };
+
+    const { pushJudgeTask } = await import("./producer.ts");
+    try {
+      await pushJudgeTask(task);
+      await actions.onEnqueued(row);
+      logger.info(`已恢复 pending ${actions.label}入队`, {
+        [actions.idKey]: row.id,
+      });
+    } catch (err) {
+      if (!isRetryableJudgeQueueError(err)) {
+        // 永久错误（消息超限等）：标记 error，避免每轮 sweeper 无限重试。
+        await actions.onPermanentError(row, err);
+        logger.error(`pending ${actions.label}因永久入队失败标记为 error`, {
+          [actions.idKey]: row.id,
+          err,
+        });
+        continue;
+      }
+      logger.error(`pending ${actions.label}恢复失败（等待下轮重试）`, {
+        [actions.idKey]: row.id,
+        err,
+      });
+    }
+  }
+}
+
 async function recoverPendingSubmissions(now: number): Promise<void> {
   const cutoff = new Date(now - PENDING_RECOVERY_MS).toISOString();
   const db = getDb();
@@ -144,74 +238,32 @@ async function recoverPendingSubmissions(now: number): Promise<void> {
     .orderBy(asc(submissions.created_at))
     .limit(200);
 
-  for (const row of rows) {
-    const runtimeConfig = row.runtime_config as RuntimeConfig | null;
-    if (!runtimeConfig) {
+  await recoverPendingRows(rows, {
+    idKey: "submission_id",
+    label: "提交",
+    onMissingRuntimeConfig: (row) => {
       logger.error("pending 提交缺少 runtime_config，跳过恢复", {
         submission_id: row.id,
       });
-      continue;
-    }
-
-    let download_url: string | undefined;
-    if (row.support_package_storage_url) {
-      try {
-        const storage = await getStorageProvider();
-        download_url = await storage.downloadUrl(
-          row.support_package_storage_url,
-        );
-      } catch (err) {
-        logger.error("pending 恢复获取支持包失败，将以无支持包任务继续", {
-          submission_id: row.id,
-          err,
-        });
-      }
-    }
-
-    const task: JudgeTask = {
-      submission_id: row.id,
-      problem_id: row.problem_id,
-      runtime_config: runtimeConfig,
-      download_url,
-      language: row.language,
-      code: row.code,
-      file_name: row.file_name ??
-        (LANGUAGE_EXT_MAP[row.language] || "main.txt"),
-      rejudge_seq: row.rejudge_seq,
-    };
-
-    const { pushJudgeTask } = await import("./producer.ts");
-    try {
-      await pushJudgeTask(task);
+    },
+    onEnqueued: async (row) => {
       await db.update(submissions)
         .set({ status: "judging" })
         .where(
           and(eq(submissions.id, row.id), eq(submissions.status, "pending")),
         );
-      logger.info("已恢复 pending 提交入队", { submission_id: row.id });
-    } catch (err) {
-      if (!isRetryableJudgeQueueError(err)) {
-        // 永久错误（消息超限等）：标记 error，避免每轮 sweeper 无限重试。
-        await db.update(submissions)
-          .set({
-            status: "error",
-            judge_finished_at: new Date().toISOString(),
-          })
-          .where(
-            and(eq(submissions.id, row.id), eq(submissions.status, "pending")),
-          );
-        logger.error("pending 提交因永久入队失败标记为 error", {
-          submission_id: row.id,
-          err,
-        });
-        continue;
-      }
-      logger.error("pending 提交恢复失败（等待下轮重试）", {
-        submission_id: row.id,
-        err,
-      });
-    }
-  }
+    },
+    onPermanentError: async (row) => {
+      await db.update(submissions)
+        .set({
+          status: "error",
+          judge_finished_at: new Date().toISOString(),
+        })
+        .where(
+          and(eq(submissions.id, row.id), eq(submissions.status, "pending")),
+        );
+    },
+  });
 }
 
 /**
@@ -230,6 +282,7 @@ export async function recoverPendingSelfTests(now: number): Promise<void> {
       problem_id: selfTests.problem_id,
       runtime_config: problems.runtime_config,
       support_package_storage_url: problems.support_package_storage_url,
+      judge_started_at: selfTests.judge_started_at,
     })
     .from(selfTests)
     .innerJoin(problems, eq(selfTests.problem_id, problems.id))
@@ -242,9 +295,10 @@ export async function recoverPendingSelfTests(now: number): Promise<void> {
     .orderBy(asc(selfTests.created_at))
     .limit(200);
 
-  for (const row of rows) {
-    const runtimeConfig = row.runtime_config as RuntimeConfig | null;
-    if (!runtimeConfig) {
+  await recoverPendingRows(rows, {
+    idKey: "self_test_id",
+    label: "自测",
+    onMissingRuntimeConfig: async (row) => {
       await db.update(selfTests)
         .set({
           status: "error",
@@ -254,69 +308,29 @@ export async function recoverPendingSelfTests(now: number): Promise<void> {
       logger.error("pending 自测缺少 runtime_config，标记为 error", {
         self_test_id: row.id,
       });
-      continue;
-    }
-
-    let download_url: string | undefined;
-    if (row.support_package_storage_url) {
-      try {
-        const storage = await getStorageProvider();
-        download_url = await storage.downloadUrl(
-          row.support_package_storage_url,
-        );
-      } catch (err) {
-        logger.error("pending 自测恢复获取支持包失败，将以无支持包任务继续", {
-          self_test_id: row.id,
-          err,
-        });
-      }
-    }
-
-    const task: JudgeTask = {
-      submission_id: row.id,
-      problem_id: row.problem_id,
-      runtime_config: runtimeConfig,
-      download_url,
-      language: row.language,
-      code: row.code,
-      file_name: row.file_name ??
-        (LANGUAGE_EXT_MAP[row.language] || "main.txt"),
-    };
-
-    const { pushJudgeTask } = await import("./producer.ts");
-    try {
-      await pushJudgeTask(task);
+    },
+    onEnqueued: async (row) => {
       await db.update(selfTests)
         .set({
           status: "judging",
-          judge_started_at: new Date().toISOString(),
+          // 恢复时保留原始 judge_started_at；只有原本为空才补当前时间。
+          judge_started_at: row.judge_started_at ?? new Date().toISOString(),
         })
         .where(
           and(eq(selfTests.id, row.id), eq(selfTests.status, "pending")),
         );
-      logger.info("已恢复 pending 自测入队", { self_test_id: row.id });
-    } catch (err) {
-      if (!isRetryableJudgeQueueError(err)) {
-        await db.update(selfTests)
-          .set({
-            status: "error",
-            judge_finished_at: new Date().toISOString(),
-          })
-          .where(
-            and(eq(selfTests.id, row.id), eq(selfTests.status, "pending")),
-          );
-        logger.error("pending 自测因永久入队失败标记为 error", {
-          self_test_id: row.id,
-          err,
-        });
-        continue;
-      }
-      logger.error("pending 自测恢复失败（等待下轮重试）", {
-        self_test_id: row.id,
-        err,
-      });
-    }
-  }
+    },
+    onPermanentError: async (row) => {
+      await db.update(selfTests)
+        .set({
+          status: "error",
+          judge_finished_at: new Date().toISOString(),
+        })
+        .where(
+          and(eq(selfTests.id, row.id), eq(selfTests.status, "pending")),
+        );
+    },
+  });
 }
 
 export async function runQueueSweeperOnce(): Promise<void> {

--- a/noj-core/src/mq/sweeper.ts
+++ b/noj-core/src/mq/sweeper.ts
@@ -9,7 +9,7 @@
 
 import { and, asc, eq, lte } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
-import { problems, submissions } from "../db/schema.ts";
+import { problems, selfTests, submissions } from "../db/schema.ts";
 import { getStorageProvider } from "../lib/storage/mod.ts";
 import { getSetting } from "../services/system-settings.ts";
 import { getRedis } from "./connection.ts";
@@ -214,6 +214,111 @@ async function recoverPendingSubmissions(now: number): Promise<void> {
   }
 }
 
+/**
+ * 恢复自测 pending 记录（与正式提交同队列，需同样防孤儿）。
+ */
+export async function recoverPendingSelfTests(now: number): Promise<void> {
+  const cutoff = new Date(now - PENDING_RECOVERY_MS).toISOString();
+  const db = getDb();
+
+  const rows = await db
+    .select({
+      id: selfTests.id,
+      language: selfTests.language,
+      code: selfTests.code,
+      file_name: selfTests.file_name,
+      problem_id: selfTests.problem_id,
+      runtime_config: problems.runtime_config,
+      support_package_storage_url: problems.support_package_storage_url,
+    })
+    .from(selfTests)
+    .innerJoin(problems, eq(selfTests.problem_id, problems.id))
+    .where(
+      and(
+        eq(selfTests.status, "pending"),
+        lte(selfTests.created_at, cutoff),
+      ),
+    )
+    .orderBy(asc(selfTests.created_at))
+    .limit(200);
+
+  for (const row of rows) {
+    const runtimeConfig = row.runtime_config as RuntimeConfig | null;
+    if (!runtimeConfig) {
+      await db.update(selfTests)
+        .set({
+          status: "error",
+          judge_finished_at: new Date().toISOString(),
+        })
+        .where(eq(selfTests.id, row.id));
+      logger.error("pending 自测缺少 runtime_config，标记为 error", {
+        self_test_id: row.id,
+      });
+      continue;
+    }
+
+    let download_url: string | undefined;
+    if (row.support_package_storage_url) {
+      try {
+        const storage = await getStorageProvider();
+        download_url = await storage.downloadUrl(
+          row.support_package_storage_url,
+        );
+      } catch (err) {
+        logger.error("pending 自测恢复获取支持包失败，将以无支持包任务继续", {
+          self_test_id: row.id,
+          err,
+        });
+      }
+    }
+
+    const task: JudgeTask = {
+      submission_id: row.id,
+      problem_id: row.problem_id,
+      runtime_config: runtimeConfig,
+      download_url,
+      language: row.language,
+      code: row.code,
+      file_name: row.file_name ??
+        (LANGUAGE_EXT_MAP[row.language] || "main.txt"),
+    };
+
+    const { pushJudgeTask } = await import("./producer.ts");
+    try {
+      await pushJudgeTask(task);
+      await db.update(selfTests)
+        .set({
+          status: "judging",
+          judge_started_at: new Date().toISOString(),
+        })
+        .where(
+          and(eq(selfTests.id, row.id), eq(selfTests.status, "pending")),
+        );
+      logger.info("已恢复 pending 自测入队", { self_test_id: row.id });
+    } catch (err) {
+      if (!isRetryableJudgeQueueError(err)) {
+        await db.update(selfTests)
+          .set({
+            status: "error",
+            judge_finished_at: new Date().toISOString(),
+          })
+          .where(
+            and(eq(selfTests.id, row.id), eq(selfTests.status, "pending")),
+          );
+        logger.error("pending 自测因永久入队失败标记为 error", {
+          self_test_id: row.id,
+          err,
+        });
+        continue;
+      }
+      logger.error("pending 自测恢复失败（等待下轮重试）", {
+        self_test_id: row.id,
+        err,
+      });
+    }
+  }
+}
+
 export async function runQueueSweeperOnce(): Promise<void> {
   const now = Date.now();
   const results = await Promise.allSettled([
@@ -228,6 +333,7 @@ export async function runQueueSweeperOnce(): Promise<void> {
       RESULT_PROCESSING_TIMEOUT_MS,
     ),
     recoverPendingSubmissions(now),
+    recoverPendingSelfTests(now),
   ]);
   for (const result of results) {
     if (result.status === "rejected") {

--- a/noj-core/src/routes/problems.ts
+++ b/noj-core/src/routes/problems.ts
@@ -13,12 +13,11 @@ import { runWithContext } from "../lib/requestContext.ts";
 import {
   createProblem,
   deleteProblem,
-  getProblem,
-  getProblemByTypeAndNumber,
   listProblems,
   updateProblem,
 } from "../services/problems.ts";
 import { applyAlgorithmTagVisibility } from "../services/problems-list.ts";
+import { resolveProblem } from "../lib/problem-resolve.ts";
 import { ADMIN_FULL_ACCESS, resolvePermissions } from "../lib/permissions.ts";
 import type {
   CreateProblemInput,
@@ -55,37 +54,6 @@ import type {
 const router = new Hono<
   { Variables: { userId: string; userRole: string } }
 >();
-
-/**
- * 双索引查找工具函数。
- * 支持通过 UUID、display_id（如 P1001）、纯数字 ID（兼容旧 seed 数据 1001/1002/1003）
- * 以及其他任意非标准 ID 格式查找题目。
- *
- * 先通过正则判断 id 格式，避免每次 display_id 请求都先多一次 UUID 查询。
- * 对于不匹配任何已知格式的 ID，fallback 到 `getProblem(id)` 直接查找。
- */
-function resolveProblem(id: string) {
-  // UUID / 纯数字（兼容旧 seed 数据 1001/1002/1003 等）：直接按 id 精确查找
-  if (
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      id,
-    ) ||
-    /^\d+$/.test(id)
-  ) {
-    return getProblem(id);
-  }
-
-  // display_id 格式：解析 "P1001" / "U42" → (type, number)
-  const match = id.match(/^([UuPp])(\d+)$/);
-  if (match) {
-    const type = match[1].toUpperCase();
-    const number = parseInt(match[2], 10);
-    return getProblemByTypeAndNumber(type, number);
-  }
-
-  // fallback：尝试直接按 id 查找（兼容非标准 ID 格式）
-  return getProblem(id);
-}
 
 /**
  * 获取题目列表。

--- a/noj-core/src/routes/self-tests.ts
+++ b/noj-core/src/routes/self-tests.ts
@@ -1,0 +1,77 @@
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth.ts";
+import { parseJsonBody } from "../lib/request.ts";
+import { BadRequestError } from "../lib/errors.ts";
+import { enforceSelfTestRateLimit } from "../lib/hardening-rate-limit.ts";
+import { resolveProblem } from "../lib/problem-resolve.ts";
+import { createSelfTest, getSelfTest } from "../services/self-tests.ts";
+import type { SelfTestInput } from "../types/self-tests.ts";
+
+type Env = {
+  Variables: {
+    userId?: string;
+    userRole?: string;
+  };
+};
+
+const router = new Hono<Env>();
+
+/** 自测代码最大长度（与正式提交一致）。 */
+const MAX_CODE_LENGTH = 100 * 1024;
+
+/**
+ * 创建自测。
+ * POST /api/v1/problems/:id/self-test
+ */
+router.post("/problems/:id/self-test", authMiddleware, async (c) => {
+  const userId = c.var.userId as string;
+  const problemId = c.req.param("id") as string;
+
+  // 自测专用限流（IP + 用户双维度）
+  await enforceSelfTestRateLimit(c, userId);
+
+  // 题目双索引解析（不存在时抛 404；返回真实 UUID 供 service 使用）
+  const problem = await resolveProblem(problemId);
+
+  const body = await parseJsonBody<Record<string, unknown>>(c);
+
+  if (!body.language || !body.code) {
+    const missing: string[] = [];
+    if (!body.language) missing.push("language");
+    if (!body.code) missing.push("code");
+    throw new BadRequestError(`缺少必填字段: ${missing.join(", ")}`);
+  }
+
+  if (typeof body.code !== "string") {
+    throw new BadRequestError("code 字段必须为字符串");
+  }
+  if (body.code.length > MAX_CODE_LENGTH) {
+    throw new BadRequestError(
+      `代码长度超过限制（${MAX_CODE_LENGTH} 字符），请精简后重新提交`,
+    );
+  }
+
+  const input: SelfTestInput = {
+    language: body.language as string,
+    code: body.code as string,
+    file_name: body.file_name as string | undefined,
+  };
+
+  const result = await createSelfTest(userId, problem.id, input);
+  return c.json({ data: result }, 201);
+});
+
+/**
+ * 查询自测详情。
+ * GET /api/v1/self-tests/:id
+ */
+router.get("/self-tests/:id", authMiddleware, async (c) => {
+  const id = c.req.param("id") as string;
+  const userId = c.var.userId as string;
+  const userRole = c.var.userRole as string | undefined;
+
+  const result = await getSelfTest(id, userId, userRole, c);
+  return c.json({ data: result });
+});
+
+export default router;

--- a/noj-core/src/routes/self-tests.ts
+++ b/noj-core/src/routes/self-tests.ts
@@ -30,9 +30,7 @@ router.post("/problems/:id/self-test", authMiddleware, async (c) => {
   // 自测专用限流（IP + 用户双维度）
   await enforceSelfTestRateLimit(c, userId);
 
-  // 题目双索引解析（不存在时抛 404；返回真实 UUID 供 service 使用）
-  const problem = await resolveProblem(problemId);
-
+  // 先做 body 解析与代码大小校验，再查询题目，避免超大请求先触发 DB 读
   const body = await parseJsonBody<Record<string, unknown>>(c);
 
   if (!body.language || !body.code) {
@@ -51,6 +49,9 @@ router.post("/problems/:id/self-test", authMiddleware, async (c) => {
     );
   }
 
+  // 题目双索引解析（不存在时抛 404；返回真实 UUID 供 service 使用）
+  const problem = await resolveProblem(problemId);
+
   const input: SelfTestInput = {
     language: body.language as string,
     code: body.code as string,
@@ -67,10 +68,7 @@ router.post("/problems/:id/self-test", authMiddleware, async (c) => {
  */
 router.get("/self-tests/:id", authMiddleware, async (c) => {
   const id = c.req.param("id") as string;
-  const userId = c.var.userId as string;
-  const userRole = c.var.userRole as string | undefined;
-
-  const result = await getSelfTest(id, userId, userRole, c);
+  const result = await getSelfTest(id, c);
   return c.json({ data: result });
 });
 

--- a/noj-core/src/services/queue.ts
+++ b/noj-core/src/services/queue.ts
@@ -3,11 +3,13 @@ import { getDb } from "../db/connection.ts";
 import {
   evaluationResults,
   problems,
+  selfTests,
   submissions,
   users,
 } from "../db/schema.ts";
 import { getRedis } from "../mq/connection.ts";
 import { logger } from "../lib/logging.ts";
+import { SELF_TEST_ID_PREFIX } from "../types/self-tests.ts";
 
 /** 评测任务队列名称（与 producer.ts 一致）。 */
 const JUDGE_QUEUE = "noj:judge:queue";
@@ -25,6 +27,8 @@ export interface QueueItem {
   language: string;
   submitted_at: string;
   submitted_by: string;
+  /** 条目类型：正式提交或自测。 */
+  kind: "submission" | "self_test";
   /** 仅 judging 和 completed 项有值。 */
   judge_started_at?: string | null;
   /** 仅 completed 项有值。 */
@@ -141,9 +145,16 @@ export async function getQueueOverview(): Promise<QueueResponse> {
     logger.warn("Redis 不可用，队列 pending 信息降级为空", { err });
   }
 
-  // 2. 查询 pending 提交的元数据（保持 Redis 队列原有顺序）
-  let pendingItems: QueueItem[] = [];
-  if (pendingIds.length > 0) {
+  // 2. 查询 pending 提交/自测的元数据（保持 Redis 队列原有顺序）
+  const pendingFormalIds = pendingIds.filter(
+    (id) => !id.startsWith(SELF_TEST_ID_PREFIX),
+  );
+  const pendingSelfIds = pendingIds.filter((id) =>
+    id.startsWith(SELF_TEST_ID_PREFIX)
+  );
+  const pendingMap = new Map<string, QueueItem>();
+
+  if (pendingFormalIds.length > 0) {
     const pendingRows = await db
       .select({
         id: submissions.id,
@@ -156,35 +167,62 @@ export async function getQueueOverview(): Promise<QueueResponse> {
       .from(submissions)
       .innerJoin(problems, eq(submissions.problem_id, problems.id))
       .innerJoin(users, eq(submissions.user_id, users.id))
-      .where(inArray(submissions.id, pendingIds));
-
-    const idMap = new Map(pendingRows.map((r) => [r.id, r]));
-    // 保持 Redis 队列顺序 (LPUSH → LRANGE 0 -1 = 最新优先)
-    // 但 API 规格要求按 submitted_at ASC 排序（先提交的先评测）
-    pendingItems = pendingIds
-      .map((id) => idMap.get(id))
-      .filter((r): r is NonNullable<typeof r> => !!r)
-      .sort(
-        (a, b) =>
-          new Date(a.submitted_at).getTime() -
-          new Date(b.submitted_at).getTime(),
-      )
-      .map((r) => ({
+      .where(inArray(submissions.id, pendingFormalIds));
+    for (const r of pendingRows) {
+      pendingMap.set(r.id, {
         id: r.id,
         problem_id: r.problem_id,
         problem_title: r.problem_title,
         language: r.language,
         submitted_at: r.submitted_at,
         submitted_by: r.submitted_by,
-      }));
+        kind: "submission",
+      });
+    }
   }
+
+  if (pendingSelfIds.length > 0) {
+    const pendingSelfRows = await db
+      .select({
+        id: selfTests.id,
+        problem_id: selfTests.problem_id,
+        problem_title: problems.title,
+        language: selfTests.language,
+        submitted_at: selfTests.created_at,
+        submitted_by: users.username,
+      })
+      .from(selfTests)
+      .innerJoin(problems, eq(selfTests.problem_id, problems.id))
+      .innerJoin(users, eq(selfTests.user_id, users.id))
+      .where(inArray(selfTests.id, pendingSelfIds));
+    for (const r of pendingSelfRows) {
+      pendingMap.set(r.id, {
+        id: r.id,
+        problem_id: r.problem_id,
+        problem_title: r.problem_title,
+        language: r.language,
+        submitted_at: r.submitted_at,
+        submitted_by: r.submitted_by,
+        kind: "self_test",
+      });
+    }
+  }
+
+  const pendingItems: QueueItem[] = pendingIds
+    .map((id) => pendingMap.get(id))
+    .filter((r): r is NonNullable<typeof r> => !!r)
+    .sort(
+      (a, b) =>
+        new Date(a.submitted_at).getTime() -
+        new Date(b.submitted_at).getTime(),
+    );
   const pendingCount = pendingQueueLength;
 
   // 4. 查询 judging 列表：DB status="judging" 且不在 pending 中
-  const judgingWhere = pendingIds.length > 0
+  const judgingWhere = pendingFormalIds.length > 0
     ? and(
       eq(submissions.status, "judging"),
-      not(inArray(submissions.id, pendingIds)),
+      not(inArray(submissions.id, pendingFormalIds)),
     )
     : eq(submissions.status, "judging");
 
@@ -212,9 +250,49 @@ export async function getQueueOverview(): Promise<QueueResponse> {
     submitted_at: r.submitted_at,
     submitted_by: r.submitted_by,
     judge_started_at: r.judge_started_at,
+    kind: "submission",
   }));
 
-  // 5. 查询 recently_completed：最近 10 条
+  const selfJudgingWhere = pendingSelfIds.length > 0
+    ? and(
+      eq(selfTests.status, "judging"),
+      not(inArray(selfTests.id, pendingSelfIds)),
+    )
+    : eq(selfTests.status, "judging");
+
+  const selfJudgingRows = await db
+    .select({
+      id: selfTests.id,
+      problem_id: selfTests.problem_id,
+      problem_title: problems.title,
+      language: selfTests.language,
+      submitted_at: selfTests.created_at,
+      submitted_by: users.username,
+      judge_started_at: selfTests.judge_started_at,
+    })
+    .from(selfTests)
+    .innerJoin(problems, eq(selfTests.problem_id, problems.id))
+    .innerJoin(users, eq(selfTests.user_id, users.id))
+    .where(selfJudgingWhere)
+    .orderBy(sql`${selfTests.judge_started_at} ASC`);
+
+  for (const r of selfJudgingRows) {
+    judgingItems.push({
+      id: r.id,
+      problem_id: r.problem_id,
+      problem_title: r.problem_title,
+      language: r.language,
+      submitted_at: r.submitted_at,
+      submitted_by: r.submitted_by,
+      judge_started_at: r.judge_started_at,
+      kind: "self_test",
+    });
+  }
+  judgingItems.sort((a, b) =>
+    (a.judge_started_at ?? "").localeCompare(b.judge_started_at ?? "")
+  );
+
+  // 5. 查询 recently_completed：最近 10 条（正式 + 自测合并）
   const completedRows = await db
     .select({
       id: submissions.id,
@@ -239,31 +317,81 @@ export async function getQueueOverview(): Promise<QueueResponse> {
     .orderBy(sql`${submissions.judge_finished_at} DESC`)
     .limit(10);
 
-  const completedItems: QueueItem[] = completedRows.map((r) => ({
-    id: r.id,
-    problem_id: r.problem_id,
-    problem_title: r.problem_title,
-    language: r.language,
-    submitted_at: r.submitted_at,
-    submitted_by: r.submitted_by,
-    judge_started_at: r.judge_started_at,
-    judge_finished_at: r.judge_finished_at,
-    status: r.status,
-    score: r.score,
-  }));
+  const selfCompletedRows = await db
+    .select({
+      id: selfTests.id,
+      problem_id: selfTests.problem_id,
+      problem_title: problems.title,
+      language: selfTests.language,
+      submitted_at: selfTests.created_at,
+      submitted_by: users.username,
+      judge_started_at: selfTests.judge_started_at,
+      judge_finished_at: selfTests.judge_finished_at,
+      status: selfTests.status,
+      score: selfTests.score,
+    })
+    .from(selfTests)
+    .innerJoin(problems, eq(selfTests.problem_id, problems.id))
+    .innerJoin(users, eq(selfTests.user_id, users.id))
+    .where(sql`${selfTests.status} IN ('finished', 'error')`)
+    .orderBy(sql`${selfTests.judge_finished_at} DESC`)
+    .limit(10);
 
-  // 6. 统计
-  const judgingWhereStats = pendingIds.length > 0
+  const completedItems: QueueItem[] = [
+    ...completedRows.map((r) => ({
+      id: r.id,
+      problem_id: r.problem_id,
+      problem_title: r.problem_title,
+      language: r.language,
+      submitted_at: r.submitted_at,
+      submitted_by: r.submitted_by,
+      judge_started_at: r.judge_started_at,
+      judge_finished_at: r.judge_finished_at,
+      status: r.status,
+      score: r.score,
+      kind: "submission" as const,
+    })),
+    ...selfCompletedRows.map((r) => ({
+      id: r.id,
+      problem_id: r.problem_id,
+      problem_title: r.problem_title,
+      language: r.language,
+      submitted_at: r.submitted_at,
+      submitted_by: r.submitted_by,
+      judge_started_at: r.judge_started_at,
+      judge_finished_at: r.judge_finished_at,
+      status: r.status,
+      score: r.score,
+      kind: "self_test" as const,
+    })),
+  ].sort((a, b) =>
+    (b.judge_finished_at ?? "").localeCompare(a.judge_finished_at ?? "")
+  ).slice(0, 10);
+
+  // 6. 统计（正式 + 自测）
+  const judgingWhereStats = pendingFormalIds.length > 0
     ? and(
       eq(submissions.status, "judging"),
-      not(inArray(submissions.id, pendingIds)),
+      not(inArray(submissions.id, pendingFormalIds)),
     )
     : eq(submissions.status, "judging");
+
+  const selfJudgingWhereStats = pendingSelfIds.length > 0
+    ? and(
+      eq(selfTests.status, "judging"),
+      not(inArray(selfTests.id, pendingSelfIds)),
+    )
+    : eq(selfTests.status, "judging");
 
   const [judgingCountRow] = await db
     .select({ count: sql<number>`count(*)` })
     .from(submissions)
     .where(judgingWhereStats);
+
+  const [selfJudgingCountRow] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(selfTests)
+    .where(selfJudgingWhereStats);
 
   const today = new Date().toISOString().slice(0, 10);
   const [completedTodayRow] = await db
@@ -273,7 +401,8 @@ export async function getQueueOverview(): Promise<QueueResponse> {
       sql`${submissions.status} IN ('finished', 'error') AND ${submissions.judge_finished_at} >= ${today}`,
     );
 
-  const judgingCount = Number(judgingCountRow?.count ?? 0);
+  const judgingCount = Number(judgingCountRow?.count ?? 0) +
+    Number(selfJudgingCountRow?.count ?? 0);
   const completedToday = Number(completedTodayRow?.count ?? 0);
 
   return {

--- a/noj-core/src/services/self-tests.ts
+++ b/noj-core/src/services/self-tests.ts
@@ -53,17 +53,16 @@ export async function createSelfTest(
 ): Promise<SelfTestResponse> {
   const db = getDb();
 
-  // 行级锁 + 读取最新题目配置，避免 admin 在自测期间清空 runtime_config 导致竞态
-  const lockedRows = await db
+  // 读取最新题目配置；不依赖行级锁（自测是只读快照，入队前若 config 变化由 judge 侧兜底）
+  const rows = await db
     .select()
     .from(problems)
     .where(eq(problems.id, problemId))
-    .for("update")
     .limit(1);
-  if (lockedRows.length === 0) {
+  if (rows.length === 0) {
     throw new NotFoundError("题目不存在");
   }
-  const problem = lockedRows[0];
+  const problem = rows[0];
 
   if (problem.is_objective) {
     throw new BadRequestError("客观题不支持代码自测");
@@ -197,9 +196,7 @@ export async function createSelfTest(
  */
 export async function getSelfTest(
   id: string,
-  viewerId?: string | null,
-  viewerRole?: string | null,
-  c?: Context,
+  c: Context,
 ): Promise<SelfTestDetail> {
   const db = getDb();
 
@@ -216,11 +213,8 @@ export async function getSelfTest(
   const row = rows[0];
 
   // 权限：owner 或 admin 可读
-  const isOwner = !!(c?.var.userId ?? viewerId) &&
-    row.user_id === (c?.var.userId ?? viewerId);
-  const isAdmin = c
-    ? await checkPermission(c, "submission:read_all")
-    : viewerRole === "admin";
+  const isOwner = !!c.var.userId && row.user_id === c.var.userId;
+  const isAdmin = await checkPermission(c, "submission:read_all");
   if (!isOwner && !isAdmin) {
     throw new NotFoundError("自测不存在");
   }

--- a/noj-core/src/services/self-tests.ts
+++ b/noj-core/src/services/self-tests.ts
@@ -1,0 +1,317 @@
+/**
+ * 代码自测服务（issue #221）。
+ *
+ * 自测与正式提交走完全相同的评测流程，但结果只写入独立的 `self_tests` 表，
+ * 不参与统计/榜单/AC 活动。
+ */
+
+import { and, eq } from "drizzle-orm";
+import { getDb } from "../db/connection.ts";
+import { problems, selfTests } from "../db/schema.ts";
+import { AppError, BadRequestError, NotFoundError } from "../lib/errors.ts";
+import { checkPermission } from "../lib/permissions.ts";
+import { getStorageProvider } from "../lib/storage/mod.ts";
+import { isRetryableJudgeQueueError, pushJudgeTask } from "../mq/producer.ts";
+import { validateJudgeImageWithKind } from "./judge-images.ts";
+import { logger } from "../lib/logging.ts";
+import { Channels, publishEvent } from "../lib/event-bus.ts";
+import type { Context } from "hono";
+import { LANGUAGE_EXT_MAP } from "../types/index.ts";
+import type { JudgeResult, JudgeTask } from "../types/index.ts";
+import type { RuntimeConfig } from "../types/problems.ts";
+import {
+  SELF_TEST_ID_PREFIX,
+  type SelfTestDetail,
+  type SelfTestInput,
+  type SelfTestResponse,
+  type SelfTestStatus,
+} from "../types/self-tests.ts";
+
+/** 详情接口返回的 output 最大长度（字节近似），与正式提交一致。 */
+const MAX_OUTPUT_LENGTH = 8 * 1024;
+
+/** 解析 details 字段（数据库存 JSON 字符串）。 */
+function parseDetails(raw: string | null): Record<string, unknown> | null {
+  if (raw === null || raw === undefined) return null;
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 创建自测并推入评测队列。
+ *
+ * @throws {NotFoundError} 题目不存在
+ * @throws {BadRequestError} 语言不支持 / 客观题不支持自测 / 题目缺少 runtime_config
+ */
+export async function createSelfTest(
+  userId: string,
+  problemId: string,
+  input: SelfTestInput,
+): Promise<SelfTestResponse> {
+  const db = getDb();
+
+  // 行级锁 + 读取最新题目配置，避免 admin 在自测期间清空 runtime_config 导致竞态
+  const lockedRows = await db
+    .select()
+    .from(problems)
+    .where(eq(problems.id, problemId))
+    .for("update")
+    .limit(1);
+  if (lockedRows.length === 0) {
+    throw new NotFoundError("题目不存在");
+  }
+  const problem = lockedRows[0];
+
+  if (problem.is_objective) {
+    throw new BadRequestError("客观题不支持代码自测");
+  }
+
+  // 验证语言（与正式提交保持一致）
+  const supportedLanguages = Object.keys(LANGUAGE_EXT_MAP);
+  if (!supportedLanguages.includes(input.language)) {
+    throw new BadRequestError(`不支持的语言: ${input.language}`);
+  }
+
+  // 生成文件默认名
+  const fileName = input.file_name || LANGUAGE_EXT_MAP[input.language] ||
+    "main.txt";
+
+  // 获取支持包 download URL
+  let download_url: string | undefined;
+  if (problem.support_package_storage_url) {
+    try {
+      const storage = await getStorageProvider();
+      download_url = await storage.downloadUrl(
+        problem.support_package_storage_url,
+      );
+    } catch (err) {
+      logger.error("自测获取支持包 download URL 失败", {
+        storage_url: problem.support_package_storage_url,
+        err,
+      });
+      // 获取失败不阻塞自测，但会跳过支持包
+    }
+  }
+
+  // 双容器 runtime_config 校验
+  const runtimeConfig = problem.runtime_config as
+    | RuntimeConfig
+    | null
+    | undefined;
+  if (!runtimeConfig) {
+    throw new AppError(
+      "题目缺少 runtime_config 配置，无法评测",
+      500,
+      "RUNTIME_CONFIG_MISSING",
+    );
+  }
+
+  await validateJudgeImageWithKind(
+    runtimeConfig.evaluator.image,
+    "evaluator",
+  );
+  await validateJudgeImageWithKind(
+    runtimeConfig.solution.image,
+    "solution",
+  );
+
+  const id = `${SELF_TEST_ID_PREFIX}${crypto.randomUUID()}`;
+  const now = new Date().toISOString();
+
+  const task: JudgeTask = {
+    submission_id: id,
+    problem_id: problemId,
+    runtime_config: runtimeConfig,
+    download_url,
+    language: input.language,
+    code: input.code,
+    file_name: fileName,
+  };
+
+  try {
+    await db.insert(selfTests).values({
+      id,
+      user_id: userId,
+      problem_id: problemId,
+      language: input.language,
+      code: input.code,
+      file_name: fileName,
+      status: "pending",
+      created_at: now,
+    });
+  } catch (dbErr) {
+    logger.error("自测记录插入失败", { err: dbErr });
+    throw new AppError(
+      "自测失败：数据库写入错误，请稍后重试",
+      500,
+      "SELF_TEST_DB_ERROR",
+    );
+  }
+
+  try {
+    await pushJudgeTask(task);
+    // 入队成功后更新状态为 judging；条件更新避免极端竞态下覆盖终态
+    await db.update(selfTests).set({
+      status: "judging",
+      judge_started_at: now,
+    }).where(
+      and(eq(selfTests.id, id), eq(selfTests.status, "pending")),
+    );
+    publishEvent(Channels.queue, JSON.stringify({ type: "queue:changed" }));
+  } catch (mqErr) {
+    logger.error("自测任务推送失败", { self_test_id: id, err: mqErr });
+    if (!isRetryableJudgeQueueError(mqErr)) {
+      await db.update(selfTests)
+        .set({
+          status: "error",
+          judge_finished_at: new Date().toISOString(),
+        })
+        .where(eq(selfTests.id, id));
+    }
+    throw new AppError(
+      "自测失败：评测队列暂时不可用，请稍后重试",
+      500,
+      "SELF_TEST_QUEUE_ERROR",
+    );
+  }
+
+  return {
+    id,
+    user_id: userId,
+    problem_id: problemId,
+    language: input.language,
+    code: input.code,
+    file_name: fileName,
+    status: "judging",
+    created_at: now,
+  };
+}
+
+/**
+ * 根据 ID 查询自测详情。
+ *
+ * 权限：仅 owner 或 admin 可见；非 owner/admin 返回 404（不暴露自测存在）。
+ */
+export async function getSelfTest(
+  id: string,
+  viewerId?: string | null,
+  viewerRole?: string | null,
+  c?: Context,
+): Promise<SelfTestDetail> {
+  const db = getDb();
+
+  const rows = await db
+    .select()
+    .from(selfTests)
+    .where(eq(selfTests.id, id))
+    .limit(1);
+
+  if (rows.length === 0) {
+    throw new NotFoundError("自测不存在");
+  }
+
+  const row = rows[0];
+
+  // 权限：owner 或 admin 可读
+  const isOwner = !!(c?.var.userId ?? viewerId) &&
+    row.user_id === (c?.var.userId ?? viewerId);
+  const isAdmin = c
+    ? await checkPermission(c, "submission:read_all")
+    : viewerRole === "admin";
+  if (!isOwner && !isAdmin) {
+    throw new NotFoundError("自测不存在");
+  }
+
+  const rawOutput = row.output ?? "";
+  const outputTruncated = rawOutput.length > MAX_OUTPUT_LENGTH;
+  const output = outputTruncated
+    ? rawOutput.slice(0, MAX_OUTPUT_LENGTH)
+    : rawOutput;
+  const details = parseDetails(row.details);
+
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    problem_id: row.problem_id,
+    language: row.language,
+    code: row.code,
+    file_name: row.file_name,
+    status: row.status as SelfTestStatus,
+    result_status: row.result_status,
+    score: row.score,
+    output,
+    output_truncated: outputTruncated,
+    details,
+    time_ms: row.time_ms,
+    memory_kb: row.memory_kb,
+    judge_started_at: row.judge_started_at,
+    judge_finished_at: row.judge_finished_at,
+    created_at: row.created_at,
+  };
+}
+
+/**
+ * 保存自测评测结果（幂等）。
+ *
+ * 只更新 `self_tests` 表，不触发统计缓存、榜单刷新或 AC 活动。
+ */
+export async function saveSelfTestResult(
+  result: JudgeResult,
+): Promise<boolean> {
+  const db = getDb();
+
+  const now = new Date().toISOString();
+  const status: SelfTestStatus = result.status === "SystemError"
+    ? "error"
+    : "finished";
+
+  const outcome = await db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select({
+        status: selfTests.status,
+        judge_started_at: selfTests.judge_started_at,
+      })
+      .from(selfTests)
+      .where(eq(selfTests.id, result.submission_id))
+      .for("update")
+      .limit(1);
+
+    if (!existing) {
+      logger.warn("自测不存在，忽略评测结果", {
+        self_test_id: result.submission_id,
+      });
+      return null;
+    }
+
+    // 已终态：忽略重复结果
+    const current = existing.status as SelfTestStatus;
+    if (current === "finished" || current === "error") {
+      logger.info("重复自测结果，跳过", {
+        self_test_id: result.submission_id,
+      });
+      return null;
+    }
+
+    await tx
+      .update(selfTests)
+      .set({
+        status,
+        result_status: result.status,
+        score: result.score,
+        output: result.output,
+        details: JSON.stringify(result.details),
+        time_ms: result.time_ms ?? null,
+        memory_kb: result.memory_kb ?? null,
+        judge_started_at: existing.judge_started_at ?? now,
+        judge_finished_at: now,
+      })
+      .where(eq(selfTests.id, result.submission_id));
+
+    return true;
+  });
+
+  return outcome === true;
+}

--- a/noj-core/src/types/self-tests.ts
+++ b/noj-core/src/types/self-tests.ts
@@ -1,0 +1,63 @@
+/**
+ * 代码自测（self-test）类型定义（issue #221）。
+ *
+ * 自测与正式提交共用评测流程，但结果只写入独立的 `self_tests` 表，
+ * 不参与正式统计/榜单/AC 活动。
+ */
+
+/** 自测 ID 前缀：用于 core 消费者区分自测结果与正式提交结果。 */
+export const SELF_TEST_ID_PREFIX = "st_";
+
+/** 自测状态枚举。 */
+export const SELF_TEST_STATUSES = [
+  "pending",
+  "judging",
+  "finished",
+  "error",
+] as const;
+
+export type SelfTestStatus = typeof SELF_TEST_STATUSES[number];
+
+/** 创建自测的请求体（problem_id 从 URL 获取，不放在 body）。 */
+export interface SelfTestInput {
+  language: string;
+  code: string;
+  file_name?: string;
+}
+
+/** 创建自测成功后的响应（基础字段，不含 result）。 */
+export interface SelfTestResponse {
+  id: string;
+  user_id: string;
+  problem_id: string;
+  language: string;
+  code: string;
+  file_name: string | null;
+  status: SelfTestStatus;
+  created_at: string;
+}
+
+/**
+ * 自测详情响应。
+ * 仅 owner/admin 可见，output 按 API 层截断返回。
+ */
+export interface SelfTestDetail {
+  id: string;
+  user_id: string;
+  problem_id: string;
+  language: string;
+  code: string | null;
+  file_name: string | null;
+  status: SelfTestStatus;
+  /** 评测结果状态（如 Accepted / WrongAnswer），未完成时为 null。 */
+  result_status: string | null;
+  score: number;
+  output: string | null;
+  output_truncated: boolean | null;
+  details: Record<string, unknown> | null;
+  time_ms: number | null;
+  memory_kb: number | null;
+  judge_started_at: string | null;
+  judge_finished_at: string | null;
+  created_at: string;
+}

--- a/noj-core/tests/mq/self-test-consumer.test.ts
+++ b/noj-core/tests/mq/self-test-consumer.test.ts
@@ -10,6 +10,8 @@ import {
 } from "../../src/db/schema.ts";
 import { handleResultMessage } from "../../src/mq/consumer.ts";
 import { recoverPendingSelfTests } from "../../src/mq/sweeper.ts";
+import { getRedis, resetRedisForTest } from "../../src/mq/connection.ts";
+import { startFakeRedis } from "./_setup.ts";
 import { SELF_TEST_ID_PREFIX } from "../../src/types/self-tests.ts";
 
 const skip = false;
@@ -21,6 +23,7 @@ const SELF_TEST_ID = `${SELF_TEST_ID_PREFIX}${crypto.randomUUID()}`;
 const SUBMISSION_ID = `tst-consumer-st-sub-${ts}`;
 const BAD_PROBLEM_ID = `tst-consumer-st-bad-problem-${ts}`;
 const PENDING_SELF_TEST_ID = `${SELF_TEST_ID_PREFIX}${crypto.randomUUID()}`;
+const RECOVERABLE_SELF_TEST_ID = `${SELF_TEST_ID_PREFIX}${crypto.randomUUID()}`;
 const now = new Date().toISOString();
 const oldNow = new Date(Date.now() - 3 * 60_000).toISOString();
 
@@ -97,6 +100,16 @@ Deno.test({
         language: "python3",
         code: "print('bad')",
         status: "pending",
+        created_at: oldNow,
+      },
+      {
+        id: RECOVERABLE_SELF_TEST_ID,
+        user_id: USER_ID,
+        problem_id: PROBLEM_ID,
+        language: "python3",
+        code: "print('recover')",
+        status: "pending",
+        judge_started_at: oldNow,
         created_at: oldNow,
       },
     ]);
@@ -197,6 +210,43 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "mq/consumer self-test: 可恢复 pending 自测成功入队且保留 judge_started_at",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const fake = startFakeRedis();
+    const prevUrl = Deno.env.get("REDIS_URL") ?? null;
+    try {
+      resetRedisForTest();
+      Deno.env.set("REDIS_URL", fake.url);
+      const redis = getRedis();
+      await redis.connect();
+
+      await recoverPendingSelfTests(Date.now());
+
+      const db = getDb();
+      const [row] = await db
+        .select()
+        .from(selfTests)
+        .where(eq(selfTests.id, RECOVERABLE_SELF_TEST_ID))
+        .limit(1);
+      assertEquals(row.status, "judging");
+      assertEquals(row.judge_started_at, oldNow);
+    } finally {
+      await fake.stop();
+      resetRedisForTest();
+      if (prevUrl !== null) {
+        Deno.env.set("REDIS_URL", prevUrl);
+      } else {
+        Deno.env.delete("REDIS_URL");
+      }
+    }
+  },
+});
+
+Deno.test({
   name: "mq/consumer self-test: pending 自测缺少 runtime_config 被标记 error",
   ignore: skip,
   sanitizeResources: false,
@@ -230,6 +280,9 @@ Deno.test({
     );
     await db.delete(selfTests).where(
       eq(selfTests.id, PENDING_SELF_TEST_ID),
+    );
+    await db.delete(selfTests).where(
+      eq(selfTests.id, RECOVERABLE_SELF_TEST_ID),
     );
     await db.delete(problems).where(eq(problems.id, PROBLEM_ID));
     await db.delete(problems).where(eq(problems.id, BAD_PROBLEM_ID));

--- a/noj-core/tests/mq/self-test-consumer.test.ts
+++ b/noj-core/tests/mq/self-test-consumer.test.ts
@@ -1,0 +1,238 @@
+import { assertEquals } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import {
+  evaluationResults,
+  problems,
+  selfTests,
+  submissions,
+  users,
+} from "../../src/db/schema.ts";
+import { handleResultMessage } from "../../src/mq/consumer.ts";
+import { recoverPendingSelfTests } from "../../src/mq/sweeper.ts";
+import { SELF_TEST_ID_PREFIX } from "../../src/types/self-tests.ts";
+
+const skip = false;
+
+const ts = Date.now();
+const USER_ID = `tst-consumer-st-user-${ts}`;
+const PROBLEM_ID = `tst-consumer-st-problem-${ts}`;
+const SELF_TEST_ID = `${SELF_TEST_ID_PREFIX}${crypto.randomUUID()}`;
+const SUBMISSION_ID = `tst-consumer-st-sub-${ts}`;
+const BAD_PROBLEM_ID = `tst-consumer-st-bad-problem-${ts}`;
+const PENDING_SELF_TEST_ID = `${SELF_TEST_ID_PREFIX}${crypto.randomUUID()}`;
+const now = new Date().toISOString();
+const oldNow = new Date(Date.now() - 3 * 60_000).toISOString();
+
+const runtimeConfig = {
+  evaluator: {
+    image: "noj-evaluator-python",
+    command: "python3 /workspace/evaluate.py",
+    time_limit_ms: 5000,
+    memory_limit_mb: 512,
+  },
+  solution: {
+    image: "noj-solution-python",
+    call_timeout_ms: 2000,
+    memory_limit_mb: 512,
+  },
+};
+
+Deno.test({
+  name: "mq/consumer self-test: 初始化数据",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const db = getDb();
+    await db.insert(users).values({
+      id: USER_ID,
+      username: `tstcst-${ts}`,
+      email: `tstcst-${ts}@test.noj`,
+      password_hash: "hash",
+      created_at: now,
+      updated_at: now,
+    });
+    await db.insert(problems).values([
+      {
+        id: PROBLEM_ID,
+        title: "消费者自测题",
+        description: "test",
+        difficulty: "easy",
+        runtime_config: runtimeConfig,
+        number: 95000 + (ts % 10000),
+        owner_id: USER_ID,
+        type: "P",
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: BAD_PROBLEM_ID,
+        title: "缺少 runtime_config 的题",
+        description: "test",
+        difficulty: "easy",
+        runtime_config: null,
+        number: 96000 + (ts % 10000),
+        owner_id: USER_ID,
+        type: "P",
+        created_at: now,
+        updated_at: now,
+      },
+    ]);
+    await db.insert(selfTests).values([
+      {
+        id: SELF_TEST_ID,
+        user_id: USER_ID,
+        problem_id: PROBLEM_ID,
+        language: "python3",
+        code: "print('hi')",
+        status: "judging",
+        created_at: now,
+      },
+      {
+        id: PENDING_SELF_TEST_ID,
+        user_id: USER_ID,
+        problem_id: BAD_PROBLEM_ID,
+        language: "python3",
+        code: "print('bad')",
+        status: "pending",
+        created_at: oldNow,
+      },
+    ]);
+    await db.insert(submissions).values({
+      id: SUBMISSION_ID,
+      user_id: USER_ID,
+      problem_id: PROBLEM_ID,
+      status: "judging",
+      language: "python3",
+      code: "print('hi')",
+      created_at: now,
+    });
+  },
+});
+
+Deno.test({
+  name: "mq/consumer self-test: st_ 前缀结果写入 self_tests 且不写正式表",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await handleResultMessage({
+      submission_id: SELF_TEST_ID,
+      status: "Accepted",
+      score: 10000,
+      output: "---RESULT---\n{}",
+      details: { cases: [] },
+      time_ms: 12,
+      memory_kb: 1024,
+    });
+
+    const db = getDb();
+    const [st] = await db
+      .select()
+      .from(selfTests)
+      .where(eq(selfTests.id, SELF_TEST_ID))
+      .limit(1);
+    assertEquals(st.status, "finished");
+    assertEquals(st.result_status, "Accepted");
+    assertEquals(st.score, 10000);
+
+    const [er] = await db
+      .select({ id: evaluationResults.id })
+      .from(evaluationResults)
+      .where(eq(evaluationResults.submission_id, SELF_TEST_ID))
+      .limit(1);
+    assertEquals(er, undefined);
+  },
+});
+
+Deno.test({
+  name: "mq/consumer self-test: 非 st_ 前缀结果写入正式表",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await handleResultMessage({
+      submission_id: SUBMISSION_ID,
+      status: "Accepted",
+      score: 1000,
+      output: "---RESULT---\n{}",
+      details: {},
+    });
+
+    const db = getDb();
+    const [er] = await db
+      .select()
+      .from(evaluationResults)
+      .where(eq(evaluationResults.submission_id, SUBMISSION_ID))
+      .limit(1);
+    assertEquals(er.status, "Accepted");
+  },
+});
+
+Deno.test({
+  name: "mq/consumer self-test: 重复自测终态结果幂等忽略",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await handleResultMessage({
+      submission_id: SELF_TEST_ID,
+      status: "WrongAnswer",
+      score: 0,
+      output: "---RESULT---\n{}",
+      details: {},
+    });
+
+    const db = getDb();
+    const [st] = await db
+      .select()
+      .from(selfTests)
+      .where(eq(selfTests.id, SELF_TEST_ID))
+      .limit(1);
+    assertEquals(st.result_status, "Accepted");
+    assertEquals(st.score, 10000);
+  },
+});
+
+Deno.test({
+  name: "mq/consumer self-test: pending 自测缺少 runtime_config 被标记 error",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await recoverPendingSelfTests(Date.now());
+
+    const db = getDb();
+    const [row] = await db
+      .select()
+      .from(selfTests)
+      .where(eq(selfTests.id, PENDING_SELF_TEST_ID))
+      .limit(1);
+    assertEquals(row.status, "error");
+  },
+});
+
+Deno.test({
+  name: "mq/consumer self-test: 清理数据",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    await db.delete(evaluationResults).where(
+      eq(evaluationResults.submission_id, SUBMISSION_ID),
+    );
+    await db.delete(submissions).where(eq(submissions.id, SUBMISSION_ID));
+    await db.delete(selfTests).where(
+      eq(selfTests.id, SELF_TEST_ID),
+    );
+    await db.delete(selfTests).where(
+      eq(selfTests.id, PENDING_SELF_TEST_ID),
+    );
+    await db.delete(problems).where(eq(problems.id, PROBLEM_ID));
+    await db.delete(problems).where(eq(problems.id, BAD_PROBLEM_ID));
+    await db.delete(users).where(eq(users.id, USER_ID));
+  },
+});

--- a/noj-core/tests/routes/self-tests.test.ts
+++ b/noj-core/tests/routes/self-tests.test.ts
@@ -1,0 +1,244 @@
+import { assertEquals } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { createApp } from "../../src/app.ts";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import { problems, selfTests, users } from "../../src/db/schema.ts";
+import { signToken } from "../../src/lib/jwt.ts";
+import { initRedisForTest, jsonRequest } from "../lib/helper.ts";
+
+// 显式启用限流（NOJ_ENV=test 时默认关闭）
+Deno.env.set("RATE_LIMIT_ENABLED", "true");
+
+await resetDbForTest();
+await initRedisForTest();
+
+const hasEnv = !!Deno.env.get("JWT_SECRET");
+const hasRedis = !!Deno.env.get("REDIS_URL");
+const skip = !(hasEnv && hasRedis);
+
+const ts = Date.now();
+const USER_ID = `tst-route-st-user-${ts}`;
+const OTHER_USER_ID = `tst-route-st-other-${ts}`;
+const PROBLEM_ID = `tst-route-st-problem-${ts}`;
+const PROBLEM_NUMBER = 90000 + (ts % 10000);
+const DISPLAY_ID = `P${PROBLEM_NUMBER}`;
+const now = new Date().toISOString();
+let TEST_TOKEN = "";
+let CREATED_SELF_TEST_ID = "";
+
+Deno.test({
+  name: "self-tests route: 初始化测试用户和题目",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    await db.insert(users).values([
+      {
+        id: USER_ID,
+        username: `tststroute-${ts}`,
+        email: `tststroute-${ts}@test.noj`,
+        password_hash: "hash",
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: OTHER_USER_ID,
+        username: `tststroute-other-${ts}`,
+        email: `tststroute-other-${ts}@test.noj`,
+        password_hash: "hash",
+        created_at: now,
+        updated_at: now,
+      },
+    ]);
+    await db.insert(problems).values({
+      id: PROBLEM_ID,
+      title: "路由自测题",
+      description: "测试",
+      difficulty: "easy",
+      runtime_config: {
+        evaluator: {
+          image: "noj-evaluator-python",
+          command: "python3 /workspace/evaluate.py",
+          time_limit_ms: 5000,
+          memory_limit_mb: 512,
+        },
+        solution: {
+          image: "noj-solution-python",
+          call_timeout_ms: 2000,
+          memory_limit_mb: 512,
+        },
+      },
+      number: PROBLEM_NUMBER,
+      owner_id: USER_ID,
+      type: "P",
+      created_at: now,
+      updated_at: now,
+    });
+    TEST_TOKEN = await signToken({ sub: USER_ID, role: "user" });
+  },
+});
+
+Deno.test({
+  name:
+    "self-tests route: POST /api/v1/problems/:id/self-test 无 token 返回 401",
+  ignore: !hasEnv,
+  fn: async () => {
+    const app = createApp();
+    const res = await jsonRequest(
+      app,
+      `/api/v1/problems/${PROBLEM_ID}/self-test`,
+      {
+        method: "POST",
+        body: { language: "python3", code: "print(1)" },
+      },
+    );
+    assertEquals(res.status, 401);
+  },
+});
+
+Deno.test({
+  name: "self-tests route: POST 缺少字段返回 400",
+  ignore: skip,
+  fn: async () => {
+    const app = createApp();
+    const res = await jsonRequest(
+      app,
+      `/api/v1/problems/${PROBLEM_ID}/self-test`,
+      {
+        method: "POST",
+        body: { language: "python3" },
+        token: TEST_TOKEN,
+      },
+    );
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "self-tests route: POST 不存在的题目返回 404",
+  ignore: skip,
+  fn: async () => {
+    const app = createApp();
+    const res = await jsonRequest(
+      app,
+      "/api/v1/problems/nonexistent/self-test",
+      {
+        method: "POST",
+        body: { language: "python3", code: "print(1)" },
+        token: TEST_TOKEN,
+      },
+    );
+    assertEquals(res.status, 404);
+  },
+});
+
+Deno.test({
+  name: "self-tests route: POST 正常创建返回 201",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const res = await jsonRequest(
+      app,
+      `/api/v1/problems/${PROBLEM_ID}/self-test`,
+      {
+        method: "POST",
+        body: { language: "python3", code: "print(1)" },
+        token: TEST_TOKEN,
+      },
+    );
+    assertEquals(res.status, 201);
+    const body = await res.json();
+    assertEquals(body.data.id.startsWith("st_"), true);
+    assertEquals(body.data.status, "judging");
+    CREATED_SELF_TEST_ID = body.data.id;
+  },
+});
+
+Deno.test({
+  name: "self-tests route: POST 支持 display_id 路径",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const res = await jsonRequest(
+      app,
+      `/api/v1/problems/${DISPLAY_ID}/self-test`,
+      {
+        method: "POST",
+        body: { language: "python3", code: "print(1)" },
+        token: TEST_TOKEN,
+      },
+    );
+    assertEquals(res.status, 201);
+  },
+});
+
+Deno.test({
+  name: "self-tests route: 非 owner 查询自测返回 404",
+  ignore: skip,
+  fn: async () => {
+    const app = createApp();
+    const otherToken = await signToken({ sub: OTHER_USER_ID, role: "user" });
+    const res = await jsonRequest(
+      app,
+      `/api/v1/self-tests/${CREATED_SELF_TEST_ID}`,
+      {
+        token: otherToken,
+      },
+    );
+    assertEquals(res.status, 404);
+  },
+});
+
+Deno.test({
+  name: "self-tests route: GET /api/v1/self-tests/:id 不存在返回 404",
+  ignore: skip,
+  fn: async () => {
+    const app = createApp();
+    const res = await jsonRequest(app, "/api/v1/self-tests/st_nonexistent", {
+      token: TEST_TOKEN,
+    });
+    assertEquals(res.status, 404);
+  },
+});
+
+Deno.test({
+  name: "self-tests route: 超过每用户限流阈值返回 429",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    let lastStatus = 0;
+    // 该用户在前面已创建过 1 次自测，这里再打 4 次应触发第 5 次 429
+    for (let i = 0; i < 4; i++) {
+      const res = await jsonRequest(
+        app,
+        `/api/v1/problems/${PROBLEM_ID}/self-test`,
+        {
+          method: "POST",
+          body: { language: "python3", code: "print(1)" },
+          token: TEST_TOKEN,
+        },
+      );
+      lastStatus = res.status;
+    }
+    assertEquals(lastStatus, 429);
+  },
+});
+
+Deno.test({
+  name: "self-tests route: 清理测试数据",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    await db.delete(selfTests).where(eq(selfTests.problem_id, PROBLEM_ID));
+    await db.delete(problems).where(eq(problems.id, PROBLEM_ID));
+  },
+});

--- a/noj-core/tests/services/queue.test.ts
+++ b/noj-core/tests/services/queue.test.ts
@@ -13,10 +13,12 @@ import {
 import {
   evaluationResults,
   problems,
+  selfTests,
   submissions,
   users,
 } from "../../src/db/schema.ts";
 import { eq } from "drizzle-orm";
+import { SELF_TEST_ID_PREFIX } from "../../src/types/self-tests.ts";
 
 const hasDb = !!Deno.env.get("DATABASE_URL");
 const skip = !hasDb;
@@ -27,6 +29,7 @@ const PROBLEM_ID = `tst-queue-prob-${ts}`;
 const SUBMISSION_PENDING_ID = `tst-queue-pend-${ts}`;
 const SUBMISSION_JUDGING_ID = `tst-queue-judg-${ts}`;
 const SUBMISSION_FINISHED_ID = `tst-queue-fin-${ts}`;
+const SELF_TEST_FINISHED_ID = `${SELF_TEST_ID_PREFIX}tst-queue-fin-${ts}`;
 
 async function setup() {
   const db = getDb();
@@ -104,6 +107,21 @@ async function setup() {
     output: "---RESULT---\n{}",
     created_at: now,
   });
+  await db.insert(selfTests).values({
+    id: SELF_TEST_FINISHED_ID,
+    user_id: USER_ID,
+    problem_id: PROBLEM_ID,
+    language: "python3",
+    code: "print('self')",
+    status: "finished",
+    result_status: "Accepted",
+    score: 10000,
+    output: "---RESULT---\n{}",
+    details: "{}",
+    judge_started_at: now,
+    judge_finished_at: now,
+    created_at: now,
+  });
 }
 
 async function teardown() {
@@ -111,6 +129,9 @@ async function teardown() {
     const db = getDb();
     await db.delete(evaluationResults).where(
       eq(evaluationResults.submission_id, SUBMISSION_FINISHED_ID),
+    );
+    await db.delete(selfTests).where(
+      eq(selfTests.user_id, USER_ID),
     );
     await db.delete(submissions).where(
       eq(submissions.user_id, USER_ID),
@@ -234,6 +255,21 @@ Deno.test({
     assertEquals(typeof overview.stats.pending_count, "number");
     assertEquals(typeof overview.stats.judging_count, "number");
     assertEquals(typeof overview.stats.completed_today, "number");
+  },
+});
+
+Deno.test({
+  name: "queue service: getQueueOverview 最近完成包含自测并标记 kind",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const overview = await getQueueOverview();
+    const selfItem = overview.recently_completed.find(
+      (item) => item.id === SELF_TEST_FINISHED_ID,
+    );
+    assertEquals(selfItem !== undefined, true);
+    assertEquals(selfItem?.kind, "self_test");
   },
 });
 

--- a/noj-core/tests/services/self-tests.test.ts
+++ b/noj-core/tests/services/self-tests.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../src/services/self-tests.ts";
 import { SELF_TEST_ID_PREFIX } from "../../src/types/self-tests.ts";
 import type { JudgeResult } from "../../src/types/index.ts";
+import type { Context } from "hono";
 
 const skip = false; // PGlite 内存数据库始终可用
 
@@ -144,7 +145,11 @@ Deno.test({
   sanitizeOps: false,
   fn: async () => {
     await assertRejects(
-      () => getSelfTest("st_nonexistent", USER_ID, "user"),
+      () =>
+        getSelfTest(
+          "st_nonexistent",
+          { var: { userId: USER_ID } } as unknown as Context,
+        ),
       NotFoundError,
     );
   },

--- a/noj-core/tests/services/self-tests.test.ts
+++ b/noj-core/tests/services/self-tests.test.ts
@@ -1,0 +1,234 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
+import { getDb, resetDbForTest } from "../../src/db/connection.ts";
+import {
+  problems,
+  selfTests,
+  submissions,
+  users,
+} from "../../src/db/schema.ts";
+import { BadRequestError, NotFoundError } from "../../src/lib/errors.ts";
+import {
+  createSelfTest,
+  getSelfTest,
+  saveSelfTestResult,
+} from "../../src/services/self-tests.ts";
+import { SELF_TEST_ID_PREFIX } from "../../src/types/self-tests.ts";
+import type { JudgeResult } from "../../src/types/index.ts";
+
+const skip = false; // PGlite 内存数据库始终可用
+
+const ts = Date.now();
+const USER_ID = `tst-st-user-${ts}`;
+const PROBLEM_ID = `tst-st-problem-${ts}`;
+const OBJECTIVE_PROBLEM_ID = `tst-st-objective-${ts}`;
+const SELF_TEST_ID = `${SELF_TEST_ID_PREFIX}${crypto.randomUUID()}`;
+
+const now = new Date().toISOString();
+
+const runtimeConfig = {
+  evaluator: {
+    image: "noj-evaluator-python",
+    command: "python3 /workspace/evaluate.py",
+    time_limit_ms: 5000,
+    memory_limit_mb: 512,
+  },
+  solution: {
+    image: "noj-solution-python",
+    call_timeout_ms: 2000,
+    memory_limit_mb: 512,
+  },
+};
+
+Deno.test({
+  name: "self-tests service: 初始化测试数据",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const db = getDb();
+    await db.insert(users).values({
+      id: USER_ID,
+      username: `tstst-${ts}`,
+      email: `tstst-${ts}@test.noj`,
+      password_hash: "hash",
+      created_at: now,
+      updated_at: now,
+    });
+    await db.insert(problems).values([
+      {
+        id: PROBLEM_ID,
+        title: "自测测试题",
+        description: "测试描述",
+        difficulty: "easy",
+        runtime_config: runtimeConfig,
+        number: 70000 + (ts % 10000),
+        owner_id: USER_ID,
+        type: "P",
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: OBJECTIVE_PROBLEM_ID,
+        title: "客观题套卷",
+        description: "客观题",
+        difficulty: "easy",
+        runtime_config: null,
+        is_objective: true,
+        number: 80000 + (ts % 10000),
+        owner_id: USER_ID,
+        type: "P",
+        created_at: now,
+        updated_at: now,
+      },
+    ]);
+  },
+});
+
+Deno.test({
+  name: "self-tests service: 不支持的语言抛出 BadRequestError",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () =>
+        createSelfTest(USER_ID, PROBLEM_ID, {
+          language: "ruby",
+          code: "puts 1",
+        }),
+      BadRequestError,
+    );
+  },
+});
+
+Deno.test({
+  name: "self-tests service: 客观题不支持自测",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () =>
+        createSelfTest(USER_ID, OBJECTIVE_PROBLEM_ID, {
+          language: "python3",
+          code: "print(1)",
+        }),
+      BadRequestError,
+    );
+  },
+});
+
+Deno.test({
+  name: "self-tests service: 题目不存在抛出 NotFoundError",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () =>
+        createSelfTest(USER_ID, "nonexistent-problem", {
+          language: "python3",
+          code: "print(1)",
+        }),
+      NotFoundError,
+    );
+  },
+});
+
+Deno.test({
+  name: "self-tests service: getSelfTest 不存在抛出 NotFoundError",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await assertRejects(
+      () => getSelfTest("st_nonexistent", USER_ID, "user"),
+      NotFoundError,
+    );
+  },
+});
+
+Deno.test({
+  name: "self-tests service: saveSelfTestResult 对不存在记录返回 false",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const result: JudgeResult = {
+      submission_id: "st_unknown",
+      status: "Accepted",
+      score: 10000,
+      output: "ok",
+      details: {},
+    };
+    const applied = await saveSelfTestResult(result);
+    assertEquals(applied, false);
+  },
+});
+
+Deno.test({
+  name: "self-tests service: saveSelfTestResult 写回且不影响正式表",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    await db.insert(selfTests).values({
+      id: SELF_TEST_ID,
+      user_id: USER_ID,
+      problem_id: PROBLEM_ID,
+      language: "python3",
+      code: "print('hi')",
+      status: "judging",
+      created_at: now,
+    });
+
+    const result: JudgeResult = {
+      submission_id: SELF_TEST_ID,
+      status: "Accepted",
+      score: 10000,
+      output: "---RESULT---\n{}",
+      details: { cases: [] },
+      time_ms: 12,
+      memory_kb: 1024,
+    };
+    const applied = await saveSelfTestResult(result);
+    assertEquals(applied, true);
+
+    const [row] = await db
+      .select()
+      .from(selfTests)
+      .where(eq(selfTests.id, SELF_TEST_ID))
+      .limit(1);
+    assertEquals(row.status, "finished");
+    assertEquals(row.result_status, "Accepted");
+    assertEquals(row.score, 10000);
+
+    const [sub] = await db
+      .select({ id: submissions.id })
+      .from(submissions)
+      .where(eq(submissions.id, SELF_TEST_ID))
+      .limit(1);
+    assertEquals(sub, undefined);
+
+    // 重复终态结果幂等忽略
+    const appliedAgain = await saveSelfTestResult(result);
+    assertEquals(appliedAgain, false);
+  },
+});
+
+Deno.test({
+  name: "self-tests service: 清理测试数据",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const db = getDb();
+    await db.delete(selfTests).where(eq(selfTests.user_id, USER_ID));
+    await db.delete(problems).where(eq(problems.id, PROBLEM_ID));
+    await db.delete(problems).where(eq(problems.id, OBJECTIVE_PROBLEM_ID));
+    await db.delete(users).where(eq(users.id, USER_ID));
+  },
+});

--- a/noj-tests/e2e/01_tags.test.ts
+++ b/noj-tests/e2e/01_tags.test.ts
@@ -142,7 +142,10 @@ e2eTest("[e2e/tags] 2.1 题目打标签并筛选命中", async () => {
   problemId = (res.body as { data: { id: string } }).data.id;
 
   // 按标签筛选命中
-  const listRes = await apiGet(`/api/v1/problems?tag=${tagId}&type=U`);
+  const listRes = await apiGet(
+    `/api/v1/problems?tag=${tagId}&type=U`,
+    adminToken,
+  );
   if (listRes.status !== 200) throw new Error("筛选失败: " + listRes.status);
   const items = (listRes.body as { data: { id: string }[] }).data;
   if (!items.some((p) => p.id === problemId)) {
@@ -155,6 +158,7 @@ e2eTest("[e2e/tags] 2.2 标签与难度组合筛选", async () => {
   if (!isE2E) return;
   const res = await apiGet(
     `/api/v1/problems?tag=${tagId}&difficulty=easy&type=U`,
+    adminToken,
   );
   if (res.status !== 200) throw new Error("组合筛选失败: " + res.status);
   const items = (res.body as { data: { id: string }[] }).data;
@@ -186,7 +190,10 @@ e2eTest("[e2e/tags] 3.1 合并标签后关联正确", async () => {
   }
 
   // 原标签已删除，关联重指向 target
-  const listRes = await apiGet(`/api/v1/problems?tag=${targetId}&type=U`);
+  const listRes = await apiGet(
+    `/api/v1/problems?tag=${targetId}&type=U`,
+    adminToken,
+  );
   const items = (listRes.body as { data: { id: string }[] }).data;
   if (!items.some((p) => p.id === problemId)) {
     throw new Error("合并后关联未重指向目标标签");

--- a/noj-tests/e2e/30_self_test.test.ts
+++ b/noj-tests/e2e/30_self_test.test.ts
@@ -1,0 +1,156 @@
+/**
+ * 代码自测 E2E 测试（issue #221）。
+ *
+ * 覆盖：
+ * - 创建自测并轮询到终态，返回分数/状态/输出
+ * - 自测不写入正式提交历史
+ * - 队列页展示自测条目（kind=self_test）
+ */
+
+import {
+  apiGet,
+  apiPost,
+  e2eTest,
+  getOrCreateUser,
+  getProblemIdByNumber,
+  isE2E,
+  TEST_PASSWORD,
+  waitForServer,
+} from "./helper.ts";
+
+const USER_KEY = "self_test_user";
+const ts = Date.now().toString(36);
+
+let token = "";
+let problemId = "";
+let selfTestId = "";
+let beforeSubmissionsTotal = 0;
+let beforeTodayStatsTotal = 0;
+
+async function pollSelfTest(
+  id: string,
+  timeoutMs = 90_000,
+): Promise<{ status: string; score: number; output: string | null }> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = await apiGet(`/api/v1/self-tests/${id}`, token);
+    if (res.status !== 200) {
+      throw new Error(
+        `查询自测失败: ${res.status} ${JSON.stringify(res.body)}`,
+      );
+    }
+    const data = (res.body as {
+      data: {
+        status: string;
+        score: number;
+        output: string | null;
+      };
+    }).data;
+    if (data.status === "finished" || data.status === "error") {
+      return data;
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`自测轮询超时: ${id}`);
+}
+
+e2eTest("[e2e/self-test] Setup", async () => {
+  if (!isE2E) return;
+  await waitForServer();
+  const user = await getOrCreateUser(
+    USER_KEY,
+    `self_test_${ts}`,
+    `self_test_${ts}@test.com`,
+    TEST_PASSWORD,
+  );
+  token = user.token;
+  problemId = await getProblemIdByNumber(1001);
+
+  // 记录自测前的正式提交总数与今日统计
+  const history = await apiGet("/api/v1/submissions", token);
+  const body = history.body as { pagination?: { total?: number } };
+  beforeSubmissionsTotal = body.pagination?.total ?? 0;
+
+  const stats = await apiGet("/api/v1/submissions/today-stats", token);
+  const statsBody = stats.body as { data?: { total?: number } };
+  beforeTodayStatsTotal = statsBody.data?.total ?? 0;
+});
+
+e2eTest("[e2e/self-test] 创建自测并返回 id", async () => {
+  if (!isE2E) return;
+  const res = await apiPost(
+    `/api/v1/problems/${problemId}/self-test`,
+    {
+      language: "python3",
+      code: `from noj_solution_sdk import register
+
+@register
+def solve(text: str) -> str:
+    return '{"gate_id":"E-07","status":"fault"}'
+`,
+    },
+    token,
+  );
+  if (res.status !== 201) {
+    throw new Error(`创建自测失败: ${res.status} ${JSON.stringify(res.body)}`);
+  }
+  const data = (res.body as { data: { id: string; status: string } }).data;
+  if (!data.id.startsWith("st_")) {
+    throw new Error(`自测 ID 应以 st_ 开头: ${data.id}`);
+  }
+  selfTestId = data.id;
+});
+
+e2eTest("[e2e/self-test] 轮询到终态并返回分数/状态/输出", async () => {
+  if (!isE2E) return;
+  const result = await pollSelfTest(selfTestId);
+  if (result.status !== "finished") {
+    throw new Error(`自测未正常完成: ${JSON.stringify(result)}`);
+  }
+  if (typeof result.score !== "number") {
+    throw new Error(`自测应返回分数: ${JSON.stringify(result)}`);
+  }
+  if (result.output === null) {
+    throw new Error(`自测应返回输出: ${JSON.stringify(result)}`);
+  }
+});
+
+e2eTest("[e2e/self-test] 自测后正式提交历史不变化", async () => {
+  if (!isE2E) return;
+  const history = await apiGet("/api/v1/submissions", token);
+  const body = history.body as { pagination?: { total?: number } };
+  const afterTotal = body.pagination?.total ?? 0;
+  if (afterTotal !== beforeSubmissionsTotal) {
+    throw new Error(
+      `自测不应影响提交历史: before=${beforeSubmissionsTotal} after=${afterTotal}`,
+    );
+  }
+
+  const stats = await apiGet("/api/v1/submissions/today-stats", token);
+  const statsBody = stats.body as { data?: { total?: number } };
+  const afterTodayStatsTotal = statsBody.data?.total ?? 0;
+  if (afterTodayStatsTotal !== beforeTodayStatsTotal) {
+    throw new Error(
+      `自测不应影响今日统计: before=${beforeTodayStatsTotal} after=${afterTodayStatsTotal}`,
+    );
+  }
+});
+
+e2eTest("[e2e/self-test] 队列概览展示自测条目", async () => {
+  if (!isE2E) return;
+  const res = await apiGet("/api/v1/queue", token);
+  if (res.status !== 200) {
+    throw new Error(`获取队列失败: ${res.status}`);
+  }
+  const body = res.body as {
+    recently_completed: Array<{ id: string; kind?: string }>;
+  };
+  const item = body.recently_completed.find((x) => x.id === selfTestId);
+  if (!item || item.kind !== "self_test") {
+    throw new Error(
+      `队列最近完成中应包含自测条目且 kind=self_test: ${
+        JSON.stringify(body.recently_completed)
+      }`,
+    );
+  }
+});

--- a/noj-tests/e2e/30_self_test.test.ts
+++ b/noj-tests/e2e/30_self_test.test.ts
@@ -143,14 +143,19 @@ e2eTest("[e2e/self-test] 队列概览展示自测条目", async () => {
     throw new Error(`获取队列失败: ${res.status}`);
   }
   const body = res.body as {
-    recently_completed: Array<{ id: string; kind?: string }>;
+    pending?: Array<{ id: string; kind?: string }>;
+    judging?: Array<{ id: string; kind?: string }>;
+    recently_completed?: Array<{ id: string; kind?: string }>;
   };
-  const item = body.recently_completed.find((x) => x.id === selfTestId);
+  const allItems = [
+    ...(body.pending ?? []),
+    ...(body.judging ?? []),
+    ...(body.recently_completed ?? []),
+  ];
+  const item = allItems.find((x) => x.id === selfTestId);
   if (!item || item.kind !== "self_test") {
     throw new Error(
-      `队列最近完成中应包含自测条目且 kind=self_test: ${
-        JSON.stringify(body.recently_completed)
-      }`,
+      `队列概览中应包含自测条目且 kind=self_test: ${JSON.stringify(allItems)}`,
     );
   }
 });

--- a/noj-tests/e2e/helper.ts
+++ b/noj-tests/e2e/helper.ts
@@ -9,17 +9,16 @@
  *   NOJ_RUN_E2E       - 设为 "1" 时启用 E2E 测试
  *   E2E_NO_CLEANUP    - 设为 "1" 时不自动清理容器（调试用）
  *   E2E_BASE_URL      - noj-core 服务地址（默认 http://localhost:8099）
- * */
+ */
 
 // ── 配置 ──────────────────────────────────────────
 
 export const isE2E = Deno.env.get("NOJ_RUN_E2E") === "1";
 export const BASE_URL = Deno.env.get("E2E_BASE_URL") || "http://localhost:8099";
 
-
 // ── API 客户端 ────────────────────────────────────
 
-export async function api(
+async function request(
   method: string,
   path: string,
   options?: {
@@ -51,6 +50,31 @@ export async function api(
   }
 
   return { status: res.status, body };
+}
+
+export async function api(
+  method: string,
+  path: string,
+  options?: {
+    body?: unknown;
+    token?: string;
+    headers?: Record<string, string>;
+  },
+): Promise<{ status: number; body: unknown }> {
+  const result = await request(method, path, options);
+  // E2E 并行分组下，admin token 可能刚被其他进程刷新而短暂失效；
+  // 若本次请求使用的正是缓存的 admin token 且返回 401，重置后重试一次。
+  if (
+    result.status === 401 &&
+    options?.token &&
+    _adminToken &&
+    options.token === _adminToken
+  ) {
+    _adminToken = null;
+    const freshToken = await getAdminToken();
+    return await request(method, path, { ...options, token: freshToken });
+  }
+  return result;
 }
 
 export function apiPost(path: string, body: unknown, token?: string) {
@@ -141,11 +165,21 @@ export async function getProblemIdByNumber(
   number: number,
   type = "P",
 ): Promise<string> {
-  const token = await getAdminToken();
-  const res = await apiGet(
+  let token = await getAdminToken();
+  let res = await apiGet(
     `/api/v1/problems?number=${number}&type=${type}&limit=1`,
     token,
   );
+  // 并发 E2E 分组下 admin token 可能刚被其他进程刷新而短暂失效；
+  // 重置缓存后重试一次。
+  if (res.status === 401) {
+    _adminToken = null;
+    token = await getAdminToken();
+    res = await apiGet(
+      `/api/v1/problems?number=${number}&type=${type}&limit=1`,
+      token,
+    );
+  }
   if (res.status !== 200) {
     throw new Error(
       `获取题目 ${type}${number} 失败: ${res.status} ${

--- a/noj-tests/e2e/trainings.test.ts
+++ b/noj-tests/e2e/trainings.test.ts
@@ -6,6 +6,7 @@ import {
   e2eTest,
   getAdminToken,
   getOrCreateUser,
+  getProblemIdByNumber,
   pollSubmission,
   submitCode,
 } from "./helper.ts";
@@ -23,6 +24,7 @@ e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", 
     `training_other_${Date.now().toString(36)}@test.com`,
   );
 
+  // 用 admin 创建 U 型题（普通用户设置 evaluator.command 已被 RBAC 拒绝）
   const problemRes = await apiPost(
     "/api/v1/problems",
     {
@@ -43,12 +45,13 @@ e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", 
         },
       },
     },
-    user.token,
+    adminToken,
   );
   if (problemRes.status !== 201) {
     throw new Error(`建题失败: ${JSON.stringify(problemRes.body)}`);
   }
   const problemId = (problemRes.body as { data: { id: string } }).data.id;
+  const sampleProblemId = await getProblemIdByNumber(1003);
 
   const created = await apiPost(
     "/api/v1/trainings",
@@ -60,13 +63,15 @@ e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", 
   }
   const trainingId = (created.body as { data: { id: string } }).data.id;
 
-  const added = await apiPost(
-    `/api/v1/trainings/${trainingId}/problems`,
-    { problem_id: problemId },
-    user.token,
-  );
-  if (added.status !== 201) {
-    throw new Error(`加题失败: ${JSON.stringify(added.body)}`);
+  for (const pid of [problemId, sampleProblemId]) {
+    const added = await apiPost(
+      `/api/v1/trainings/${trainingId}/problems`,
+      { problem_id: pid },
+      user.token,
+    );
+    if (added.status !== 201) {
+      throw new Error(`加题失败: ${JSON.stringify(added.body)}`);
+    }
   }
 
   const hidden = await apiGet(`/api/v1/trainings/${trainingId}`, other.token);
@@ -74,7 +79,18 @@ e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", 
     throw new Error(`私有题单应对他人 404: ${hidden.status}`);
   }
 
-  const subId = await submitCode(user.token, problemId, "print(1)");
+  // 用样例题 P1003（A+B）验证 AC 进度聚合
+  const subId = await submitCode(
+    user.token,
+    sampleProblemId,
+    `from noj_solution_sdk import register
+
+@register
+def solve(text: str) -> str:
+    a, b = map(int, text.strip().split())
+    return str(a + b)
+`,
+  );
   await pollSubmission(user.token, subId);
   const problems = await apiGet(
     `/api/v1/trainings/${trainingId}/problems`,
@@ -83,8 +99,11 @@ e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", 
   if (problems.status !== 200) {
     throw new Error(`取题单题目失败: ${problems.status}`);
   }
-  const problemsData = (problems.body as { data: { accepted: boolean }[] }).data;
-  if (!problemsData[0]?.accepted) {
+  const problemsData = (problems.body as {
+    data: Array<{ problem_id: string; accepted: boolean }>;
+  }).data;
+  const sample = problemsData.find((p) => p.problem_id === sampleProblemId);
+  if (!sample?.accepted) {
     throw new Error("AC 后进度应为 true");
   }
 
@@ -103,7 +122,7 @@ e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", 
     throw new Error("公开列表应包含该题单");
   }
 
-  const deleted = await apiDelete(`/api/v1/problems/${problemId}`, user.token);
+  const deleted = await apiDelete(`/api/v1/problems/${problemId}`, adminToken);
   if (deleted.status !== 204 && deleted.status !== 200) {
     throw new Error(`删题失败: ${deleted.status}`);
   }
@@ -111,8 +130,10 @@ e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", 
     `/api/v1/trainings/${trainingId}/problems`,
     user.token,
   );
-  const afterData = (afterDelete.body as { data: unknown[] }).data;
-  if (afterData.length !== 0) {
+  const afterData = (afterDelete.body as {
+    data: Array<{ problem_id: string }>;
+  }).data;
+  if (afterData.some((p) => p.problem_id === problemId)) {
     throw new Error("删除题目后题单关联应自动清理");
   }
 });

--- a/noj-ui/components/editor/ActivityBar.vue
+++ b/noj-ui/components/editor/ActivityBar.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
-type Tab = 'description' | 'history' | 'settings'
+type Tab = 'description' | 'history' | 'settings' | 'self-test'
 
-defineProps<{ active: Tab }>()
+const props = withDefaults(defineProps<{
+  active: Tab
+  showSelfTest?: boolean
+}>(), {
+  showSelfTest: false,
+})
 defineEmits<{ select: [value: Tab] }>()
 
 interface Item {
@@ -10,11 +15,14 @@ interface Item {
   icon: string
 }
 
-const items: Item[] = [
+const items = computed<Item[]>(() => [
   { key: 'description', label: '题目描述', icon: 'i-lucide-book-open' },
   { key: 'history', label: '提交历史', icon: 'i-lucide-history' },
+  ...(props.showSelfTest
+    ? [{ key: 'self-test' as const, label: '自测', icon: 'i-lucide-flask-conical' }]
+    : []),
   { key: 'settings', label: '设置', icon: 'i-lucide-settings' },
-]
+])
 </script>
 
 <template>

--- a/noj-ui/components/editor/EditorSidebar.vue
+++ b/noj-ui/components/editor/EditorSidebar.vue
@@ -3,8 +3,9 @@ import MarkdownRenderer from '~/components/shared/MarkdownRenderer.vue'
 import { getStatusColor, getStatusLabel } from '~/utils/submissionFormat'
 import type { EditorTheme } from '~/composables/useEditorTheme'
 import type { PolledSubmission } from '~/composables/useSubmissionPolling'
+import type { PolledSelfTest } from '~/composables/useSelfTestPolling'
 
-type Tab = 'description' | 'history' | 'settings'
+type Tab = 'description' | 'history' | 'settings' | 'self-test'
 
 interface Problem {
   id: string
@@ -37,15 +38,21 @@ interface Submission {
   } | null
 }
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   active: Tab
   problem: Problem
   submissions: Submission[]
   activeSubmission: PolledSubmission | null
   isPollingActive: boolean
+  selfTest: PolledSelfTest | null
+  isPollingSelfTest: boolean
+  selfTestError: string
+  showSelfTest?: boolean
   themeMode: EditorTheme
   draftEnabled: boolean
-}>()
+}>(), {
+  showSelfTest: false,
+})
 
 const emit = defineEmits<{
   'update:themeMode': [value: EditorTheme]
@@ -228,6 +235,56 @@ function formatElapsed(iso: string) {
           </div>
           <UIcon name="i-lucide-chevron-right" class="absolute right-2 top-3 text-text-muted opacity-0 group-hover:opacity-100 transition-opacity size-3.5" />
         </button>
+      </div>
+    </div>
+
+    <!-- 自测 tab -->
+    <div v-else-if="active === 'self-test' && showSelfTest" class="p-4 space-y-4">
+      <div class="flex items-center justify-between">
+        <h3 class="text-sm font-semibold text-text">自测</h3>
+        <UIcon name="i-lucide-loader-2" class="animate-spin text-primary size-3" v-if="isPollingSelfTest" />
+      </div>
+
+      <div v-if="selfTestError" class="text-xs text-red-600 bg-red-50 border border-red-200 rounded-md px-3 py-2">
+        {{ selfTestError }}
+      </div>
+
+      <div v-if="!selfTest && !isPollingSelfTest" class="text-xs text-text-muted text-center py-4 border border-dashed border-border rounded-md">
+        点击「自测」运行完整评测
+      </div>
+
+      <div v-if="selfTest" class="space-y-3">
+        <div class="flex items-center justify-between">
+          <span
+            class="inline-flex items-center gap-1 text-11px px-2 py-0.5 rounded font-semibold"
+            :style="{
+              background: getStatusColor(selfTest.status, selfTest.result_status) + '22',
+              color: getStatusColor(selfTest.status, selfTest.result_status),
+            }"
+          >
+            <UIcon name="i-lucide-loader-2" class="animate-spin size-[10px]" v-if="selfTest.status === 'pending' || selfTest.status === 'judging'" />
+            {{ getStatusLabel(selfTest.status, selfTest.result_status) }}
+          </span>
+          <span class="text-sm font-mono font-semibold text-text">
+            {{ selfTest.status === 'finished' ? `${formatScore(selfTest.score)} 分` : '—' }}
+          </span>
+        </div>
+
+        <div v-if="selfTest.status === 'finished' && (selfTest.time_ms || selfTest.memory_kb)" class="flex items-center gap-3 text-xs text-text-muted">
+          <span v-if="selfTest.time_ms" class="inline-flex items-center gap-1">
+            <UIcon name="i-lucide-timer" class="size-[11px]" />
+            {{ selfTest.time_ms }}ms
+          </span>
+          <span v-if="selfTest.memory_kb" class="inline-flex items-center gap-1">
+            <UIcon name="i-lucide-memory-stick" class="size-[11px]" />
+            {{ Math.round(selfTest.memory_kb / 1024) }}MB
+          </span>
+        </div>
+
+        <div v-if="selfTest.output" class="text-xs">
+          <div class="text-text-secondary mb-1 font-medium">输出</div>
+          <pre class="whitespace-pre-wrap break-words bg-bg-page border border-border rounded-md p-3 text-[11px] leading-relaxed max-h-72 overflow-y-auto">{{ selfTest.output }}</pre>
+        </div>
       </div>
     </div>
 

--- a/noj-ui/components/editor/EditorToolbar.vue
+++ b/noj-ui/components/editor/EditorToolbar.vue
@@ -21,6 +21,8 @@ const props = defineProps<{
   themeMode: EditorTheme
   canSubmit: boolean
   submitting: boolean
+  canSelfTest: boolean
+  selfTesting: boolean
   sidebarVisible: boolean
   draftState: DraftState
   draftSavedAt: Date | null
@@ -36,6 +38,7 @@ const emit = defineEmits<{
   'toggle-sidebar': []
   'open-settings': []
   submit: []
+  'self-test': []
   back: []
 }>()
 
@@ -157,6 +160,20 @@ const draftDotClass = computed(() => {
       >
         <UIcon name="i-lucide-settings" class="size-4" />
       </button>
+
+      <UButton
+        v-if="canSelfTest"
+        color="neutral"
+        variant="outline"
+        size="md"
+        class="ml-1 font-medium"
+        :disabled="!canSelfTest || selfTesting"
+        @click="emit('self-test')"
+      >
+        <UIcon name="i-lucide-loader-2" class="animate-spin size-3.5" v-if="selfTesting"/>
+        <UIcon name="i-lucide-flask-conical" class="size-3.5" v-else/>
+        <span>{{ selfTesting ? '自测中...' : '自测' }}</span>
+      </UButton>
 
       <UButton color="primary" size="md" class="ml-1 font-medium" :disabled="!canSubmit || submitting"
         @click="emit('submit')">

--- a/noj-ui/components/editor/EditorWorkspace.vue
+++ b/noj-ui/components/editor/EditorWorkspace.vue
@@ -5,6 +5,7 @@ import { extractApiError } from '~/utils/apiError'
 import { useEditorTheme } from '~/composables/useEditorTheme'
 import { useDraftStorage } from '~/composables/useDraftStorage'
 import { useSubmissionPolling } from '~/composables/useSubmissionPolling'
+import { useSelfTestPolling } from '~/composables/useSelfTestPolling'
 import { useResizableSplitter } from '~/composables/useResizableSplitter'
 
 /**
@@ -53,6 +54,11 @@ const props = withDefaults(
       language: string,
       code: string,
     ) => Promise<{ id: string }>
+    selfTest?: (
+      problemId: string,
+      language: string,
+      code: string,
+    ) => Promise<{ id: string }>
     templateUrl?: (problemId: string) => string
     draftKey: string
     openSubmissionUrl: (id: string) => string
@@ -68,6 +74,7 @@ const props = withDefaults(
     subtitle: '',
     canSubmit: true,
     submissionFilter: undefined,
+    selfTest: undefined,
   },
 )
 
@@ -92,7 +99,7 @@ const { state: draftState, savedAt: draftSavedAt, clear: clearDraft } = useDraft
 )
 
 // 侧栏
-const sidebarTab = ref<'description' | 'history' | 'settings'>('description')
+const sidebarTab = ref<'description' | 'history' | 'settings' | 'self-test'>('description')
 const sidebarVisible = ref(true)
 // 结构出 width 让它成为顶层 ref：v-model 模板用法依赖 Vue 顶层 setup 绑定
 // 的自动 unwrap，对象属性访问的 ref 不会被 unwrap，会报
@@ -106,6 +113,15 @@ const {
   isPolling: isPollingActive,
   start: startPolling,
 } = useSubmissionPolling(activeSubmissionId)
+
+// 自测轮询
+const activeSelfTestId = ref<string | null>(null)
+const {
+  selfTest: activeSelfTest,
+  isPolling: isPollingSelfTest,
+  error: selfTestPollError,
+  start: startSelfTestPolling,
+} = useSelfTestPolling(activeSelfTestId)
 
 // 提交终态为 Accepted 时通知调用方刷新题目详情（AC 后算法标签立即可见）
 watch(activeSubmission, (submission) => {
@@ -160,6 +176,38 @@ async function handleSubmit() {
     submitError.value = extractApiError(err).message
   } finally {
     submitting.value = false
+  }
+}
+
+// 自测
+const selfTesting = ref(false)
+const selfTestError = ref('')
+const selfTestDisplayError = computed(
+  () => selfTestError.value || selfTestPollError.value,
+)
+const hasSelfTest = computed(() => !!props.selfTest)
+const canSelfTest = computed(
+  () => hasSelfTest.value && isLoggedIn.value && code.value.trim().length > 0,
+)
+
+async function handleSelfTest() {
+  if (!props.problem || !props.selfTest) return
+  if (!canSelfTest.value) {
+    selfTestError.value = isLoggedIn.value ? '请先编写代码' : '请先登录'
+    return
+  }
+  selfTesting.value = true
+  selfTestError.value = ''
+  try {
+    const res = await props.selfTest(props.problem.id, language.value, code.value)
+    // 自动切到自测 Tab + 启动轮询
+    sidebarTab.value = 'self-test'
+    sidebarVisible.value = true
+    startSelfTestPolling(res.id)
+  } catch (err: unknown) {
+    selfTestError.value = extractApiError(err).message
+  } finally {
+    selfTesting.value = false
   }
 }
 
@@ -266,6 +314,8 @@ const toolbarProblem = computed(() => {
           :theme-mode="theme"
           :can-submit="canSubmit"
           :submitting="submitting"
+          :can-self-test="canSelfTest"
+          :self-testing="selfTesting"
           :sidebar-visible="sidebarVisible"
           :draft-state="draftState"
           :draft-saved-at="draftSavedAt"
@@ -276,6 +326,7 @@ const toolbarProblem = computed(() => {
           @open-settings="openSettings"
           @toggle-sidebar="sidebarVisible = !sidebarVisible"
           @submit="handleSubmit"
+          @self-test="handleSelfTest"
           @back="goBack"
         >
           <template #actions>
@@ -286,6 +337,7 @@ const toolbarProblem = computed(() => {
         <div class="flex-1 flex min-h-0">
           <ActivityBar
             :active="sidebarTab"
+            :show-self-test="hasSelfTest"
             @select="(v) => { sidebarTab = v; sidebarVisible = true }"
           />
 
@@ -298,6 +350,10 @@ const toolbarProblem = computed(() => {
                 :submissions="submissions"
                 :active-submission="activeSubmission"
                 :is-polling-active="isPollingActive"
+                :self-test="activeSelfTest"
+                :is-polling-self-test="isPollingSelfTest"
+                :self-test-error="selfTestDisplayError"
+                :show-self-test="hasSelfTest"
                 :theme-mode="theme"
                 :draft-enabled="draftEnabled"
                 @update:theme-mode="setTheme($event)"

--- a/noj-ui/components/feature/QueueRow.vue
+++ b/noj-ui/components/feature/QueueRow.vue
@@ -9,6 +9,7 @@ interface QueueItemShape {
   language: string
   submitted_by: string
   submitted_at: string
+  kind?: 'submission' | 'self_test'
   judge_started_at?: string | null
   status?: string
   score?: number | null
@@ -41,8 +42,13 @@ function elapsed(): string {
 
 <template>
   <div class="flex items-center gap-3 px-4 py-2.5 text-13px border-b border-border last:border-b-0 hover:bg-bg-page">
-    <NuxtLink :to="`/submissions/${item.id}`" class="text-blue-700 no-underline font-mono whitespace-nowrap min-w-[80px] hover:underline">#{{ item.id.slice(0, 8) }}</NuxtLink>
+    <NuxtLink v-if="item.kind !== 'self_test'" :to="`/submissions/${item.id}`" class="text-blue-700 no-underline font-mono whitespace-nowrap min-w-[80px] hover:underline">#{{ item.id.slice(0, 8) }}</NuxtLink>
+    <span v-else class="inline-flex items-center gap-1 font-mono whitespace-nowrap min-w-[80px] text-purple-700">
+      <UIcon name="i-lucide-flask-conical" class="size-3.5" />
+      #{{ item.id.slice(0, 8) }}
+    </span>
     <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-text">{{ item.problem_id }} {{ item.problem_title }}</span>
+    <span v-if="item.kind === 'self_test'" class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-purple-100 text-purple-700">自测</span>
     <span class="text-text-secondary min-w-[70px] text-center text-xs">{{ getLanguageLabel(item.language) }}</span>
     <span class="text-text-secondary min-w-[60px]">{{ item.submitted_by }}</span>
     <span class="text-text-muted text-xs min-w-[100px]">{{ formatDateTime(item.submitted_at) }}</span>

--- a/noj-ui/composables/useSelfTestPolling.ts
+++ b/noj-ui/composables/useSelfTestPolling.ts
@@ -1,0 +1,81 @@
+/**
+ * 单个自测的实时状态轮询 composable
+ *
+ * 与 useSubmissionPolling 类似，但走 /api/v1/self-tests/:id，
+ * 状态为 pending / judging / finished / error。
+ */
+import { extractApiError } from '~/utils/apiError';
+
+export type SelfTestStatus = 'pending' | 'judging' | 'finished' | 'error';
+
+export interface PolledSelfTest {
+  id: string;
+  status: SelfTestStatus;
+  result_status: string | null;
+  score: number;
+  language: string;
+  created_at: string;
+  time_ms?: number | null;
+  memory_kb?: number | null;
+  output?: string | null;
+  details?: Record<string, unknown> | null;
+}
+
+const TERMINAL_STATUSES: SelfTestStatus[] = ['finished', 'error'];
+const POLL_INTERVAL_MS = 1500;
+
+export function useSelfTestPolling(selfTestIdRef: Ref<string | null>) {
+  const selfTest = ref<PolledSelfTest | null>(null);
+  const isPolling = ref(false);
+  const error = ref<string | null>(null);
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function stop() {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+    isPolling.value = false;
+  }
+
+  async function fetchOnce() {
+    const id = selfTestIdRef.value;
+    if (!id) return;
+    try {
+      const res = await useApi().api.get<{ data: PolledSelfTest }>(
+        `/api/v1/self-tests/${id}`,
+        { silent: true },
+      );
+      selfTest.value = res.data;
+      error.value = null;
+      if (TERMINAL_STATUSES.includes(res.data.status)) {
+        stop();
+      }
+    } catch (e) {
+      error.value = extractApiError(e).message;
+      // 避免无限 spinner：轮询出错时停止，错误信息由页面展示
+      stop();
+    }
+  }
+
+  function start(id: string) {
+    stop();
+    selfTest.value = null;
+    error.value = null;
+    isPolling.value = true;
+    selfTestIdRef.value = id;
+    void fetchOnce();
+    timer = setInterval(fetchOnce, POLL_INTERVAL_MS);
+  }
+
+  onUnmounted(stop);
+
+  return {
+    selfTest,
+    isPolling,
+    error,
+    start,
+    stop,
+  };
+}

--- a/noj-ui/pages/editor/[id].vue
+++ b/noj-ui/pages/editor/[id].vue
@@ -112,6 +112,15 @@ function submit(pid: string, language: string, code: string) {
     .then((r) => r.data)
 }
 
+function selfTest(pid: string, language: string, code: string) {
+  return api
+    .post<{ data: { id: string } }>(`/api/v1/problems/${pid}/self-test`, {
+      language,
+      code,
+    })
+    .then((r) => r.data)
+}
+
 function submissionFilter(s: WorkspaceSubmission): boolean {
   if (!isContest.value) return true
   const p = data.value?.data as ContestProblem | undefined
@@ -173,6 +182,7 @@ const templateUrl = computed(() => isContest.value
     :retry="refresh"
     :history-url="historyUrl"
     :submit="submit"
+    :self-test="isContest ? undefined : selfTest"
     :template-url="templateUrl"
     :draft-key="draftKey"
     :open-submission-url="(id: string) => `/submissions/${id}`"

--- a/noj-ui/pages/queue.vue
+++ b/noj-ui/pages/queue.vue
@@ -7,6 +7,7 @@ interface QueueItem {
   language: string
   submitted_at: string
   submitted_by: string
+  kind?: 'submission' | 'self_test'
   judge_started_at?: string | null
   judge_finished_at?: string | null
   status?: string

--- a/openspec/changes/code-self-test/.openspec.yaml
+++ b/openspec/changes/code-self-test/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/code-self-test/design.md
+++ b/openspec/changes/code-self-test/design.md
@@ -1,0 +1,102 @@
+## Context
+
+NOJ 当前正式提交链路为：`POST /api/v1/submissions` → 写 `submissions` + `evaluationResults` → `pushJudgeTask` → noj-judge 双容器评测 → 结果消费者写回并更新统计/榜单/AC 活动。用户没有“不污染正式记录的先跑一次完整评测”的能力。
+
+Issue #221 要求支持代码自测：与正式评测走完全相同的评测路径（Evaluator + Solution + evaluate.py），但结果不计入正式评测记录。LMCC 场景下自测也需要看到分数，因此不采用 HydroOJ 的 run-only 模式。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 提供 `POST /api/v1/problems/:id/self-test` 与 `GET /api/v1/self-tests/:id`。
+- 自测结果独立存储在 `self_tests` 表，长期保留，不影响 `submissions` / `evaluationResults` / 统计 / 榜单 / AC 活动。
+- 复用现有评测队列与 noj-judge，**noj-judge 零改动**。
+- 前端编辑器提供“自测”按钮与侧栏“自测”Tab，通过轮询展示结果。
+- 队列页展示自测任务并标记。
+- 自测限流比正式提交更严格。
+
+**Non-Goals:**
+
+- 不做任意自定义输入/run-only 模式（第一版自测 = 完整评测）。
+- 不开放竞赛模式自测。
+- 不做自测历史列表页（数据长期保留，但 UI 第一版不提供）。
+- 不修改 noj-judge 的 MQ 协议、沙箱、评测逻辑。
+
+## Decisions
+
+### D1. 独立 `self_tests` 表，而非在 `submissions` 上加标记
+
+- **选择**：新增单表 `self_tests`，字段包含状态/分数/输出/详情/时间戳。
+- **理由**：与正式提交完全隔离，所有统计/榜单/AC 查询天然不受影响；避免在既有 `submissions` 查询中到处加 `is_self_test` 过滤。
+- **备选**：在 `submissions` 加 `kind` 或 `is_self_test` 列——会污染所有正式查询与索引，且历史语义不清。
+
+### D2. 自测 ID 使用 `st_` 前缀，消费者按前缀路由
+
+- **选择**：`self_tests.id = "st_" + uuid`，`JudgeTask.submission_id` 直接使用该 ID；`mq/consumer.ts` 检测 `submission_id.startsWith("st_")` 后调用 `saveSelfTestResult`。
+- **理由**：noj-judge 将 `submission_id` 视为不透明字符串，不需要改 Rust 代码；core 侧无需新增 MQ 队列或消息字段。
+- **备选**：新增 `JudgeTask.kind` 字段或独立结果队列——前者需要 judge 感知/透传，后者需要额外消费者或队列配置，均偏离“judge 零改动”。
+
+区分链路：
+
+1. **ID 生成时区分**：正式提交 `submission_id = crypto.randomUUID()`；自测 `self_test_id = "st_" + crypto.randomUUID()`。
+2. **评测队列 / noj-judge 层不区分**：`JudgeTask.submission_id` 与 `JudgeResult.submission_id` 对 judge 而言只是不透明字符串，原样透传，因此 judge 零改动。
+3. **core 消费者按前缀区分**：收到结果后，`submission_id.startsWith("st_")` 为真时走 `saveSelfTestResult`，否则走正式 `saveEvaluationResult`。
+4. **队列页按前缀区分**：从 Redis 队列拿到 ID 后，`st_` 开头查 `self_tests` 并标记 `kind: "self_test"`，否则查 `submissions` 并标记为正式提交。
+
+不引入 `JudgeTask.kind` 的原因：judge 结果里不会自动带回该字段，core 仍无法从结果区分；而 ID 前缀在创建、队列、结果、查询全链路天然可见，实现成本最低。
+
+### D3. 自测结果写回独立幂等逻辑
+
+- **选择**：`saveSelfTestResult` 只更新 `self_tests` 表，不做 `applyNewResult` / `refreshRankingsView` / `createActivity`；已终态的自测结果直接忽略。
+- **理由**：自测不参与任何正式统计；幂等处理避免重复结果覆盖。
+- **备选**：复用 `saveEvaluationResult` 加分支——耦合正式提交的状态机与统计副作用，风险高。
+
+### D4. 复用同一 Redis 队列，队列页展示自测条目
+
+- **选择**：自测任务 `pushJudgeTask` 到现有 `noj:judge:queue`；`services/queue.ts` 的 pending/judging 查询同时从 `self_tests` 解析 `st_` 开头的 ID，并给条目增加 `kind: "self_test"` 标记。
+- **理由**：不改 judge 队列消费；队列页计数一致，用户可看到自测排队。
+- **备选**：独立队列或队列页隐藏自测——前者需要额外 judge 实例/队列配置，后者会造成 `pending_count` 与展示不一致。
+
+### D5. 自测 API 与轮询
+
+- **选择**：`POST /api/v1/problems/:id/self-test` 返回 `201 { id, status: "judging", ... }`；前端轮询 `GET /api/v1/self-tests/:id`。
+- **理由**：与现有正式提交体验一致，避免同步长连接；实现简单可靠。
+- **备选**：SSE 推送——需要新增自测事件通道，第一版不必要。
+
+### D6. 自测限流独立且更严格
+
+- **选择**：在 `hardening-rate-limit.ts` 新增 `SELF_TEST_IP_LIMIT` / `SELF_TEST_USER_LIMIT`；默认每用户 60 秒窗口 4 次，IP 维度保留一个较宽的防滥用上限（如 60 秒 30 次），创建自测时 IP + 用户双维度限流。
+- **理由**：自测消耗评测容器资源但无正式记录，需要防滥用。
+- **备选**：复用正式提交限流——无法体现自测更高的资源成本。
+
+### D7. 自测 pending 恢复
+
+- **选择**：`mq/sweeper.ts` 增加 `recoverPendingSelfTests()`，扫描 `self_tests` 中超过 2 分钟的 pending，重新入队或标记 error。
+- **理由**：自测与正式任务共用队列，core 在“写表 → 入队”之间崩溃时不能留下永久 pending。
+- **备选**：不恢复——自测非关键，但会残留脏数据且用户看到永久 pending。
+
+### D8. 前端交互
+
+- **选择**：`EditorWorkspace` 增加 `selfTest` prop（仅普通题库传入）；工具栏增加“自测”按钮；侧栏新增“自测”Tab，展示状态/分数/输出。
+- **理由**：复用现有编辑器布局，改动最小；竞赛模式不传 prop 即隐藏。
+- **备选**：题目详情页加入口——第一版不做，避免扩大改动面。
+
+## Risks / Trade-offs
+
+- [自测与正式任务共用队列，自测可能挤占正式评测资源] → 独立限流 + 队列本身有长度上限；后续可考虑自测优先级/单独队列。
+- [`st_` 前缀依赖字符串约定] → 在 core 内定义为常量，并确保正式提交 ID 仍为 UUID；消费者按前缀路由有单测覆盖。
+- [队列页新增 `kind` 字段影响前端类型/展示] → 前端按 `kind === "self_test"` 显示“自测”标记，向后兼容缺省视为正式提交。
+- [自测表长期保留导致数据增长] → 已确认长期保留；后续如需要可增加清理任务，不阻塞本变更。
+- [自测结果页/队列页可能泄露他人自测] → `GET /self-tests/:id` 仅 owner/admin 可读；队列页只显示用户名/题目/ID 等非敏感信息。
+
+## Migration Plan
+
+1. `deno task db:generate` 生成 `self_tests` 表迁移；`deno task db:migrate` 应用。
+2. 发布 noj-core：新表、自测 service/route、消费者路由、sweeper、queue 展示、限流。
+3. 发布 noj-ui：编辑器自测按钮/Tab、轮询 composable。
+4. 发布 noj-tests：自测 E2E。
+5. 回滚策略：新表不影响现有功能；代码回滚后删除新迁移即可（未上线数据时）。
+
+## Open Questions
+
+无。

--- a/openspec/changes/code-self-test/proposal.md
+++ b/openspec/changes/code-self-test/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+LMCC 青少年组要求“运行已经写好的 Python 代码”，对标 HydroOJ 的自测（pretest）是刷题体验标配：提交前先验证代码能否通过完整评测。当前 NOJ 只有正式提交，用户无法在不污染评测历史/统计/榜单的前提下先跑一次完整评测。
+
+## What Changes
+
+- 新增“代码自测”能力：用户从编辑器发起自测，**与正式评测走完全相同的双容器评测流程**（Evaluator + Solution + evaluate.py），但结果**不计入正式提交记录、统计、榜单、AC 活动**。
+- 新增独立 `self_tests` 表（长期保留），与 `submissions` / `evaluationResults` 完全隔离。
+- 新增自测 API：
+  - `POST /api/v1/problems/:id/self-test` — 创建自测并推入评测队列
+  - `GET /api/v1/self-tests/:id` — 查询自测状态/分数/输出
+- 评测消费者通过自测 ID 前缀 `st_` 路由结果到 `saveSelfTestResult`，**noj-judge 层零改动**。
+- 前端编辑器新增“自测”按钮与侧栏“自测”Tab，展示状态/分数/输出，通过轮询获取结果。
+- 自测任务与正式任务共用 Redis 评测队列；队列页展示自测条目并标记为自测。
+- 新增独立更严格的自测限流（IP + 用户双维度，默认每用户 60s 4 次），防止滥用评测资源。
+- 第一版**不做任意自定义输入**，自测即完整评测；不开放竞赛模式。
+
+## Capabilities
+
+### New Capabilities
+
+- `code-self-test`: 代码自测的完整能力——独立数据模型、创建/查询 API、评测结果路由、前端自测交互、限流与队列可见性。
+
+### Modified Capabilities
+
+- `database-schema`: 新增 `self_tests` 表（用户/题目/语言/代码/状态/分数/输出/详情/时间戳）。
+- `queue-overview`: 队列概览 API 与页面需要展示自测任务，并标记条目类型为 `self_test`。
+
+## Impact
+
+- **noj-core**：新增 `src/db/schema.ts` 表定义与 Drizzle 迁移；新增 `src/services/self-tests.ts`、`src/routes/self-tests.ts`；修改 `src/mq/consumer.ts`（自测结果路由）、`src/mq/sweeper.ts`（自测 pending 恢复）、`src/services/queue.ts`（队列概览包含自测）、`src/lib/hardening-rate-limit.ts`（自测限流）、`src/app.ts`（挂载路由）。
+- **noj-ui**：修改 `EditorWorkspace` / `EditorToolbar` / `EditorSidebar`，新增自测按钮与自测结果 Tab；新增 `composables/useSelfTestPolling.ts`。
+- **noj-tests**：新增自测 E2E，覆盖“自测返回分数/状态/输出”和“自测后历史/统计/榜单不变”。
+- **API**：新增 `/api/v1/problems/:id/self-test` 与 `/api/v1/self-tests/:id`。
+- **依赖**：无新增外部依赖；noj-judge 无改动。

--- a/openspec/changes/code-self-test/specs/code-self-test/spec.md
+++ b/openspec/changes/code-self-test/specs/code-self-test/spec.md
@@ -1,0 +1,150 @@
+## ADDED Requirements
+
+### Requirement: 创建自测
+
+系统 SHALL 提供 `POST /api/v1/problems/:id/self-test` 端点，允许登录用户对编程题发起自测。
+
+请求体 MUST 包含 `language` 与 `code`，可选 `file_name`。校验规则 MUST 与正式提交一致：题目存在、语言受支持、`runtime_config` 存在、代码为字符串且长度不超过 100KB、评测镜像通过白名单校验。
+
+创建成功时系统 MUST 返回 `201` 和自测响应，包含 `id`（格式为 `st_<uuid>`）、`status`、`problem_id`、`language`、`code`、`file_name`、`created_at`；初始 `status` 为 `pending`，入队成功后为 `judging`。
+
+系统 MUST 在创建自测时执行自测专用限流（IP + 用户双维度），默认每用户 60 秒窗口最多 4 次，IP 维度保留较宽的防滥用上限。
+
+系统 MUST 仅允许普通题库场景发起自测；竞赛模式下不提供该端点或返回 403/404。
+
+#### Scenario: 登录用户创建自测
+
+- **WHEN** 登录用户 POST `/api/v1/problems/:id/self-test`，提供合法 `language` 和 `code`
+- **THEN** 系统创建 `self_tests` 记录并推入评测队列，返回 `201` 和自测 ID
+
+#### Scenario: 未登录创建自测被拒
+
+- **WHEN** 未登录用户 POST `/api/v1/problems/:id/self-test`
+- **THEN** 系统返回 `401`
+
+#### Scenario: 题目不存在
+
+- **WHEN** 用户 POST 不存在的题目 ID 的 self-test
+- **THEN** 系统返回 `404`
+
+#### Scenario: 语言不支持
+
+- **WHEN** 用户 POST 的 `language` 不在支持语言列表中
+- **THEN** 系统返回 `400`
+
+#### Scenario: 代码超长被拒
+
+- **WHEN** 用户 POST 的 `code` 长度超过 100KB
+- **THEN** 系统返回 `400`
+
+#### Scenario: 自测限流触发
+
+- **WHEN** 用户在限流窗口内发起超过阈值的自测请求
+- **THEN** 系统返回 `429`
+
+### Requirement: 查询自测结果
+
+系统 SHALL 提供 `GET /api/v1/self-tests/:id` 端点，允许自测 owner 或管理员查询自测状态与结果。
+
+响应 MUST 包含 `id`、`user_id`、`problem_id`、`language`、`code`、`file_name`、`status`、`result_status`、`score`、`output`、`details`、`time_ms`、`memory_kb`、`judge_started_at`、`judge_finished_at`、`created_at`。
+
+非 owner 且非 admin 访问 MUST 返回 `404`（不暴露自测存在）。
+
+#### Scenario: owner 查询自测结果
+
+- **WHEN** 自测 owner GET `/api/v1/self-tests/:id`
+- **THEN** 系统返回该自测的状态、分数、输出与详情
+
+#### Scenario: 非 owner 查询被拒
+
+- **WHEN** 非 owner 且非 admin 用户 GET `/api/v1/self-tests/:id`
+- **THEN** 系统返回 `404`
+
+#### Scenario: 自测不存在
+
+- **WHEN** 用户 GET 不存在的 `/api/v1/self-tests/:id`
+- **THEN** 系统返回 `404`
+
+### Requirement: 自测结果不计入正式记录
+
+自测结果 MUST NOT 写入 `submissions` 或 `evaluationResults` 表。
+
+自测完成 MUST NOT 影响：提交历史、今日/总提交统计、榜单、AC 活动/算法标签门控、竞赛排名。
+
+系统 SHOULD 将自测结果长期保留在 `self_tests` 表中。
+
+#### Scenario: 自测后提交历史不变
+
+- **WHEN** 用户完成一次自测后查询自己的提交历史
+- **THEN** 提交历史中不出现该自测记录
+
+#### Scenario: 自测后统计不变
+
+- **WHEN** 用户完成一次自测后查询今日/总提交统计
+- **THEN** 统计值与自测前一致
+
+#### Scenario: 自测后榜单不变
+
+- **WHEN** 用户完成一次自测后查询榜单
+- **THEN** 榜单不因该自测发生变化
+
+### Requirement: 自测结果路由与幂等写回
+
+评测结果消费者 MUST 根据 `submission_id` 前缀 `st_` 将结果路由到自测结果写回逻辑。
+
+自测结果写回 MUST 更新 `self_tests` 表的状态为 `finished` 或 `error`，并写入分数、输出、详情、耗时、内存、完成时间。
+
+自测结果写回 MUST 是幂等的：已处于终态的自测结果 MUST 被忽略。
+
+自测结果写回 MUST NOT 触发正式提交的统计缓存更新、榜单刷新或 AC 活动创建。
+
+#### Scenario: 自测结果正常写回
+
+- **WHEN** noj-judge 返回 `submission_id` 以 `st_` 开头的评测结果
+- **THEN** 系统将该结果写入 `self_tests` 表，不写入正式表
+
+#### Scenario: 重复自测结果被忽略
+
+- **WHEN** 消费者收到同一自测 ID 的重复终态结果
+- **THEN** 系统忽略重复结果，不覆盖已存在结果
+
+#### Scenario: 自测结果不触发 AC 活动
+
+- **WHEN** 自测结果为 Accepted
+- **THEN** 系统不创建 `first_accepted` 社区活动
+
+### Requirement: 自测前端交互
+
+编辑器页面 SHALL 在普通题库模式提供“自测”按钮。
+
+点击自测后，前端 SHALL 调用 `POST /api/v1/problems/:id/self-test`，并在收到自测 ID 后轮询 `GET /api/v1/self-tests/:id`，直到状态为 `finished` 或 `error`。
+
+编辑器侧栏 SHALL 提供“自测”Tab，展示自测状态、分数与输出（输出按 API 截断长度展示）。
+
+竞赛模式 MUST 不显示“自测”按钮。
+
+#### Scenario: 编辑器发起自测
+
+- **WHEN** 用户在普通题库编辑器点击“自测”
+- **THEN** 前端创建自测并轮询结果，侧栏展示状态/分数/输出
+
+#### Scenario: 竞赛模式不显示自测按钮
+
+- **WHEN** 用户进入竞赛模式编辑器
+- **THEN** 工具栏不显示“自测”按钮
+
+### Requirement: 自测队列可见性
+
+自测任务 MUST 与正式任务共用评测队列。
+
+队列概览 MUST 在 `pending`、`judging`、`recently_completed` 中包含自测条目，并标记 `kind: "self_test"`，使前端可以区分自测与正式提交。
+
+#### Scenario: 队列页展示自测条目
+
+- **WHEN** 队列中存在自测任务
+- **THEN** 队列概览返回该自测条目且 `kind` 为 `self_test`
+
+#### Scenario: 队列页展示正式提交条目
+
+- **WHEN** 队列中存在正式提交任务
+- **THEN** 队列概览返回该正式提交条目且 `kind` 为 `submission`（或兼容缺省）

--- a/openspec/changes/code-self-test/specs/database-schema/spec.md
+++ b/openspec/changes/code-self-test/specs/database-schema/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: 自测表（self_tests）
+
+系统 SHALL 提供 `self_tests` 表存储用户自测记录，与正式 `submissions` / `evaluationResults` 完全隔离。
+
+| 字段 | 类型 | 约束 | 说明 |
+|------|------|------|------|
+| id | TEXT | PRIMARY KEY | 格式 `st_<uuid>` |
+| user_id | TEXT | NOT NULL, FK → users.id | 发起自测的用户 |
+| problem_id | TEXT | NOT NULL, FK → problems.id | 自测题目 |
+| language | TEXT | NOT NULL | 编程语言标识 |
+| code | TEXT | NOT NULL | 源代码 |
+| file_name | TEXT | NULL | 用户文件名 |
+| status | TEXT | NOT NULL, DEFAULT 'pending' | pending / judging / finished / error |
+| result_status | TEXT | NULL | 评测结果状态（如 Accepted / WrongAnswer），未完成时为 NULL |
+| score | INTEGER | NOT NULL, DEFAULT 0 | 得分 ×100 |
+| output | TEXT | NOT NULL, DEFAULT '' | 评测输出 |
+| details | TEXT | NOT NULL, DEFAULT '{}' | JSON 详情 |
+| time_ms | INTEGER | NULL | 耗时（毫秒） |
+| memory_kb | INTEGER | NULL | 内存（KB） |
+| judge_started_at | TEXT | NULL | 开始评测时间 |
+| judge_finished_at | TEXT | NULL | 完成评测时间 |
+| created_at | TEXT | NOT NULL | ISO 8601 |
+
+系统 SHOULD 长期保留 `self_tests` 数据，不参与正式统计/榜单计算。
+
+#### Scenario: 创建自测记录
+
+- **WHEN** 用户发起自测
+- **THEN** `self_tests` 表新增一行，`id` 以 `st_` 开头，`status` 为 `pending`，`score` 为 0
+
+#### Scenario: 自测结果写回
+
+- **WHEN** 自测评测完成
+- **THEN** `self_tests` 行更新为 `finished`/`error`，并写入分数、输出、详情与完成时间
+
+#### Scenario: 自测不影响正式表
+
+- **WHEN** 自测记录写入或更新
+- **THEN** `submissions` 与 `evaluationResults` 表不发生任何变化

--- a/openspec/changes/code-self-test/specs/queue-overview/spec.md
+++ b/openspec/changes/code-self-test/specs/queue-overview/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: 队列概览展示自测任务
+
+系统 SHALL 在 `GET /api/v1/queue` 的 `pending`、`judging`、`recently_completed` 数组中展示自测任务，与正式提交共用同一队列。
+
+自测条目 MUST 包含与正式条目相同的字段，并额外包含 `kind: "self_test"`；正式条目 SHOULD 包含 `kind: "submission"`（兼容缺省时可省略，前端按 `kind === "self_test"` 判断自测）。
+
+`stats.pending_count` 与 `stats.judging_count` MUST 包含自测任务，保证计数与列表一致。
+
+#### Scenario: 队列中存在自测 pending 任务
+
+- **WHEN** 自测任务已入队且尚未被消费
+- **THEN** `GET /api/v1/queue` 的 `pending` 数组包含该自测条目，`kind` 为 `self_test`
+
+#### Scenario: 队列中存在自测 judging 任务
+
+- **WHEN** 自测任务正在评测
+- **THEN** `GET /api/v1/queue` 的 `judging` 数组包含该自测条目，`kind` 为 `self_test`
+
+#### Scenario: 队列中存在自测完成记录
+
+- **WHEN** 自测任务已完成
+- **THEN** `GET /api/v1/queue` 的 `recently_completed` 数组可能包含该自测条目，`kind` 为 `self_test`
+
+#### Scenario: 队列统计包含自测
+
+- **WHEN** 队列中同时存在正式提交与自测任务
+- **THEN** `stats.pending_count` 与 `stats.judging_count` 同时计入两者，数值与列表长度一致

--- a/openspec/changes/code-self-test/tasks.md
+++ b/openspec/changes/code-self-test/tasks.md
@@ -1,0 +1,55 @@
+## 1. 数据模型与类型
+
+- [x] 1.1 在 `noj-core/src/db/schema.ts` 新增 `self_tests` 表定义（字段见 database-schema spec，含 user_id/problem_id/created_at 索引）
+- [x] 1.2 运行 `deno task db:generate` 生成 Drizzle 迁移，并 `deno task db:migrate` 应用
+- [x] 1.3 新建 `noj-core/src/types/self-tests.ts`，定义 `SelfTestStatus`、`SelfTestInput`、`SelfTestResponse`、`SelfTestDetail`
+- [x] 1.4 定义自测 ID 前缀常量（如 `SELF_TEST_ID_PREFIX = "st_"`），并在正式提交 ID 生成处保持 UUID 不冲突
+
+## 2. 后端 Service
+
+- [x] 2.1 实现 `services/self-tests.ts` 的 `createSelfTest(userId, problemId, input)`：校验题目/语言/runtime_config/镜像，写入 `self_tests`，`pushJudgeTask` 后更新为 judging
+- [x] 2.2 实现 `getSelfTest(id, viewerId, viewerRole, c)`：仅 owner/admin 可读，output 按 8KB 截断，details 解析 JSON
+- [x] 2.3 实现 `saveSelfTestResult(result)`：幂等写回 `self_tests`，不触发统计/榜单/AC 活动
+- [x] 2.4 编写并跑通 `tests/services/self-tests.test.ts`（创建成功/题目不存在/语言不支持/队列失败/结果幂等/权限）
+
+## 3. 自测限流
+
+- [x] 3.1 在 `lib/hardening-rate-limit.ts` 新增 `SELF_TEST_IP_LIMIT` / `SELF_TEST_USER_LIMIT`（默认每用户 60s / 4 次；IP 维度保留较宽上限）
+- [x] 3.2 实现 `enforceSelfTestRateLimit(c, userId)` 并在创建自测路由调用
+- [x] 3.3 编写限流测试（超阈值返回 429，Redis 不可用 fail-closed）
+
+## 4. 后端 API 与路由
+
+- [x] 4.1 新建 `routes/self-tests.ts`：`POST /api/v1/problems/:id/self-test` 与 `GET /api/v1/self-tests/:id`
+- [x] 4.2 抽取/复用题目双索引解析 `resolveProblem`（当前位于 `routes/problems.ts` 内部），供自测路由使用
+- [x] 4.3 在 `app.ts` 挂载自测路由
+- [x] 4.4 编写并跑通 `tests/routes/self-tests.test.ts`（401/404/400/429/权限/正常创建与查询）
+
+## 5. MQ 消费者与 sweeper
+
+- [x] 5.1 修改 `mq/consumer.ts`：`submission_id` 以 `st_` 开头时调用 `saveSelfTestResult`，否则走正式 `saveEvaluationResult`
+- [x] 5.2 修改 `mq/sweeper.ts`：新增 `recoverPendingSelfTests()`，扫描 `self_tests` 中超过 2 分钟的 pending 重新入队或标记 error
+- [x] 5.3 编写消费者/sweeper 相关测试（前缀路由、重复结果幂等、pending 恢复）
+
+## 6. 队列概览
+
+- [x] 6.1 修改 `services/queue.ts`：pending/judging/recently_completed 同时从 `self_tests` 解析 `st_` 开头 ID，并返回 `kind`
+- [x] 6.2 更新 `GET /api/v1/queue` 相关测试：自测条目带 `kind: "self_test"`，统计包含自测
+- [x] 6.3 更新前端队列页类型与展示：`kind === "self_test"` 时显示“自测”标记
+
+## 7. 前端
+
+- [x] 7.1 新增 `composables/useSelfTestPolling.ts`（可参考 `useSubmissionPolling`）
+- [x] 7.2 修改 `EditorWorkspace`：新增 `selfTest` prop、自测状态与轮询逻辑、侧栏“自测”Tab
+- [x] 7.3 修改 `EditorToolbar`：新增“自测”按钮（仅传入 `selfTest` 时显示）
+- [x] 7.4 修改 `EditorSidebar`：新增“自测”Tab 内容（状态/分数/输出）
+- [x] 7.5 修改 `pages/editor/[id].vue`：普通题库传入 `selfTest`，竞赛模式不传
+- [x] 7.6 运行 `deno lint` / `deno fmt` / `nuxt build`
+
+## 8. E2E 与收尾
+
+- [x] 8.1 新建 `noj-tests/e2e/self-test.test.ts`：创建自测、轮询到终态、返回分数/状态/输出
+- [x] 8.2 E2E 断言自测后提交历史/统计/榜单/AC 活动不变化
+- [x] 8.3 E2E 断言队列页展示自测条目且标记正确
+- [x] 8.4 运行 noj-core 全量测试、noj-ui 构建、noj-tests 全量 E2E
+- [x] 8.5 确认 OpenSpec 变更（proposal/design/specs/tasks）齐全且可归档


### PR DESCRIPTION
## 关联 Issue

Closes #221

## 变更摘要

- 新增代码自测能力：用户可在编辑器发起自测，走与正式提交完全相同的双容器评测流程，但结果只写入独立 `self_tests` 表，不影响提交历史、统计、榜单与 AC 活动。
- noj-judge 零改动；通过 `st_` 前缀在 core 消费者侧路由自测结果。
- 前端新增“自测”按钮与侧栏“自测”Tab，队列页展示自测条目并标记 `kind: "self_test"`。
- 自测默认每用户 60s / 4 次限流。

## 变更类型

- [x] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [x] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

- [x] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [x] 数据库迁移（新建或修改 `drizzle/` 文件）
- [x] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [x] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）— 本次无 judge 改动
- [ ] 本地 `deno task test` 通过 — core 全量 832 passed / 2 failed（avatar S3 环境噪音，与本次无关）；相关自测/路由/消费者/队列测试 25 passed
- [x] 新功能 / 修复有对应测试
- [x] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [x] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 补充说明

- OpenSpec change：`openspec/changes/code-self-test/`
- noj-tests 全量 E2E 未在本机运行（需要完整评测栈）；已新增 `noj-tests/e2e/30_self_test.test.ts`
- 已知 core 全量测试中 `avatar` 两个用例失败与本 PR 无关，疑似 S3/MinIO 共享对象环境问题。