### PR TITLE
fix(ui): 修复主页手机模式下签到区顶塌公告轮播区域

### DIFF
--- a/noj-ui/pages/index.vue
+++ b/noj-ui/pages/index.vue
@@ -4,6 +4,7 @@
             <div class="flex flex-col flex-1">
                 <div class="flex flex-col lg:flex-row flex-1 min-h-[320px] bg-white">
                     <!-- Carousel -->
+                    <!-- 手机模式下内容为 absolute 定位，容器需 min-h 保底，避免高度塌缩被签到区顶塌 -->
                     <div
                         class="flex-1 min-w-0 relative overflow-hidden min-h-[320px]"
                         role="region"

--- a/noj-ui/pages/index.vue
+++ b/noj-ui/pages/index.vue
@@ -5,7 +5,7 @@
                 <div class="flex flex-col lg:flex-row flex-1 min-h-[320px] bg-white">
                     <!-- Carousel -->
                     <div
-                        class="flex-1 min-w-0 relative overflow-hidden"
+                        class="flex-1 min-w-0 relative overflow-hidden min-h-[320px]"
                         role="region"
                         aria-roledescription="轮播图"
                         aria-label="公告轮播"


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

<!--
在下方写 Closes #123 / Fixes #456 / Resolves #789（必须是关键字 + 数字格式）。
GitHub 检测到后会在 PR merge 时自动关闭对应 issue。
注意：必须是关键字 + 英文井号，例如 `Closes #186`（不是 `关闭 #186` 也不是 `Closes issue #186`）。
issue 未提供 / 不适用 → 写 "无"。
-->

无

## 变更摘要

<!-- 1-3 句话说清做了什么、为什么。 -->
- 修复主页手机模式下签到区顶塌公告轮播区域的问题：
- 手机模式下（lg:flex-row 不生效）轮播容器内部内容全为 absolute 定位，导致自身高度塌缩为 0，签到区因此向上顶塌公告区域
- 为轮播容器加 `min-h-[320px]` 保底高度，手机模式纵向排列时公告区保持固定高度，不再被签到区挤压
- 横屏模式（lg:flex-row）下轮播 flex-1 自适应、签到区定宽，布局不受影响
- 本commit由AI生成。

## 变更类型

<!-- 勾选所有适用的项 -->

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

<!-- 勾选所有受影响的模块 / 数据 / 行为 -->

- [ ] `noj-core` 后端
- [x] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [ ] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

<!-- 提交前自查，确保所有项打勾。CI 会强制跑一遍，但本地先过能省一轮 CI 时间。 -->

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [x] 本地 `deno task test` 通过
- [ ] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [x] GPG 签名可用

## 截图 / 录屏（可选）

修改前
<img width="1048" height="2106" alt="截图 2026-08-27 06-02-18" src="https://github.com/user-attachments/assets/81d346c1-ae48-46f9-b83f-df43b32e4f39" />
修改后
<img width="1048" height="2106" alt="截图 2026-08-27 06-04-39" src="https://github.com/user-attachments/assets/7a4989c7-b278-4dca-9009-7ba3791db851" />


<!-- UI 变更强烈建议附上。拖入图片或贴 GIF 链接均可。 -->

## 补充说明（可选）

- 本commit由AI生成。

<!-- reviewer 关注点、风险、回滚方案、相关 PR 链接等。 -->
