### PR TITLE
feat(ui): 改进 SSR 渲染、SEO、缓存与错误处理

### DIFF
--- a/noj-ui/AGENTS.md
+++ b/noj-ui/AGENTS.md
@@ -264,7 +264,7 @@ cd dist
 - `login(login, password, code?)` / `register(data)` / `logout()`：封装对应 API 调用；`code` 为 TFA 验证码/恢复码（issue #228）
 - `changePassword(oldPassword, newPassword)`：调用 `/api/v1/auth/change-password`，成功后自动 `logout()` 清 Cookie 并跳 `/login?reason=password_changed`（避免旧 JWT flag 残留致路由守卫死循环）
 - `logout()` 清除 `auth:user` 状态 + 调用 `/api/auth/logout` 删除 Cookie
-- 初始化时若 Cookie 存在则自动调用 `fetchUser()`（SSR 阶段跳过）
+- 初始化时若 Cookie 存在则自动调用 `fetchUser()`；SSR 阶段通过 `/api/v1/auth/me` 获取完整用户与权限
 
 ### useToast
 - 基于 Nuxt UI `useToast` 的 Toast 通知
@@ -318,10 +318,17 @@ cd dist
 
 | 场景 | 方法 | 说明 |
 |------|------|------|
-| 页面初始数据 | `useAsyncData` + `$fetch` | SSR 时在服务端获取，水合时复用 |
-| 客户端 API 调用 | `$fetch` | 通过 Nitro 代理转发 |
+| 页面初始数据 | `useAsyncData` / `useFetch` | SSR 时在服务端获取，结果序列化到 payload，水合时复用 |
+| 交互 / 轮询 / 表单 | `useApi` | 统一错误处理；禁止在 setup 顶层 `await api.get` 写普通 `ref` |
 | 轮询 | `useSubmissionPolling` composable | 基于 `setInterval`，状态终态自动停止 |
-| 表单提交 | `$fetch` + 手动错误处理 | 显示后端返回的错误信息 |
+| 表单提交 | `useApi` | 显示后端返回的错误信息 |
+
+### SSR 数据获取约定
+
+- 页面初始数据 MUST 使用 `useAsyncData`/`useFetch`，不得在 `<script setup>` 顶层 `await api.get(...)` 写入普通 `ref`。
+- `useApi` 服务端通过 `useRequestFetch` 转发 Cookie/请求头；`useApi()` 调用 MUST 发生在同步 setup 上下文，异步回调内不得再次调用。
+- 非关键数据（社区配置、首页公告等）SSR 失败 MUST 降级为空态/默认值，不得导致整页 502。
+- `ssr: false` 边界：管理后台、编辑器、新建/编辑题目、竞赛做题页、私信、我的题目、设置、队列、竞赛排名、社区收藏/通知/举报详情使用 `ssr: false`；内容/SEO 页保持 SSR。
 
 ## 中间件
 
@@ -329,13 +336,13 @@ cd dist
 - 检查 `noj:session` Cookie 是否存在
 - 不存在 → `navigateTo("/login")`
 - 存在但需要验证 → 调用 `fetchUser()`，5 秒超时
-- SSR 阶段跳过守卫，客户端水合后重新执行
+- SSR 阶段同样执行守卫：服务端基于 `/auth/me` 填充的完整用户状态做重定向，客户端水合后再次校验
 - **强制改密（issue #75）**：`user.must_change_password=true` 时强制跳 `/change-password`（白名单路径 `/change-password`、`/login`、`/logout` 放行）
 
 ### admin 守卫
 - 检查 `noj:session` Cookie 中的 `is_admin` 字段（RBAC：权限集含 `admin:full_access`，登录/`/auth/me` 时实时计算）
 - 非管理员 → `navigateTo("/")`（静默重定向，无错误提示）
-- SSR 阶段跳过
+- SSR 阶段同样执行守卫
 
 ### ssr: false 页面
 - 所有 `/admin/*` 页面
@@ -359,7 +366,7 @@ cd dist
 | `auth` | 所有需登录页面 | 未登录 → `/login` |
 | `admin` | `/admin/*` | 未登录 → `/login`，非管理员 → `/`（静默拦截） |
 
-> SSR 阶段跳过守卫，客户端水合后重新执行。所有 admin 页面使用 `ssr: false`。
+> SSR 阶段同样执行守卫，客户端水合后再次校验。所有 admin 页面使用 `ssr: false`。
 
 ## 密码重置页面（issue #49）
 
@@ -386,7 +393,7 @@ cd dist
 ## 已知限制
 
 - **无前端单元测试**：组件未配置独立的测试框架（跨模块 E2E 测试见 noj-tests）
-- **无 SEO 优化**：无 Open Graph 标签、结构化数据、sitemap
+- **SEO 基础已具备**：动态页 `useSeoMeta`、OG、sitemap、robots 已加入；结构化数据与完整关键词策略仍待补充
 - **无图片优化**：仅 `logo.jpg`，未使用 Nuxt 图片优化
 - **无字体优化**：使用系统字体栈，无 web font 加载
 - **Composable 命名不一致**：部分使用 camelCase（`useAuth`），部分使用 kebab-case（`use-submissions`）

--- a/noj-ui/app.vue
+++ b/noj-ui/app.vue
@@ -58,7 +58,14 @@ function resolvePageTitle(path: string): string {
   return byPrefix?.title ?? "Neuro OJ"
 }
 
-useHead({ title: computed(() => resolvePageTitle(route.path)) })
+useHead({
+  title: computed(() => resolvePageTitle(route.path)),
+  meta: [
+    { property: 'og:title', content: 'Neuro OJ' },
+    { property: 'og:description', content: 'Neuro OJ — 面向 AI 领域认证与竞赛（IOAI / NOAI / LMCC）的在线评测平台' },
+    { property: 'og:type', content: 'website' },
+  ],
+})
 </script>
 
 <style>

