### PR TITLE
fix(ui): 提交详情页卡片优化与测试点明细可折叠展开

### DIFF
--- a/noj-ui/components/submission/SubmissionCaseResults.vue
+++ b/noj-ui/components/submission/SubmissionCaseResults.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { formatMemory, formatTime } from '~/utils/submissionFormat'
-import { isSubmissionCasePassed, normalizeSubmissionCases } from '~/utils/submissionCaseResults'
-import { useToast } from '~/composables/useToast'
+import { isSubmissionCasePassed, normalizeSubmissionCases, type SubmissionCaseResult } from '~/utils/submissionCaseResults'
+import { useCopyText } from '~/composables/useCopyText'
 
 const props = defineProps<{
   details: unknown
 }>()
 
-const { toast } = useToast()
+const { copyText } = useCopyText()
 
 const cases = computed(() => normalizeSubmissionCases(props.details))
 const passedCount = computed(() => cases.value.filter((item) => isSubmissionCasePassed(item.status)).length)
@@ -18,18 +18,17 @@ const hiddenCount = computed(() => cases.value.length - visibleCount.value)
 // 当前展开的测试点（单行展开）
 const expandedId = ref<string | null>(null)
 
-function toggleExpand(caseId: string) {
-  expandedId.value = expandedId.value === caseId ? null : caseId
+function hasOutput(item: SubmissionCaseResult) {
+  return item.expectedOutput !== null || item.actualOutput !== null
 }
 
-async function copyText(text: string | null, label: string) {
-  if (!text) return
-  try {
-    await navigator.clipboard.writeText(text)
-    toast.success(`${label}已复制`)
-  } catch {
-    toast.error("复制失败，请手动复制")
-  }
+function canExpand(item: SubmissionCaseResult) {
+  return item.visibility !== 'hidden' && hasOutput(item)
+}
+
+function toggleExpand(item: SubmissionCaseResult) {
+  if (!canExpand(item)) return
+  expandedId.value = expandedId.value === item.caseId ? null : item.caseId
 }
 
 const statusLabels: Record<string, string> = {
@@ -90,8 +89,14 @@ function statusClass(status: string) {
         <tbody>
           <template v-for="item in cases" :key="`${item.visibility}-${item.caseId}`">
             <tr
-              class="cursor-pointer border-b border-border last:border-0 transition-colors hover:bg-primary-hover"
-              @click="toggleExpand(item.caseId)"
+              class="border-b border-border last:border-0 transition-colors"
+              :class="canExpand(item) ? 'cursor-pointer hover:bg-primary-hover' : ''"
+              :tabindex="canExpand(item) ? 0 : undefined"
+              :role="canExpand(item) ? 'button' : undefined"
+              :aria-expanded="canExpand(item) ? expandedId === item.caseId : undefined"
+              @click="toggleExpand(item)"
+              @keydown.enter.prevent="toggleExpand(item)"
+              @keydown.space.prevent="toggleExpand(item)"
             >
               <th scope="row" class="px-4 py-3 text-left font-mono text-xs font-medium text-text">
                 {{ item.caseId }}
@@ -116,10 +121,11 @@ function statusClass(status: string) {
                 </span>
                 <span v-else class="inline-flex items-center gap-1">
                   <UIcon
+                    v-if="hasOutput(item)"
                     :name="expandedId === item.caseId ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
                     class="size-3.5"
                   />
-                  <span v-if="item.expectedOutput !== null || item.actualOutput !== null">查看期望与实际输出</span>
+                  <span v-if="hasOutput(item)">查看期望与实际输出</span>
                   <span v-else class="text-text-muted">--</span>
                 </span>
               </td>

--- a/noj-ui/components/submission/SubmissionCaseResults.vue
+++ b/noj-ui/components/submission/SubmissionCaseResults.vue
@@ -1,16 +1,36 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { formatMemory, formatTime } from '~/utils/submissionFormat'
 import { isSubmissionCasePassed, normalizeSubmissionCases } from '~/utils/submissionCaseResults'
+import { useToast } from '~/composables/useToast'
 
 const props = defineProps<{
   details: unknown
 }>()
 
+const { toast } = useToast()
+
 const cases = computed(() => normalizeSubmissionCases(props.details))
 const passedCount = computed(() => cases.value.filter((item) => isSubmissionCasePassed(item.status)).length)
 const visibleCount = computed(() => cases.value.filter((item) => item.visibility === 'visible').length)
 const hiddenCount = computed(() => cases.value.length - visibleCount.value)
+
+// 当前展开的测试点（单行展开）
+const expandedId = ref<string | null>(null)
+
+function toggleExpand(caseId: string) {
+  expandedId.value = expandedId.value === caseId ? null : caseId
+}
+
+async function copyText(text: string | null, label: string) {
+  if (!text) return
+  try {
+    await navigator.clipboard.writeText(text)
+    toast.success(`${label}已复制`)
+  } catch {
+    toast.error("复制失败，请手动复制")
+  }
+}
 
 const statusLabels: Record<string, string> = {
   Accepted: '通过',
@@ -43,15 +63,17 @@ function statusClass(status: string) {
     aria-labelledby="submission-case-results-title"
   >
     <div class="flex flex-wrap items-center justify-between gap-2 border-b border-border bg-bg-page px-4 py-3">
-      <div>
-        <h2 id="submission-case-results-title" class="text-sm font-semibold text-text">测试点明细</h2>
-        <p class="mt-1 text-xs text-text-muted">
-          {{ passedCount }}/{{ cases.length }} 个测试点通过
-          <span v-if="visibleCount"> · {{ visibleCount }} 个可见</span>
-          <span v-if="hiddenCount"> · {{ hiddenCount }} 个隐藏</span>
-        </p>
+      <div class="flex items-center gap-2">
+        <UIcon name="i-lucide-list-checks" class="size-5 text-text-muted" />
+        <div>
+          <h2 id="submission-case-results-title" class="text-sm font-semibold text-text">测试点明细</h2>
+          <p class="mt-1 text-xs text-text-muted">
+            {{ passedCount }}/{{ cases.length }} 个测试点通过
+            <span v-if="visibleCount"> · {{ visibleCount }} 个可见</span>
+            <span v-if="hiddenCount"> · {{ hiddenCount }} 个隐藏</span>
+          </p>
+        </div>
       </div>
-      <UIcon name="i-lucide-list-checks" class="size-5 text-text-muted" />
     </div>
 
     <div class="overflow-x-auto">
@@ -66,44 +88,69 @@ function statusClass(status: string) {
           </tr>
         </thead>
         <tbody>
-          <tr v-for="item in cases" :key="`${item.visibility}-${item.caseId}`" class="border-b border-border last:border-0">
-            <th scope="row" class="px-4 py-3 text-left font-mono text-xs font-medium text-text">
-              {{ item.caseId }}
-              <span v-if="item.visibility === 'hidden'" class="ml-1 text-[11px] font-sans text-text-muted">隐藏</span>
-            </th>
-            <td class="px-4 py-3">
-              <span class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold" :class="statusClass(item.status)">
-                <UIcon :name="isSubmissionCasePassed(item.status) ? 'i-lucide-check' : 'i-lucide-x'" class="size-3.5" />
-                {{ statusLabel(item.status) }}
-              </span>
-            </td>
-            <td class="whitespace-nowrap px-4 py-3 font-mono text-xs text-text-secondary">
-              {{ formatTime(item.timeMs) }}
-            </td>
-            <td class="whitespace-nowrap px-4 py-3 font-mono text-xs text-text-secondary">
-              {{ formatMemory(item.memoryKb) }}
-            </td>
-            <td class="px-4 py-3 text-xs text-text-secondary">
-              <span v-if="item.visibility === 'hidden'" class="inline-flex items-center gap-1 text-text-muted">
-                <UIcon name="i-lucide-lock" class="size-3.5" />
-                隐藏用例不展示输出
-              </span>
-              <details v-else-if="item.expectedOutput !== null || item.actualOutput !== null" class="max-w-[440px]">
-                <summary class="cursor-pointer select-none text-primary hover:underline">查看期望与实际输出</summary>
-                <div class="mt-2 grid gap-2 sm:grid-cols-2">
+          <template v-for="item in cases" :key="`${item.visibility}-${item.caseId}`">
+            <tr
+              class="cursor-pointer border-b border-border last:border-0 transition-colors hover:bg-primary-hover"
+              @click="toggleExpand(item.caseId)"
+            >
+              <th scope="row" class="px-4 py-3 text-left font-mono text-xs font-medium text-text">
+                {{ item.caseId }}
+                <span v-if="item.visibility === 'hidden'" class="ml-1 text-[11px] font-sans text-text-muted">隐藏</span>
+              </th>
+              <td class="px-4 py-3">
+                <span class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold" :class="statusClass(item.status)">
+                  <UIcon :name="isSubmissionCasePassed(item.status) ? 'i-lucide-check' : 'i-lucide-x'" class="size-3.5" />
+                  {{ statusLabel(item.status) }}
+                </span>
+              </td>
+              <td class="whitespace-nowrap px-4 py-3 font-mono text-xs text-text-secondary">
+                {{ formatTime(item.timeMs) }}
+              </td>
+              <td class="whitespace-nowrap px-4 py-3 font-mono text-xs text-text-secondary">
+                {{ formatMemory(item.memoryKb) }}
+              </td>
+              <td class="px-4 py-3 text-xs text-text-secondary">
+                <span v-if="item.visibility === 'hidden'" class="inline-flex items-center gap-1 text-text-muted">
+                  <UIcon name="i-lucide-lock" class="size-3.5" />
+                  隐藏用例不展示输出
+                </span>
+                <span v-else class="inline-flex items-center gap-1">
+                  <UIcon
+                    :name="expandedId === item.caseId ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+                    class="size-3.5"
+                  />
+                  <span v-if="item.expectedOutput !== null || item.actualOutput !== null">查看期望与实际输出</span>
+                  <span v-else class="text-text-muted">--</span>
+                </span>
+              </td>
+            </tr>
+            <!-- 展开详情行（紧跟对应测试点下方） -->
+            <tr
+              v-if="expandedId === item.caseId && (item.expectedOutput !== null || item.actualOutput !== null)"
+              class="border-b border-border bg-bg-page/50"
+            >
+              <td colspan="5" class="px-4 py-4">
+                <div class="grid gap-4">
+                  <!-- 期望输出 -->
                   <div class="min-w-0">
-                    <p class="mb-1 text-[11px] font-semibold text-text-muted">期望输出</p>
-                    <pre class="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-bg-page p-2 font-mono text-[11px] text-text">{{ item.expectedOutput ?? '--' }}</pre>
+                    <div class="mb-1.5 flex items-center justify-between">
+                      <p class="text-[11px] font-semibold text-text-muted">期望输出</p>
+                      <UButton size="xs" color="neutral" variant="ghost" icon="i-lucide-copy" @click.stop="copyText(item.expectedOutput, '期望输出')">复制</UButton>
+                    </div>
+                    <pre class="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-[#0d1117] p-3 font-mono text-[11px] leading-relaxed text-[#e6edf3]">{{ item.expectedOutput ?? '--' }}</pre>
                   </div>
+                  <!-- 实际输出 -->
                   <div class="min-w-0">
-                    <p class="mb-1 text-[11px] font-semibold text-text-muted">实际输出</p>
-                    <pre class="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-bg-page p-2 font-mono text-[11px] text-text">{{ item.actualOutput ?? '--' }}</pre>
+                    <div class="mb-1.5 flex items-center justify-between">
+                      <p class="text-[11px] font-semibold text-text-muted">实际输出</p>
+                      <UButton size="xs" color="neutral" variant="ghost" icon="i-lucide-copy" @click.stop="copyText(item.actualOutput, '实际输出')">复制</UButton>
+                    </div>
+                    <pre class="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-[#0d1117] p-3 font-mono text-[11px] leading-relaxed text-[#e6edf3]">{{ item.actualOutput ?? '--' }}</pre>
                   </div>
                 </div>
-              </details>
-              <span v-else>--</span>
-            </td>
-          </tr>
+              </td>
+            </tr>
+          </template>
         </tbody>
       </table>
     </div>

--- a/noj-ui/composables/useCopyText.ts
+++ b/noj-ui/composables/useCopyText.ts
@@ -1,0 +1,21 @@
+import { useToast } from './useToast';
+
+/**
+ * 复制文本到剪贴板的统一封装。
+ * 复制失败时给出统一错误提示，避免各页面重复实现。
+ */
+export function useCopyText() {
+  const { toast } = useToast();
+
+  async function copyText(text: string | null, label: string) {
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(`${label}已复制`);
+    } catch {
+      toast.error('复制失败，请手动复制');
+    }
+  }
+
+  return { copyText };
+}

--- a/noj-ui/pages/submissions/[id].vue
+++ b/noj-ui/pages/submissions/[id].vue
@@ -3,7 +3,7 @@ import { useRoute } from "vue-router"
 import hljs from "highlight.js"
 import "highlight.js/styles/github-dark.css"
 import SubmissionCaseResults from "~/components/submission/SubmissionCaseResults.vue"
-import { useToast } from "~/composables/useToast"
+import { useCopyText } from "~/composables/useCopyText"
 import { getLanguageLabel, formatScore, formatTime, formatMemory, statusBadgeColors, getResultDef, verdictClasses, formatDateTime } from "~/utils/submissionFormat"
 import { problemUrl, publicUrl } from "~/utils/publicIdentifiers"
 
@@ -48,17 +48,7 @@ const isFinished = computed(
 )
 const showOutput = ref(false)
 const showCode = ref(false)
-const { toast } = useToast()
-
-async function copyText(text: string | null, label: string) {
-  if (!text) return
-  try {
-    await navigator.clipboard.writeText(text)
-    toast.success(`${label}已复制`)
-  } catch {
-    toast.error("复制失败，请手动复制")
-  }
-}
+const { copyText } = useCopyText()
 // 自动轮询：基础数据公开访问，未登录也能查看；等 auth token 就绪后开始轮询
 let pollTimer: ReturnType<typeof setInterval> | null = null
 let pollReqId = 0

--- a/noj-ui/pages/submissions/[id].vue
+++ b/noj-ui/pages/submissions/[id].vue
@@ -3,6 +3,7 @@ import { useRoute } from "vue-router"
 import hljs from "highlight.js"
 import "highlight.js/styles/github-dark.css"
 import SubmissionCaseResults from "~/components/submission/SubmissionCaseResults.vue"
+import { useToast } from "~/composables/useToast"
 import { getLanguageLabel, formatScore, formatTime, formatMemory, statusBadgeColors, getResultDef, verdictClasses, formatDateTime } from "~/utils/submissionFormat"
 import { problemUrl, publicUrl } from "~/utils/publicIdentifiers"
 
@@ -45,7 +46,19 @@ const submission = computed(() => data.value?.data ?? null)
 const isFinished = computed(
   () => submission.value?.status === "finished" || submission.value?.status === "error",
 )
-const showOutput = ref(true)
+const showOutput = ref(false)
+const showCode = ref(false)
+const { toast } = useToast()
+
+async function copyText(text: string | null, label: string) {
+  if (!text) return
+  try {
+    await navigator.clipboard.writeText(text)
+    toast.success(`${label}已复制`)
+  } catch {
+    toast.error("复制失败，请手动复制")
+  }
+}
 // 自动轮询：基础数据公开访问，未登录也能查看；等 auth token 就绪后开始轮询
 let pollTimer: ReturnType<typeof setInterval> | null = null
 let pollReqId = 0
@@ -229,13 +242,35 @@ watch(
           </div>
         </div>
       </div>
-      <!-- 代码区 -->
+      <!-- 测试点明细（挪到提交代码上方） -->
+      <SubmissionCaseResults
+        v-if="submission.status === 'finished' && submission.result"
+        :details="submission.result.details"
+      />
+      <!-- 提交代码 -->
       <div class="bg-[#0d1117] border border-[#30363d] rounded-xl overflow-hidden">
-        <div class="flex items-center gap-2 px-4 py-2.5 bg-[#161b22] text-[#8b949e] text-xs font-mono border-b border-[#30363d]">
-          <UIcon name="i-lucide-file-text" class="size-4" />
-          <span>{{ submission.file_name || "main.py" }}</span>
-        </div>
-        <pre v-if="submission.code !== null" class="p-4 overflow-x-auto text-xs leading-relaxed"><code :ref="codeRef" :class="`language-${codeLanguage}`" class="font-mono text-[#e6edf3] whitespace-pre">{{ submission.code }}</code></pre>
+        <button
+          class="flex items-center justify-between w-full px-4 py-3 bg-[#161b22] text-[#8b949e] text-xs font-mono border-b border-[#30363d] cursor-pointer hover:bg-[#1c2128]"
+          @click="showCode = !showCode"
+        >
+          <span class="flex items-center gap-2">
+            <UIcon name="i-lucide-file-text" class="size-4" />
+            <span>提交代码</span>
+            <span class="text-[#8b949e]/60">{{ submission.file_name || "main.py" }}</span>
+          </span>
+          <span class="flex items-center gap-2">
+            <UIcon
+              v-if="submission.code !== null"
+              name="i-lucide-copy"
+              class="size-4 hover:text-[#e6edf3]"
+              title="复制代码"
+              @click.stop="copyText(submission.code, '代码')"
+            />
+            <UIcon name="i-lucide-chevron-down" class="size-4" v-if="!showCode"/>
+            <UIcon name="i-lucide-chevron-up" class="size-4" v-else/>
+          </span>
+        </button>
+        <pre v-if="submission.code !== null" v-show="showCode" class="p-4 overflow-x-auto text-xs leading-relaxed"><code :ref="codeRef" :class="`language-${codeLanguage}`" class="font-mono text-[#e6edf3] whitespace-pre">{{ submission.code }}</code></pre>
         <div v-else class="flex flex-col items-center justify-center gap-2 py-12 text-[#8b949e] text-sm">
           <UIcon name="i-lucide-lock" class="size-6" />
           <span>登录后查看源代码</span>
@@ -251,15 +286,27 @@ watch(
       <!-- 输出区（仅 finished 有内容） -->
       <div
         v-if="submission.status === 'finished' && submission.result"
-        class="bg-white border border-border rounded-xl overflow-hidden"
+        class="bg-[#0d1117] border border-[#30363d] rounded-xl overflow-hidden"
       >
         <button
-          class="flex items-center justify-between w-full px-4 py-3 bg-bg-page border-0 border-b border-border text-sm font-semibold text-text cursor-pointer hover:bg-primary-hover"
+          class="flex items-center justify-between w-full px-4 py-3 bg-[#161b22] text-[#8b949e] text-xs font-mono border-b border-[#30363d] cursor-pointer hover:bg-[#1c2128]"
           @click="showOutput = !showOutput"
         >
-          <span>评测输出</span>
-          <UIcon name="i-lucide-chevron-down" class="size-4" v-if="!showOutput"/>
-          <UIcon name="i-lucide-chevron-up" class="size-4" v-else/>
+          <span class="flex items-center gap-2">
+            <UIcon name="i-lucide-terminal" class="size-4" />
+            <span>评测输出</span>
+          </span>
+          <span class="flex items-center gap-2">
+            <UIcon
+              v-if="submission.result?.output != null"
+              name="i-lucide-copy"
+              class="size-4 hover:text-[#e6edf3]"
+              title="复制评测输出"
+              @click.stop="copyText(submission.result?.output ?? null, '评测输出')"
+            />
+            <UIcon name="i-lucide-chevron-down" class="size-4" v-if="!showOutput"/>
+            <UIcon name="i-lucide-chevron-up" class="size-4" v-else/>
+          </span>
         </button>
         <pre v-if="submission.result.output != null" v-show="showOutput" class="p-4 overflow-x-auto text-xs leading-relaxed bg-[#0d1117] text-[#e6edf3]"><code class="font-mono whitespace-pre-wrap break-all">{{ submission.result.output }}</code></pre>
         <div v-else class="flex flex-col items-center justify-center gap-2 py-8 text-text-muted text-sm">
@@ -274,10 +321,6 @@ watch(
           </NuxtLink>
         </div>
       </div>
-      <SubmissionCaseResults
-        v-if="submission.status === 'finished' && submission.result"
-        :details="submission.result.details"
-      />
     </template>
   </div>
 </template>


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->
- 提交详情页（/submissions/:id）卡片优化与测试点明细可折叠展开：

1. **提交代码卡片**：标题栏改「提交代码」（文件名作次要标注），做成可折叠并默认折叠，展开后标题栏右上角有复制按钮。
2. **评测输出卡片**：默认折叠，添加终端图标与复制按钮；收缩状态（字体/按钮位置/边框/hover）与提交代码卡片统一。
3. **测试点明细**：整行可点展开，期望/实际输出在对应测试点行下方展开（深色代码块 + 复制按钮）；头部图标移到标题左侧。
4. **卡片顺序**：测试点明细挪到提交代码上方；两个可折叠卡片标题栏高度对齐。
- 本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [x] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）

修改前
<img width="3840" height="2194" alt="截图 2026-08-27 05-58-50" src="https://github.com/user-attachments/assets/ce489c0b-4123-429e-91fb-692735674119" />
<img width="3840" height="2194" alt="截图 2026-08-27 05-58-55" src="https://github.com/user-attachments/assets/4c10b6e4-29fa-4824-9422-1ab04a474ad7" />
修改后
<img width="3840" height="2194" alt="截图 2026-08-27 05-58-27" src="https://github.com/user-attachments/assets/8449c110-c758-4719-851c-422c22c5a5d8" />
<img width="3840" height="2194" alt="截图 2026-08-27 05-58-31" src="https://github.com/user-attachments/assets/aa7c4694-d2de-410f-a9fe-aaec726651ec" />
<img width="3840" height="2194" alt="截图 2026-08-27 05-58-33" src="https://github.com/user-attachments/assets/0da7596c-039b-4db8-9685-64f622f3141d" />


<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）

- 本commit由AI生成。

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
