### PR TITLE
chore(root): 忽略 devtool 运行时 PID 与冗余 source-command-opsx wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,12 @@ docker-data/
 .jj/repo/op_heads/
 .jj/repo/store/
 
+# --- AI tool migration artifacts ---
+# `source-command-opsx-*` 是 opsx 命令的 source-command 包装 wrapper，
+# 与 `.agents/skills/openspec-*` 功能重复，迁移完成后应删除；
+# 在清理完成前临时忽略，防止误提交。
+.agents/skills/source-command-opsx-*/
+
 # --- Build Artifacts ---
 tmp/
 coverage/
@@ -67,6 +73,8 @@ noj-core/data/storage/
 
 # --- Dev tool locks (devtool.sh advisory locks for concurrent safety) ---
 scripts/dev/locks/
+# PID 文件由 `devtool.sh start` 启动模块时写入，用于模块存活追踪
+scripts/dev/logs/*.pid
 
 # --- IDE metadata (project-local, not shareable) ---
 *.iml


### PR DESCRIPTION
## 摘要

更新 `.gitignore` 防御性规则，并清理与本项目无关的 wrapper 与运行时文件：

| 类别 | 文件 | 处理 |
|------|------|------|
| 运行时产物 | `scripts/dev/logs/{core,judge,ui}.pid` | 物理删除（devtool.sh 启动时写入） |
| 冗余 wrapper | `.agents/skills/source-command-opsx-{apply,archive,explore,propose,sync}/` | 物理删除（与 `openspec-*` 功能重复） |
| 防御性兜底 | `.gitignore` | 忽略 `scripts/dev/logs/*.pid` 与 `.agents/skills/source-command-opsx-*/` |

## 背景

1. **source-command-opsx-*** 是 opsx 命令的 source-command 包装 wrapper，与 `.agents/skills/openspec-*` 功能完全重复，属于迁移中间产物。
2. **\*.pid 文件** 是 devtool.sh 启动模块时写入的运行时 PID，缺一个被遗忘的忽略规则。

## 变更详情

```
 .gitignore | 8 ++++++++
 1 file changed, 8 insertions(+)
```

## 关于 review skill 的说明（**不在本 PR 范围**）

> 原 PR 草稿曾包含 `review skill` 三处副本的删除（mattpocock/skills 引入），但 review skill 仍可能由部分工作流使用，**已从本 PR 移除**。
>
> review skill 当前保留在 `.agents/skills/`、`.claude/skills/`、`.opencode/skills/` 三处。如未来需要删除，请另开 PR 单独讨论。

## 测试

- [x] `git status` 干净，无遗留未跟踪文件（除本地暂存的 review skill 评估外）
- [x] GPG 签名验证：`Good signature from chenmou2012`（commit `5b9fb14f`）
- [x] `jj log` 父提交为 `66410d74 main`，符合 PR 工作流
- [ ] CI 待跑（PR 触发后）

## 备注

- 物理删除的 5 个 wrapper 目录与 3 个 PID 文件不再出现在 `git status` 中
- `.gitignore` 已加上两层兜底，未来即使重新生成也不会污染