### PR TITLE
fix: 修复题单进度测试 CI 失败

### DIFF
--- a/noj-core/tests/services/trainings.test.ts
+++ b/noj-core/tests/services/trainings.test.ts
@@ -231,7 +231,7 @@ Deno.test({
       await db.insert(evaluationResults).values({
         id: crypto.randomUUID(),
         submission_id: subId,
-        status: "Accepted",
+        status: "finished",
         score: 10000,
         output: "",
         time_ms: 1,


### PR DESCRIPTION
## 背景

Core DB CI 中的题单进度测试失败：`getAcceptedProblemIds` 按服务契约筛选 `evaluation_results.status = finished`，但测试 fixture 写入了 `Accepted`，导致已通过题目未被聚合。

## 修改

- 将 `noj-core/tests/services/trainings.test.ts` 中该 fixture 的评测结果状态改为 `finished`
- 不修改生产代码和运行时行为
- 本 PR 与用户自带模型（BYOK）PR 分离

## 验证

- `deno fmt --check`
- `deno lint`
- `deno test -A --no-check tests/services/trainings.test.ts`：2 passed
- CI 同构 Core DB 测试：700 passed，0 failed，17 ignored