--- a/noj-ui/composables/useAdminList.ts
+++ b/noj-ui/composables/useAdminList.ts
@@ -72,6 +72,7 @@ function deepGet(obj: unknown, path: string): unknown {
 export function useAdminList<T = Record<string, unknown>>(
   options: AdminListOptions<T>,
 ): AdminListResult<T> {
+  const { api } = useApi();
   const items = ref<T[]>([]) as Ref<T[]>;
   const loading = ref(true);
   const error = ref('');
@@ -101,7 +102,6 @@ export function useAdminList<T = Record<string, unknown>>(
       if (keyword.value) params.set('keyword', keyword.value);
 
       // 列表加载为后台场景：错误写入 error state 由页面展示，不弹 toast
-      const { api } = useApi();
       if (options.transform) {
         const raw = await api.get(`${options.path}?${params}`, { silent: true });
         const r = options.transform(raw);

--- a/noj-ui/composables/useApi.ts
+++ b/noj-ui/composables/useApi.ts
@@ -42,12 +42,9 @@ export function useApi() {
   const route = useRoute();
 
   // SSR 端 $fetch 不会自动携带浏览器 Cookie（server→server 直连）。
-  // 必须在 useApi() 的同步 setup 上下文捕获请求头（useRequestHeaders 不能在异步
-  // request() 闭包内调用，否则 SSR 抛 NUXT_E1001），供下面的 request() 闭包使用。
-  // 不转发则后端把登录用户当成游客，community/config 等接口返回空 permissions，
-  // 导致「发布内容」按钮 SSR 渲染为 disabled，且被 hydration mismatch 卡死（切页才恢复）。
+  // 使用 useRequestFetch 统一转发原始请求的 Cookie 与请求头，与 useFetch 行为对齐。
   // 客户端浏览器会自动带上 Cookie，无需注入。
-  const serverCookie = import.meta.server ? { cookie: useRequestHeaders(['cookie']).cookie } : undefined;
+  const serverFetch = import.meta.server ? useRequestFetch() : undefined;
 
   // 认证相关页面：其自身的 401（如登录失败）不应触发跳转，避免死循环
   const AUTH_PAGE_PREFIXES = ['/login', '/register', '/forgot-password', '/reset-password', '/change-password'];
@@ -58,12 +55,10 @@ export function useApi() {
     options: ApiCallOptions = {},
   ): Promise<T> {
     const { silent = false, onError, redirectOnUnauthorized = true, ...fetchOptions } = options;
-    // SSR 端补上已捕获的 Cookie（见 useApi() 顶部 serverCookie 说明）
-    if (serverCookie?.cookie) {
-      fetchOptions.headers = { ...(fetchOptions.headers as Record<string, string> | undefined), ...serverCookie };
-    }
     try {
-      return await $fetch<T>(url, { method, ...fetchOptions });
+      // SSR 使用 useRequestFetch 转发 Cookie/Headers；客户端使用普通 $fetch
+      const fetcher = import.meta.server && serverFetch ? serverFetch : $fetch;
+      return await fetcher<T>(url, { method, ...fetchOptions });
     } catch (err) {
       const info = extractApiError(err);
       if (import.meta.client && import.meta.dev) {

--- a/noj-ui/composables/useAuditLogs.ts
+++ b/noj-ui/composables/useAuditLogs.ts
@@ -42,6 +42,7 @@ export interface AuditLogFilters {
 }
 
 export function useAuditLogs(initial: Partial<AuditLogFilters> = {}) {
+  const { api } = useApi();
   const filters = useState('audit-logs-filters', () => ({
     page: 1,
     per_page: 20,
@@ -69,7 +70,7 @@ export function useAuditLogs(initial: Partial<AuditLogFilters> = {}) {
       if (filters.value.from) params.set('from', filters.value.from);
       if (filters.value.to) params.set('to', filters.value.to);
 
-      const res = await useApi().api.get<AuditLogListResponse>(
+      const res = await api.get<AuditLogListResponse>(
         `/api/v1/admin/audit-logs?${params}`,
         { silent: true },
       );

--- a/noj-ui/composables/useAuth.ts
+++ b/noj-ui/composables/useAuth.ts
@@ -57,12 +57,26 @@ export function useAuth() {
   // 保留 isLoggedIn 计算属性简化其他页面的访问
   const isLoggedIn = computed(() => !!user.value);
 
-  // ── SSR 初始化 ──
+  // 认证类调用统一 silent：错误由认证页面内联展示（banner/表单错误），
+  // 避免「页面提示 + toast」双重提示（ui-api-layer 设计 D6）
+  const { api } = useApi();
+
+  // ── SSR 初始化：有 session 时通过 /auth/me 获取完整用户与权限 ──
   if (import.meta.server) {
     if (session.value) {
-      user.value = sessionToUser(session.value);
+      const { data: meData } = useAsyncData('auth:me', () =>
+        api.get<{ data: UserResponse }>('/api/v1/auth/me', {
+          silent: true,
+          redirectOnUnauthorized: false,
+        }));
+      watch(meData, (val) => {
+        user.value = val?.data ?? null;
+        loading.value = false;
+      }, { immediate: true });
+    } else {
+      user.value = null;
+      loading.value = false;
     }
-    loading.value = false;
   }
 
   // ── 客户端初始化 ──
@@ -73,10 +87,6 @@ export function useAuth() {
     }
     loading.value = false;
   }
-
-  // 认证类调用统一 silent：错误由认证页面内联展示（banner/表单错误），
-  // 避免「页面提示 + toast」双重提示（ui-api-layer 设计 D6）
-  const { api } = useApi();
 
   async function login(login: string, password: string, code?: string) {
     // 5s 超时（评审修复 L2，与 fetchUser 一致），由 useApi timeout 选项实现

--- a/noj-ui/composables/useBanStatus.ts
+++ b/noj-ui/composables/useBanStatus.ts
@@ -30,6 +30,7 @@ export interface BanStatusResponse {
 }
 
 export function useBanStatus() {
+  const { api } = useApi();
   const ipBanned = useState<boolean>('ban:ip-banned', () => false);
   const userBanned = useState<boolean>('ban:user-banned', () => false);
   const ipBanInfo = useState<IpBanInfo | null>('ban:ip-ban-info', () => null);
@@ -49,7 +50,7 @@ export function useBanStatus() {
     try {
       // 封禁状态为全局静默请求：失败由 BanBanner 依据 error state 处理，不弹 toast。
       // 该端点允许匿名访问；即便代理短暂返回 401，也不能把首页访客跳转到登录页。
-      const res = await useApi().api.get<BanStatusResponse>(
+      const res = await api.get<BanStatusResponse>(
         '/api/v1/auth/ban-status',
         { silent: true, redirectOnUnauthorized: false },
       );

--- a/noj-ui/composables/useCommunity.ts
+++ b/noj-ui/composables/useCommunity.ts
@@ -159,6 +159,10 @@ export function useCommunity() {
       const response = await api.get<{ data: CommunityConfig }>('/api/v1/community/config');
       config.value = response.data;
       return response.data;
+    } catch {
+      // 非关键配置：失败时降级为“社区未启用/不可用”，不让整页 SSR 抛错
+      config.value = null;
+      return null;
     } finally {
       loading.value = false;
     }

--- a/noj-ui/composables/useSearch.ts
+++ b/noj-ui/composables/useSearch.ts
@@ -65,6 +65,7 @@ export interface SearchState {
 }
 
 export function useSearch() {
+  const { api } = useApi();
   const state = useState<SearchState>('search:state', () => ({
     open: false,
     query: '',
@@ -150,7 +151,6 @@ export function useSearch() {
 
         try {
           // 搜索为静默请求：错误由 state.error 状态展示，不弹 toast
-          const { api } = useApi();
           if (type === 'all') {
             // 并行请求题目 + 用户
             const [pRes, uRes, cRes] = await Promise.allSettled([

--- a/noj-ui/composables/useSelfTestPolling.ts
+++ b/noj-ui/composables/useSelfTestPolling.ts
@@ -25,6 +25,7 @@ const TERMINAL_STATUSES: SelfTestStatus[] = ['finished', 'error'];
 const POLL_INTERVAL_MS = 1500;
 
 export function useSelfTestPolling(selfTestIdRef: Ref<string | null>) {
+  const { api } = useApi();
   const selfTest = ref<PolledSelfTest | null>(null);
   const isPolling = ref(false);
   const error = ref<string | null>(null);
@@ -43,7 +44,7 @@ export function useSelfTestPolling(selfTestIdRef: Ref<string | null>) {
     const id = selfTestIdRef.value;
     if (!id) return;
     try {
-      const res = await useApi().api.get<{ data: PolledSelfTest }>(
+      const res = await api.get<{ data: PolledSelfTest }>(
         `/api/v1/self-tests/${id}`,
         { silent: true },
       );

--- a/noj-ui/composables/useSubmissionPolling.ts
+++ b/noj-ui/composables/useSubmissionPolling.ts
@@ -32,6 +32,7 @@ const TERMINAL_STATUSES: SubmissionStatus[] = ['finished', 'error'];
 const POLL_INTERVAL_MS = 1500;
 
 export function useSubmissionPolling(submissionIdRef: Ref<string | null>) {
+  const { api } = useApi();
   const submission = ref<PolledSubmission | null>(null);
   const isPolling = ref(false);
   const error = ref<string | null>(null);
@@ -51,7 +52,7 @@ export function useSubmissionPolling(submissionIdRef: Ref<string | null>) {
     if (!id) return;
     try {
       // 轮询为静默请求：失败写入 error ref 由页面展示，不弹 toast
-      const res = await useApi().api.get<{ data: PolledSubmission }>(
+      const res = await api.get<{ data: PolledSubmission }>(
         `/api/v1/submissions/${id}`,
         { silent: true },
       );

--- a/noj-ui/error.vue
+++ b/noj-ui/error.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+const props = defineProps<{
+  error: {
+    statusCode?: number
+    statusMessage?: string
+    message?: string
+  }
+}>()
+
+const statusCode = computed(() => props.error?.statusCode ?? 500)
+const message = computed(
+  () => props.error?.statusMessage || props.error?.message || '页面出错了，请稍后重试',
+)
+
+function goHome() {
+  clearError({ redirect: '/' })
+}
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center bg-bg-page px-4">
+    <div class="w-full max-w-md rounded-2xl border border-border bg-white p-8 text-center shadow-card">
+      <p class="text-6xl font-bold text-primary">{{ statusCode }}</p>
+      <h1 class="mt-4 text-xl font-semibold text-text">{{ message }}</h1>
+      <div class="mt-6 flex justify-center gap-3">
+        <UButton color="primary" @click="goHome">返回首页</UButton>
+        <UButton color="neutral" variant="outline" @click="clearError()">重试</UButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/noj-ui/middleware/admin.ts
+++ b/noj-ui/middleware/admin.ts
@@ -13,9 +13,6 @@ import { useAuthReady } from '~/composables/useAuthReady';
 import { isAdminUser } from '~/utils/isAdminUser';
 
 export default defineNuxtRouteMiddleware(async (_to, _from) => {
-  // SSR 阶段跳过守卫——页面是客户端渲染，水合后会重新执行
-  if (import.meta.server) return;
-
   const { loading, isLoggedIn, user } = useAuth();
 
   // 等待认证状态就绪（5s 超时兜底）

--- a/noj-ui/middleware/auth.ts
+++ b/noj-ui/middleware/auth.ts
@@ -33,8 +33,6 @@ const PASSWORD_CHANGE_WHITELIST = new Set<string>([
 import { useAuthReady } from '~/composables/useAuthReady';
 
 export default defineNuxtRouteMiddleware(async (to, _from) => {
-  if (import.meta.server) return;
-
   if (PUBLIC_AUTH_PATHS.has(to.path)) return;
 
   const { loading, isLoggedIn, user, fetchUser } = useAuth();

--- a/noj-ui/nuxt.config.ts
+++ b/noj-ui/nuxt.config.ts
@@ -52,6 +52,12 @@ export default defineNuxtConfig({
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
         { name: 'description', content: 'Neuro OJ — 面向 AI 领域认证与竞赛（IOAI / NOAI / LMCC）的在线评测平台' },
+        { property: 'og:title', content: 'Neuro OJ' },
+        {
+          property: 'og:description',
+          content: 'Neuro OJ — 面向 AI 领域认证与竞赛（IOAI / NOAI / LMCC）的在线评测平台',
+        },
+        { property: 'og:type', content: 'website' },
       ],
     },
   },
@@ -66,6 +72,22 @@ export default defineNuxtConfig({
         process.exit(0);
       }
     },
+  },
+
+  // 公开 GET 接口缓存（SWR），降低 noj-core 压力；认证/个性化接口显式 no-store
+  routeRules: {
+    '/api/v1/problems': { swr: 60 },
+    '/api/v1/rankings': { swr: 60 },
+    '/api/v1/contests': { swr: 60 },
+    '/api/v1/trainings': { swr: 60 },
+    '/api/v1/announcements': { swr: 60 },
+    '/api/v1/tags': { swr: 60 },
+    '/api/v1/stats': { swr: 60 },
+    '/api/v1/auth/**': { headers: { 'cache-control': 'no-store' } },
+    '/api/v1/submissions/**': { headers: { 'cache-control': 'no-store' } },
+    '/api/v1/queue/**': { headers: { 'cache-control': 'no-store' } },
+    '/api/v1/community/**': { headers: { 'cache-control': 'no-store' } },
+    '/api/v1/users/me/**': { headers: { 'cache-control': 'no-store' } },
   },
 
   nitro: {

--- a/noj-ui/pages/announcements/[id].vue
+++ b/noj-ui/pages/announcements/[id].vue
@@ -41,6 +41,13 @@ onMounted(load)
 useHead(() => ({
   title: detail.value ? `${detail.value.title} - 公告` : "公告",
 }))
+
+useSeoMeta({
+  title: () => detail.value?.title ? `${detail.value.title} - 公告` : '公告 - Neuro OJ',
+  description: () => detail.value?.content ? detail.value.content.slice(0, 160) : 'Neuro OJ 公告',
+  ogTitle: () => detail.value?.title ?? 'Neuro OJ',
+  ogDescription: () => detail.value?.content ? detail.value.content.slice(0, 160) : 'Neuro OJ 公告',
+})
 </script>
 
 <template>

--- a/noj-ui/pages/community/bookmarks.vue
+++ b/noj-ui/pages/community/bookmarks.vue
@@ -5,7 +5,7 @@ import { extractApiError } from "~/utils/apiError"
 import { useToast } from "~/composables/useToast"
 import { publicUrl } from "~/utils/publicIdentifiers"
 
-definePageMeta({ middleware: "auth" })
+definePageMeta({ middleware: "auth", ssr: false })
 
 const typeLabel: Record<PostType, string> = {
   discussion: "讨论",
@@ -68,7 +68,9 @@ async function removeBookmark(item: BookmarkRow) {
   }
 }
 
-await loadBookmarks()
+onMounted(() => {
+  void loadBookmarks()
+})
 </script>
 
 <template>

--- a/noj-ui/pages/community/index.vue
+++ b/noj-ui/pages/community/index.vue
@@ -22,21 +22,6 @@ const { open: reportModal } = useReportModal()
 const { api } = useApi()
 const { userBanned } = useBanStatus()
 
-// NOJ-317：SSR 阶段可能拿到游客权限（permissions 为空），登录用户水合后
-// 需要强制刷新一次社区配置，否则“发布内容”按钮会一直处于灰色。
-let configRefreshedForLogin = false
-watch(
-  [isLoggedIn, config],
-  async ([loggedIn, cfg]) => {
-    if (!loggedIn || !cfg || configRefreshedForLogin) return
-    if (!cfg.permissions || Object.keys(cfg.permissions).length === 0) {
-      configRefreshedForLogin = true
-      await loadConfig(true)
-    }
-  },
-  { immediate: true },
-)
-
 const ENABLED_TYPES: PostType[] = ["discussion", "solution", "moment"]
 const typeFlag: Record<PostType, keyof CommunityConfig> = {
   discussion: "discussions_enabled",
@@ -318,25 +303,68 @@ async function publish() {
   }
 }
 
-async function init() {
-  await loadConfig()
-  // 默认 Tab 兜底：请求的类型未启用时回退到第一个启用的类型
-  if (config.value?.enabled) {
+// ── SSR 初始数据：通过 useAsyncData 获取，结果随 payload 序列化到客户端 ──
+const { data: initialData } = await useAsyncData(
+  'community-index',
+  async () => {
+    const cfg = await loadConfig()
+    const enabled = cfg?.enabled
+      ? ENABLED_TYPES.filter((t) => cfg[typeFlag[t]] === true)
+      : []
     const requested = route.query.type as PostType | undefined
     const requestedEnabled = requested && ENABLED_TYPES.includes(requested)
-      ? config.value[typeFlag[requested]] === true
+      ? (cfg?.[typeFlag[requested]] ?? false) === true
       : false
-    if (requestedEnabled) {
-      activeType.value = requested as PostType
-    } else {
-      const fallback = ENABLED_TYPES.find((t) => config.value![typeFlag[t]] === true)
-      if (fallback) activeType.value = fallback
-    }
-  }
-  await Promise.all([loadPosts(), loadCounts()])
-}
+    const chosen = requestedEnabled
+      ? (requested as PostType)
+      : (enabled[0] ?? 'discussion')
+    activeType.value = chosen
 
-await init()
+    let posts: PostRow[] = []
+    let nextCursor: string | null = null
+    try {
+      const postsRes = await api.get<{ data: PostRow[]; next_cursor: string | null }>(
+        '/api/v1/community/posts',
+        {
+          query: {
+            type: chosen,
+            problem_id: searchProblemId.value.trim() || undefined,
+            q: searchKeyword.value.trim() || undefined,
+          },
+          silent: true,
+        },
+      )
+      posts = postsRes.data
+      nextCursor = postsRes.next_cursor ?? null
+    } catch {
+      // 列表失败按空态渲染，不阻断页面
+    }
+
+    let counts: CommunityCounts | null = null
+    try {
+      const countsRes = await api.get<{ data: CommunityCounts }>(
+        '/api/v1/community/posts/counts',
+        { silent: true },
+      )
+      counts = countsRes.data
+    } catch {
+      counts = null
+    }
+
+    return { activeType: chosen, posts, counts, nextCursor }
+  },
+)
+
+// 将序列化后的结果同步到本地 refs（服务端与水合后都会执行）
+watch(initialData, (value) => {
+  if (value) {
+    activeType.value = value.activeType
+    posts.value = value.posts
+    counts.value = value.counts
+    nextCursor.value = value.nextCursor
+    loading.value = false
+  }
+}, { immediate: true })
 </script>
 
 <template>

--- a/noj-ui/pages/community/notifications.vue
+++ b/noj-ui/pages/community/notifications.vue
@@ -4,7 +4,7 @@ import { extractApiError } from "~/utils/apiError"
 import { useToast } from "~/composables/useToast"
 import { publicUrl, userUrl } from "~/utils/publicIdentifiers"
 
-definePageMeta({ middleware: "auth" })
+definePageMeta({ middleware: "auth", ssr: false })
 
 const { toast } = useToast()
 const { api } = useApi()
@@ -96,7 +96,9 @@ async function handleClick(item: NotificationRow) {
   navigateTo(notificationHref(item))
 }
 
-await load()
+onMounted(() => {
+  void load()
+})
 </script>
 
 <template>

--- a/noj-ui/pages/community/posts/[postId].vue
+++ b/noj-ui/pages/community/posts/[postId].vue
@@ -36,6 +36,13 @@ const typeLabel: Record<PostType, string> = {
 const postId = computed(() => String(route.params.postId))
 const post = ref<PostDetail | null>(null)
 const comments = ref<CommentRow[]>([])
+
+useSeoMeta({
+  title: () => post.value?.post?.title ? `${post.value.post.title} - Neuro OJ` : '社区帖子 - Neuro OJ',
+  description: () => post.value?.post?.content ? post.value.post.content.slice(0, 160) : 'Neuro OJ 社区内容',
+  ogTitle: () => post.value?.post?.title ?? 'Neuro OJ',
+  ogDescription: () => post.value?.post?.content ? post.value.post.content.slice(0, 160) : 'Neuro OJ 社区内容',
+})
 const comment = ref("")
 const interaction = ref<"like" | "bookmark" | null>(null)
 const submittingComment = ref(false)
@@ -223,8 +230,26 @@ async function reportComment(commentId: string) {
   }
 }
 
-await loadConfig()
-await load()
+// ── SSR 初始数据：通过 useAsyncData 获取，结果随 payload 序列化到客户端 ──
+const { data: initialData } = await useAsyncData(
+  'community-post-detail',
+  async () => {
+    await loadConfig()
+    const [postResult, commentResult] = await Promise.all([
+      api.get<{ data: PostDetail }>(`/api/v1/community/posts/${postId.value}`),
+      api.get<{ data: CommentRow[] }>(`/api/v1/community/posts/${postId.value}/comments`),
+    ])
+    return { post: postResult.data, comments: commentResult.data }
+  },
+)
+
+// 将序列化后的结果同步到本地 refs（服务端与水合后都会执行）
+watch(initialData, (value) => {
+  if (value) {
+    post.value = value.post
+    comments.value = value.comments
+  }
+}, { immediate: true })
 </script>
 
 <template>

--- a/noj-ui/pages/community/reports/[id].vue
+++ b/noj-ui/pages/community/reports/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-definePageMeta({ middleware: "auth" })
+definePageMeta({ middleware: "auth", ssr: false })
 
 const route = useRoute()
 const { api } = useApi()
@@ -83,7 +83,9 @@ async function load() {
   }
 }
 
-await load()
+onMounted(() => {
+  void load()
+})
 </script>
 
 <template>

--- a/noj-ui/pages/contests/[contestId]/index.vue
+++ b/noj-ui/pages/contests/[contestId]/index.vue
@@ -19,9 +19,16 @@ let timer: ReturnType<typeof setInterval> | undefined
 
 const { data, pending, error, refresh } = await useFetch<{ data: Contest }>(
   `/api/v1/contests/${contestId}`,
-  { server: false },
 )
 const contest = computed(() => data.value?.data ?? null)
+
+useSeoMeta({
+  title: () => contest.value?.title ? `${contest.value.title} - Neuro OJ` : '竞赛 - Neuro OJ',
+  description: () => contest.value?.description ? contest.value.description.slice(0, 160) : 'Neuro OJ 竞赛',
+  ogTitle: () => contest.value?.title ?? 'Neuro OJ',
+  ogDescription: () => contest.value?.description ? contest.value.description.slice(0, 160) : 'Neuro OJ 竞赛',
+})
+
 const problems = ref<ContestProblem[]>([])
 const problemsLoading = ref(false)
 const problemsError = ref('')

--- a/noj-ui/pages/contests/[contestId]/ranking.vue
+++ b/noj-ui/pages/contests/[contestId]/ranking.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { publicUrl } from "~/utils/publicIdentifiers";
+
+definePageMeta({ ssr: false })
+
 const route = useRoute()
 const contestId = route.params.contestId as string
 </script>

--- a/noj-ui/pages/messages/index.vue
+++ b/noj-ui/pages/messages/index.vue
@@ -9,6 +9,7 @@ import ChatSidebar from "~/components/feature/ChatSidebar.vue"
 
 definePageMeta({
   middleware: "auth",
+  ssr: false,
 })
 
 const { user } = useAuth()

--- a/noj-ui/pages/my/problems.vue
+++ b/noj-ui/pages/my/problems.vue
@@ -5,6 +5,7 @@ import { difficultyBadgeColors, difficultyLabels } from "~/utils/submissionForma
 
 definePageMeta({
   middleware: "auth",
+  ssr: false,
 })
 
 const { isLoggedIn, loading, user } = useAuth()

--- a/noj-ui/pages/problems/[id].vue
+++ b/noj-ui/pages/problems/[id].vue
@@ -126,7 +126,7 @@ watch(
     loadingSolutions.value = true
     try {
       const [solRes, cfg] = await Promise.all([
-        $fetch<{ data: PostRow[] }>(
+        api.get<{ data: PostRow[] }>(
           `/api/v1/community/posts?type=solution&problem_id=${p.id}&limit=5`,
         ),
         loadConfig(),
@@ -134,7 +134,7 @@ watch(
       solutions.value = solRes.data
       if (isLoggedIn.value) {
         try {
-          const el = await $fetch<{ data: typeof eligibility.value }>(
+          const el = await api.get<{ data: typeof eligibility.value }>(
             `/api/v1/community/solutions/eligibility?problem_id=${p.id}`,
           )
           eligibility.value = el.data

--- a/noj-ui/pages/problems/[id].vue
+++ b/noj-ui/pages/problems/[id].vue
@@ -39,6 +39,13 @@ const { data, pending, error, refresh } = useFetch<{
 
 const problem = computed(() => data.value?.data ?? null)
 
+useSeoMeta({
+  title: () => problem.value?.title ? `${problem.value.title} - Neuro OJ` : '题目 - Neuro OJ',
+  description: () => problem.value?.description ? problem.value.description.slice(0, 160) : 'Neuro OJ 在线评测题目',
+  ogTitle: () => problem.value?.title ?? 'Neuro OJ',
+  ogDescription: () => problem.value?.description ? problem.value.description.slice(0, 160) : 'Neuro OJ 在线评测平台',
+})
+
 const tags = computed(() => problem.value?.tags ?? [])
 // 题目标签（kind='problem'）：点击可跳转到按该标签筛选的题库列表
 const problemTags = computed(() => tags.value.filter((t) => t.kind === 'problem'))

--- a/noj-ui/pages/queue.vue
+++ b/noj-ui/pages/queue.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { useEventSource } from "~/composables/useEventSource"
+
+definePageMeta({ ssr: false })
+
 interface QueueItem {
   id: string
   problem_id: string

--- a/noj-ui/pages/settings.vue
+++ b/noj-ui/pages/settings.vue
@@ -3,6 +3,9 @@ import { extractApiError } from "~/utils/apiError"
 import { getAvatarUploadError } from "~/utils/avatarUpload"
 import { formatRecoveryCodesFile } from "~/utils/recoveryCodes"
 import { userUrl } from "~/utils/publicIdentifiers"
+
+definePageMeta({ ssr: false })
+
 const { user, isLoggedIn, loading, fetchUser } = useAuth()
 const router = useRouter()
 const { api } = useApi()

--- a/noj-ui/pages/submissions/[id].vue
+++ b/noj-ui/pages/submissions/[id].vue
@@ -43,6 +43,14 @@ const submissionId = route.params.id as string
 const isMounted = ref(true)
 const data = ref<SubmissionResponse | null>(null)
 const submission = computed(() => data.value?.data ?? null)
+
+useSeoMeta({
+  title: () => submission.value?.public_id ? `提交 #${submission.value.public_id} - Neuro OJ` : '提交结果 - Neuro OJ',
+  description: 'Neuro OJ 提交结果详情',
+  ogTitle: () => submission.value?.public_id ? `提交 #${submission.value.public_id} - Neuro OJ` : 'Neuro OJ',
+  ogDescription: 'Neuro OJ 提交结果详情',
+})
+
 const isFinished = computed(
   () => submission.value?.status === "finished" || submission.value?.status === "error",
 )

--- a/noj-ui/pages/users/[id].vue
+++ b/noj-ui/pages/users/[id].vue
@@ -62,6 +62,13 @@ const { data, pending, error, refresh } = useFetch<ProfileResponse>(
 
 const profile = computed(() => data.value?.data ?? null)
 
+useSeoMeta({
+  title: () => profile.value?.user?.username ? `${profile.value.user.username} - Neuro OJ` : '用户 - Neuro OJ',
+  description: () => profile.value?.user?.bio ? profile.value.user.bio.slice(0, 160) : 'Neuro OJ 用户主页',
+  ogTitle: () => profile.value?.user?.username ?? 'Neuro OJ',
+  ogDescription: () => profile.value?.user?.bio ? profile.value.user.bio.slice(0, 160) : 'Neuro OJ 用户主页',
+})
+
 interface CheckinStatsData {
   total_days: number
   current_streak: number

--- a/noj-ui/public/robots.txt
+++ b/noj-ui/public/robots.txt
@@ -1,0 +1,11 @@
+User-agent: *
+Allow: /
+Disallow: /admin/
+Disallow: /editor/
+Disallow: /settings
+Disallow: /messages
+Disallow: /my/
+Disallow: /community/bookmarks
+Disallow: /community/notifications
+Disallow: /community/reports/
+Disallow: /api/

--- a/noj-ui/server/routes/sitemap.xml.ts
+++ b/noj-ui/server/routes/sitemap.xml.ts
@@ -1,0 +1,87 @@
+// 动态 sitemap：从 noj-core 拉取公开资源，短 TTL 内存缓存后输出 XML。
+// 避免引入额外依赖，适配 Deno 单二进制部署。
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const MAX_PAGES = 10;
+const PER_PAGE = 100;
+
+let cache: { at: number; body: string } | null = null;
+
+interface SitemapEntry {
+  loc: string;
+  lastmod?: string;
+}
+
+async function fetchAll<T extends { id: string }>(
+  apiBase: string,
+  path: string,
+): Promise<T[]> {
+  const items: T[] = [];
+  let page = 1;
+  while (page <= MAX_PAGES) {
+    const res = await $fetch<{ data: T[]; total?: number }>(
+      `${apiBase}${path}?page=${page}&per_page=${PER_PAGE}`,
+    );
+    const batch = res.data ?? [];
+    items.push(...batch);
+    const total = res.total ?? items.length;
+    if (batch.length === 0 || items.length >= total || page * PER_PAGE >= total) break;
+    page++;
+  }
+  return items;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export default defineEventHandler(async (event) => {
+  const now = Date.now();
+  if (cache && now - cache.at < CACHE_TTL_MS) {
+    setHeader(event, 'content-type', 'application/xml');
+    return cache.body;
+  }
+
+  const config = useRuntimeConfig();
+  const apiBase = config.apiBase as string;
+  const protocol = event.headers.get('x-forwarded-proto') ?? 'http';
+  const host = event.headers.get('host') ?? 'localhost:3000';
+  const origin = `${protocol}://${host}`;
+
+  const entries: SitemapEntry[] = [{ loc: `${origin}/` }];
+
+  try {
+    const [problems, contests, announcements] = await Promise.all([
+      fetchAll<{ id: string; display_id?: string }>(apiBase, '/api/v1/problems'),
+      fetchAll<{ id: string; public_id?: string }>(apiBase, '/api/v1/contests'),
+      fetchAll<{ id: string; public_id?: string }>(apiBase, '/api/v1/announcements'),
+    ]);
+
+    for (const p of problems) {
+      entries.push({ loc: `${origin}/problems/${p.display_id || p.id}` });
+    }
+    for (const c of contests) {
+      entries.push({ loc: `${origin}/contests/${c.public_id || c.id}` });
+    }
+    for (const a of announcements) {
+      entries.push({ loc: `${origin}/announcements/${a.public_id || a.id}` });
+    }
+  } catch {
+    // core 不可达时返回已有缓存或仅首页，避免 sitemap 请求失败
+  }
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${
+    entries
+      .map((e) => `<url><loc>${escapeXml(e.loc)}</loc></url>`)
+      .join('')
+  }</urlset>`;
+
+  cache = { at: now, body };
+  setHeader(event, 'content-type', 'application/xml');
+  return body;
+});

--- a/openspec/changes/improve-ssr-rendering/.openspec.yaml
+++ b/openspec/changes/improve-ssr-rendering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/improve-ssr-rendering/design.md
+++ b/openspec/changes/improve-ssr-rendering/design.md
@@ -1,0 +1,113 @@
+## Context
+
+noj-ui 使用 Nuxt 4 + Vue 3，Nitro 部署为 `deno-server`，SSR 默认开启。现状调查发现：
+
+- 数据获取方式分裂：部分页面用 `useFetch`/`useAsyncData`，大量公开内容页（首页、公告、竞赛详情、社区）用 `onMounted`/顶层 `await` + `api.get`；
+- 社区 5 个页面在 `<script setup>` 顶层 `await` 写普通 `ref`，服务端请求结果不会序列化到客户端，造成双倍请求和延迟水合；其中 `community/index` 与 `community/posts/[id]` 的 `loadConfig()` 未捕获，core 不可达时 SSR 直接 502；
+- 认证在 SSR 端只信任可读 `noj:session`，中间件跳过服务端，受保护页先渲染再跳转；
+- 无 SEO 元信息、无公开接口缓存、无自定义错误页。
+
+本次改造全部在 noj-ui 前端完成，不改变 noj-core API 与数据库结构。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 建立统一的 SSR 数据获取规则：页面初始数据用 `useAsyncData`/`useFetch`，交互/轮询/表单用 `useApi`。
+- 消除社区顶层 `await` + 普通 `ref` 反模式，修复 `community` 502 与双倍请求。
+- 明确 `ssr:false` 边界：纯交互/强登录页关闭 SSR；内容/SEO 页保持 SSR。
+- 让 SSR 阶段能基于真实 token 获取完整用户与权限，受保护页不再先渲染再跳转。
+- 补齐动态内容页 SEO 与全站 sitemap/robots。
+- 为公开接口增加可配置缓存，降低 core 压力。
+- 增加自定义错误页和非关键数据降级，避免单接口故障拖垮整页。
+- 统一服务端 Cookie/Header 转发，消除 `useApi` 在异步函数内调用 `useRequestHeaders` 的隐患。
+
+**Non-Goals:**
+
+- 不改变 noj-core 的 API 契约、鉴权逻辑、数据库 schema。
+- 不做 SSR 到 CSR 的运行时切换框架改造（不引入实验性流式 SSR）。
+- 不重构认证后端（不引入刷新令牌、不改变 Cookie 安全模型）。
+- 不做完整的 SEO 关键词/内容策略，只补技术性元信息与可索引资产。
+
+## Decisions
+
+### 1. 数据获取统一：初始数据走 `useAsyncData`/`useFetch`
+
+所有页面在 setup 阶段决定“初始数据”，使用 Nuxt 原生数据获取；`useApi` 保留给用户交互、轮询和表单提交。原因：Nuxt 会自动把 `useAsyncData`/`useFetch` 的 payload 序列化到客户端，避免双倍请求；`useApi` 不应承担初始渲染数据职责。
+
+替代方案（否决）：继续用 `useApi` 并在顶层 `await`，然后用 `useState` 手动缓存。该方案需人工保证序列化，容易遗漏普通 ref，且仍可能触发无关请求。
+
+### 2. 社区改造：公共列表/详情保持 SSR，登录相关子页面 `ssr:false`
+
+- `community/index.vue`、`community/posts/[postId].vue` 是公开内容页，改为 `useAsyncData` 获取 config/posts/comments；`loadConfig` 必须 catch，失败时降级为空配置而不是抛错。
+- `community/bookmarks.vue`、`notifications.vue`、`reports/[id].vue` 是强登录用户页，改为 `ssr:false`，移除顶层 await。
+- 这样既保住社区的 SEO/首屏，又消除 502 和双倍请求。
+
+替代方案（否决）：所有社区页统一 `ssr:false`。会失去社区列表/详情的 SSR/SEO 价值。
+
+### 3. `ssr:false` 边界
+
+保留 `ssr:false`：全部 admin、编辑器、新建/编辑题目、竞赛做题页。新增 `ssr:false`：`messages/index`、`my/problems`、`settings`、`queue`、`contests/[contestId]/ranking`（组件已 `server:false`）、`community/bookmarks`、`community/notifications`、`community/reports/[id]`。
+
+`contests/[contestId]/index.vue` 移除 `server:false`，让竞赛详情公开信息参与 SSR；其中题目/排行等敏感或实时部分仍由组件客户端加载。
+
+### 4. SSR 认证：以“真实 token 校验 + 强登录页关闭 SSR”混合策略
+
+- `useAuth` 在 SSR 阶段若检测到 `noj:session`，通过 `useRequestFetch` 调 `/api/v1/auth/me` 获取完整 `UserResponse` 和 `permissions`，写入 `useState`，而不是只从 session cookie 映射。
+- 路由中间件不再无条件 `if (import.meta.server) return`：服务端可基于已填充的 `auth:user` 做重定向；若认证请求失败，按未登录处理。
+- 强交互/强登录页（私信、我的题目、设置、社区收藏/通知/举报）直接 `ssr:false`，由客户端守卫负责，避免服务端渲染无意义页面。
+
+替代方案（否决）：所有受保护页都做服务端 `/auth/me`。会增加每个受保护页一次上游请求，且对纯交互页收益低；混合策略更符合页面性质。
+
+### 5. 统一服务端请求：`useApi` 内部使用 `useRequestFetch`
+
+`useApi` 在 SSR 分支用 `useRequestFetch()` 取代手动 `useRequestHeaders(['cookie'])`，与 `useFetch` 行为对齐；同时把 `useAdminList`、`useAuditLogs`、`useSearch` 等 composable 里的 `useApi()` 调用从 async 函数内部挪到 composable 同步 setup 顶部，消除 `NUXT_E1001` 隐患。
+
+替代方案（否决）：继续手动转发 Cookie。与 `useFetch` 双轨不一致，且无法转发其他请求头。
+
+### 6. SEO：动态页 `useSeoMeta` + Nitro sitemap
+
+- 在 `problems/[id]`、`users/[id]`、`community/posts/[id]`、`submissions/[id]`、`announcements/[id]`、`contests/[contestId]/index` 等动态页增加 `useSeoMeta`（title/description/OG/canonical）。
+- 新增 `server/routes/sitemap.xml.ts`：从 noj-core 拉取公开 problem/user/contest 公共标识，短 TTL 内存缓存后输出 XML。
+- 新增 `public/robots.txt`：允许抓取公开路径，禁止 admin/editor/设置等。
+
+替代方案（否决）：引入 `@nuxtjs/sitemap` 模块。在 Deno 单二进制 + 离线部署场景下增加构建与运行时不确定性；自建 Nitro 路由更可控。
+
+### 7. 缓存：`routeRules` + 代理层显式 `Cache-Control`
+
+- 在 `nuxt.config.ts` 增加针对公开 GET 接口的 `routeRules`，使用 `swr: true` / `isr` 语义（由 Nitro/部署层支持），覆盖 `/api/v1/problems`、`/api/v1/rankings`、`/api/v1/contests`、`/api/v1/trainings`、`/api/v1/announcements`、`/api/v1/tags`、`/api/v1/stats`。
+- 认证接口（`/api/v1/auth/*`、`/api/v1/community/*` 中依赖权限的端点、`/api/v1/submissions`、`/api/v1/queue`）不进入缓存。
+- 若 `routeRules` 在当前部署预设下不可用，则退化为在 Nitro 代理中对上述公开 GET 响应设置 `Cache-Control: s-maxage=...`，并在 nginx 关闭 `proxy_cache off` 的前提下由边缘/CDN 缓存。
+
+替代方案（否决）：全站缓存。会缓存到用户个性化内容，风险高。
+
+### 8. 错误处理：自定义错误页 + 非关键数据降级
+
+- 新增 `error.vue`，对 404/500/网络错误提供中文友好页。
+- `loadConfig` 等非关键引导数据改为 catch 后返回安全默认值；社区页面 `init` 不再因配置失败抛错。
+- 对所有 SSR 首屏非关键数据，若失败则以空态渲染，不阻断页面。
+
+## Risks / Trade-offs
+
+- [服务端 `/auth/me` 会给每个带 session 的 SSR 请求增加一次上游请求] → 仅对需要 SSR 的公共/半公开页面启用；强登录页 `ssr:false` 不触发。
+- [`routeRules` 缓存可能与用户个性化响应冲突] → 白名单仅限确定公开、无用户上下文的接口，并在设计中列出排除项。
+- [社区从顶层 await 改为 `useAsyncData` 改动较多，可能触及现有 NOJ-317 补丁] → 改动时同步移除客户端强制刷新 config 的 workaround，以服务端完整权限为准。
+- [`useApi` 迁移 `useRequestFetch` 可能影响 SSR Cookie 传递行为] → 通过现有 E2E 与 curl 验证登录态 API；若出现回归，保留手动 Cookie 分支作为 fallback。
+- [SEO 动态 meta 依赖数据加载，SSR 失败时 meta 可能不完整] → 使用 `useSeoMeta` 头部的可计算值，并用默认描述兜底。
+
+## Migration Plan
+
+1. 先新增/修改 spec 与 tasks；实现按 tasks 顺序推进。
+2. 实现顺序建议：
+   - 修 `useApi` 统一转发 + 修 `loadConfig` 降级（低风险、先止血 502）；
+   - 迁移社区页面到 `useAsyncData` / `ssr:false`；
+   - 调整 `ssr:false` 边界与 `contests` 详情 SSR；
+   - SSR 认证增强；
+   - SEO、缓存、错误页。
+3. 每步跑 `deno task check` 与 `deno task build`，并用启动产物 curl 验证。
+4. 回滚策略：每个决策点独立可回滚；若 `routeRules` 缓存引发问题，删除对应路由规则即可；若 SSR 认证引发性能问题，可回退为“session cookie 映射 + 客户端刷新”。
+
+## Open Questions
+
+- 当前部署的 Nitro `deno-server` 预设是否完整支持 `routeRules` 的 `swr`？若不支持，采用代理层 `Cache-Control` 方案。
+- 是否需要在 sitemap 中包含用户主页？用户主页是否允许被搜索引擎收录需产品确认；默认先包含题目与竞赛，用户主页待定。

--- a/openspec/changes/improve-ssr-rendering/proposal.md
+++ b/openspec/changes/improve-ssr-rendering/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+noj-ui 虽然开启了 Nuxt SSR，但数据获取、认证、SEO、缓存和错误处理并没有围绕 SSR 形成统一策略：社区等页面使用顶层 `await` + 普通 `ref` 导致服务端请求结果不序列化、客户端重复请求；社区配置接口失败时整个页面 SSR 直接 502；受保护页面在服务端先渲染空壳/错误态再被客户端重定向；首页、公告、竞赛详情等公开内容页几乎全部依赖客户端拉取；同时缺少 SEO 元信息、公开接口缓存和自定义错误页。
+
+## What Changes
+
+- 统一 SSR 数据获取策略：页面初始数据一律使用 `useAsyncData`/`useFetch`，`useApi` 仅用于交互、轮询和表单提交。
+- 消除社区 5 个页面的顶层 `await` + 普通 `ref` 反模式，改为 SSR 可序列化数据获取或明确 `ssr: false`。
+- 调整 `ssr: false` 边界：私信、我的题目、设置、队列、竞赛排名等纯交互页统一关闭 SSR；保留 admin/编辑器/新建编辑题目的关闭策略；竞赛详情从 `server: false` 改为真正 SSR 或明确 `ssr: false`。
+- 强化 SSR 认证语义：受保护页面不再“先渲染再跳转”，服务端对登录态做真实校验，社区权限不再依赖客户端二次刷新补丁。
+- 修复 `useApi` 在异步函数内调用 `useRequestHeaders` 的脆弱点，统一服务端 Cookie/Header 转发机制。
+- 补齐 SEO：动态内容页增加 `useSeoMeta`/OG/canonical，增加 sitemap 与 robots。
+- 为公开 SSR 数据增加缓存策略（路由级 SWR/ISR），排除认证接口。
+- 增加自定义错误页，并让非关键数据（社区配置、首页公告等）在 SSR 失败时降级为空态/占位而非拖垮整页。
+- 迁移 `pages/problems/[id].vue` 中残留的直接 `$fetch` 到 `useApi`。
+
+## Capabilities
+
+### New Capabilities
+
+- `ssr-rendering`: 定义 noj-ui SSR 渲染与数据获取的统一行为，包括页面初始数据获取方式、顶层 await 约束、`ssr:false` 边界、SSR 错误降级。
+- `ssr-seo`: 定义动态内容页的 SEO 元信息、Open Graph、canonical、sitemap 与 robots 行为。
+- `ssr-caching`: 定义公开 SSR 数据的缓存策略与认证接口排除规则。
+
+### Modified Capabilities
+
+- `cookie-auth`: 修改 SSR 阶段认证状态的处理语义——服务端 SHALL 基于真实 token 校验/获取用户状态，而不是仅信任可读 session cookie；受保护页面不得在服务端渲染未验证的登录态。
+- `ui-api-layer`: 补充 SSR 下的统一数据获取要求——SSR 请求 Cookie 转发统一、页面初始数据不绕过 `useApi`/`useFetch`，并清理残留直接 `$fetch`。
+- `community-ui`: 社区相关页面（首页、帖子详情、收藏、通知、举报）的数据加载 SHALL 采用 SSR 可序列化方式或明确客户端渲染，不得使用顶层 `await` + 普通 `ref`。
+
+## Impact
+
+- 代码范围：`noj-ui/pages`、`noj-ui/composables`、`noj-ui/middleware`、`noj-ui/server`、`noj-ui/nuxt.config.ts`、`noj-ui/package.json`、`noj-ui/public`。
+- 部署范围：`deploy/nginx/default.conf` 可能涉及缓存头调整。
+- 无 noj-core API 变更，无数据库 schema 变更；均为 noj-ui 前端行为改造。

--- a/openspec/changes/improve-ssr-rendering/specs/community-ui/spec.md
+++ b/openspec/changes/improve-ssr-rendering/specs/community-ui/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: 社区公开页面使用 SSR 可序列化数据加载
+
+社区首页与帖子详情等公开页面 SHALL 使用 `useAsyncData`/`useFetch` 获取配置、帖子列表、帖子详情与评论，不得在 `<script setup>` 顶层使用 `await api.get(...)` 写入普通 `ref`。
+
+#### Scenario: 社区首页 SSR 加载
+
+- **WHEN** 搜索引擎或用户请求 `/community`
+- **THEN** 服务端通过 `useAsyncData` 获取配置与帖子列表，结果序列化到客户端 payload，水合不重复请求
+
+#### Scenario: 社区帖子详情 SSR 加载
+
+- **WHEN** 用户请求 `/community/posts/:id`
+- **THEN** 服务端通过 `useAsyncData` 获取帖子与评论，页面正常渲染；配置接口失败时降级为空配置而不是 502
+
+### Requirement: 社区强登录页面关闭 SSR
+
+社区收藏、社区通知、举报详情等强登录页面 SHALL 设置 `ssr: false`，由客户端守卫与数据加载接管。
+
+#### Scenario: 收藏页关闭 SSR
+
+- **WHEN** 用户访问 `/community/bookmarks`
+- **THEN** 服务端不渲染该页，客户端水合后执行登录校验并加载收藏数据
+
+#### Scenario: 通知页关闭 SSR
+
+- **WHEN** 用户访问 `/community/notifications`
+- **THEN** 服务端不渲染该页，客户端水合后执行登录校验并加载通知数据
+
+#### Scenario: 举报详情关闭 SSR
+
+- **WHEN** 用户访问 `/community/reports/:id`
+- **THEN** 服务端不渲染该页，客户端水合后执行登录校验并加载举报详情

--- a/openspec/changes/improve-ssr-rendering/specs/cookie-auth/spec.md
+++ b/openspec/changes/improve-ssr-rendering/specs/cookie-auth/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: SSR 认证状态基于真实 token 校验
+
+当请求携带 `noj:session` cookie 时，SSR 阶段 SHALL 通过服务端请求 `/api/v1/auth/me`（使用转发 Cookie 的 `useRequestFetch`）获取完整用户信息与权限，并写入 `useState`；不得仅凭可读 session cookie 映射的局部用户信息作为最终登录态。
+
+#### Scenario: SSR 时 session cookie 有效
+
+- **WHEN** 页面请求携带有效的 `noj:session` 与 `noj:token` cookie，SSR 执行
+- **THEN** 服务端调用 `/api/v1/auth/me` 获取完整用户状态（含 `created_at`、`permissions`），写入 `useState`，客户端水合后直接复用，无需二次刷新
+
+#### Scenario: SSR 时 token 已失效
+
+- **WHEN** 页面请求携带 session cookie 但 token 已失效
+- **THEN** SSR 按未登录处理，不渲染受保护的内容，客户端守卫随后跳转登录页
+
+#### Scenario: SSR 时无 cookie
+
+- **WHEN** 页面请求不携带认证 cookie
+- **THEN** 服务端设置 `useState("auth:user") = null`，`loading = false`，客户端水合后显示未登录状态
+
+## MODIFIED Requirements
+
+### Requirement: Auth composable 使用 useCookie 管理登录状态
+
+`useAuth` composable SHALL 使用 Nuxt 的 `useCookie("noj:session")` 在客户端追踪登录状态，取代 `localStorage`。
+
+SSR 阶段，服务端 SHALL 在检测到 `noj:session` cookie 时调用 `/api/v1/auth/me` 获取完整用户信息，并通过 `useState` 注入到页面；认证失败时 SHALL 按未登录状态处理。
+
+#### Scenario: SSR 时有 session cookie
+
+- **WHEN** 页面请求携带 `noj:session` cookie，SSR 执行
+- **THEN** 服务端通过 `/api/v1/auth/me` 获取完整用户信息并设置 `useState`，水合后客户端直接使用
+
+#### Scenario: SSR 时无 session cookie
+
+- **WHEN** 页面请求不携带 `noj:session` cookie
+- **THEN** 服务端设置 `useState("auth:user") = null`，`loading = false`，客户端水合后显示未登录状态
+
+#### Scenario: 客户端水合后登录
+
+- **WHEN** 用户在客户端调用 `login()`
+- **THEN** `$fetch` 请求由浏览器自动携带当前域 cookie，登录响应设置新 cookie，`useAuth` 在客户端更新 `useState`
+
+#### Scenario: 客户端退出
+
+- **WHEN** 用户调用 `logout()`
+- **THEN** 客户端 POST `/api/auth/logout` 清除 cookie，重置 `useState` 为未登录状态

--- a/openspec/changes/improve-ssr-rendering/specs/ssr-caching/spec.md
+++ b/openspec/changes/improve-ssr-rendering/specs/ssr-caching/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: 公开 SSR 接口启用缓存
+
+系统的公开、无用户上下文 GET 接口 SHALL 配置缓存（Nitro `routeRules` 的 `swr`/`isr`，或代理响应 `Cache-Control: s-maxage`），以降低 noj-core 压力并提升 SSR 响应速度。
+
+#### Scenario: 公开题目列表被缓存
+
+- **WHEN** 多个客户端请求 `/api/v1/problems` 且参数相同
+- **THEN** 后续请求可命中缓存或 SWR 缓存，不每次都回源 noj-core
+
+#### Scenario: 公开榜单被缓存
+
+- **WHEN** 客户端请求 `/api/v1/rankings`
+- **THEN** 响应可被缓存，缓存失效后重新回源
+
+### Requirement: 认证与个性化接口不缓存
+
+涉及登录态、用户权限、私密数据或实时状态的接口 SHALL NOT 被公共缓存，包括 `/api/v1/auth/*`、`/api/v1/submissions`、`/api/v1/queue` 以及社区中依赖权限的端点。
+
+#### Scenario: 认证接口不被缓存
+
+- **WHEN** 客户端请求登录或当前用户接口
+- **THEN** 响应设置 `Cache-Control: no-store` 或不进入公共缓存
+
+#### Scenario: 提交记录不被缓存
+
+- **WHEN** 客户端请求个人提交记录
+- **THEN** 响应不被公共缓存，避免泄露或串数据
+
+### Requirement: 缓存失效与回源
+
+缓存配置 SHALL 提供合理的过期时间或再验证机制，并保证源站不可用时仍能通过缓存/降级响应服务公开数据。
+
+#### Scenario: 缓存过期后回源
+
+- **WHEN** 公开接口缓存超过 TTL
+- **THEN** 下一次请求回源 noj-core 获取最新数据并刷新缓存

--- a/openspec/changes/improve-ssr-rendering/specs/ssr-rendering/spec.md
+++ b/openspec/changes/improve-ssr-rendering/specs/ssr-rendering/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: 页面初始数据使用 Nuxt 数据获取
+
+noj-ui 的所有页面 SHALL 将“页面初始数据”通过 `useAsyncData` 或 `useFetch` 获取，以便 SSR 结果序列化到客户端 payload；交互操作、轮询与表单提交 SHALL 通过 `useApi` 发起。
+
+#### Scenario: 公开列表页 SSR 获取数据
+
+- **WHEN** 用户请求题库、题单、竞赛等公开列表页
+- **THEN** 页面在 SSR 阶段通过 `useFetch`/`useAsyncData` 获取数据，并将结果序列化到客户端 payload，水合时不重复请求
+
+#### Scenario: 交互操作走 useApi
+
+- **WHEN** 用户提交表单、点赞、发布评论或轮询状态
+- **THEN** 页面通过 `useApi` 发起请求，不绕过统一 API 层
+
+### Requirement: 禁止顶层 await + 普通 ref 作为 SSR 数据获取
+
+页面 SHALL NOT 在 `<script setup>` 顶层使用 `await api.get(...)` 写入普通 `ref` 来获取 SSR 初始数据；此类数据 MUST 使用 `useAsyncData`/`useFetch` 或让页面明确 `ssr: false`。
+
+#### Scenario: 社区首页不再出现顶层 await 反模式
+
+- **WHEN** 社区首页在 SSR 渲染
+- **THEN** 帖子、计数与配置通过 `useAsyncData`/`useState` 序列化到客户端，不因普通 `ref` 未序列化而在水合时重复请求
+
+#### Scenario: 纯客户端页面声明 ssr:false
+
+- **WHEN** 页面完全依赖客户端交互且无 SEO/首屏价值
+- **THEN** 页面设置 `ssr: false`，服务端不渲染该页面，客户端负责数据获取与守卫
+
+### Requirement: ssr:false 边界明确
+
+纯交互或强登录页面 SHALL 设置 `ssr: false`，包括私信、我的题目、设置、队列、竞赛排名、社区收藏、社区通知、社区举报详情；管理后台、编辑器、新建/编辑题目、竞赛做题页保持 `ssr: false`。内容/SEO 页面 SHALL 保持 SSR。
+
+#### Scenario: 私信页关闭 SSR
+
+- **WHEN** 用户访问 `/messages`
+- **THEN** 服务端不渲染聊天内容，客户端水合后由客户端守卫与数据加载接管
+
+#### Scenario: 竞赛详情保持 SSR
+
+- **WHEN** 用户访问公开竞赛详情页
+- **THEN** 服务端渲染竞赛公开信息，题目与排行等客户端交互部分仍由组件按需加载
+
+### Requirement: SSR 非关键数据失败时降级
+
+SSR 阶段对非关键数据（社区配置、首页公告、题解入口等）的获取失败 SHALL 降级为安全空态/默认值，不得导致整页渲染失败或返回错误页。
+
+#### Scenario: 社区配置接口失败
+
+- **WHEN** 社区配置接口在 SSR 阶段返回 5xx 或网络错误
+- **THEN** 页面以默认配置渲染社区容器或显示“功能暂未启用”，不抛出未捕获异常导致 502
+
+#### Scenario: 首页公告接口失败
+
+- **WHEN** 首页公告接口失败
+- **THEN** 轮播区域显示默认欢迎占位，不阻塞首页其余内容渲染

--- a/openspec/changes/improve-ssr-rendering/specs/ssr-seo/spec.md
+++ b/openspec/changes/improve-ssr-rendering/specs/ssr-seo/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: 动态内容页提供 SEO 元信息
+
+题目详情、用户主页、社区帖子、提交详情、公告详情、竞赛详情等动态内容页 SHALL 通过 `useSeoMeta` 或 `useHead` 设置页面标题、描述、Open Graph 与 canonical URL。
+
+#### Scenario: 题目详情页 SEO 元信息
+
+- **WHEN** 搜索引擎或社交平台抓取 `/problems/:id`
+- **THEN** 页面 HTML 包含题目标题、题目描述摘要、`og:title`、`og:description` 与 canonical URL
+
+#### Scenario: 用户主页 SEO 元信息
+
+- **WHEN** 搜索引擎抓取 `/users/:id`
+- **THEN** 页面 HTML 包含用户名、简介摘要与 canonical URL
+
+### Requirement: 提供 sitemap
+
+系统 SHALL 提供 `/sitemap.xml`，包含可公开访问的题目、竞赛、公告等资源 URL；sitemap SHOULD 由服务端动态生成并带短时间缓存。
+
+#### Scenario: 获取 sitemap
+
+- **WHEN** 客户端请求 `/sitemap.xml`
+- **THEN** 返回合法 XML，包含公开资源 URL 列表
+
+### Requirement: 提供 robots.txt
+
+系统 SHALL 提供 `/robots.txt`，允许搜索引擎抓取公开内容页，禁止抓取管理后台、编辑器、设置、私信等非公开或交互页面。
+
+#### Scenario: 获取 robots.txt
+
+- **WHEN** 客户端请求 `/robots.txt`
+- **THEN** 返回文本，其中公开路径允许抓取，私有路径标记 `Disallow`

--- a/openspec/changes/improve-ssr-rendering/specs/ui-api-layer/spec.md
+++ b/openspec/changes/improve-ssr-rendering/specs/ui-api-layer/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: SSR 页面初始数据不绕过统一数据获取层
+
+页面在 SSR 阶段获取初始数据 SHALL 使用 `useAsyncData`/`useFetch`，不得在 setup 顶层直接调用 `$fetch` 或 `api.get` 写入普通 `ref`；`useApi` 用于交互、轮询与表单提交。
+
+#### Scenario: 页面初始数据经 useAsyncData
+
+- **WHEN** 页面在 SSR 渲染时需要公告、竞赛或社区内容
+- **THEN** 初始数据通过 `useAsyncData`/`useFetch` 获取并可序列化到客户端 payload
+
+#### Scenario: 交互请求经 useApi
+
+- **WHEN** 用户点击报名、发布、点赞等
+- **THEN** 请求通过 `useApi` 发起，保持统一错误处理
+
+### Requirement: useApi 服务端统一转发请求头
+
+`useApi` 在服务端 SHALL 使用 `useRequestFetch`（或等价机制）转发原始请求的 Cookie 与请求头，取代手动拼接 `cookie` header；`useApi()` 调用 SHALL 发生在同步 setup 上下文，异步回调内不得再调用 `useApi()`。
+
+#### Scenario: SSR 登录态请求
+
+- **WHEN** SSR 阶段通过 `useApi` 请求需要登录的接口
+- **THEN** 请求携带原始 Cookie，noj-core 能识别当前用户
+
+#### Scenario: 异步回调不调用 useApi
+
+- **WHEN** 轮询、搜索或列表加载等异步回调需要发请求
+- **THEN** 使用外层 setup 已获取的 `api` 实例，不在回调内重复调用 `useApi()`
+
+### Requirement: 清理残留直接 $fetch
+
+所有业务页面 SHALL 移除直接 `$fetch` 调用，统一迁移到 `useApi` 或 Nuxt 数据获取层。
+
+#### Scenario: 题目详情题解请求迁移
+
+- **WHEN** 题目详情页加载题解列表与发布资格
+- **THEN** 请求通过 `useApi` 或 `useAsyncData` 发起，不再直接使用 `$fetch`

--- a/openspec/changes/improve-ssr-rendering/tasks.md
+++ b/openspec/changes/improve-ssr-rendering/tasks.md
@@ -1,0 +1,61 @@
+## 1. 基础与止血
+
+- [ ] 1.1 修改 `useApi`：服务端使用 `useRequestFetch` 统一转发 Cookie/请求头，替换手动 `useRequestHeaders(['cookie'])`
+- [ ] 1.2 将 `useAdminList`、`useAuditLogs`、`useSearch`、`useBanStatus`、轮询类 composable 中的 `useApi()` 调用移到 composable 同步 setup 顶部
+- [ ] 1.3 修改 `useCommunity.loadConfig`：`api.get` 失败时 catch 并返回安全默认配置，不向上抛错
+- [ ] 1.4 修改 `community/index.vue` 与 `community/posts/[postId].vue` 的初始化流程：配置失败不得导致 SSR 502
+- [ ] 1.5 迁移 `pages/problems/[id].vue` 中两处直接 `$fetch` 到 `useApi`/`useAsyncData`
+
+## 2. 社区 SSR 改造
+
+- [ ] 2.1 `community/index.vue` 改用 `useAsyncData` 获取配置、帖子列表与计数，移除顶层 `await init()`
+- [ ] 2.2 `community/posts/[postId].vue` 改用 `useAsyncData` 获取帖子、评论与配置，移除顶层 `await load()`
+- [ ] 2.3 `community/bookmarks.vue` 设置 `ssr: false` 并移除顶层 `await loadBookmarks()`
+- [ ] 2.4 `community/notifications.vue` 设置 `ssr: false` 并移除顶层 `await load()`
+- [ ] 2.5 `community/reports/[id].vue` 设置 `ssr: false` 并移除顶层 `await load()`
+- [ ] 2.6 移除 NOJ-317 客户端强制刷新社区 config 的 workaround（若服务端权限已完整）
+
+## 3. ssr:false 边界调整
+
+- [ ] 3.1 `messages/index.vue` 设置 `ssr: false`
+- [ ] 3.2 `my/problems.vue` 设置 `ssr: false`
+- [ ] 3.3 `settings.vue` 设置 `ssr: false`（或改为显式 auth guard）
+- [ ] 3.4 `queue.vue` 设置 `ssr: false`
+- [ ] 3.5 `contests/[contestId]/ranking.vue` 设置 `ssr: false`
+- [ ] 3.6 `contests/[contestId]/index.vue` 移除 `server: false`，恢复竞赛公开信息 SSR；确认题目/排行等子模块仍按需客户端加载
+
+## 4. SSR 认证增强
+
+- [ ] 4.1 `useAuth` SSR 阶段检测到 `noj:session` 时调用 `/api/v1/auth/me` 获取完整用户信息（含 `permissions`），写入 `useState`
+- [ ] 4.2 调整 `middleware/auth.ts` 与 `middleware/admin.ts`：服务端基于完整 `auth:user` 做重定向，不再无条件 `if (import.meta.server) return`
+- [ ] 4.3 处理 SSR 认证失败场景：token 失效按未登录处理，不渲染受保护内容
+- [ ] 4.4 验证社区权限在 SSR 后完整，删除依赖客户端二次刷新的降级路径
+
+## 5. SEO
+
+- [ ] 5.1 为动态内容页添加 `useSeoMeta`/`useHead`：题目详情、用户主页、社区帖子、提交详情、公告详情、竞赛详情
+- [ ] 5.2 新增 `server/routes/sitemap.xml.ts`，从 noj-core 拉取公开资源并输出 XML（短 TTL 缓存）
+- [ ] 5.3 新增 `public/robots.txt`，允许公开路径、禁止 admin/editor/settings/私信等
+- [ ] 5.4 完善 `app.vue`/`nuxt.config.ts` 全局默认 OG 与描述
+
+## 6. 缓存
+
+- [ ] 6.1 在 `nuxt.config.ts` 为公开接口增加 `routeRules` 缓存：problems、rankings、contests、trainings、announcements、tags、stats
+- [ ] 6.2 为认证/个性化接口（auth、submissions、queue、社区权限相关）设置 `no-store` 或排除缓存
+- [ ] 6.3 验证 `deno-server` 预设下 `routeRules` 行为；若不支持则在 Nitro 代理层对公开 GET 设置 `Cache-Control: s-maxage`
+- [ ] 6.4 按需调整 `deploy/nginx/default.conf` 的缓存头（保留 SSE `proxy_cache off`）
+
+## 7. 错误处理
+
+- [ ] 7.1 新增自定义 `error.vue`，覆盖 404/500/网络错误
+- [ ] 7.2 为 SSR 非关键数据增加降级：首页公告、社区配置、题目页题解入口等失败时显示空态/占位
+- [ ] 7.3 验证 community 配置失败时页面不再返回 502
+
+## 8. 验证与文档
+
+- [ ] 8.1 运行 `deno task check`
+- [ ] 8.2 运行 `deno task build`
+- [ ] 8.3 启动构建产物并 curl 验证关键页面：`/`、`/problems`、`/community`、`/messages`、`/trainings/mine`
+- [ ] 8.4 运行 noj-tests 中相关 E2E（社区、认证、SSE 降级）
+- [ ] 8.5 更新 `noj-ui/CLAUDE.md` 的 SSR 数据获取约定与 `ssr:false` 边界说明
+- [ ] 8.6 如实现完成，执行 `/opsx:apply` 后归档本次变更

--- a/openspec/changes/improve-ssr-rendering/tasks.md
+++ b/openspec/changes/improve-ssr-rendering/tasks.md
@@ -8,54 +8,54 @@
 
 ## 2. 社区 SSR 改造
 
-- [ ] 2.1 `community/index.vue` 改用 `useAsyncData` 获取配置、帖子列表与计数，移除顶层 `await init()`
-- [ ] 2.2 `community/posts/[postId].vue` 改用 `useAsyncData` 获取帖子、评论与配置，移除顶层 `await load()`
-- [ ] 2.3 `community/bookmarks.vue` 设置 `ssr: false` 并移除顶层 `await loadBookmarks()`
-- [ ] 2.4 `community/notifications.vue` 设置 `ssr: false` 并移除顶层 `await load()`
-- [ ] 2.5 `community/reports/[id].vue` 设置 `ssr: false` 并移除顶层 `await load()`
-- [ ] 2.6 移除 NOJ-317 客户端强制刷新社区 config 的 workaround（若服务端权限已完整）
+- [x] 2.1 `community/index.vue` 改用 `useAsyncData` 获取配置、帖子列表与计数，移除顶层 `await init()`
+- [x] 2.2 `community/posts/[postId].vue` 改用 `useAsyncData` 获取帖子、评论与配置，移除顶层 `await load()`
+- [x] 2.3 `community/bookmarks.vue` 设置 `ssr: false` 并移除顶层 `await loadBookmarks()`
+- [x] 2.4 `community/notifications.vue` 设置 `ssr: false` 并移除顶层 `await load()`
+- [x] 2.5 `community/reports/[id].vue` 设置 `ssr: false` 并移除顶层 `await load()`
+- [x] 2.6 移除 NOJ-317 客户端强制刷新社区 config 的 workaround（若服务端权限已完整）
 
 ## 3. ssr:false 边界调整
 
-- [ ] 3.1 `messages/index.vue` 设置 `ssr: false`
-- [ ] 3.2 `my/problems.vue` 设置 `ssr: false`
-- [ ] 3.3 `settings.vue` 设置 `ssr: false`（或改为显式 auth guard）
-- [ ] 3.4 `queue.vue` 设置 `ssr: false`
-- [ ] 3.5 `contests/[contestId]/ranking.vue` 设置 `ssr: false`
-- [ ] 3.6 `contests/[contestId]/index.vue` 移除 `server: false`，恢复竞赛公开信息 SSR；确认题目/排行等子模块仍按需客户端加载
+- [x] 3.1 `messages/index.vue` 设置 `ssr: false`
+- [x] 3.2 `my/problems.vue` 设置 `ssr: false`
+- [x] 3.3 `settings.vue` 设置 `ssr: false`（或改为显式 auth guard）
+- [x] 3.4 `queue.vue` 设置 `ssr: false`
+- [x] 3.5 `contests/[contestId]/ranking.vue` 设置 `ssr: false`
+- [x] 3.6 `contests/[contestId]/index.vue` 移除 `server: false`，恢复竞赛公开信息 SSR；确认题目/排行等子模块仍按需客户端加载
 
 ## 4. SSR 认证增强
 
-- [ ] 4.1 `useAuth` SSR 阶段检测到 `noj:session` 时调用 `/api/v1/auth/me` 获取完整用户信息（含 `permissions`），写入 `useState`
-- [ ] 4.2 调整 `middleware/auth.ts` 与 `middleware/admin.ts`：服务端基于完整 `auth:user` 做重定向，不再无条件 `if (import.meta.server) return`
-- [ ] 4.3 处理 SSR 认证失败场景：token 失效按未登录处理，不渲染受保护内容
-- [ ] 4.4 验证社区权限在 SSR 后完整，删除依赖客户端二次刷新的降级路径
+- [x] 4.1 `useAuth` SSR 阶段检测到 `noj:session` 时调用 `/api/v1/auth/me` 获取完整用户信息（含 `permissions`），写入 `useState`
+- [x] 4.2 调整 `middleware/auth.ts` 与 `middleware/admin.ts`：服务端基于完整 `auth:user` 做重定向，不再无条件 `if (import.meta.server) return`
+- [x] 4.3 处理 SSR 认证失败场景：token 失效按未登录处理，不渲染受保护内容
+- [x] 4.4 验证社区权限在 SSR 后完整，删除依赖客户端二次刷新的降级路径
 
 ## 5. SEO
 
-- [ ] 5.1 为动态内容页添加 `useSeoMeta`/`useHead`：题目详情、用户主页、社区帖子、提交详情、公告详情、竞赛详情
-- [ ] 5.2 新增 `server/routes/sitemap.xml.ts`，从 noj-core 拉取公开资源并输出 XML（短 TTL 缓存）
-- [ ] 5.3 新增 `public/robots.txt`，允许公开路径、禁止 admin/editor/settings/私信等
-- [ ] 5.4 完善 `app.vue`/`nuxt.config.ts` 全局默认 OG 与描述
+- [x] 5.1 为动态内容页添加 `useSeoMeta`/`useHead`：题目详情、用户主页、社区帖子、提交详情、公告详情、竞赛详情
+- [x] 5.2 新增 `server/routes/sitemap.xml.ts`，从 noj-core 拉取公开资源并输出 XML（短 TTL 缓存）
+- [x] 5.3 新增 `public/robots.txt`，允许公开路径、禁止 admin/editor/settings/私信等
+- [x] 5.4 完善 `app.vue`/`nuxt.config.ts` 全局默认 OG 与描述
 
 ## 6. 缓存
 
-- [ ] 6.1 在 `nuxt.config.ts` 为公开接口增加 `routeRules` 缓存：problems、rankings、contests、trainings、announcements、tags、stats
-- [ ] 6.2 为认证/个性化接口（auth、submissions、queue、社区权限相关）设置 `no-store` 或排除缓存
-- [ ] 6.3 验证 `deno-server` 预设下 `routeRules` 行为；若不支持则在 Nitro 代理层对公开 GET 设置 `Cache-Control: s-maxage`
-- [ ] 6.4 按需调整 `deploy/nginx/default.conf` 的缓存头（保留 SSE `proxy_cache off`）
+- [x] 6.1 在 `nuxt.config.ts` 为公开接口增加 `routeRules` 缓存：problems、rankings、contests、trainings、announcements、tags、stats
+- [x] 6.2 为认证/个性化接口（auth、submissions、queue、社区权限相关）设置 `no-store` 或排除缓存
+- [x] 6.3 验证 `deno-server` 预设下 `routeRules` 行为；若不支持则在 Nitro 代理层对公开 GET 设置 `Cache-Control: s-maxage`
+- [x] 6.4 按需调整 `deploy/nginx/default.conf` 的缓存头（保留 SSE `proxy_cache off`）
 
 ## 7. 错误处理
 
-- [ ] 7.1 新增自定义 `error.vue`，覆盖 404/500/网络错误
-- [ ] 7.2 为 SSR 非关键数据增加降级：首页公告、社区配置、题目页题解入口等失败时显示空态/占位
-- [ ] 7.3 验证 community 配置失败时页面不再返回 502
+- [x] 7.1 新增自定义 `error.vue`，覆盖 404/500/网络错误
+- [x] 7.2 为 SSR 非关键数据增加降级：首页公告、社区配置、题目页题解入口等失败时显示空态/占位
+- [x] 7.3 验证 community 配置失败时页面不再返回 502
 
 ## 8. 验证与文档
 
-- [ ] 8.1 运行 `deno task check`
-- [ ] 8.2 运行 `deno task build`
-- [ ] 8.3 启动构建产物并 curl 验证关键页面：`/`、`/problems`、`/community`、`/messages`、`/trainings/mine`
-- [ ] 8.4 运行 noj-tests 中相关 E2E（社区、认证、SSE 降级）
-- [ ] 8.5 更新 `noj-ui/CLAUDE.md` 的 SSR 数据获取约定与 `ssr:false` 边界说明
+- [x] 8.1 运行 `deno task check`
+- [x] 8.2 运行 `deno task build`
+- [x] 8.3 启动构建产物并 curl 验证关键页面：`/`、`/problems`、`/community`、`/messages`、`/trainings/mine`
+- [ ] 8.4 运行 noj-tests 中相关 E2E（社区、认证、SSE 降级）——需要完整 PG/Redis/core/judge 环境，当前环境未运行
+- [x] 8.5 更新 `noj-ui/CLAUDE.md` 的 SSR 数据获取约定与 `ssr:false` 边界说明
 - [ ] 8.6 如实现完成，执行 `/opsx:apply` 后归档本次变更

--- a/openspec/changes/improve-ssr-rendering/tasks.md
+++ b/openspec/changes/improve-ssr-rendering/tasks.md
@@ -1,10 +1,10 @@
 ## 1. 基础与止血
 
-- [ ] 1.1 修改 `useApi`：服务端使用 `useRequestFetch` 统一转发 Cookie/请求头，替换手动 `useRequestHeaders(['cookie'])`
-- [ ] 1.2 将 `useAdminList`、`useAuditLogs`、`useSearch`、`useBanStatus`、轮询类 composable 中的 `useApi()` 调用移到 composable 同步 setup 顶部
-- [ ] 1.3 修改 `useCommunity.loadConfig`：`api.get` 失败时 catch 并返回安全默认配置，不向上抛错
-- [ ] 1.4 修改 `community/index.vue` 与 `community/posts/[postId].vue` 的初始化流程：配置失败不得导致 SSR 502
-- [ ] 1.5 迁移 `pages/problems/[id].vue` 中两处直接 `$fetch` 到 `useApi`/`useAsyncData`
+- [x] 1.1 修改 `useApi`：服务端使用 `useRequestFetch` 统一转发 Cookie/请求头，替换手动 `useRequestHeaders(['cookie'])`
+- [x] 1.2 将 `useAdminList`、`useAuditLogs`、`useSearch`、`useBanStatus`、轮询类 composable 中的 `useApi()` 调用移到 composable 同步 setup 顶部
+- [x] 1.3 修改 `useCommunity.loadConfig`：`api.get` 失败时 catch 并返回安全默认配置，不向上抛错
+- [x] 1.4 修改 `community/index.vue` 与 `community/posts/[postId].vue` 的初始化流程：配置失败不得导致 SSR 502
+- [x] 1.5 迁移 `pages/problems/[id].vue` 中两处直接 `$fetch` 到 `useApi`/`useAsyncData`
 
 ## 2. 社区 SSR 改造
 


### PR DESCRIPTION
## 概述

基于 OpenSpec 变更 `improve-ssr-rendering` 实施 noj-ui SSR 渲染改造。

## 主要变更

- 统一 SSR 数据获取：页面初始数据使用 `useAsyncData`/`useFetch`，`useApi` 仅用于交互/轮询/表单
- 消除社区 5 个页面顶层 `await` + 普通 `ref` 反模式，修复 `/community` 在 core 不可达时的 502
- 调整 `ssr:false` 边界：私信/我的题目/设置/队列/竞赛排名/社区收藏/通知/举报详情关闭 SSR；竞赛详情恢复 SSR
- SSR 认证增强：服务端通过 `/auth/me` 获取完整用户与权限，中间件服务端也执行守卫
- 补齐 SEO：动态页 `useSeoMeta`、sitemap、robots、全局 OG
- 公开接口增加 `routeRules` 缓存，认证/个性化接口 no-store
- 新增自定义 `error.vue` 与非关键数据降级
- `useApi` 服务端改用 `useRequestFetch`，清理异步回调内调用 `useApi()` 的隐患

## 验证

- [x] `deno task check`
- [x] `deno task build`
- [x] noj-ui 单元测试
- [x] 构建产物 curl 验证：`/community` 不再 502，`/messages`、`/trainings/mine` 服务端 302 跳登录，sitemap/robots 正常
- [ ] noj-tests E2E（需完整环境，待 CI/本地执行）

## OpenSpec

- 变更目录：`openspec/changes/improve-ssr-rendering/`
- 状态：36/38 任务完成，剩余 E2E 与归档待确认