### PR TITLE
fix(ui): 竞赛页 Tab 默认展开详情并修复需点两次切换

### DIFF
--- a/noj-ui/pages/contests/[contestId]/index.vue
+++ b/noj-ui/pages/contests/[contestId]/index.vue
@@ -52,10 +52,10 @@ watch(() => route.query.tab, (value) => {
 })
 
 const tabItems = [
-  { label: '详情', icon: 'i-lucide-info', slot: 'detail' },
-  { label: '题目', icon: 'i-lucide-list-checks', slot: 'problems' },
-  { label: '答疑', icon: 'i-lucide-message-circle-question', slot: 'clarifications' },
-  { label: '排名', icon: 'i-lucide-trophy', slot: 'ranking' },
+  { value: 0, label: '详情', icon: 'i-lucide-info', slot: 'detail' },
+  { value: 1, label: '题目', icon: 'i-lucide-list-checks', slot: 'problems' },
+  { value: 2, label: '答疑', icon: 'i-lucide-message-circle-question', slot: 'clarifications' },
+  { value: 3, label: '排名', icon: 'i-lucide-trophy', slot: 'ranking' },
 ]
 
 const countdown = computed(() => {


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->
- 竞赛页 Tab（详情/题目/答疑/排名）初始无选中、需点两次才展开，根因是 UTabs trigger value（无 value 字段时为字符串索引）与 activeTab（数字）类型不匹配；为 tabItems 补充数字 value 后默认展开详情、一次点击即切换。
- 本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
更改前
<img width="3840" height="2194" alt="截图 2026-08-23 14-36-48" src="https://github.com/user-attachments/assets/4eff08f0-55fe-4672-bf45-c295f52bf4ef" />
更改后
<img width="3840" height="2194" alt="截图 2026-08-23 14-23-11" src="https://github.com/user-attachments/assets/42252ccf-89ae-485f-ad1e-0c65151f44f9" />



<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）
**根因**

UTabs 的 trigger value 在 item 无 value 字段时为 String(index)（字符串 "0"、"1"…），而页面传入的 activeTab = ref(0) 是数字——reka-ui 严格匹配失败：

初始：数字 0 ≠ 字符串 "0" → 无任何 tab 被选中 → 详情不展开（"不是默认展开"）
第一次点击：URL 已同步（?tab=problems）但页面重渲染后 activeTab 恢复数字 → 仍不匹配 → 需再点一次才展开
- 本commit由AI生成。

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
