### PR TITLE
fix(ui): 通知空状态铃铛图标与文案同行居中对齐

### DIFF
--- a/noj-ui/pages/community/notifications.vue
+++ b/noj-ui/pages/community/notifications.vue
@@ -98,7 +98,7 @@ await load()
     </div>
     <p v-if="error" class="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">{{ error }}</p>
     <div v-else-if="loading" class="py-12 text-center text-text-secondary">加载中…</div>
-    <div v-else-if="notifications.length === 0" class="rounded-lg border border-dashed border-border p-10 text-center text-text-secondary"><UIcon name="i-lucide-bell" class="mx-auto mb-3 size-[28px]" />暂无通知。</div>
+    <div v-else-if="notifications.length === 0" class="rounded-lg border border-dashed border-border p-10 text-text-secondary flex items-center justify-center gap-2"><UIcon name="i-lucide-bell" class="size-[28px]" />暂无通知。</div>
     <div v-else class="space-y-3">
       <button
         v-for="item in notifications"


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->

- 通知空状态（暂无通知）的铃铛图标因 mx-auto 对 inline 元素不生效而未居中，改为 flex 布局使图标与文案同行对齐并整体居中。本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
修复前
<img width="1181" height="382" alt="截图 2026-08-23 06-51-47" src="https://github.com/user-attachments/assets/f2093a25-1764-4ba9-b696-8b1ceedef4aa" />
修复后
<img width="1181" height="382" alt="截图 2026-08-23 06-51-51" src="https://github.com/user-attachments/assets/3fc34572-47c0-49ef-aeee-13d222b22e25" />

<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）
本commit由AI生成。
<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
