### PR TITLE
feat(ui): 导航栏新增题单入口并移除移动端抽屉搜索

### DIFF
--- a/noj-ui/components/layout/Navbar.vue
+++ b/noj-ui/components/layout/Navbar.vue
@@ -16,14 +16,6 @@
             >
                 <UButton class="md:hidden" color="neutral" variant="ghost" square icon="i-lucide-menu" aria-label="打开菜单" />
                 <template #body>
-                    <button
-                        type="button"
-                        class="flex items-center gap-2 px-3 py-2.5 text-sm text-text-secondary no-underline rounded-md transition-colors hover:bg-primary-hover hover:text-text"
-                        @click="openSearch; mobileOpen = false"
-                    >
-                        <UIcon name="i-lucide-search" class="size-4" />
-                        搜索
-                    </button>
                     <NuxtLink
                         v-for="item in navItems"
                         :key="item.to"
@@ -107,6 +99,7 @@ const baseNavItems: NavItem[] = [
   { label: '题库', to: '/problems', icon: 'i-lucide-book-open' },
   { label: '竞赛', to: '/contests', icon: 'i-lucide-trophy' },
   { label: '榜单', to: '/ranking', icon: 'i-lucide-medal' },
+  { label: '题单', to: '/trainings', icon: 'i-lucide-list-todo' },
   { label: '社区', to: '/community', icon: 'i-lucide-messages-square', needsCommunity: true },
   { label: '提交记录', to: '/submissions', icon: 'i-lucide-file-text' },
   { label: '队列', to: '/queue', icon: 'i-lucide-list-ordered' },


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->

- 新增「题单」导航项（/trainings，图标 i-lucide-list-todo），桌面导航与移动端抽屉共用，便于直达题单列表。
- 移除移动端导航抽屉侧边栏的搜索按钮——该场景搜索无法正常触发，并且导航栏上也有搜索。
- 并入 nav 容器 flex-1 修复，确保新增导航项后宽屏不误折叠（配合「更多」响应式收纳，宽度不足时才折叠）。
- 本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [x] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）
<img width="1048" height="2134" alt="截图 2026-08-25 06-10-44" src="https://github.com/user-attachments/assets/ba9c31c4-9fef-4152-b395-8bd1508dc328" />


<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
- 分支 feat/ui-navbar-training-entry 基于 main，并合入了 fix/ui-navbar-overflow（nav flex-1 修复），避免加项后宽屏误折叠。
- CDP 实测：桌面宽屏导航显示「首页/题库/竞赛/榜单/题单/社区/提交记录/队列/关于」共 9 项；移动端抽屉无搜索按钮、含题单入口。
- 本commit由AI生成。