### PR TITLE
fix(core,ui): 修复 #311-#319 系列 UI/核心问题

### DIFF
--- a/noj-core/src/lib/errors.ts
+++ b/noj-core/src/lib/errors.ts
@@ -51,8 +51,8 @@ export class ConflictError extends AppError {
  * 用于认证失败场景（如密码错误、令牌无效）。
  */
 export class UnauthorizedError extends AppError {
-  constructor(message: string) {
-    super(message, 401, "UNAUTHORIZED");
+  constructor(message: string, code?: string) {
+    super(message, 401, code ?? "UNAUTHORIZED");
     this.name = "UnauthorizedError";
   }
 }

--- a/noj-core/src/services/auth/auth-login.ts
+++ b/noj-core/src/services/auth/auth-login.ts
@@ -137,7 +137,7 @@ export async function loginUser(
         "auth.login_failure",
         { reason: "wrong_tfa_code", login: input.login },
       );
-      throw new UnauthorizedError("用户名或密码错误");
+      throw new UnauthorizedError("验证码输入错误", "TFA_INVALID");
     }
   }
 

--- a/noj-core/tests/services/auth_tfa.test.ts
+++ b/noj-core/tests/services/auth_tfa.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import { assertEquals } from "jsr:@std/assert@^1";
 import { eq } from "drizzle-orm";
 import { TOTP } from "otpauth";
 import { getDb, resetDbForTest } from "../../src/db/connection.ts";
@@ -77,15 +77,19 @@ Deno.test({
     const userRows = await getDb().select().from(users).where(
       eq(users.id, userId),
     );
-    await assertRejects(
-      () =>
-        loginUser({
-          login: userRows[0].username,
-          password: "TestPwd-2024-Xy9",
-          code: "000000",
-        }),
-      UnauthorizedError,
-    );
+    let caught: { code?: string } | null = null;
+    try {
+      await loginUser({
+        login: userRows[0].username,
+        password: "TestPwd-2024-Xy9",
+        code: "000000",
+      });
+    } catch (err) {
+      caught = err as { code?: string };
+    }
+    assertEquals(caught instanceof UnauthorizedError, true);
+    // issue #316：错误验证码应返回可区分的 TFA_INVALID，而不是“用户名或密码错误”
+    assertEquals(caught?.code, "TFA_INVALID");
   },
 });
 

