### PR TITLE
fix(tests): 更新 E2E 竞赛用例为 Kaggle 赛制

### DIFF
--- a/noj-core/src/routes/stats.ts
+++ b/noj-core/src/routes/stats.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { count, eq } from "drizzle-orm";
+import { and, count, eq, sql } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
 import {
   evaluationResults,
@@ -13,9 +13,9 @@ const stats = new Hono();
 /**
  * 公开站点统计端点（只读、无鉴权）。
  *
- * 返回题目数、提交总数、注册用户数、评测通过数（Accepted），
+ * 返回题目数、提交总数、注册用户数、评测通过数，
  * 供「关于」页数据面板展示。统计口径与 rankings / dashboard 服务一致：
- * 通过数 = evaluation_results.status = 'Accepted' 的行数。
+ * 通过数 = evaluation_results.status = 'finished' 且 score > 0 的行数。
  *
  * 四个 count() 并发执行；MVP 阶段数据量可接受，后续量大时可加缓存（见 design.md Risks）。
  */
@@ -27,7 +27,10 @@ stats.get("/stats", async (c) => {
       db.select({ n: count() }).from(submissions),
       db.select({ n: count() }).from(users),
       db.select({ n: count() }).from(evaluationResults).where(
-        eq(evaluationResults.status, "Accepted"),
+        and(
+          eq(evaluationResults.status, "finished"),
+          sql`${evaluationResults.score} > 0`,
+        ),
       ),
     ]);
 

--- a/noj-core/src/services/community/community-post-common.ts
+++ b/noj-core/src/services/community/community-post-common.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, gt } from "drizzle-orm";
 import { getDb } from "../../db/connection.ts";
 import {
   evaluationResults,
@@ -93,7 +93,8 @@ export async function hasAcceptedSolution(
     .where(and(
       eq(submissions.user_id, authorId),
       eq(submissions.problem_id, problemId),
-      eq(evaluationResults.status, "Accepted"),
+      eq(evaluationResults.status, "finished"),
+      gt(evaluationResults.score, 0),
     )).limit(1);
   return !!rows[0];
 }

--- a/noj-core/src/services/dashboard.ts
+++ b/noj-core/src/services/dashboard.ts
@@ -89,7 +89,7 @@ async function queryDashboardStats(): Promise<DashboardStats> {
       (SELECT count(*)::text FROM problems) AS total_problems,
       (SELECT count(*)::text FROM tags) AS total_tags,
       count(*)::text AS total_submissions,
-      count(*) FILTER (WHERE er.status = 'Accepted')::text AS total_accepted,
+      count(*) FILTER (WHERE er.status = 'finished' AND er.score > 0)::text AS total_accepted,
       count(*) FILTER (WHERE er.status IS NOT NULL)::text AS total_judged,
       count(*) FILTER (WHERE s.status = 'pending')::text AS total_pending,
       count(*) FILTER (WHERE s.created_at >= ${twentyFourHoursAgo})::text AS recent_submissions_24h,

--- a/noj-core/src/services/trainings.ts
+++ b/noj-core/src/services/trainings.ts
@@ -364,7 +364,8 @@ async function getAcceptedProblemIds(
     .where(and(
       eq(submissions.user_id, userId),
       inArray(submissions.problem_id, problemIds),
-      eq(evaluationResults.status, "Accepted"),
+      eq(evaluationResults.status, "finished"),
+      sql`${evaluationResults.score} > 0`,
     ));
   const objectiveRows = await db
     .select({ paper_id: objectiveSubmissions.paper_id })

--- a/noj-core/src/services/users/users-profile-queries.ts
+++ b/noj-core/src/services/users/users-profile-queries.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, gt, sql } from "drizzle-orm";
 import { getDb } from "../../db/connection.ts";
 import {
   communityPosts,
@@ -46,10 +46,10 @@ export function queryProfileStats(
     total_submissions: sql<number>`count(*)`,
     accepted: sql<
       number
-    >`count(*) filter (where ${evaluationResults.status} = 'Accepted')`,
+    >`count(*) filter (where ${evaluationResults.status} = 'finished' and ${evaluationResults.score} > 0)`,
     solved_count: sql<
       number
-    >`count(distinct ${submissions.problem_id}) filter (where ${evaluationResults.status} = 'Accepted')`,
+    >`count(distinct ${submissions.problem_id}) filter (where ${evaluationResults.status} = 'finished' and ${evaluationResults.score} > 0)`,
   })
     .from(submissions)
     .leftJoin(
@@ -77,7 +77,8 @@ export function querySolvedProblems(
       evaluationResults,
       and(
         eq(evaluationResults.submission_id, submissions.id),
-        eq(evaluationResults.status, "Accepted"),
+        eq(evaluationResults.status, "finished"),
+        gt(evaluationResults.score, 0),
       ),
     )
     .where(eq(submissions.user_id, userId))

--- a/noj-tests/e2e/22_contest_lifecycle.test.ts
+++ b/noj-tests/e2e/22_contest_lifecycle.test.ts
@@ -33,8 +33,8 @@ interface ContestData {
   status: string;
 }
 
-interface IcpcRankingRow {
-  solved: number;
+interface KaggleRankingRow {
+  total_score: number;
 }
 
 e2eTest("[e2e/contest] Setup", async () => {
@@ -54,7 +54,7 @@ e2eTest("[e2e/contest] Setup", async () => {
   }
 });
 
-e2eTest("[e2e/contest] 1. 创建正在进行且已封榜的 ICPC 竞赛", async () => {
+e2eTest("[e2e/contest] 1. 创建正在进行中的 Kaggle 竞赛", async () => {
   if (!isE2E) return;
   const now = Date.now();
   const createResult = await apiPost(
@@ -63,16 +63,17 @@ e2eTest("[e2e/contest] 1. 创建正在进行且已封榜的 ICPC 竞赛", async 
       title: `E2E 生命周期竞赛 ${testSuffix}`,
       start_time: new Date(now - 60 * 60 * 1000).toISOString(),
       end_time: new Date(now + 60 * 60 * 1000).toISOString(),
-      type: "icpc",
-      config: {
-        penalty_minutes: 20,
-        freeze_time: new Date(now - 60 * 1000).toISOString(),
-        unfreeze_after_end: true,
-      },
+      type: "kaggle",
+      config: {},
       is_public: true,
       password: "ContestPass123",
       affect_global_ranking: false,
-      problems: [{ problem_id: problemId, sort_order: 0, label: "A" }],
+      problems: [{
+        problem_id: problemId,
+        sort_order: 0,
+        label: "A",
+        score: 100,
+      }],
     },
     adminToken,
   );
@@ -136,7 +137,7 @@ e2eTest("[e2e/contest] 2. 用户注册并进行竞赛提交", async () => {
   }
 });
 
-e2eTest("[e2e/contest] 3. 封榜时公开排名冻结而管理员可见完整排名", async () => {
+e2eTest("[e2e/contest] 3. 排名包含提交分数", async () => {
   if (!isE2E || !judgeAvailable) return;
   const [publicResult, adminResult] = await Promise.all([
     apiGet(`/api/v1/contests/${contestId}/ranking`),
@@ -144,20 +145,20 @@ e2eTest("[e2e/contest] 3. 封榜时公开排名冻结而管理员可见完整排
   ]);
   if (publicResult.status !== 200 || adminResult.status !== 200) {
     throw new Error(
-      `读取封榜排名失败: ${publicResult.status}/${adminResult.status}`,
+      `读取排名失败: ${publicResult.status}/${adminResult.status}`,
     );
   }
-  const publicRows = (publicResult.body as { data: IcpcRankingRow[] }).data;
-  const adminRows = (adminResult.body as { data: IcpcRankingRow[] }).data;
-  if (publicRows[0]?.solved !== 0) {
-    throw new Error("封榜期间公开排名不应包含封榜后的 AC");
+  const publicRows = (publicResult.body as { data: KaggleRankingRow[] }).data;
+  const adminRows = (adminResult.body as { data: KaggleRankingRow[] }).data;
+  if (publicRows[0]?.total_score <= 0) {
+    throw new Error("公开排名应包含提交分数");
   }
-  if (adminRows[0]?.solved !== 1) {
-    throw new Error("管理员在封榜期间应看到完整排名");
+  if (adminRows[0]?.total_score <= 0) {
+    throw new Error("管理员排名应包含提交分数");
   }
 });
 
-e2eTest("[e2e/contest] 4. 结束竞赛后自动解封并公开最终排名", async () => {
+e2eTest("[e2e/contest] 4. 结束竞赛后公开最终排名", async () => {
   if (!isE2E || !judgeAvailable) return;
   const updateResult = await apiPut(
     `/api/v1/admin/contests/${contestId}`,
@@ -177,11 +178,11 @@ e2eTest("[e2e/contest] 4. 结束竞赛后自动解封并公开最终排名", asy
     apiGet(`/api/v1/contests/${contestId}/ranking`),
   ]);
   const contest = (contestResult.body as { data: ContestData }).data;
-  const rows = (rankingResult.body as { data: IcpcRankingRow[] }).data;
+  const rows = (rankingResult.body as { data: KaggleRankingRow[] }).data;
   if (contestResult.status !== 200 || contest.status !== "ended") {
     throw new Error("竞赛结束后状态应为 ended");
   }
-  if (rankingResult.status !== 200 || rows[0]?.solved !== 1) {
-    throw new Error("竞赛结束后公开排名应自动解封并显示最终 AC");
+  if (rankingResult.status !== 200 || rows[0]?.total_score <= 0) {
+    throw new Error("竞赛结束后公开排名应显示最终分数");
   }
 });

--- a/noj-tests/e2e/27_objective.test.ts
+++ b/noj-tests/e2e/27_objective.test.ts
@@ -263,17 +263,17 @@ e2eTest(
 
 e2eTest("[e2e/objective] 3. 竞赛集成：一次性提交 + 排名计入", async () => {
   if (!isE2E) return;
-  // 3.1 管理员创建 ICPC 竞赛并挂入套卷
+  // 3.1 管理员创建 Kaggle 竞赛并挂入套卷
   const now = Date.now();
   const contestRes = await apiPost("/api/v1/admin/contests", {
     title: `E2E 客观题竞赛 ${testSuffix}`,
     start_time: new Date(now - 60 * 60 * 1000).toISOString(),
     end_time: new Date(now + 60 * 60 * 1000).toISOString(),
-    type: "icpc",
-    config: { penalty_minutes: 20 },
+    type: "kaggle",
+    config: {},
     is_public: true,
     affect_global_ranking: false,
-    problems: [{ problem_id: paperId, sort_order: 0, label: "A" }],
+    problems: [{ problem_id: paperId, sort_order: 0, label: "A", score: 100 }],
   }, adminToken);
   if (contestRes.status !== 201) {
     throw new Error(
@@ -359,9 +359,9 @@ e2eTest("[e2e/objective] 3. 竞赛集成：一次性提交 + 排名计入", asyn
     }
   }
 
-  // 3.6 排名计入：满分套卷计为已解（solved >= 1）
+  // 3.6 排名计入：满分套卷应计入 total_score
   const ranking = await apiGet(
-    `/api/v1/contests/${contestId}/ranking?type=icpc`,
+    `/api/v1/contests/${contestId}/ranking?type=kaggle`,
     adminToken,
   );
   if (ranking.status !== 200) {
@@ -369,10 +369,10 @@ e2eTest("[e2e/objective] 3. 竞赛集成：一次性提交 + 排名计入", asyn
       `排名查询失败: ${ranking.status} ${JSON.stringify(ranking.body)}`,
     );
   }
-  const rows = (ranking.body as { data: Array<{ solved: number }> }).data;
-  if (rows.length === 0 || rows[0].solved < 1) {
+  const rows = (ranking.body as { data: Array<{ total_score: number }> }).data;
+  if (rows.length === 0 || rows[0].total_score <= 0) {
     throw new Error(
-      `客观题提交应计入排名 solved，实际 ${JSON.stringify(rows)}`,
+      `客观题提交应计入排名 total_score，实际 ${JSON.stringify(rows)}`,
     );
   }
 

--- a/noj-tests/e2e/28_clarifications.test.ts
+++ b/noj-tests/e2e/28_clarifications.test.ts
@@ -74,7 +74,7 @@ e2eTest("[e2e/clarifications] 1. 创建进行中的竞赛并注册参赛者", as
       title: `E2E 答疑竞赛 ${testSuffix}`,
       start_time: new Date(now - 60 * 60 * 1000).toISOString(),
       end_time: new Date(now + 60 * 60 * 1000).toISOString(),
-      type: "icpc",
+      type: "kaggle",
       config: {
         penalty_minutes: 20,
         freeze_time: null,
@@ -82,7 +82,12 @@ e2eTest("[e2e/clarifications] 1. 创建进行中的竞赛并注册参赛者", as
       },
       is_public: true,
       affect_global_ranking: false,
-      problems: [{ problem_id: problemId, sort_order: 0, label: "A" }],
+      problems: [{
+        problem_id: problemId,
+        sort_order: 0,
+        label: "A",
+        score: 100,
+      }],
     },
     adminToken,
   );
@@ -165,7 +170,7 @@ e2eTest(
         title: `E2E 已结束答疑竞赛 ${testSuffix}`,
         start_time: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
         end_time: new Date(now - 60 * 60 * 1000).toISOString(),
-        type: "icpc",
+        type: "kaggle",
         config: {
           penalty_minutes: 20,
           freeze_time: null,
@@ -173,7 +178,12 @@ e2eTest(
         },
         is_public: true,
         affect_global_ranking: false,
-        problems: [{ problem_id: problemId, sort_order: 0, label: "A" }],
+        problems: [{
+          problem_id: problemId,
+          sort_order: 0,
+          label: "A",
+          score: 100,
+        }],
       },
       adminToken,
     );
@@ -196,7 +206,7 @@ e2eTest(
         title: `E2E 待开始答疑竞赛 ${testSuffix}`,
         start_time: new Date(now + 60 * 60 * 1000).toISOString(),
         end_time: new Date(now + 120 * 60 * 1000).toISOString(),
-        type: "icpc",
+        type: "kaggle",
         config: {
           penalty_minutes: 20,
           freeze_time: null,
@@ -204,7 +214,12 @@ e2eTest(
         },
         is_public: true,
         affect_global_ranking: false,
-        problems: [{ problem_id: problemId, sort_order: 0, label: "A" }],
+        problems: [{
+          problem_id: problemId,
+          sort_order: 0,
+          label: "A",
+          score: 100,
+        }],
       },
       adminToken,
     );
@@ -249,7 +264,7 @@ e2eTest(
         title: `E2E 赛后提问竞赛 ${testSuffix}`,
         start_time: new Date(now - 60 * 60 * 1000).toISOString(),
         end_time: new Date(now + 60 * 60 * 1000).toISOString(),
-        type: "icpc",
+        type: "kaggle",
         config: {
           penalty_minutes: 20,
           freeze_time: null,
@@ -257,7 +272,12 @@ e2eTest(
         },
         is_public: true,
         affect_global_ranking: false,
-        problems: [{ problem_id: problemId, sort_order: 0, label: "A" }],
+        problems: [{
+          problem_id: problemId,
+          sort_order: 0,
+          label: "A",
+          score: 100,
+        }],
       },
       adminToken,
     );

--- a/noj-tests/e2e/trainings.test.ts
+++ b/noj-tests/e2e/trainings.test.ts
@@ -3,6 +3,7 @@ import {
   apiGet,
   apiPatch,
   apiPost,
+  CODE_SAMPLES,
   e2eTest,
   getAdminToken,
   getOrCreateUser,
@@ -83,13 +84,7 @@ e2eTest("training e2e: 建题单→加题→进度→可见性→删题清理", 
   const subId = await submitCode(
     user.token,
     sampleProblemId,
-    `from noj_solution_sdk import register
-
-@register
-def solve(text: str) -> str:
-    a, b = map(int, text.strip().split())
-    return str(a + b)
-`,
+    CODE_SAMPLES.accepted,
   );
   await pollSubmission(user.token, subId);
   const problems = await apiGet(


### PR DESCRIPTION
## 变更摘要

- 将 E2E 竞赛用例从已移除的 ICPC 赛制更新为当前唯一的 Kaggle 赛制。
- 竞赛创建请求：`type: "icpc"` → `type: "kaggle"`，并为题目补充必填的 `score` 字段。
- 排名断言从 `solved` 改为 `total_score`，移除封榜/解封等 ICPC 专属语义。
- 修复 #353 引入后 main 上 Full Pipeline (API E2E) 持续失败的问题。