### PR TITLE
fix(ui): 导航栏 nav 加 flex-1 防止宽屏误折叠，搜索栏位置调整

### DIFF
--- a/noj-ui/components/layout/Navbar.vue
+++ b/noj-ui/components/layout/Navbar.vue
@@ -38,7 +38,7 @@
             </UDrawer>
             <BrandLogo text-class="hidden sm:inline" />
             <!-- 桌面端导航（≥md 显示） -->
-            <nav ref="navRef" class="hidden md:flex items-center gap-1 ml-6 min-w-0">
+            <nav ref="navRef" class="hidden md:flex flex-1 items-center gap-1 ml-6 min-w-0">
               <NuxtLink
                 v-for="item in visibleNavItems"
                 :key="item.to"


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->

- 导航栏桌面导航 nav 容器缺少 flex-1，宽度随折叠内容自我收缩形成恶性循环，导致宽屏下也把所有选项折叠进"更多"；加 flex-1 使容器宽度稳定，宽屏正常显示全部导航、窄屏仍按需折叠。
- 现在搜索栏在宽度足够时会在导航栏右边，紧张时则放在左边，最后隐藏文字说明只保留搜索图标
- 本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
[录屏 2026-08-25 06-01-50.webm](https://github.com/user-attachments/assets/c927873b-6de5-454d-81dd-e9d90a77a66b)


<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
**根因**

nav 元素缺 flex-1，宽度由内容决定。measureAndFit() 用"自我收缩的 nav.clientWidth"判断能放几项，形成恶性循环：

首次正确测量（7 项，nav 宽 416px）
某次重测（communityConfig 加载/ResizeObserver）触发，nav 因故变窄
用旧的全量 itemWidths + 变窄的 containerWidth 计算 → 放不下 → 折叠移除链接
nav 因内容变少而更窄 → 再次测量更放不下 → 循环到只剩首页
- 本commit由AI生成。