--- a/noj-ui/components/feature/training/AddToTrainingMenu.vue
+++ b/noj-ui/components/feature/training/AddToTrainingMenu.vue
@@ -72,14 +72,13 @@ async function createAndAdd() {
       <template #body>
         <div class="space-y-3 p-4">
         <div class="space-y-2">
-          <label
-            v-for="training in mineTrainings"
-            :key="training.id"
-            class="flex items-center gap-2 text-sm"
-          >
-            <UCheckbox v-model="selected" :value="training.id" />
-            {{ training.title }}
-          </label>
+          <!-- issue #311：必须用 UCheckboxGroup 才能让 v-model 作为多选数组，
+               单独使用 UCheckbox v-model="selected" 会被 Reka 当成布尔值切换，
+               导致“选择一个题单后全部勾选/按钮状态异常”。 -->
+          <UCheckboxGroup
+            v-model="selected"
+            :items="mineTrainings.map((t) => ({ label: t.title, value: t.id }))"
+          />
           <p v-if="mineTrainings.length === 0" class="text-sm text-text-secondary">
             你还没有题单，可以新建一个。
           </p>

--- a/noj-ui/components/layout/Navbar.vue
+++ b/noj-ui/components/layout/Navbar.vue
@@ -131,8 +131,13 @@ function measureAndFit() {
   const nav = navRef.value
   if (!nav || typeof window === 'undefined') return
   const links = Array.from(nav.querySelectorAll<HTMLElement>(':scope > a'))
-  // 首次测量所有链接宽度（仅首次全部可见时能拿到真实宽度；之后隐藏项不再测量）
-  if (itemWidths.value.length !== links.length) {
+  // 只在全部导航项都处于 DOM 中时重测宽度；一旦有项被收进“更多”，
+  // 隐藏项已从 DOM 移除，不能再用当前可见链接数覆盖完整宽度数组，
+  // 否则窗口重新拉大后“更多”中的项永远无法展开（issue #319）。
+  if (
+    visibleCount.value === navItems.value.length &&
+    links.length === navItems.value.length
+  ) {
     itemWidths.value = links.map((a) => a.getBoundingClientRect().width + 4) // gap-1 = 4px
   }
   const containerWidth = nav.clientWidth

--- a/noj-ui/components/objective/ObjectiveProblemEditor.vue
+++ b/noj-ui/components/objective/ObjectiveProblemEditor.vue
@@ -185,6 +185,8 @@ function isAnswer(key: string) {
   if (!editing.value) return false
   const arr = editing.value.answer
   if (editing.value.type === 'judge') return arr.includes(key === 'true')
+  // 单选只允许一个答案被勾选；避免从多选/判断切换后旧答案导致多个 radio 同时高亮
+  if (editing.value.type === 'single') return arr.length === 1 && arr[0] === key
   return arr.includes(key)
 }
 
@@ -210,6 +212,11 @@ async function onSaveQuestion() {
     }
     if (e.answer.length === 0) {
       toast.error('请选择正确答案')
+      return
+    }
+    // 单选只允许一个答案；多选/判断切换残留的旧答案会在保存前被拦截
+    if (e.type === 'single' && e.answer.length !== 1) {
+      toast.error('单选题请只选择一个正确答案')
       return
     }
     payload = {

--- a/noj-ui/components/ui/ToastBanner.vue
+++ b/noj-ui/components/ui/ToastBanner.vue
@@ -53,4 +53,10 @@ defineEmits<{ close: [] }>()
   transform: translateX(-50%) translateY(-20px);
   opacity: 0;
 }
+
+/* issue #316：深色模式功能未完善前，错误/提示横幅统一保持白字，避免被浏览器深色样式改成黑字 */
+:deep([data-slot="title"]),
+:deep([data-slot="description"]) {
+  color: white;
+}
 </style>

--- a/noj-ui/pages/community/index.vue
+++ b/noj-ui/pages/community/index.vue
@@ -15,6 +15,21 @@ const { config, loadConfig } = useCommunity()
 const { toast } = useToast()
 const { api } = useApi()
 
+// NOJ-317：SSR 阶段可能拿到游客权限（permissions 为空），登录用户水合后
+// 需要强制刷新一次社区配置，否则“发布内容”按钮会一直处于灰色。
+let configRefreshedForLogin = false
+watch(
+  [isLoggedIn, config],
+  async ([loggedIn, cfg]) => {
+    if (!loggedIn || !cfg || configRefreshedForLogin) return
+    if (!cfg.permissions || Object.keys(cfg.permissions).length === 0) {
+      configRefreshedForLogin = true
+      await loadConfig(true)
+    }
+  },
+  { immediate: true },
+)
+
 const ENABLED_TYPES: PostType[] = ["discussion", "solution", "moment"]
 const typeFlag: Record<PostType, keyof CommunityConfig> = {
   discussion: "discussions_enabled",

--- a/noj-ui/pages/login.vue
+++ b/noj-ui/pages/login.vue
@@ -367,6 +367,12 @@ async function handleLogin() {
       clearError()
       return;
     }
+    // TFA 验证码/恢复码错误：不再误报为“用户名和密码错误”
+    if (e.data?.code === "TFA_INVALID") {
+      fieldErrors.code = "验证码输入错误，请重新输入"
+      clearError()
+      return;
+    }
     setError(extractApiError(e).message)
   } finally {
     loading.value = false

--- a/noj-ui/pages/messages/index.vue
+++ b/noj-ui/pages/messages/index.vue
@@ -126,6 +126,13 @@ function scrollToBottom() {
   })
 }
 
+// 判断消息列表当前是否已接近底部；如果是，收到新消息后应自动滚动露出新消息
+function isNearBottom(threshold = 80) {
+  const el = messagesContainer.value
+  if (!el) return false
+  return el.scrollHeight - el.scrollTop - el.clientHeight < threshold
+}
+
 // SSE 实时接收新消息
 useEventSource({
   url: "/api/v1/conversations/events",
@@ -134,7 +141,9 @@ useEventSource({
     "message:new": async (data: unknown) => {
       const evt = data as { conversation_id: string }
       if (evt.conversation_id === selectedConversationId.value) {
+        const shouldAutoScroll = isNearBottom()
         await loadMessages()
+        if (shouldAutoScroll) scrollToBottom()
         // 正在查看的会话收到新消息后立即已读，避免红点堆积
         await markAsRead()
         await sidebarRef.value?.refresh()
@@ -144,7 +153,12 @@ useEventSource({
       messagingEnabled.value = false
     },
   },
-  fetchFn: () => { if (selectedConversationId.value) loadMessages() },
+  fetchFn: async () => {
+    if (!selectedConversationId.value) return
+    const shouldAutoScroll = isNearBottom()
+    await loadMessages()
+    if (shouldAutoScroll) scrollToBottom()
+  },
   fallbackIntervalMs: 3000,
 })
 

--- a/noj-ui/pages/settings.vue
+++ b/noj-ui/pages/settings.vue
@@ -46,6 +46,7 @@ const saveError = ref("")
 const avatarUploading = ref(false)
 const avatarInput = ref<HTMLInputElement | null>(null)
 const avatarPreviewKey = ref(Date.now()) // 上传/删除后破缓存
+const avatarError = ref("") // issue #314：超过 2MB 等校验错误内联展示，避免“没有反应”
 const { dialog } = useDialog()
 const { toast } = useToast()
 
@@ -54,8 +55,10 @@ async function handleAvatarUpload(e: Event) {
   const input = e.target as HTMLInputElement
   const file = input.files?.[0]
   if (!file) return
+  avatarError.value = ""
   const validationError = getAvatarUploadError(file)
   if (validationError) {
+    avatarError.value = validationError
     toast.error(validationError)
     input.value = ""
     return
@@ -71,8 +74,10 @@ async function handleAvatarUpload(e: Event) {
     )
     if (user.value) user.value.avatar_url = res.data.avatar_url
     avatarPreviewKey.value = Date.now()
+    avatarError.value = ""
     toast.success("头像已更新")
   } catch (err: unknown) {
+    avatarError.value = extractApiError(err).message
     toast.error(extractApiError(err).message)
   } finally {
     avatarUploading.value = false
@@ -250,6 +255,9 @@ async function handleTfaRegenerate() {
 function handleDownloadRecoveryCodes() {
   if (tfaRecoveryCodes.value.length === 0) return
 
+  // 清除上一次遗留的错误提示，避免“下载已成功但仍显示失败”
+  tfaError.value = ""
+
   try {
     const content = formatRecoveryCodesFile(tfaRecoveryCodes.value)
     const blob = new Blob([content], { type: "text/plain;charset=utf-8" })
@@ -257,8 +265,12 @@ function handleDownloadRecoveryCodes() {
     const link = document.createElement("a")
     link.href = url
     link.download = `neuro-oj-recovery-codes-${new Date().toISOString().slice(0, 10)}.txt`
+    link.style.display = "none"
+    document.body.appendChild(link)
     link.click()
-    setTimeout(() => URL.revokeObjectURL(url), 0)
+    link.remove()
+    // 稍后释放 URL，避免下载尚未开始时提前回收
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
     toast.success("恢复码文件已下载")
   } catch {
     tfaError.value = "恢复码文件生成失败，请手动复制保存"
@@ -328,6 +340,7 @@ async function handleCopyRecoveryCodes() {
               <input ref="avatarInput" type="file" accept="image/png,image/jpeg,image/webp" class="hidden" @change="handleAvatarUpload" />
             </div>
             <p class="text-xs text-text-muted">支持 png / jpeg / webp，最大 2MB</p>
+            <p v-if="avatarError" class="text-xs text-error-text">{{ avatarError }}</p>
           </div>
         </div>
 

--- a/noj-ui/pages/trainings/[id].vue
+++ b/noj-ui/pages/trainings/[id].vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import type { Training, TrainingProblem } from '~/composables/useTrainings'
+import { useTrainings } from '~/composables/useTrainings'
 
 const route = useRoute()
+const router = useRouter()
 const trainingId = route.params.id as string
 const { user } = useAuth()
+const { deleteTraining } = useTrainings()
+const { dialog } = useDialog()
+const { toast } = useToast()
 
 const { data: trainingData, pending, error, refresh } = await useFetch<{ data: Training }>(
   `/api/v1/trainings/${trainingId}`,
@@ -17,6 +22,22 @@ const training = computed(() => trainingData.value?.data)
 const problems = computed(() => problemsData.value?.data ?? [])
 const isOwner = computed(() => training.value?.created_by === user.value?.id)
 const showEdit = ref(false)
+
+// issue #311：题单缺少删除入口，补上带二次确认的删除按钮
+async function handleDeleteTraining() {
+  const ok = await dialog.confirm(
+    '确定删除该题单？删除后题目关联也会一并清除，且无法恢复。',
+    { title: '删除题单', confirmText: '删除', danger: true },
+  )
+  if (!ok) return
+  try {
+    await deleteTraining(trainingId)
+    toast.success('题单已删除')
+    router.push('/trainings')
+  } catch {
+    // useApi 已弹错误
+  }
+}
 </script>
 
 <template>
@@ -49,6 +70,17 @@ const showEdit = ref(false)
               @click="showEdit = true"
             >
               编辑
+            </UButton>
+            <UButton
+              v-if="isOwner"
+              icon="i-lucide-trash-2"
+              size="xs"
+              color="red"
+              variant="ghost"
+              class="text-white/80 hover:text-white"
+              @click="handleDeleteTraining"
+            >
+              删除
             </UButton>
           </div>
           <p class="mt-4 whitespace-pre-line text-sm leading-6 text-slate-300">


### PR DESCRIPTION
Closes #311
Closes #313
Closes #314
Closes #315
Closes #316
Closes #317
Closes #318
Closes #319

Refs #312（当前主干已包含“清除草稿后恢复题目模板”的逻辑，本 PR 一并做回归验证）

## 变更内容

- **#319**：修复导航栏收起后窗口拉大无法重新展开的问题（保留完整导航宽度数据）
- **#318**：消息页收到新消息时，若用户位于底部则自动滚动露出新消息
- **#317**：登录用户水合后强制刷新社区配置，避免“发布内容”按钮因 SSR 游客权限而灰置
- **#316**：2FA 验证码错误时后端返回 `TFA_INVALID`，前端显示“验证码输入错误”；错误横幅保持白字
- **#315**：恢复码下载前清理历史错误，并兼容浏览器下载触发方式
- **#314**：头像超过 2MB 时增加内联错误提示
- **#313**：修复单选客观题答案残留/多选高亮导致无法保存的问题
- **#311**：修复加入题单多选逻辑，并新增题单删除入口
- **#312**：主干已包含清除草稿后恢复模板，本 PR 构建验证覆盖

## 验证

- `noj-ui deno task check` 通过
- `noj-ui deno task build` 通过
- `noj-core deno task check` 通过
- `noj-core TFA 相关测试通过`