### PR TITLE
fix(ui): 社区收藏空状态图标与文案同行居中

### DIFF
--- a/noj-ui/pages/community/bookmarks.vue
+++ b/noj-ui/pages/community/bookmarks.vue
@@ -84,8 +84,8 @@ await loadBookmarks()
 
     <p v-if="error" class="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">{{ error }}</p>
     <div v-else-if="loading" class="py-12 text-center text-text-secondary">加载中…</div>
-    <div v-else-if="bookmarks.length === 0" class="rounded-lg border border-dashed border-border p-10 text-center text-text-secondary">
-      <UIcon name="i-lucide-bookmark" class="mx-auto mb-3 text-text-secondary size-[28px]" />
+    <div v-else-if="bookmarks.length === 0" class="rounded-lg border border-dashed border-border p-10 text-text-secondary flex items-center justify-center gap-2">
+      <UIcon name="i-lucide-bookmark" class="text-text-secondary size-[28px]" />
       还没有可展示的收藏内容。
     </div>
     <div v-else class="space-y-4">


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->
- 修复社区收藏空状态图标与文案同行不居中的问题
- 本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
更改前
<img width="3840" height="2194" alt="截图 2026-08-23 16-11-01" src="https://github.com/user-attachments/assets/520e792a-e6ea-4ed8-8841-7fc783eacb09" />

更改后
<img width="3840" height="2194" alt="截图 2026-08-23 16-10-04" src="https://github.com/user-attachments/assets/0523759c-f534-4c50-b38a-3975415debf7" />




<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）
**根因**

bookmarks.vue 空状态（"还没有可展示的收藏内容"）与之前通知页空状态同样的问题——图标用 mx-auto mb-3，但 UIcon 是 inline 元素，mx-auto 对 inline 不生效（mb-3 垂直 margin 也不生效），图标不居中且与文本同行错位。

**修复**

容器改为 flex items-center justify-center gap-2（图标在文本左边、垂直居中、整体居中），图标去掉 mx-auto mb-3——与通知页空状态最终形态一致：


- 本commit由AI生成。

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
