### PR TITLE
fix(ui): 确认弹窗只保留一条分割线

### DIFF
--- a/noj-ui/components/ui/DialogModal.vue
+++ b/noj-ui/components/ui/DialogModal.vue
@@ -59,8 +59,8 @@ function onCancel() {
     :ui="{ content: 'bg-default flex flex-col divide-y-0 focus:outline-none', footer: 'flex justify-end gap-3' }"
     @after:leave="$emit('after:leave')"
   >
-    <template #body>
-      <UInput v-if="mode === 'prompt'" v-model="input" :placeholder="placeholder" class="mt-1" @keyup.enter="onConfirm" />
+    <template v-if="mode === 'prompt'" #body>
+      <UInput v-model="input" :placeholder="placeholder" class="mt-1" @keyup.enter="onConfirm" />
     </template>
 
     <template #footer>

--- a/noj-ui/components/ui/DialogModal.vue
+++ b/noj-ui/components/ui/DialogModal.vue
@@ -56,7 +56,7 @@ function onCancel() {
     v-model:open="open"
     :title="modalTitle"
     :description="message"
-    :ui="{ content: 'bg-default flex flex-col focus:outline-none', footer: 'flex justify-end gap-3' }"
+    :ui="{ content: 'bg-default flex flex-col divide-y-0 focus:outline-none', footer: 'flex justify-end gap-3' }"
     @after:leave="$emit('after:leave')"
   >
     <template #body>

--- a/noj-ui/components/ui/DialogModal.vue
+++ b/noj-ui/components/ui/DialogModal.vue
@@ -56,7 +56,7 @@ function onCancel() {
     v-model:open="open"
     :title="modalTitle"
     :description="message"
-    :ui="{ content: 'bg-default flex flex-col focus:outline-none', footer: 'flex justify-end gap-3 border-t border-default' }"
+    :ui="{ content: 'bg-default flex flex-col divide-y-0 focus:outline-none', footer: 'flex justify-end gap-3 border-t border-default' }"
     @after:leave="$emit('after:leave')"
   >
     <template v-if="mode === 'prompt'" #body>

--- a/noj-ui/components/ui/DialogModal.vue
+++ b/noj-ui/components/ui/DialogModal.vue
@@ -56,7 +56,7 @@ function onCancel() {
     v-model:open="open"
     :title="modalTitle"
     :description="message"
-    :ui="{ footer: 'flex justify-end gap-3' }"
+    :ui="{ content: 'bg-default flex flex-col focus:outline-none', footer: 'flex justify-end gap-3' }"
     @after:leave="$emit('after:leave')"
   >
     <template #body>

--- a/noj-ui/components/ui/DialogModal.vue
+++ b/noj-ui/components/ui/DialogModal.vue
@@ -56,7 +56,7 @@ function onCancel() {
     v-model:open="open"
     :title="modalTitle"
     :description="message"
-    :ui="{ content: 'bg-default flex flex-col divide-y-0 focus:outline-none', footer: 'flex justify-end gap-3' }"
+    :ui="{ content: 'bg-default flex flex-col focus:outline-none', footer: 'flex justify-end gap-3 border-t border-default' }"
     @after:leave="$emit('after:leave')"
   >
     <template v-if="mode === 'prompt'" #body>


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->

- 修复用户菜单「登出」确认弹窗的双分割线与中间空白：UModal 默认 divide-y 在 header/body/footer 间生成两条线，且空 body 仍占位渲染空白。移除多余线条与空白，仅保留按钮区上方一条分割线，弹窗层次更清晰。本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
修复前
<img width="778" height="430" alt="截图 2026-08-23 08-07-02" src="https://github.com/user-attachments/assets/c5689609-b2c5-4a98-a5d4-0786022984f0" />
修复后
<img width="778" height="430" alt="截图 2026-08-23 08-07-08" src="https://github.com/user-attachments/assets/ece52b49-cc06-4c70-8e6e-36e83f8feb6c" />

<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）
本commit由AI生成。
<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
