### PR TITLE
fix(ui): 竞赛页选中 Tab 文字深色模式下保持白色

### DIFF
--- a/noj-ui/assets/css/main.css
+++ b/noj-ui/assets/css/main.css
@@ -300,3 +300,13 @@
 ) {
   color: var(--color-text-on-color);
 }
+
+/* ---- dark 模式下选中 Tab 文字保持白色（可读性修复）----
+ * Nuxt UI Tabs pill 变体选中项用 data-[state=active]:text-inverted，
+ * 而 --ui-text-inverted 在 dark 模式为深色（与按钮白字问题同源），
+ * 导致竞赛页等选中 Tab 在深色模式下文字变深、对比度不足。
+ * 这里对选中 Tab 强制使用恒白 token --color-text-on-color（#ffffff），
+ * 与按钮规则一致；未包 @layer，优先级高于 utilities layer。 */
+.dark [data-slot="trigger"][data-state="active"] {
+  color: var(--color-text-on-color);
+}


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->
- 竞赛详情页选中的 Tab 在浏览器深色模式下文字变深（Nuxt UI Tabs 选中项用 text-inverted，其 --ui-text-inverted 在 dark 下为深色）；新增规则强制选中 Tab 使用恒白 token --color-text-on-color，与常见蓝色按钮白字的修复策略一致。
- 本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
更改前
<img width="1429" height="749" alt="截图 2026-08-25 02-09-56" src="https://github.com/user-attachments/assets/cf2f4794-b8a6-4efa-9409-cfdad436ac0f" />

更改后
<img width="1429" height="749" alt="截图 2026-08-25 01-23-21" src="https://github.com/user-attachments/assets/bb4a2ebe-ecfa-420c-8b2c-ab74f4291b81" />



<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）
**根因**

Nuxt UI Tabs 的 pill 变体选中项用 data-[state=active]:text-inverted，依赖 --ui-text-inverted——该变量在 dark 模式下是深色（与之前按钮白字问题同源），导致竞赛详情页选中的 Tab 在深色模式下文字变深、对比度不足。

**修复**

main.css 追加全局规则（与按钮白字规则一致，所有 Tabs 受益）：

```
.dark [data-slot="trigger"][data-state="active"] {
  color: var(--color-text-on-color);  /* 恒白 token #ffffff */
}
```
- 本commit由AI生成。

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
