### PR TITLE
fix(root): 修复开发服务后台进程托管

### DIFF
--- a/openspec/changes/archive/2026-08-23-detach-dev-services/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-23-detach-dev-services/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-23
+skip_specs: true

--- a/openspec/changes/archive/2026-08-23-detach-dev-services/design.md
+++ b/openspec/changes/archive/2026-08-23-detach-dev-services/design.md
@@ -1,0 +1,50 @@
+## Context
+
+`scripts/dev/devtool.sh` 的 `spawn_target` 已在支持 `setsid` 的系统上创建独立会话，但 macOS 当前环境没有该命令，现有后备分支只使用 shell 后台运行。服务进程因此仍可能继承终端生命周期；PID 和日志文件格式已经被 `status`、`stop` 等命令使用，不能改变。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 让 macOS 和其他没有 `setsid` 的环境中的开发服务在启动命令返回后继续运行。
+- 让后台进程不依赖启动终端的标准输入。
+- 保持现有启动顺序、日志位置、PID 文件和停止流程兼容。
+
+**Non-Goals:**
+
+- 不引入新的外部依赖或系统服务管理器。
+- 不改变 core、ui、judge 的业务代码和运行参数。
+- 不改变 Docker 基础设施的生命周期管理。
+
+## Decisions
+
+### 使用 `nohup` 作为 `setsid` 的跨平台后备
+
+保留 Linux 等环境的 `setsid` 路径；当命令不可用时使用系统自带的 `nohup`。`nohup` 是 macOS 和常见 Unix 环境的基础命令，能够忽略终端关闭时的 `SIGHUP`，比直接后台运行更适合当前脚本的轻量守护需求。
+
+替代方案是强制依赖 `setsid` 或引入 `daemonize` 等第三方工具，但会降低 macOS 可用性或增加安装前置条件。
+
+### 所有后台路径统一重定向标准输入
+
+将标准输入重定向到 `/dev/null`，标准输出和标准错误继续追加到对应日志文件。这样服务不会持有已关闭的终端管道，也不会在终端退出后等待交互输入。
+
+### 保持现有 PID 语义
+
+继续使用 `$!` 写入 `scripts/dev/logs/<target>.pid`。`nohup` 和 `setsid` 都只作为启动包装，实际服务命令和现有状态/停止逻辑不变。
+
+### 避免 `pipefail` 下的状态检测误判
+
+将 Docker 服务状态判断中的 `grep -qE` 改为完整消费输入后再丢弃匹配结果。这样不会因 `grep -q` 提前退出导致上游 `docker compose` 收到 SIGPIPE，从而保证启动、停止和状态命令得到真实的基础设施状态。
+
+## Risks / Trade-offs
+
+- [Risk] `nohup` 只能保证忽略 `SIGHUP`，不能替代完整的系统级服务管理。→ 本变更只面向本地开发，并用端口/健康检查确认启动结果。
+- [Risk] 进程异常退出时可能留下旧 PID 文件。→ 现有 `read_pid` 会验证 PID 存活，后续启动会覆盖陈旧 PID 文件；本次不改变该机制。
+- [Risk] Docker CLI 输出格式在未来版本变化可能影响文本匹配。→ 保持现有服务名匹配规则，仅修复管道退出状态，不扩大匹配范围。
+
+## Migration Plan
+
+1. 修改 `spawn_target` 的后备启动分支，并为 `setsid` 分支补充标准输入重定向。
+2. 使用脚本语法检查和 `devtool.sh start` 验证服务在启动命令结束后仍存活。
+3. 用 `devtool.sh status`、8000 健康检查和 3000 端口检查确认运行状态。
+4. 如需回滚，恢复 `scripts/dev/devtool.sh` 的单个函数即可，不涉及数据迁移。

--- a/openspec/changes/archive/2026-08-23-detach-dev-services/proposal.md
+++ b/openspec/changes/archive/2026-08-23-detach-dev-services/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+在 macOS 上通常没有 `setsid`，`devtool.sh` 的后台启动逻辑会退化为普通后台进程。启动命令结束或终端会话关闭后，noj-core、noj-ui 和 noj-judge 可能收到会话结束信号并退出，导致服务看似启动成功但无法持续运行。
+
+## What Changes
+
+- 为开发服务启动增加跨平台的 `nohup` 后备方案。
+- 启动后台进程时将标准输入重定向到 `/dev/null`，并继续将标准输出和错误输出写入现有日志文件。
+- 修正 `pipefail` 与 `grep -q` 组合导致的 Docker 基础设施状态误判。
+- 保持现有 PID 文件、状态检查、停止命令和 Linux `setsid` 路径不变。
+
+## Capabilities
+
+### New Capabilities
+
+不适用：这是纯本地开发工具修复，不引入业务能力或运行时 API。
+
+### Modified Capabilities
+
+不适用：不改变产品需求或服务端运行时协议。
+
+## Impact
+
+- 受影响文件：`scripts/dev/devtool.sh`。
+- 影响本地开发服务的生命周期管理；不修改生产代码、数据库、API 或第三方依赖。
+- 需要验证启动脚本语法，以及服务在启动命令返回后仍保持运行。

