### PR TITLE
feat(root): 提供一键生产部署脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ __pycache__/
 # --- Docker ---
 docker-data/
 
+# --- 生产备份 ---
+# PostgreSQL dump 包含用户数据，不得进入 Git。
+/backups/
+
 # --- Jujutsu (jj) ---
 .jj/repo/op_heads/
 .jj/repo/store/

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -31,7 +31,27 @@ server {
 }
 ```
 
-## 启动
+## 生产部署脚本
+
+推荐使用仓库根目录的部署入口，脚本会检查生产配置、保护环境文件、复用生产
+Compose、等待健康检查，并且不会删除数据卷：
+
+```bash
+# 首次执行：创建 .env.prod 和随机密钥；填写提示的人工配置后再次执行
+bash scripts/deploy/deploy.sh install
+
+# 日常运维
+bash scripts/deploy/deploy.sh status
+bash scripts/deploy/deploy.sh logs core
+bash scripts/deploy/deploy.sh backup
+bash scripts/deploy/deploy.sh upgrade
+```
+
+镜像拉取由 Docker daemon 负责。若官方源访问不稳定，请在 Docker daemon 配置
+registry mirror 或 HTTP(S) proxy 后重试；评测镜像仍可通过 `JUDGE_IMAGE_BASE`
+配置镜像前缀。部署脚本不会把代理凭据写入仓库或日志。
+
+## 手动启动
 
 ```bash
 cp .env.prod.example .env.prod

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -29,6 +29,16 @@ cd noj-core && deno task check:prod
 cd ..
 ```
 
+也可以使用仓库提供的生产部署入口完成检查和启动：
+
+```bash
+bash scripts/deploy/deploy.sh install
+```
+
+首次执行会创建权限为 `600` 的 `.env.prod` 并生成部分随机密钥，然后停止并提示
+填写域名、版本、邮件 Provider、管理员账号和 Judge 隔离 Docker socket。填写完成
+后再次执行同一命令即可继续部署。
+
 `.env.prod` 中必须填写：
 
 | 变量 | 说明 |
@@ -64,16 +74,22 @@ cd ..
 # 并将解密后的 HTTP 流量转发到本机 ${NGINX_PORT:-8080} 端口（默认 8080）。
 # 示例见 deploy/README.md。
 
-# 4) 执行一次性初始化（迁移 + 系统数据 + 管理员）
+# 4) 手动方式：执行一次性初始化（迁移 + 系统数据 + 管理员）
 docker compose --env-file .env.prod -f docker-compose.prod.yml up -d migrate
 docker compose --env-file .env.prod -f docker-compose.prod.yml logs migrate
 
-# 5) 启动全部服务
+# 5) 手动方式：启动全部服务
 docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
 
 # 6) 查看状态
 docker compose --env-file .env.prod -f docker-compose.prod.yml ps
 curl https://你的域名/healthz
+```
+
+使用部署脚本时，上述初始化、启动和健康检查由以下命令统一完成：
+
+```bash
+bash scripts/deploy/deploy.sh install
 ```
 
 > 评测 Worker 不得挂载应用宿主机的 `/var/run/docker.sock`。生产 Compose 要求
@@ -121,6 +137,19 @@ ghcr.io/neuro-oj/noj-solution-python   all_versions  solution
 - 轮换 `NOJ_LLM_STORE_KEY` 后，需要用新主密钥重新加密所有 Provider Key。
 
 ## 4. 日常运维
