### PR TITLE
fix(ui): 社区通知页用户名与通知文本垂直居中

### DIFF
--- a/noj-ui/pages/community/notifications.vue
+++ b/noj-ui/pages/community/notifications.vue
@@ -113,7 +113,7 @@ await load()
             <UIcon :name="typeIcon[item.notification.type]" class="size-3.5" />
           </span>
           <div class="min-w-0 flex-1">
-            <p class="text-sm text-text"><template v-if="item.actor"><UserIdentity :user="item.actor" size="sm" /></template><template v-else><strong>系统</strong></template>{{ typeLabel[item.notification.type] }}</p>
+            <p class="text-sm text-text flex items-center gap-1"><template v-if="item.actor"><UserIdentity :user="item.actor" size="sm" /></template><template v-else><strong>系统</strong></template>{{ typeLabel[item.notification.type] }}</p>
             <p v-if="item.notification.data.reason" class="mt-1 text-xs text-text-secondary">{{ item.notification.data.reason }}</p>
             <NuxtTime class="mt-1 block text-xs text-text-muted" :datetime="item.notification.created_at" relative locale="zh-CN" />
           </div>


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->
- 修复问题，社区通知界面的通知用户名不是居中
- 本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
更改前
<img width="3840" height="2194" alt="截图 2026-08-23 15-57-46" src="https://github.com/user-attachments/assets/79c045b6-575d-4635-8f9e-701c90fd5c9e" />

更改后
<img width="3840" height="2194" alt="截图 2026-08-23 15-56-30" src="https://github.com/user-attachments/assets/08633479-05e1-46cd-bfde-85f0216a1e8a" />




<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）
**根因**

notifications.vue 第 116 行的通知项文本 <p> 里，UserIdentity（inline-flex：头像+用户名）与后面的 typeLabel 文本按基线对齐混排——UserIdentity 的头像（24px）和用户名与旁边文字不在同一条垂直线上，看起来用户名不居中。
- 本commit由AI生成。

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
