### PR TITLE
fix(ui): 修复用户主页未定义变量导致的 SSR 崩溃

### DIFF
--- a/noj-ui/pages/users/[id].vue
+++ b/noj-ui/pages/users/[id].vue
@@ -310,9 +310,9 @@ async function toggleFollow() {
             <div class="flex items-center gap-3">
               <span
                 class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
-                :class="badgeColors[problem.difficulty] || ''"
+                :class="difficultyBadgeColors[problem.difficulty] || ''"
               >
-                {{ difficultyLabel[problem.difficulty] || problem.difficulty }}
+                {{ difficultyLabels[problem.difficulty] || problem.difficulty }}
               </span>
               <span class="text-xs text-text-muted">{{ formatDate(problem.accepted_at) }}</span>
             </div>
@@ -346,9 +346,9 @@ async function toggleFollow() {
             <div class="flex items-center gap-3">
               <span
                 class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
-                :class="badgeColors[problem.difficulty] || ''"
+                :class="difficultyBadgeColors[problem.difficulty] || ''"
               >
-                {{ difficultyLabel[problem.difficulty] || problem.difficulty }}
+                {{ difficultyLabels[problem.difficulty] || problem.difficulty }}
               </span>
               <span class="text-xs text-text-muted">{{ formatDate(problem.created_at) }}</span>
             </div>


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->
- 用户主页 pages/users/[id].vue 的「已通过题目 / 创建的题目」列表 v-for 里有两个引用未定义变量的 bug：
1. badgeColors[problem.difficulty]（class 绑定，第 313/349 行）——页面 import 的是 difficultyBadgeColors，从未定义 badgeColors
2. difficultyLabel[problem.difficulty]（文本插值，第 315/351 行）——import 的是 difficultyLabels（复数），模板误用单数
当列表为空时不执行；一旦用户有已通过或创建的题目，SSR 渲染 v-for 时 undefined['medium'] 抛 TypeError: Cannot read properties of undefined (reading 'medium') → 500 报错页 → 刷新后空白页。
- 本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
更改前
<img width="3840" height="2194" alt="截图 2026-08-23 08-48-30" src="https://github.com/user-attachments/assets/f33706eb-2955-4150-b4ff-2894b8a52c7a" />

<img width="3840" height="2194" alt="截图 2026-08-23 08-56-44" src="https://github.com/user-attachments/assets/48aa53a9-9d48-4599-9c16-75e14cf9eb11" />
更改后
<img width="3840" height="2194" alt="截图 2026-08-23 08-56-17" src="https://github.com/user-attachments/assets/b8238aef-4a9c-44ac-882b-51fec14f9fc6" />



<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）
问题表现：刚注册时可以正常访问用户主页，使用一段时间后用户主页无法正常显示，显示空白页（如果这时清空缓存刷新会出现一次报错页面，然后再刷新又是空白页）

这个 bug 的复现是数据驱动的——代码里 badgeColors / difficultyLabel 两个未定义变量一直存在（旧版本至今未变），但只有当对应列表有数据时 v-for 才会执行并崩溃。

- 复现步骤

前提：一个满足以下任一条件的账号——

触发点 A：账号通过（AC）过至少一道题 → 用户主页「已通过题目」列表非空（第 313-315 行 v-for）
触发点 B：账号创建过至少一道 U 型题目 → 用户主页「创建的题目」列表非空（第 349-351 行 v-for）
（两者都是同一崩溃表达式，二选一即可触发）

- 操作：

登录该账号
访问该用户的个人主页 /users/{id}
SSR 渲染列表时执行 badgeColors[problem.difficulty]（class 绑定）或 difficultyLabel[problem.difficulty]（文本插值）——两个变量都未定义，undefined['medium'] 抛 TypeError: Cannot read properties of undefined (reading 'medium')
首次（清缓存）→ 500 报错页；再刷新 → 空白页

- 为什么"刚部署正常，后来崩"

刚部署时：账号还没有通过/创建的题目 → 两个列表为空 → v-for 不渲染 → badgeColors/difficultyLabel 永不求值 → 页面正常
用了一段时间后：只要 AC 过一道题或创建过一道 U 题 → 列表出现数据 → v-for 渲染 → 崩溃

- 为什么"任意用户主页都空白"

如果浏览的是他人主页：createdProblems 接口对非本人返回 403（空），但**「已通过题目」来自公开的 profile 接口**——只要对方 AC 过题，同样触发崩溃。所以只要有"有数据的用户"就崩，看起来像"任意用户主页都空白"。

- 本commit由AI生成。

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