+
+推荐使用部署脚本：
+
+```bash
+bash scripts/deploy/deploy.sh status
+bash scripts/deploy/deploy.sh logs core
+bash scripts/deploy/deploy.sh logs judge --follow
+bash scripts/deploy/deploy.sh backup
+```
+
+`backup` 只创建 PostgreSQL custom-format 备份；Redis、MinIO 和 `.env.prod` 的备份
+仍需按照 [备份与灾备 Issue #326](https://github.com/Neuro-OJ/neuro-oj/issues/326)
+另行规划，备份文件默认保存在仓库根目录的 `backups/` 且权限为 `600`。
 
 ```bash
 # 查看服务状态

--- a/openspec/changes/production-deploy-script/.openspec.yaml
+++ b/openspec/changes/production-deploy-script/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/production-deploy-script/design.md
+++ b/openspec/changes/production-deploy-script/design.md
@@ -1,0 +1,66 @@
+## Context
+
+生产部署已经由 `docker-compose.prod.yml`、`.env.prod.example` 和运营者文档定义；Compose 包含一次性 `migrate` 服务、core、UI、judge、LLM Gateway、Nginx、PostgreSQL、Redis 和 MinIO。当前缺少统一入口，用户需要手工拼接多条 Compose 和 CLI 命令。开发用 `scripts/dev/devtool.sh` 依赖本机 Deno/Rust 进程，不应复用于生产。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 在 `scripts/deploy/deploy.sh` 提供一致的生产生命周期命令。
+- 复用现有生产 Compose 的依赖条件、迁移和健康检查，不复制服务拓扑。
+- 在执行前完成不泄露 secret 的配置与宿主环境检查。
+- 首次安装、升级、停止和备份操作可重复且保留持久化数据。
+
+**Non-Goals:**
+
+- 不重新设计 Docker Compose 服务、网络或卷布局。
+- 不自动创建独立 rootless Docker daemon；只检查其 socket 配置。
+- 不实现 Kubernetes、Terraform、云数据库或完整灾备系统。
+- 不替代 #326 的 PostgreSQL/Redis/MinIO 多副本备份和恢复演练。
+
+## Decisions
+
+### 1. 使用 Bash 薄封装，而不是新增部署运行时
+
+选择 Bash 是因为生产主机已有 Docker Compose，且项目已有 Bash 运维脚本；这样用户不必额外安装 Deno、Rust 或 Node.js。脚本通过数组传递 Compose 参数，避免对环境文件执行 `source`，防止 secret 中的特殊字符或命令替换带来风险。
+
+备选方案是把部署逻辑写入 Deno CLI，但生产镜像中的部署主机未必安装 Deno，且会重复已有 Compose 能力。
+
+### 2. 以生产 Compose 为唯一编排来源
+
+脚本固定解析仓库根目录的 `docker-compose.prod.yml`，通过 `--env-file` 注入 `.env.prod`，并将 Compose 子命令的退出码原样传递。迁移、系统初始化、管理员引导和容器健康检查继续由 Compose 定义，避免脚本和 Compose 出现两套依赖顺序。
+
+### 3. 配置初始化采用“复制模板 + 生成部分随机密钥”
+
+首次 `install` 只在目标文件不存在时复制 `.env.prod.example`，然后为数据库、Redis、MinIO、JWT、TFA 和 LLM Gateway 等密钥生成随机值；域名、版本、邮件 Provider、S3 应用配置和管理员账号仍要求用户填写。已有文件只检查，不自动重写。
+
+脚本不在 stdout/stderr 打印 secret；检查结果只显示配置键和脱敏后的原因。环境文件权限固定收紧为 `600`，并在启动前拒绝占位符。
+
+### 4. 命令边界
+
+- `install`：前置检查、初始化配置、拉取镜像、运行一次性迁移服务、启动全部服务、等待关键服务健康。
+- `start`：检查配置后启动全部服务；Compose 会处理已完成的迁移服务。
+- `upgrade`：检查配置、拉取目标版本、重新启动服务并等待健康。
+- `stop`：使用 Compose stop，保留所有数据卷。
+- `status`：显示 Compose 状态，并额外标记配置文件和隔离 socket 检查结果。
+- `logs [service]`：默认显示最近日志，可选服务名和 follow 模式。
+- `backup`：只创建 PostgreSQL custom-format 备份到 `backups/`，不删除或覆盖已有备份。
+
+### 5. 网络与镜像策略
+
+脚本不在应用层实现镜像代理，而是让 Docker daemon 的 registry mirror、HTTP(S) proxy 和 `docker login` 继续负责镜像获取；拉取失败时输出针对官方源、国内镜像加速器和代理的排查建议。生产 Compose 的 `JUDGE_IMAGE_BASE` 继续控制评测镜像白名单前缀。
+
+## Risks / Trade-offs
+
+- [生产主机依赖 Docker Compose v2] → 启动前执行 `docker compose version` 检查并给出安装提示。
+- [自动生成密钥后用户无法从输出恢复] → 仅生成并写入权限为 600 的 `.env.prod`，脚本不覆盖该文件；管理员密码不自动生成，要求用户明确填写。
+- [镜像拉取可能耗时或受网络限制] → 将拉取作为独立可见阶段，失败时保留已有服务和数据，并提示代理/镜像源排查方向。
+- [Compose healthcheck 不一定代表外部 TLS 已配置] → 脚本只检查容器服务健康，并明确提示外部 TLS 终止和域名解析仍需用户配置。
+- [数据库备份不是完整灾备] → `backup` 明确只覆盖 PostgreSQL，并在文档中链接 #326 和完整备份 Runbook。
+
+## Migration Plan
+
+1. 用户将脚本随仓库获取，在填写 `.env.prod` 后执行 `install`。
+2. 现有手工部署无需迁移；脚本使用相同的 Compose 文件、环境变量和数据卷。
+3. 若脚本执行失败，可继续使用文档中的原始 Compose 命令排查；不会执行 `down -v` 或删除数据。
+4. 升级前可执行 `backup`，升级失败时把 `NOJ_VERSION` 改回上一版本后执行 `upgrade`。

--- a/openspec/changes/production-deploy-script/proposal.md
+++ b/openspec/changes/production-deploy-script/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Neuro OJ 当前的开发启动脚本不能直接满足生产部署需求，用户仍需手工完成环境初始化、数据库迁移、服务启动和健康检查，首次部署容易遗漏关键步骤或使用不安全的默认配置。现在补充统一的生产部署入口，可以降低安装门槛并为后续升级、备份和故障排查提供稳定流程。
+
+## What Changes
+
+- 新增面向用户的生产部署脚本，支持首次安装、启动、停止、升级、状态查看和日志查看。
+- 自动检查 Docker/Compose、必要资源和端口，并以可读方式报告问题。
+- 初始化生产环境配置和随机密钥，保护已有环境文件，不静默覆盖用户配置。
+- 编排基础设施和应用服务，执行数据库迁移、系统初始化、管理员初始化和题目支持包构建/导入。
+- 支持官方镜像、国内镜像或代理配置，并提供健康检查和失败诊断。
+- 将 LLM Gateway 的生产配置纳入部署检查。
+- 补充生产部署文档、环境模板和脚本 smoke test。
+- 不改变现有开发脚本和 Docker Compose 的服务职责；部署脚本作为生产流程封装层。
+
+## Capabilities
+
+### New Capabilities
+
+- `production-deployment`: 面向用户的 Neuro OJ 生产环境安装、启动、升级、检查和停止流程。
+
+### Modified Capabilities
+
+- 无。
+
+## Impact
+
+- 新增 `scripts/deploy/` 生产部署脚本及其测试/辅助文件。
+- 可能补充生产 Compose 配置、环境变量模板和部署文档，但不重新设计现有服务拓扑。
+- 涉及 Docker、Docker Compose、PostgreSQL、Redis、MinIO、noj-core、noj-ui、noj-judge 和可选的 noj-llm-gateway。
+- 不新增运行时依赖；脚本默认使用 Bash、Docker Compose 和项目现有管理命令。

--- a/openspec/changes/production-deploy-script/specs/production-deployment/spec.md
+++ b/openspec/changes/production-deploy-script/specs/production-deployment/spec.md
@@ -1,0 +1,90 @@
+## Purpose
+
+为 Neuro OJ 用户提供可重复、可检查且不会误删持久化数据的生产部署入口，降低首次安装和后续升级的操作复杂度。
+
+## ADDED Requirements
+
+### Requirement: 生产配置初始化与安全检查
+
+部署入口 MUST 使用仓库根目录的生产环境模板初始化配置文件，并在执行会启动或变更服务的操作前检查生产必填项、占位值、secret 文件权限和 Docker Compose 配置；检查失败时 MUST 停止后续操作并给出不包含 secret 明文的错误信息。
+
+#### Scenario: 首次安装创建配置模板
+
+- **WHEN** 用户执行安装命令且 `.env.prod` 不存在
+- **THEN** 系统创建权限受限的 `.env.prod`，保留需要用户填写的域名、版本、邮件和存储配置，并提示用户完成配置后重新执行安装
+
+#### Scenario: 已有配置不被覆盖
+
+- **WHEN** 用户执行安装命令且 `.env.prod` 已存在
+- **THEN** 系统 MUST 保留已有配置，不得静默覆盖或在输出中打印其中的 secret 值
+
+#### Scenario: 生产配置校验失败
+
+- **WHEN** 必填项缺失、仍使用占位值、secret 文件权限过宽、Docker/Compose 不可用或生产 Compose 配置无效
+- **THEN** 系统返回非零退出码，并指出配置键或检查项以及修复建议
+
+### Requirement: 生产生命周期命令
+
+部署入口 MUST 提供 install、start、upgrade、stop、status 和 logs 命令，并默认使用 `docker-compose.prod.yml` 与 `.env.prod`；命令失败时 MUST 返回非零退出码。
+
+#### Scenario: 启动生产服务
+
+- **WHEN** 用户执行 `start`
+- **THEN** 系统校验配置后启动生产 Compose 中的服务，并报告 Compose 操作结果
+
+#### Scenario: 安全停止服务
+
+- **WHEN** 用户执行 `stop`
+- **THEN** 系统停止生产服务但保留 PostgreSQL、Redis、MinIO、题目包和 judge 缓存数据卷
+
+#### Scenario: 查看服务状态和日志
+
+- **WHEN** 用户执行 `status` 或 `logs [service]`
+- **THEN** 系统展示生产 Compose 的服务状态或指定服务日志，并且不输出环境文件中的 secret 值
+
+### Requirement: 首次安装与升级流程
+
+安装和升级 MUST 复用生产 Compose 中定义的迁移、系统初始化、管理员引导和健康检查机制；安装流程 MUST 在应用服务对外可用前完成一次性初始化，升级流程 MUST 先拉取目标版本镜像并保留已有数据。
+
+#### Scenario: 首次安装成功
+
+- **WHEN** 用户已完成生产配置并执行 `install`
+- **THEN** 系统拉取目标版本镜像，等待基础设施就绪，完成数据库迁移、系统数据初始化和管理员引导，启动全部服务并执行健康检查
+
+#### Scenario: 初始化失败阻止对外启动
+
+- **WHEN** 数据库迁移、系统初始化、管理员引导或基础设施健康检查失败
+- **THEN** 系统返回非零退出码，报告失败服务或阶段，并不得宣称部署成功
+
+#### Scenario: 升级保留数据
+
+- **WHEN** 用户修改 `NOJ_VERSION` 后执行 `upgrade`
+- **THEN** 系统拉取新版本并重建服务，复用已有数据卷，执行必要迁移，并在健康检查通过后报告升级完成
+
+### Requirement: 可恢复的备份和诊断
+
+部署入口 MUST 提供一个不删除数据的数据库备份操作，并在部署失败时给出可执行的状态、日志和配置检查建议；备份操作 MUST 使用受限文件权限保存产物。
+
+#### Scenario: 创建 PostgreSQL 备份
+
+- **WHEN** 用户执行 `backup`
+- **THEN** 系统在指定备份目录创建带时间戳的 PostgreSQL 备份文件，文件默认仅属主可读写，并报告文件路径
+
+#### Scenario: 备份前置条件不满足
+
+- **WHEN** PostgreSQL 服务未运行或备份命令失败
+- **THEN** 系统返回非零退出码并提示如何查看服务状态和日志，不删除现有备份
+
+### Requirement: 外部依赖和生产安全边界
+
+部署入口 MUST 检查 Docker daemon、Docker Compose、必要的 Judge Docker socket 和宿主机端口；MUST 不自动挂载应用宿主机 Docker socket、不删除数据卷、不把密钥写入镜像或日志，并 MUST 对官方镜像、镜像加速器和代理的配置方式提供清晰提示。
+
+#### Scenario: Judge 隔离 Docker socket 缺失
+
+- **WHEN** `JUDGE_DOCKER_SOCKET` 未配置、路径不存在或配置为应用宿主机默认 Docker socket
+- **THEN** 系统在启动 Judge Worker 前失败，并提示使用独立隔离的 Docker daemon socket
+
+#### Scenario: Docker 镜像网络失败
+
+- **WHEN** 拉取镜像因网络、代理或镜像源不可达而失败
+- **THEN** 系统返回非零退出码，并提示用户检查 Docker daemon 的 registry mirror、代理或镜像版本配置

--- a/openspec/changes/production-deploy-script/tasks.md
+++ b/openspec/changes/production-deploy-script/tasks.md
@@ -1,0 +1,22 @@
+## 1. 部署脚本基础能力
+
+- [x] 1.1 新增 `scripts/deploy/deploy.sh`，解析仓库根目录、生产环境文件、Compose 文件和命令参数，并验证 Bash、Docker 与 Docker Compose 可用；通过 `bash scripts/deploy/deploy.sh --help` 验证帮助输出。
+- [x] 1.2 实现生产配置初始化、占位值检查、必填项检查、`.env.prod` 权限检查和 Compose 配置检查；通过临时配置文件验证缺失项/占位值返回非零且不打印 secret。
+- [x] 1.3 实现 Docker daemon、宿主端口和 `JUDGE_DOCKER_SOCKET` 隔离配置检查；通过模拟缺失/危险 socket 配置验证脚本在启动前失败。
+
+## 2. 生命周期与初始化
+
+- [x] 2.1 实现 `install`，在首次安装时创建并保护 `.env.prod`、生成必要随机密钥、提示用户补齐人工配置，并在配置完整后拉取镜像、运行迁移初始化、启动服务和等待健康状态；通过 shell smoke test 验证命令顺序和失败传播。
+- [x] 2.2 实现 `start`、`stop`、`status` 和 `logs [service] [--follow]`，确保停止操作不使用 `down -v` 或删除数据卷；通过 shell 单元测试验证 Compose 参数和退出码传递。
+- [x] 2.3 实现 `upgrade`，按配置的 `NOJ_VERSION` 拉取镜像、执行 Compose 更新、等待健康状态并保留数据卷；通过 dry-run/模拟 Compose 验证升级不会调用破坏性清理。
+- [x] 2.4 实现 `backup`，使用 PostgreSQL 容器创建带时间戳的 custom-format 备份，设置受限文件权限且不覆盖已有文件；通过模拟数据库容器验证备份路径、权限和失败传播。
+
+## 3. 文档与可运维性
+
+- [x] 3.1 更新 `scripts/README.md` 和生产部署文档，记录安装前置条件、命令、配置文件、镜像源/代理排查、LLM Gateway、Judge 隔离 socket、备份边界和回滚方式；通过文档链接和命令示例检查确认内容完整。
+- [x] 3.2 更新部署模板或必要的 Compose 配置说明，确保脚本使用的变量与 `.env.prod.example`、`docker-compose.prod.yml` 一致；通过 `docker compose --env-file .env.prod.example -f docker-compose.prod.yml config`（使用测试替换值）验证配置可解析。
+
+## 4. 验证
+
+- [x] 4.1 为脚本增加不依赖真实生产资源的 shell 测试，覆盖帮助、初始化保护、secret 不泄露、非法配置、命令退出码和数据卷安全边界；通过项目约定的脚本测试命令运行。
+- [x] 4.2 运行 ShellCheck（若环境可用）、Compose 配置校验、完整 Bash 语法检查和生产部署 smoke test，并记录未覆盖的真实 Docker/网络前置条件；通过所有可执行检查后完成本变更。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,10 @@ scripts/
 │   ├── logs/              #   日志 + PID 文件目录
 │   └── locks/             #   devtool 同工具防双开锁
 │
+├── deploy/                # 生产部署
+│   ├── deploy.sh          #   生产安装、启动、升级、停止、备份入口
+│   └── test-deploy.sh     #   不依赖真实生产资源的部署脚本测试
+│
 └── e2e/                   # 跨模块 E2E 测试
     ├── setup.sh           #   启动 E2E 环境
     ├── check-setup.sh     #   检查 E2E SDK 镜像刷新与失败传播
@@ -35,6 +39,11 @@ scripts/
 | **单模块启动**                           | `bash scripts/dev/devtool.sh start <core\|ui\|judge\|infra>`    |
 | **单模块重启**                           | `bash scripts/dev/devtool.sh stop <core\|ui\|judge> && bash scripts/dev/devtool.sh start <core\|ui\|judge>` |
 | **更新环境变量模板（保留自定义）**       | `bash scripts/dev/devtool.sh init-env --merge`                  |
+| **首次生产部署**                         | `bash scripts/deploy/deploy.sh install`                          |
+| **启动/停止生产服务**                    | `bash scripts/deploy/deploy.sh start` / `stop`                   |
+| **升级生产版本**                         | `bash scripts/deploy/deploy.sh upgrade`                          |
+| **查看生产状态/日志**                    | `bash scripts/deploy/deploy.sh status` / `logs [service]`        |
+| **创建 PostgreSQL 备份**                 | `bash scripts/deploy/deploy.sh backup`                          |
 | **手动初始化数据库**                     | `cd noj-core && deno task db:migrate`（初始化见 `deno task dev-setup`） |
 | **手动构建题目包**                       | `cd noj-core && deno task problems:build`                              |
 | **跑跨模块 E2E 测试**                    | `bash scripts/e2e/run-all.sh`                                   |
@@ -53,3 +62,6 @@ cd noj-judge && cargo run
 ```
 
 详细开发指南见 [`dev/README.md`](dev/README.md)。
+
+生产部署脚本使用 `.env.prod` 和 `docker-compose.prod.yml`，详细说明见
+[`生产部署文档`](../noj-docs/docs/operators/production-deploy.md)。

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+#
+# Neuro OJ 生产部署入口。
+#
+# 用法：
+#   bash scripts/deploy/deploy.sh install
+#   bash scripts/deploy/deploy.sh start
+#   bash scripts/deploy/deploy.sh upgrade
+#   bash scripts/deploy/deploy.sh stop
+#   bash scripts/deploy/deploy.sh status
+#   bash scripts/deploy/deploy.sh logs [service] [--follow]
+#   bash scripts/deploy/deploy.sh backup
+#
+# 脚本只封装 docker-compose.prod.yml，不执行 down -v、不删除数据卷，
+# 也不会 source 环境文件，避免环境变量中的特殊字符触发 shell 解析。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env.prod"
+ENV_TEMPLATE="$REPO_ROOT/.env.prod.example"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.prod.yml"
+BACKUP_DIR="$REPO_ROOT/backups"
+DOCKER_BIN="${NOJ_DEPLOY_DOCKER_BIN:-docker}"
+DRY_RUN=0
+FOLLOW=0
+
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; RESET='\033[0m'
+else
+  GREEN=''; YELLOW=''; RED=''; RESET=''
+fi
+
+ok() { printf "%b✓%b %s\n" "$GREEN" "$RESET" "$*"; }
+warn() { printf "%b!%b %s\n" "$YELLOW" "$RESET" "$*" >&2; }
+fail() {
+  printf "%b✗%b %s\n" "$RED" "$RESET" "$*" >&2
+  exit 1
+}
+section() { printf "\n== %s ==\n" "$*"; }
+
+usage() {
+  cat <<'EOF'
+Neuro OJ 生产部署工具
+
+用法：
+  deploy.sh install                  首次初始化配置并部署
+  deploy.sh start                    启动生产服务
+  deploy.sh upgrade                  拉取 NOJ_VERSION 并升级服务
+  deploy.sh stop                     停止服务（保留数据卷）
+  deploy.sh status                   查看服务状态
+  deploy.sh logs [service]           查看最近日志
+  deploy.sh logs [service] --follow  持续查看日志
+  deploy.sh backup                   创建 PostgreSQL 备份
+
+选项：
+  --env-file FILE       使用指定的生产环境文件
+  --compose-file FILE   使用指定的 Compose 文件
+  --backup-dir DIR      指定备份目录（默认 ./backups）
+  --dry-run             只检查并显示将执行的操作，不修改服务或文件
+  -h, --help            显示帮助
+
+环境变量：
+  NOJ_DEPLOY_DOCKER_BIN  仅用于测试，指定 Docker CLI 路径
+EOF
+}
+
+parse_args() {
+  COMMAND=""
+  POSITIONAL=()
+  while (($# > 0)); do
+    case "$1" in
+      install|start|upgrade|stop|status|logs|backup)
+        if [[ -n "$COMMAND" ]]; then
+          POSITIONAL+=("$1")
+        else
+          COMMAND="$1"
+        fi
+        ;;
+      --env-file)
+        (($# >= 2)) || fail "--env-file 需要一个文件路径"
+        ENV_FILE="$2"
+        shift
+        ;;
+      --env-file=*) ENV_FILE="${1#*=}" ;;
+      --compose-file)
+        (($# >= 2)) || fail "--compose-file 需要一个文件路径"
+        COMPOSE_FILE="$2"
+        shift
+        ;;
+      --compose-file=*) COMPOSE_FILE="${1#*=}" ;;
+      --backup-dir)
+        (($# >= 2)) || fail "--backup-dir 需要一个目录路径"
+        BACKUP_DIR="$2"
+        shift
+        ;;
+      --backup-dir=*) BACKUP_DIR="${1#*=}" ;;
+      --follow|-f) FOLLOW=1 ;;
+      --dry-run) DRY_RUN=1 ;;
+      -h|--help) usage; exit 0 ;;
+      --) shift; POSITIONAL+=("$@"); break ;;
+      *) POSITIONAL+=("$1") ;;
+    esac
+    shift
+  done
+  [[ -n "$COMMAND" ]] || { usage; exit 2; }
+}
+
+env_value() {
+  local key="$1" value
+  [[ -f "$ENV_FILE" ]] || return 0
+  value="$(awk -v key="$key" '
+    index($0, key "=") == 1 { print substr($0, length(key) + 2); exit }
+  ' "$ENV_FILE")"
+  case "$value" in
+    "\""*"\""|"'"*"'") value="${value:1:${#value}-2}" ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+set_env_value() {
+  local key="$1" value="$2" tmp
+  tmp="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+  if ! awk -v key="$key" -v value="$value" '
+    BEGIN { found = 0 }
+    index($0, key "=") == 1 {
+      print key "=" value
+      found = 1
+      next
+    }
+    { print }
+    END { if (!found) print key "=" value }
+  ' "$ENV_FILE" >"$tmp"; then
+    rm -f "$tmp"
+    fail "更新生产配置失败"
+  fi
+  chmod 600 "$tmp"
+  mv "$tmp" "$ENV_FILE"
+}
+
+generate_secret() {
+  command -v openssl >/dev/null 2>&1 ||
+    fail "首次初始化需要 openssl，用于生成随机密钥"
+  openssl rand -hex 32 | tr -d '\n'
+}
+
+initialize_env() {
+  section "初始化生产配置"
+  [[ -f "$ENV_TEMPLATE" ]] || fail "找不到生产配置模板：$ENV_TEMPLATE"
+  if [[ -e "$ENV_FILE" ]]; then
+    [[ -f "$ENV_FILE" ]] || fail "生产配置路径不是普通文件：$ENV_FILE"
+    chmod 600 "$ENV_FILE"
+    ok "保留已有配置：$ENV_FILE"
+    return 0
+  fi
+
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将从 $ENV_TEMPLATE 创建 $ENV_FILE"
+    return 0
+  fi
+
+  umask 077
+  cp "$ENV_TEMPLATE" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+
+  local key value
+  for key in \
+    POSTGRES_PASSWORD \
+    REDIS_PASSWORD \
+    MINIO_ROOT_PASSWORD \
+    S3_SECRET_KEY \
+    JWT_SECRET \
+    TFA_ENCRYPTION_KEY \
+    NOJ_LLM_SERVICE_TOKEN \
+    NOJ_LLM_STORE_KEY; do
+    value="$(generate_secret)"
+    set_env_value "$key" "$value"
+  done
+  set_env_value MINIO_ROOT_USER "nojminio$(openssl rand -hex 6)"
+  set_env_value S3_ACCESS_KEY "nojs3$(openssl rand -hex 6)"
+
+  ok "已创建并保护 $ENV_FILE"
+  warn "请填写 NOJ_VERSION、DOMAIN、APP_URL、邮件 Provider、管理员账号和 Judge Docker socket"
+  warn "配置完成后重新执行：bash scripts/deploy/deploy.sh install"
+  exit 2
+}
+
+check_file_permissions() {
+  local mode
+  mode="$(stat -f '%Lp' "$ENV_FILE" 2>/dev/null || stat -c '%a' "$ENV_FILE" 2>/dev/null || true)"
+  [[ -n "$mode" ]] || fail "无法读取生产配置文件权限：$ENV_FILE"
+  if [[ "$mode" != "600" && "$mode" != "400" ]]; then
+    fail "生产配置文件权限必须为 600 或 400：$ENV_FILE"
+  fi
+}
+
+is_placeholder() {
+  local value="$1"
+  [[ -z "$value" ]] && return 0
+  case "$value" in
+    *change-me*|*change-this*|*changeme*|*example*|*placeholder*|*replace-me*|*your-*|test|xxx*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+check_required_values() {
+  local key value
+  local required_keys=(
+    NOJ_VERSION APP_URL CORS_ALLOWED_ORIGINS TRUSTED_PROXIES
+    POSTGRES_PASSWORD REDIS_PASSWORD MINIO_ROOT_USER MINIO_ROOT_PASSWORD
+    S3_ACCESS_KEY S3_SECRET_KEY S3_BUCKET S3_ENDPOINT STORAGE_PROVIDER
+    JWT_SECRET TFA_ENCRYPTION_KEY NOJ_LLM_SERVICE_TOKEN NOJ_LLM_STORE_KEY
+    ADMIN_EMAIL ADMIN_PASS EMAIL_PROVIDER JUDGE_DOCKER_SOCKET JUDGE_DOCKER_SOCKET_GID
+  )
+  local missing=0
+  for key in "${required_keys[@]}"; do
+    value="$(env_value "$key")"
+    if is_placeholder "$value"; then
+      printf "  - %s 未配置或仍是占位值\n" "$key" >&2
+      missing=1
+    fi
+  done
+  ((missing == 0)) || fail "生产配置未完成，请先修复上面的配置项"
+
+  case "$(env_value EMAIL_PROVIDER)" in
+    aliyun)
+      for key in ALIBABA_ACCESS_KEY_ID ALIBABA_ACCESS_KEY_SECRET ALIBABA_FROM_EMAIL; do
+        value="$(env_value "$key")"
+        is_placeholder "$value" && { printf "  - %s 未配置或仍是占位值\n" "$key" >&2; missing=1; }
+      done
+      ;;
+    tencent)
+      for key in TENCENT_SECRET_ID TENCENT_SECRET_KEY TENCENT_FROM_EMAIL TENCENT_REGION; do
+        value="$(env_value "$key")"
+        is_placeholder "$value" && { printf "  - %s 未配置或仍是占位值\n" "$key" >&2; missing=1; }
+      done
+      ;;
+    *)
+      printf "  - EMAIL_PROVIDER 必须是 aliyun 或 tencent\n" >&2
+      missing=1
+      ;;
+  esac
+
+  [[ "$(env_value STORAGE_PROVIDER)" == "s3" ]] || {
+    printf "  - STORAGE_PROVIDER 必须设置为 s3\n" >&2
+    missing=1
+  }
+  [[ "$(env_value JWT_SECRET)" != *test* ]] || {
+    printf "  - JWT_SECRET 不得使用测试密钥\n" >&2
+    missing=1
+  }
+  [[ "$(env_value JUDGE_DOCKER_SOCKET_GID)" =~ ^[0-9]+$ ]] || {
+    printf "  - JUDGE_DOCKER_SOCKET_GID 必须是数字\n" >&2
+    missing=1
+  }
+  [[ "$(env_value NOJ_VERSION)" != "latest" ]] || {
+    printf "  - NOJ_VERSION 必须使用不可变 Release 标签，不得使用 latest\n" >&2
+    missing=1
+  }
+  ((missing == 0)) || fail "生产配置校验失败"
+}
+
+check_judge_socket() {
+  local socket_path="$(env_value JUDGE_DOCKER_SOCKET)"
+  case "$socket_path" in
+    /var/run/docker.sock|/run/docker.sock)
+      fail "禁止将应用宿主机 Docker socket 挂载给 judge：$socket_path"
+      ;;
+  esac
+  [[ -e "$socket_path" ]] ||
+    fail "Judge 隔离 Docker socket 不存在：$socket_path"
+  ok "Judge 使用独立 Docker socket"
+}
+
+check_port_value() {
+  local port="$(env_value NGINX_PORT)"
+  port="${port:-8080}"
+  [[ "$port" =~ ^[0-9]+$ ]] && ((port >= 1 && port <= 65535)) ||
+    fail "NGINX_PORT 必须是 1-65535 的端口号"
+  if command -v lsof >/dev/null 2>&1 &&
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    warn "NGINX_PORT=$port 已被其他进程监听；启动时可能发生端口冲突"
+  fi
+}
+
+check_dependencies() {
+  section "检查部署环境"
+  command -v "$DOCKER_BIN" >/dev/null 2>&1 ||
+    fail "找不到 Docker CLI：$DOCKER_BIN"
+  "$DOCKER_BIN" info >/dev/null 2>&1 || fail "Docker daemon 未运行或当前用户无权限"
+  "$DOCKER_BIN" compose version >/dev/null 2>&1 ||
+    fail "Docker Compose v2 不可用"
+  [[ -f "$COMPOSE_FILE" ]] || fail "找不到生产 Compose 文件：$COMPOSE_FILE"
+  ok "Docker daemon 与 Compose 可用"
+}
+
+check_configuration() {
+  [[ -f "$ENV_FILE" ]] || fail "找不到生产配置：$ENV_FILE，请先执行 install"
+  check_file_permissions
+  check_required_values
+  check_judge_socket
+  check_port_value
+
+  if ((DRY_RUN)); then
+    ok "[dry-run] 跳过会输出 Compose 解析结果的命令"
+  else
+    "$DOCKER_BIN" compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" config --quiet ||
+      fail "Docker Compose 配置无效，请检查环境变量和生产 Compose 文件"
+  fi
+  ok "生产配置检查通过"
+}
+
+run_compose() {
+  if ((DRY_RUN)); then
+    printf "[dry-run] docker compose --env-file %s -f %s" "$ENV_FILE" "$COMPOSE_FILE"
+    printf " %s" "$@"
+    printf "\n"
+    return 0
+  fi
+  "$DOCKER_BIN" compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+}
+
+wait_for_stack() {
+  section "等待服务健康"
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将等待 Compose healthcheck 完成"
+    return 0
+  fi
+  run_compose up -d --wait --wait-timeout 180 --remove-orphans ||
+    fail "服务启动或健康检查失败，请执行 status 和 logs 排查"
+  ok "生产服务已通过 Compose 健康检查"
+}
+
+prepare_and_check() {
+  check_dependencies
+  check_configuration
+}
+
+install() {
+  initialize_env
+  prepare_and_check
+  section "拉取生产镜像"
+  run_compose pull
+  wait_for_stack
+  ok "生产部署完成"
+}
+
+start() {
+  prepare_and_check
+  wait_for_stack
+  ok "生产服务已启动"
+}
+
+upgrade() {
+  prepare_and_check
+  section "拉取目标版本镜像"
+  run_compose pull
+  wait_for_stack
+  ok "生产服务已升级"
+}
+
+stop() {
+  prepare_and_check
+  section "停止生产服务"
+  run_compose stop
+  ok "服务已停止，数据卷已保留"
+}
+
+status() {
+  prepare_and_check
+  run_compose ps
+}
+
+logs() {
+  prepare_and_check
+  local args=(logs --tail=200)
+  if ((FOLLOW)); then args+=(--follow); fi
+  if ((${#POSITIONAL[@]} > 0)); then args+=("${POSITIONAL[@]}"); fi
+  run_compose "${args[@]}"
+}
+
+backup() {
+  prepare_and_check
+  local pg_user pg_db timestamp target index
+  pg_user="$(env_value POSTGRES_USER)"
+  pg_db="$(env_value POSTGRES_DB)"
+  pg_user="${pg_user:-noj}"
+  pg_db="${pg_db:-noj}"
+  timestamp="$(date '+%Y%m%d-%H%M%S')"
+  target="$BACKUP_DIR/postgres-$timestamp.dump"
+  index=1
+  while [[ -e "$target" ]]; do
+    target="$BACKUP_DIR/postgres-$timestamp-$index.dump"
+    index=$((index + 1))
+  done
+
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将创建 PostgreSQL 备份：$target"
+    return 0
+  fi
+
+  umask 077
+  mkdir -p "$BACKUP_DIR"
+  chmod 700 "$BACKUP_DIR"
+  if ! "$DOCKER_BIN" compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" \
+    exec -T postgres pg_dump -U "$pg_user" -d "$pg_db" -Fc >"$target"; then
+    rm -f "$target"
+    fail "PostgreSQL 备份失败；已有备份未被修改"
+  fi
+  chmod 600 "$target"
+  ok "PostgreSQL 备份已创建：$target"
+  warn "该备份不包含 Redis、MinIO 和环境文件；完整灾备请参照 #326"
+}
+
+main() {
+  parse_args "$@"
+  case "$COMMAND" in
+    install) install ;;
+    start) start ;;
+    upgrade) upgrade ;;
+    stop) stop ;;
+    status) status ;;
+    logs) logs ;;
+    backup) backup ;;
+    *) fail "未知命令：$COMMAND" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/deploy/test-deploy.sh
+++ b/scripts/deploy/test-deploy.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# deploy.sh 的无 Docker 生产资源测试。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/deploy.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-deploy-test.XXXXXX")"
+FAKE_DOCKER="$TEST_ROOT/fake-docker"
+FAKE_LOG="$TEST_ROOT/docker.log"
+ENV_FILE="$TEST_ROOT/.env.prod"
+COMPOSE_FILE="$TEST_ROOT/docker-compose.prod.yml"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+
+cat >"$FAKE_DOCKER" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$*" >>"${NOJ_DEPLOY_TEST_LOG:?}"
+if [[ "${NOJ_DEPLOY_TEST_FAIL:-}" == "up" && " $* " == *" up "* ]]; then
+  exit 23
+fi
+if [[ "${1:-}" == "compose" && " $* " == *" pg_dump "* ]]; then
+  printf 'fake postgres dump\n'
+fi
+EOF
+chmod +x "$FAKE_DOCKER"
+
+cat >"$ENV_FILE" <<'EOF'
+NOJ_VERSION=v0.1.0
+APP_URL=https://noj.test
+CORS_ALLOWED_ORIGINS=https://noj.test
+TRUSTED_PROXIES=172.28.0.0/16
+POSTGRES_PASSWORD=strong-postgres-password
+POSTGRES_USER=noj
+POSTGRES_DB=noj
+REDIS_PASSWORD=strong-redis-password
+MINIO_ROOT_USER=minio-root
+MINIO_ROOT_PASSWORD=strong-minio-password
+S3_ACCESS_KEY=noj-storage
+S3_SECRET_KEY=strong-storage-password
+S3_BUCKET=noj-support-packages
+S3_ENDPOINT=http://minio:9000
+STORAGE_PROVIDER=s3
+JWT_SECRET=strong-random-jwt-secret-value-1234567890
+TFA_ENCRYPTION_KEY=strong-random-tfa-secret-value-1234567890
+NOJ_LLM_SERVICE_TOKEN=strong-llm-service-token
+NOJ_LLM_STORE_KEY=strong-llm-store-key
+ADMIN_EMAIL=admin@noj.test
+ADMIN_PASS=strong-admin-password
+EMAIL_PROVIDER=aliyun
+ALIBABA_ACCESS_KEY_ID=aliyun-id
+ALIBABA_ACCESS_KEY_SECRET=aliyun-secret
+ALIBABA_FROM_EMAIL=admin@noj.test
+JUDGE_DOCKER_SOCKET=__TEST_ROOT__/isolated-docker.sock
+JUDGE_DOCKER_SOCKET_GID=10001
+NGINX_PORT=18080
+EOF
+sed -i.bak "s#__TEST_ROOT__#$TEST_ROOT#g" "$ENV_FILE"
+touch "$TEST_ROOT/isolated-docker.sock"
+chmod 600 "$ENV_FILE"
+printf 'services:\n  fake:\n    image: alpine:3\n' >"$COMPOSE_FILE"
+
+run_deploy() {
+  NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" \
+  NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+    bash "$DEPLOY_SCRIPT" "$@" --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE"
+}
+
+[[ "$(bash "$DEPLOY_SCRIPT" --help)" == *"生产部署工具"* ]] || fail "帮助输出缺少工具标题"
+pass "帮助输出"
+
+new_env="$TEST_ROOT/new.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" install --env-file "$new_env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/install.out" 2>"$TEST_ROOT/install.err"; then
+  fail "首次初始化应该提示补齐配置并返回非零"
+fi
+[[ -f "$new_env" ]] || fail "首次初始化未创建配置文件"
+[[ "$(stat -f '%Lp' "$new_env" 2>/dev/null || stat -c '%a' "$new_env")" == "600" ]] ||
+  fail "新建配置文件权限不是 600"
+grep -q '^JWT_SECRET=' "$new_env" || fail "首次初始化未写入随机密钥"
+if grep -q '^JWT_SECRET=change-' "$new_env"; then fail "首次初始化仍保留 JWT 占位值"; fi
+pass "首次配置初始化与权限保护"
+
+if run_deploy start >/dev/null 2>"$TEST_ROOT/start.err"; then
+  :
+else
+  fail "合法配置的 start 不应失败"
+fi
+grep -q 'compose.*up -d --wait' "$FAKE_LOG" || fail "start 未调用 Compose 健康等待"
+if grep -q 'down -v' "$FAKE_LOG"; then fail "部署脚本不得删除数据卷"; fi
+pass "启动参数与数据卷安全边界"
+
+run_deploy stop >/dev/null 2>"$TEST_ROOT/stop.err" || fail "合法配置的 stop 不应失败"
+grep -q 'compose.*stop' "$FAKE_LOG" || fail "stop 未调用 Compose stop"
+run_deploy upgrade >/dev/null 2>"$TEST_ROOT/upgrade.err" || fail "合法配置的 upgrade 不应失败"
+grep -q 'compose.*pull' "$FAKE_LOG" || fail "upgrade 未拉取镜像"
+run_deploy logs core >/dev/null 2>"$TEST_ROOT/logs.err" || fail "合法配置的 logs 不应失败"
+grep -q 'compose.*logs.*core' "$FAKE_LOG" || fail "logs 未传递服务名"
+log_lines_before="$(wc -l <"$FAKE_LOG")"
+run_deploy upgrade --dry-run >/dev/null 2>"$TEST_ROOT/dry-run.err" || fail "合法配置的 dry-run 不应失败"
+if tail -n +$((log_lines_before + 1)) "$FAKE_LOG" | grep -E ' pull| up ' >/dev/null; then
+  fail "dry-run 不应执行 Compose 变更操作"
+fi
+pass "生命周期命令"
+
+set +e
+NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" \
+NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+NOJ_DEPLOY_TEST_FAIL=up \
+  bash "$DEPLOY_SCRIPT" start --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/failed.out" 2>"$TEST_ROOT/failed.err"
+failed_status=$?
+set -e
+[[ "$failed_status" != "0" ]] || fail "Compose 失败未传递为部署失败"
+pass "Compose 失败状态传递"
+
+cp "$ENV_FILE" "$TEST_ROOT/unsafe.env"
+sed -i.bak 's#JUDGE_DOCKER_SOCKET=.*#JUDGE_DOCKER_SOCKET=/var/run/docker.sock#' "$TEST_ROOT/unsafe.env"
+chmod 600 "$TEST_ROOT/unsafe.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" start --env-file "$TEST_ROOT/unsafe.env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/unsafe.out" 2>"$TEST_ROOT/unsafe.err"; then
+  fail "应用宿主机 Docker socket 应该被拒绝"
+fi
+grep -q '应用宿主机 Docker socket' "$TEST_ROOT/unsafe.err" || fail "危险 socket 错误提示缺失"
+pass "Judge Docker socket 隔离检查"
+
+cp "$ENV_FILE" "$TEST_ROOT/missing-socket.env"
+sed -i.bak "s#JUDGE_DOCKER_SOCKET=.*#JUDGE_DOCKER_SOCKET=$TEST_ROOT/missing.sock#" "$TEST_ROOT/missing-socket.env"
+chmod 600 "$TEST_ROOT/missing-socket.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" start --env-file "$TEST_ROOT/missing-socket.env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/missing-socket.out" 2>"$TEST_ROOT/missing-socket.err"; then
+  fail "缺失的 Judge Docker socket 应该被拒绝"
+fi
+grep -q 'Docker socket 不存在' "$TEST_ROOT/missing-socket.err" || fail "缺失 socket 错误提示缺失"
+pass "Judge Docker socket 存在性检查"
+
+cp "$ENV_FILE" "$TEST_ROOT/invalid.env"
+sed -i.bak 's/NOJ_VERSION=v0.1.0/NOJ_VERSION=change-me-release-tag/' "$TEST_ROOT/invalid.env"
+chmod 600 "$TEST_ROOT/invalid.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" start --env-file "$TEST_ROOT/invalid.env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/invalid.out" 2>"$TEST_ROOT/invalid.err"; then
+  fail "占位配置应该失败"
+fi
+grep -q 'NOJ_VERSION' "$TEST_ROOT/invalid.err" || fail "占位配置错误未指出配置键"
+if grep -q 'strong-' "$TEST_ROOT/invalid.err" "$TEST_ROOT/invalid.out"; then
+  fail "配置检查输出泄露了 secret"
+fi
+pass "占位配置拒绝与 secret 不泄露"
+
+if run_deploy backup --backup-dir "$TEST_ROOT/backups" >/dev/null 2>"$TEST_ROOT/backup.err"; then
+  :
+else
+  fail "合法配置的 backup 不应失败"
+fi
+backup_file="$(find "$TEST_ROOT/backups" -type f -name 'postgres-*.dump' -print -quit)"
+[[ -n "$backup_file" ]] || fail "未生成 PostgreSQL 备份"
+[[ "$(stat -f '%Lp' "$backup_file" 2>/dev/null || stat -c '%a' "$backup_file")" == "600" ]] ||
+  fail "备份文件权限不是 600"
+pass "PostgreSQL 备份与文件权限"
+
+printf '全部部署脚本测试通过\n'


