### PR TITLE
fix(ui): 深色模式下彩色 solid 按钮文字改为白色以提高可读性

### DIFF
--- a/noj-ui/app.vue
+++ b/noj-ui/app.vue
@@ -64,7 +64,7 @@ useHead({ title: computed(() => resolvePageTitle(route.path)) })
     --c-success-text: #137333; --c-info-text: #1967d2; --c-warning-text: #92400e; --c-error-text: #b91c1c;
     --c-text: #1e293b; --c-text-secondary: #64748b; --c-text-muted: #64748b;
     --header-h: 64px;
-    --c-border: #e2e8f0; --c-bg-page: #f8fafc; --c-white: #ffffff;
+    --c-border: #e2e8f0; --c-bg-page: #f8fafc; --c-white: #ffffff; --c-text-on-color: #ffffff;
     /* 深色背景上的正文色（footer 等）：#64748b on #0f172a 仅 3.75:1，不达 WCAG AA 4.5:1 */
     --c-text-on-dark: #94a3b8;
 }

--- a/noj-ui/assets/css/main.css
+++ b/noj-ui/assets/css/main.css
@@ -288,7 +288,7 @@
  * ⚠️ 后期正式做深色模式（从根源修复按钮文字颜色，如在 Nuxt UI 主题
  * 覆盖中让 solid 彩色按钮在 dark 下使用对比色文字）后，本条补丁即
  * 冗余，应整体删除，避免与主题层重复设置。 */
-.dark button[data-slot="base"]:is(
+.dark [data-slot="base"]:is(
   [class~="bg-primary"],
   [class~="bg-secondary"],
   [class~="bg-success"],
@@ -296,5 +296,5 @@
   [class~="bg-warning"],
   [class~="bg-info"]
 ) {
-  color: #fff;
+  color: var(--c-white);
 }

--- a/noj-ui/assets/css/main.css
+++ b/noj-ui/assets/css/main.css
@@ -35,6 +35,7 @@
   --color-text-muted: var(--c-text-muted);
   --color-border: var(--c-border);
   --color-white: var(--c-white);
+  --color-text-on-color: var(--c-text-on-color);
   --color-bg-page: var(--c-bg-page);
   --color-bg-dark: var(--c-bg-dark);
   --color-bg-dark-2: var(--c-bg-dark-2);
@@ -280,15 +281,16 @@
  * 在 dark 模式为 --ui-color-neutral-900（深色）：这是为 bg-inverted
  * （dark 下白底）元素设计的反转色，用在彩色 solid 按钮上就变成
  * 「primary 蓝底 + 深字」，对比度不足。
- * 这里仅对 solid 彩色按钮（class 含独立 token bg-primary/bg-success 等）
- * 强制白字；[class~="..."] 精确匹配 token，避免误伤 outline 变体的
- * hover:bg-primary/10（无独立 bg-* token），也不影响 neutral solid
- * 按钮与 bg-inverted 元素。未包 @layer，优先级高于 utilities layer。
+ * 这里仅对 button/a 形态的 solid 彩色按钮（class 含独立 token
+ * bg-primary/bg-success 等）使用主题前景色；[class~="..."] 精确匹配 token，
+ * 避免误伤 outline 变体的 hover:bg-primary/10（无独立 bg-* token），也不影响
+ * neutral solid 按钮与其他使用 data-slot="base" 的组件。未包 @layer，优先级高于
+ * utilities layer。
  *
  * ⚠️ 后期正式做深色模式（从根源修复按钮文字颜色，如在 Nuxt UI 主题
  * 覆盖中让 solid 彩色按钮在 dark 下使用对比色文字）后，本条补丁即
  * 冗余，应整体删除，避免与主题层重复设置。 */
-.dark [data-slot="base"]:is(
+.dark :is(button, a)[data-slot="base"]:is(
   [class~="bg-primary"],
   [class~="bg-secondary"],
   [class~="bg-success"],
@@ -296,5 +298,5 @@
   [class~="bg-warning"],
   [class~="bg-info"]
 ) {
-  color: var(--c-white);
+  color: var(--color-text-on-color);
 }

--- a/noj-ui/assets/css/main.css
+++ b/noj-ui/assets/css/main.css
@@ -274,3 +274,27 @@
 [data-reka-popper-content-wrapper] {
   z-index: 50 !important;
 }
+
+/* ---- dark 模式下彩色 solid 按钮文字保持白色（可读性修复）----
+ * Nuxt UI 按钮 solid 变体文字用 text-inverted，而 --ui-text-inverted
+ * 在 dark 模式为 --ui-color-neutral-900（深色）：这是为 bg-inverted
+ * （dark 下白底）元素设计的反转色，用在彩色 solid 按钮上就变成
+ * 「primary 蓝底 + 深字」，对比度不足。
+ * 这里仅对 solid 彩色按钮（class 含独立 token bg-primary/bg-success 等）
+ * 强制白字；[class~="..."] 精确匹配 token，避免误伤 outline 变体的
+ * hover:bg-primary/10（无独立 bg-* token），也不影响 neutral solid
+ * 按钮与 bg-inverted 元素。未包 @layer，优先级高于 utilities layer。
+ *
+ * ⚠️ 后期正式做深色模式（从根源修复按钮文字颜色，如在 Nuxt UI 主题
+ * 覆盖中让 solid 彩色按钮在 dark 下使用对比色文字）后，本条补丁即
+ * 冗余，应整体删除，避免与主题层重复设置。 */
+.dark button[data-slot="base"]:is(
+  [class~="bg-primary"],
+  [class~="bg-secondary"],
+  [class~="bg-success"],
+  [class~="bg-error"],
+  [class~="bg-warning"],
+  [class~="bg-info"]
+) {
+  color: #fff;
+}


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->

- 深色模式下 Nuxt UI 彩色 solid 按钮文字为深色、对比度不足，新增 CSS 覆盖强制其使用白色文字，仅作用于 solid 彩色按钮，提升可读性，如果之后要做深色模式适配请注意这部分代码。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [x] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
---------------------------------------------------------------
更改前：
---------------------------------------------------------------

<img width="3840" height="2194" alt="截图 2026-08-23 06-10-48" src="https://github.com/user-attachments/assets/2ef0ad8b-8a56-4572-b35f-aa3fe324fa10" />
<img width="3840" height="2194" alt="截图 2026-08-23 06-10-42" src="https://github.com/user-attachments/assets/f05b1bf5-0ea7-4ab0-89f6-a9e129c35af6" />

---------------------------------------------------------------
更改后（截图不全，此改动影响了多数界面）：
---------------------------------------------------------------

<img width="3840" height="2194" alt="截图 2026-08-23 06-11-00
" src="https://github.com/user-attachments/assets/df78c9d8-ac85-4fb3-bdec-5f3588cefeb8" />
<img width="3840" height="2194" alt="截图 2026-08-23 06-11-07" src="https://github.com/user-attachments/assets/6aeab9a5-c09f-4388-a5ad-c892a1cf9c1b" />


<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
如果之后要做深色模式适配请注意这部分代码，本commit的改动由AI生成。