--- a/openspec/changes/archive/2026-08-23-detach-dev-services/tasks.md
+++ b/openspec/changes/archive/2026-08-23-detach-dev-services/tasks.md
@@ -1,0 +1,9 @@
+## 1. 后台进程托管
+
+- [x] 1.1 修改 `scripts/dev/devtool.sh` 的 `spawn_target`，在没有 `setsid` 时使用 `nohup`，并在所有后台启动路径将标准输入重定向到 `/dev/null`；同时修正 `pipefail` 下 Docker 状态检测的 `grep -q` 误判；通过 `bash -n scripts/dev/devtool.sh` 验证脚本语法。
+- [x] 1.2 保持现有 PID 文件、日志重定向和停止流程不变；通过 `devtool.sh start` 后命令返回仍能读取存活 PID，且 `devtool.sh status` 显示 core/ui/judge 运行。
+
+## 2. 启动验证
+
+- [x] 2.1 启动全部开发模块并验证 core `/health` 返回 healthy、ui 端口 3000 可访问、judge 进程仍存活；记录 `devtool.sh status` 结果。
+- [x] 2.2 使用 OpenSpec 严格校验 `detach-dev-services`，并运行 `git diff --check` 确认变更无格式问题。

--- a/scripts/dev/devtool.sh
+++ b/scripts/dev/devtool.sh
@@ -492,9 +492,12 @@ spawn_target() {
 
   # setsid 启动新进程组（部分内核支持，便于后续杀整组）
   if command -v setsid >/dev/null 2>&1; then
-    setsid "$@" >>"$log_file" 2>&1 &
+    setsid "$@" >>"$log_file" 2>&1 </dev/null &
+  elif command -v nohup >/dev/null 2>&1; then
+    # macOS 默认没有 setsid，使用 POSIX nohup 脱离终端会话。
+    nohup "$@" >>"$log_file" 2>&1 </dev/null &
   else
-    "$@" >>"$log_file" 2>&1 &
+    fail "未找到 setsid 或 nohup，无法将 $target 脱离终端启动"
   fi
   local pid=$!
   echo "$pid" >"$pid_file"
@@ -508,7 +511,7 @@ start_infra() {
   fi
 
   # 已运行则跳过
-  if docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -qE 'postgres|redis'; then
+  if docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -E 'postgres|redis' >/dev/null 2>&1; then
     ok "基础设施已在运行"
     return 0
   fi
@@ -567,7 +570,7 @@ start_core() {
   if ! command -v docker >/dev/null 2>&1; then
     fail "未检测到 docker"
   fi
-  if ! docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -qE 'postgres|redis'; then
+  if ! docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -E 'postgres|redis' >/dev/null 2>&1; then
     warn "基础设施未运行，建议先运行: devtool.sh start infra"
   fi
 
@@ -807,7 +810,7 @@ stop_infra() {
     warn "docker 命令不可用，跳过 infra 停止"
     return 0
   fi
-  if ! docker compose -f "$COMPOSE_FILE" ps 2>/dev/null | grep -qE 'postgres|redis'; then
+  if ! docker compose -f "$COMPOSE_FILE" ps 2>/dev/null | grep -E 'postgres|redis' >/dev/null 2>&1; then
     echo "基础设施未运行"
     return 0
   fi
@@ -923,7 +926,7 @@ status_human_line() {
 status_human() {
   echo "━━━ 基础设施 ━━━"
   if command -v docker >/dev/null 2>&1; then
-    if docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -qE 'postgres|redis'; then
+    if docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -E 'postgres|redis' >/dev/null 2>&1; then
       (cd "$REPO_ROOT" && docker compose -f "$COMPOSE_FILE" ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null) \
         | grep -E 'postgres|redis|NAME' || true
     else
@@ -979,7 +982,7 @@ status_json_module() {
 status_json() {
   local infra_running="false"
   if command -v docker >/dev/null 2>&1 \
-     && docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -qE 'postgres|redis'; then
+     && docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -E 'postgres|redis' >/dev/null 2>&1; then
     infra_running="true"
   fi
 


### PR DESCRIPTION
## 摘要

- macOS 没有 `setsid` 时使用 `nohup` 脱离终端，并将标准输入重定向到 `/dev/null`。
- 修复 `pipefail` 与 `grep -q` 组合导致 PostgreSQL/Redis 状态误判的问题。
- 保留现有 PID、日志、停止流程，并归档对应 OpenSpec 变更。

## 验证

- `bash -n scripts/dev/devtool.sh`
- `devtool.sh status` 显示 PostgreSQL、Redis、core、ui、judge 均运行。
- core `/health` 返回 `healthy`，UI 返回 HTTP 200。
- OpenSpec 严格校验和变更检查通过。

提交已使用 GPG 密钥 `399F0FEBDBCF0C71` 签名。