### PR DESCRIPTION
## 概述

实现 #349，为用户提供统一的生产部署入口，封装现有 `docker-compose.prod.yml`，降低首次安装和日常升级的操作复杂度。

## 主要变更

- 新增 `scripts/deploy/deploy.sh`：
  - `install`：初始化 `.env.prod`、生成随机密钥、拉取镜像、启动并等待健康检查
  - `start` / `upgrade` / `stop` / `status` / `logs`
  - `backup`：创建 PostgreSQL custom-format 备份
  - 支持 `--env-file`、`--compose-file`、`--backup-dir` 和 `--dry-run`
- 增加生产配置、占位值、secret 文件权限、端口和 Judge 隔离 Docker socket 检查。
- 明确不使用 `down -v`，不删除持久化数据卷，不 source 环境文件，不输出 secret。
- 增加不依赖真实生产资源的部署脚本 smoke test。
- 更新脚本索引、部署说明和生产运维文档。
- 忽略生产 PostgreSQL 备份目录。
- 增加 OpenSpec proposal/design/spec/tasks，11/11 任务完成。

## 验证

- `bash -n scripts/deploy/deploy.sh scripts/deploy/test-deploy.sh`
- `bash scripts/deploy/test-deploy.sh`
- `docker compose --env-file .env.prod.example -f docker-compose.prod.yml config -q`
- `openspec validate production-deploy-script --strict`
- ShellCheck：本机未安装，未执行

## 部署说明

首次使用：

```bash
bash scripts/deploy/deploy.sh install
```

首次执行会创建 `.env.prod` 并提示用户填写域名、Release 版本、邮件 Provider、管理员账号和 Judge 隔离 Docker socket；真实生产部署仍需用户提供这些环境和凭据。

Closes #349