### PR TITLE
fix(root): 完善镜像供应链与回滚流程

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -8,6 +8,10 @@
 # ── 版本与域名 ─────────────────────────────────────────────────────
 # ghcr.io 镜像版本标签（必须使用已发布的不可变 Release tag）
 NOJ_VERSION=change-me-release-tag
+# 生产启动/升级时强制校验六个应用镜像的 Cosign keyless 签名；本地测试才设为 false
+NOJ_ENFORCE_IMAGE_SIGNATURES=true
+# Cosign 证书身份正则；默认只信任本仓库的 Release workflow
+NOJ_COSIGN_CERT_IDENTITY_REGEX=^https://github.com/Neuro-OJ/neuro-oj/.github/workflows/release.yml@.*$
 # 对外域名（不含协议）
 DOMAIN=change-me.example.com
 # 容器 Nginx 映射到宿主机的端口；同机外部 TLS 终止建议 8080，云 LB 直连可设 80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,21 @@ concurrency:
 jobs:
 
   # ===========================================================================
+  # 生产镜像供应链配置检查：在 PR 阶段提前阻止 latest 和未固定 digest 回归。
+  # ===========================================================================
+  supply-chain:
+    name: Production Supply Chain
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 检查供应链约束
+        run: bash scripts/release/test-supply-chain.sh
+
+  # ===========================================================================
   # 变更检测（dorny/paths-filter）
   #
   # PR 上按改动路径生成 core/ui/judge 三个模块 flag；各模块 job 据此

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,8 @@
 # =============================================================================
-# Neuro OJ 公测发布：构建并推送 ghcr.io 镜像
+# Neuro OJ 生产镜像发布：候选构建 → 安全门禁 → 正式 Release tag → 发布验证
 #
-# 触发条件：
-#   - GitHub Release 发布（release: published）
-#   - 手动 workflow_dispatch（补发）
-#
-# 不在 push / pull_request 上触发。
-# 每次 Release 构建并推送 6 个镜像：
-#   noj-core / noj-ui / noj-judge / noj-llm-gateway / noj-evaluator-python / noj-solution-python
-# 平台：linux/amd64（公测阶段只支持 amd64）
+# 触发条件：GitHub Release published 或 workflow_dispatch。
+# 普通 push / pull_request 不发布生产镜像。
 # =============================================================================
 
 name: Release Images
@@ -21,17 +15,31 @@ on:
 permissions:
   contents: read
   packages: write
-  # GHA 缓存（docker build-push-action cache-to=type=gha）需要写入权限
   actions: write
+  id-token: write
+  attestations: write
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAMESPACE: neuro-oj
 
 jobs:
-  build-and-push:
-    name: Build & Push ${{ matrix.name }}
+  supply-chain-check:
+    name: 检查供应链配置
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 检查生产发布约束
+        run: bash scripts/release/check-supply-chain.sh
+
+  build-and-gate:
+    name: Build and gate ${{ matrix.name }}
+    needs: supply-chain-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -62,40 +70,223 @@ jobs:
       - name: 设置 Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: 计算镜像标签
-        id: meta
-        run: |
-          VERSION="${{ github.event.release.tag_name || github.ref_name }}"
-          if [ -z "$VERSION" ]; then
-            echo "::error::无法确定 Release 版本号"
-            exit 1
-          fi
-          TAGS="$REGISTRY/$IMAGE_NAMESPACE/${{ matrix.name }}:${VERSION}"
-          TAGS="$TAGS,$REGISTRY/$IMAGE_NAMESPACE/${{ matrix.name }}:latest"
-          if [ "${{ github.event.release.prerelease == true }}" = "true" ]; then
-            TAGS="$TAGS,$REGISTRY/$IMAGE_NAMESPACE/${{ matrix.name }}:beta"
-          fi
-          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: 安装 Cosign
+        uses: sigstore/cosign-installer@v3.7.0
 
       - name: 登录 ghcr.io
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 构建并推送镜像
+      - name: 计算候选与 Release 标签
+        id: meta
+        shell: bash
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.name }}
+        run: |
+          set -Eeuo pipefail
+          version="${{ github.event.release.tag_name || github.ref_name }}"
+          if [[ ! "$version" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::版本必须是合法 Release tag（例如 v0.1.0 或 0.1.1-rc.1）：$version"
+            exit 1
+          fi
+          candidate="$IMAGE:${version}-build.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"
+          release="$IMAGE:$version"
+          {
+            echo "version=$version"
+            echo "candidate=$candidate"
+            echo "release=$release"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 构建并推送候选镜像
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.candidate }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=min
+          provenance: mode=max
+          sbom: true
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: 扫描候选镜像漏洞
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ steps.meta.outputs.candidate }}
+          format: table
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: 生成候选镜像 SBOM
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ steps.meta.outputs.candidate }}
+          format: spdx-json
+          output: sbom-${{ matrix.name }}.spdx.json
+          vuln-type: os,library
+          exit-code: "0"
+
+      - name: 上传 SBOM 文件
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ matrix.name }}-${{ steps.meta.outputs.version }}
+          path: sbom-${{ matrix.name }}.spdx.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: 签名候选 digest 并附加 SBOM attestation
+        env:
+          COSIGN_YES: "true"
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.name }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -Eeuo pipefail
+          cosign sign "$IMAGE@$DIGEST"
+          cosign attest \
+            --type spdxjson \
+            --predicate "sbom-${{ matrix.name }}.spdx.json" \
+            "$IMAGE@$DIGEST"
+
+      - name: 绑定 GitHub 构建来源证明
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: 发布正式 Release 标签
+        env:
+          SOURCE: ${{ steps.meta.outputs.candidate }}
+          TARGET: ${{ steps.meta.outputs.release }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -Eeuo pipefail
+          docker buildx imagetools create --tag "$TARGET" "$SOURCE@$DIGEST"
+          actual="$(docker buildx imagetools inspect "$TARGET" | awk '/^Digest:/ {print $2; exit}')"
+          [[ "$actual" == "$DIGEST" ]] || {
+            echo "::error::正式标签 digest 不匹配：期望 $DIGEST，实际 $actual"
+            exit 1
+          }
+
+      - name: 保存发布元数据
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.name }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          printf '%s %s %s\n' "$IMAGE" "$VERSION" "$DIGEST" > release-${{ matrix.name }}.txt
+
+      - name: 上传发布元数据
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-metadata-${{ matrix.name }}
+          path: release-${{ matrix.name }}.txt
+          if-no-files-found: error
+          retention-days: 90
+
+  verify-release:
+    name: 验证正式 Release 镜像
+    needs: build-and-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 设置 Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 安装 Cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: 登录 ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 下载发布元数据
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-metadata-*
+          path: release-metadata
+          merge-multiple: true
+
+      - name: 验证 digest、签名、来源证明和 smoke test
+        env:
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          shopt -s nullglob
+          files=(release-metadata/release-*.txt)
+          [[ "${#files[@]}" -eq 6 ]] || {
+            echo "::error::发布元数据数量错误，期望 6，实际 ${#files[@]}"
+            exit 1
+          }
+
+          for metadata in "${files[@]}"; do
+            read -r image version digest < "$metadata"
+            release="$image:$version"
+            actual="$(docker buildx imagetools inspect "$release" | awk '/^Digest:/ {print $2; exit}')"
+            [[ "$actual" == "$digest" ]] || {
+              echo "::error::$release digest 不匹配：期望 $digest，实际 $actual"
+              exit 1
+            }
+
+            cosign verify \
+              --certificate-identity-regexp "^https://github.com/${REPOSITORY}/.github/workflows/release.yml@.*$" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "$image@$digest" >/dev/null
+
+            cosign verify-attestation \
+              --type spdxjson \
+              --certificate-identity-regexp "^https://github.com/${REPOSITORY}/.github/workflows/release.yml@.*$" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "$image@$digest" >/dev/null
+
+            gh attestation verify "oci://$image@$digest" \
+              --repo "$REPOSITORY" \
+              --signer-workflow "$REPOSITORY/.github/workflows/release.yml" >/dev/null
+
+            docker pull "$image@$digest" >/dev/null
+            case "$image" in
+              */noj-core)
+                docker run --rm --entrypoint /bin/sh "$image@$digest" -c \
+                  'test -x /app/bin/noj-core && test -x /app/bin/noj && test "$(id -u)" != 0'
+                ;;
+              */noj-ui)
+                docker run --rm --entrypoint /bin/sh "$image@$digest" -c \
+                  'test -x /app/noj-ui && test "$(id -u)" != 0'
+                ;;
+              */noj-judge)
+                docker run --rm --entrypoint /bin/sh "$image@$digest" -c \
+                  'test -x /usr/local/bin/noj-judge && test "$(id -u)" != 0'
+                ;;
+              */noj-llm-gateway)
+                docker run --rm --entrypoint /bin/sh "$image@$digest" -c \
+                  'command -v deno >/dev/null && test "$(id -u)" != 0'
+                ;;
+              */noj-evaluator-python|*/noj-solution-python)
+                docker run --rm --entrypoint python3 "$image@$digest" -c \
+                  'import sys; assert sys.version_info >= (3, 12)'
+                ;;
+              *)
+                echo "::error::未覆盖的发布镜像：$image"
+                exit 1
+                ;;
+            esac
+            echo "已验证 $release@$digest"
+          done

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -43,7 +43,7 @@ x-core-env: &core-env
 services:
   # ── 一次性初始化：迁移 + 系统数据 + 管理员引导 ────────────────────
   migrate:
-    image: ${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-core:${NOJ_VERSION:-latest}
+    image: "${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-core:${NOJ_VERSION:?NOJ_VERSION is required}"
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-
@@ -63,7 +63,7 @@ services:
 
   # ── 核心 API ──────────────────────────────────────────────────────
   core:
-    image: ${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-core:${NOJ_VERSION:-latest}
+    image: "${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-core:${NOJ_VERSION:?NOJ_VERSION is required}"
     environment:
       <<: *core-env
     depends_on:
@@ -99,7 +99,7 @@ services:
 
   # ── 前端 SSR ──────────────────────────────────────────────────────
   ui:
-    image: ${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-ui:${NOJ_VERSION:-latest}
+    image: "${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-ui:${NOJ_VERSION:?NOJ_VERSION is required}"
     environment:
       NUXT_API_BASE: http://core:8000
       NUXT_NOJ_ENV: ${NUXT_NOJ_ENV:-production}
@@ -129,7 +129,7 @@ services:
 
   # ── 评测 Worker ───────────────────────────────────────────────────
   judge:
-    image: ${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-judge:${NOJ_VERSION:-latest}
+    image: "${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-judge:${NOJ_VERSION:?NOJ_VERSION is required}"
     environment:
       REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379/0
       JUDGE_QUEUE: ${JUDGE_QUEUE:-noj:judge:queue}
@@ -175,7 +175,7 @@ services:
 
   # ── LLM Gateway ───────────────────────────────────────────────────
   llm-gateway:
-    image: ${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-llm-gateway:${NOJ_VERSION:-latest}
+    image: "${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-llm-gateway:${NOJ_VERSION:?NOJ_VERSION is required}"
     environment:
       NOJ_LLM_PORT: "8001"
       NOJ_LLM_SERVICE_TOKEN: ${NOJ_LLM_SERVICE_TOKEN:?NOJ_LLM_SERVICE_TOKEN is required}
@@ -213,7 +213,7 @@ services:
 
   # ── 反向代理 / TLS ────────────────────────────────────────────────
   nginx:
-    image: nginx:1.27-alpine
+    image: nginx:1.27-alpine@sha256:62223d644fa234c3a1cc785ee14242ec47a77364226f1c811d2f669f96dc2ac8
     ports:
       # 默认映射到宿主机 8080，避免与外部 TLS 终止层（如宿主机 Nginx）的 80 冲突；
       # 若直接由云 LB 转发 80，可设置 NGINX_PORT=80。
@@ -229,7 +229,7 @@ services:
 
   # ── PostgreSQL ────────────────────────────────────────────────────
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16-alpine@sha256:075f7ba66bc9b3ce7d6b8b635208ff61cd7cf1a67d71ec530eec5d7ae0cbe571
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-noj}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
@@ -247,7 +247,7 @@ services:
 
   # ── Redis（带密码 + AOF）─────────────────────────────────────────
   redis:
-    image: redis:7-alpine
+    image: redis:7-alpine@sha256:1db42ccef14898aa29bae778452d567534b59c107129cbc1163fb552de184d3c
     command:
       - redis-server
       - --requirepass
@@ -269,7 +269,7 @@ services:
 
   # ── MinIO（自建对象存储）─────────────────────────────────────────
   minio:
-    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z@sha256:d051d800a3025588f37f69f132bb5ef718547a9a4ee95ddee44e04ad952a0a96
     command: server /data --console-address :9001
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
@@ -282,7 +282,7 @@ services:
 
   # ── MinIO bucket 初始化（一次性，带重试等待 MinIO 就绪）──────────
   minio-init:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:eb4ea9884b77704230e2423e9004d2fa738dc272876b9cc41a297d29443b8780
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-

--- a/noj-core/Dockerfile
+++ b/noj-core/Dockerfile
@@ -8,7 +8,7 @@
 # 平台：linux/amd64（公测阶段只支持 amd64）。
 
 # ── Builder：安装依赖并编译两个二进制 ─────────────────────────────
-FROM denoland/deno:debian-2.9.5 AS builder
+FROM denoland/deno:debian-2.9.5@sha256:5d46f925d213e9adaf18a0664b291fe973c91ba7b929572877610dcaaf09ee2b AS builder
 
 WORKDIR /build
 
@@ -45,7 +45,7 @@ RUN mkdir -p /build/bin \
         --output /build/bin/noj scripts/noj.ts
 
 # ── Runtime：只保留二进制与必需文件 ────────────────────────────────
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:5ae3c39ebd15e229dcedd5cee596b2497182493d41ff162e824ba13fc1b2b867
 
 # ca-certificates：HTTPS 出站；zip：problems:build；wget：healthcheck
 RUN apt-get update \

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -6,6 +6,7 @@
 ## 1. 前置条件
 
 - 一台 Linux 服务器（amd64），已安装 Docker Engine 与 Docker Compose v2。
+- 已安装 Cosign（用于校验生产应用镜像的 keyless 签名）；Docker CLI 可用 Buildx。
 - Deno 2.x（仅用于部署前运行 `noj-core` 的配置检查命令）。
 - 一个已解析到服务器的域名。
 - 外部 TLS 终止（宿主机 Nginx / Caddy / 云负载均衡），负责 HTTPS → 容器 HTTP 端口。
@@ -43,7 +44,9 @@ bash scripts/deploy/deploy.sh install
 
 | 变量 | 说明 |
 |------|------|
-| `NOJ_VERSION` | 要部署的 Release 标签，如 `v0.1.0` |
+| `NOJ_VERSION` | 要部署的已签名 Release 标签，如 `v0.1.0`；禁止使用 `latest`/`beta` |
+| `NOJ_ENFORCE_IMAGE_SIGNATURES` | 生产必须保持 `true`，启动/升级前校验六个应用镜像的 Cosign 签名 |
+| `NOJ_COSIGN_CERT_IDENTITY_REGEX` | Cosign 证书身份正则，默认只信任本仓库的 Release workflow |
 | `DOMAIN` | 对外域名（不含协议），compose/Nginx 使用 |
 | `APP_URL` | `https://你的域名` |
 | `CORS_ALLOWED_ORIGINS` | `https://你的域名` |
@@ -93,6 +96,18 @@ curl https://你的域名/healthz
 ```bash
 bash scripts/deploy/deploy.sh install
 ```
+
+部署脚本在 `install`、`start` 和 `upgrade` 前会校验 `NOJ_VERSION` 对应的六个应用镜像
+digest 与 Cosign keyless 签名。默认信任当前仓库的 Release workflow；如需变更签名身份，
+必须通过受保护的生产配置显式设置 `NOJ_COSIGN_CERT_IDENTITY_REGEX`。可以单独执行：
+
+```bash
+bash scripts/deploy/deploy.sh verify
+```
+
+`NOJ_ENFORCE_IMAGE_SIGNATURES=false` 仅用于本地 fake-Docker 测试，不得用于生产环境。
+成功启动或升级后，脚本会在 `backups/current-deployment.txt` 记录当前 Release 版本和六个
+应用镜像 digest；升级失败时不会覆盖上一份成功部署记录。
 
 > 评测 Worker 不得挂载应用宿主机的 `/var/run/docker.sock`。生产 Compose 要求
 > `JUDGE_DOCKER_SOCKET` 指向只服务于 judge 的 rootless daemon socket，并以非 root
@@ -218,22 +233,28 @@ docker compose --env-file .env.prod -f docker-compose.prod.yml exec redis \
 
 ## 6. 升级
 
-1. 在 GitHub 发布新 Release（如 `v0.1.1`），`release.yml` 会自动推送镜像。
-2. 在服务器修改 `.env.prod` 中的 `NOJ_VERSION=v0.1.1`。
-3. 拉取新镜像并重建：
+1. 在 GitHub 发布新 Release（如 `v0.1.1`）。Release workflow 会先构建候选镜像，
+   完成漏洞扫描、SBOM、签名和来源证明后，才创建正式版本标签。
+2. 确认 Release workflow 的六个镜像验证全部成功，并在服务器修改 `.env.prod` 中的
+   `NOJ_VERSION=v0.1.1`。
+3. 升级前创建备份并拉取新镜像：
 
 ```bash
-docker compose --env-file .env.prod -f docker-compose.prod.yml pull
-docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+bash scripts/deploy/deploy.sh upgrade
 ```
 
-4. 数据库迁移由 `core` 启动时自动执行；也可先手动跑一次 `migrate` 服务。
+部署脚本会先校验镜像签名，再创建并校验生产备份，然后拉取镜像并等待 Compose 健康检查。
+数据库迁移由 `migrate` 一次性服务执行；升级前必须确认新版本迁移与旧版本应用兼容。
 
 ## 7. 回滚
 
-- 将 `.env.prod` 的 `NOJ_VERSION` 改回上一版本，重新 `pull` + `up -d`。
+- 确认上一版本 Release 仍可拉取且签名有效，将 `.env.prod` 的 `NOJ_VERSION` 改回上一版本，
+  执行 `bash scripts/deploy/deploy.sh verify` 后再执行 `bash scripts/deploy/deploy.sh start`。
 - 数据库 schema 采用只追加迁移，**不自动回滚**；如需回退 schema，请人工评估并备份后操作。
 - 评测镜像也按 Release tag 发布，回滚时需要把 `judge_images` 白名单指向旧 tag（若使用 `all_versions` 则无需改白名单，只需题目/系统设置中的镜像 tag 指向旧版本）。
+
+如果新版本已经执行了不兼容的数据库迁移，不能只切换应用镜像；必须停止服务、确认备份
+可恢复后，按备份恢复流程处理数据，再启动上一版本。
 
 ## 8. 备份提示
 

--- a/noj-judge/Dockerfile
+++ b/noj-judge/Dockerfile
@@ -11,7 +11,7 @@
 # Worker 使用非 root 用户运行；禁止挂载应用宿主机的 /var/run/docker.sock。
 
 # ── Builder：编译 release 二进制 ────────────────────────────────────
-FROM rust:1.86-slim-bookworm AS builder
+FROM rust:1.86-slim-bookworm@sha256:a044f7ab9a762f95be2ee7eb2c49e4d4a4ec60011210de9f7da01d552cae3a55 AS builder
 
 WORKDIR /build
 
@@ -28,7 +28,7 @@ RUN cargo build --release --bin noj-judge && \
     test -f /tmp/noj-judge || { echo "ERROR: binary not found after build" >&2; exit 1; }
 
 # ── Runtime：只保留二进制 ───────────────────────────────────────────
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:5ae3c39ebd15e229dcedd5cee596b2497182493d41ff162e824ba13fc1b2b867
 
 # ca-certificates：支持包/预签名 URL 的 HTTPS 下载
 RUN apt-get update \

--- a/noj-judge/docker/evaluator-python/Dockerfile
+++ b/noj-judge/docker/evaluator-python/Dockerfile
@@ -9,7 +9,7 @@
 # （如 `python3 /workspace/evaluate.py`）。容器默认 cmd 设为 sleep infinity，
 # 因为容器是通过 exec 启动评测脚本而非 docker run。
 
-FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
+FROM python:3.12-slim@sha256:a249c9f47e05708dd367f3fe8ada03cf347390fad66fb8b0518c0ef55ae3cb84
 LABEL org.opencontainers.image.description="Neuro OJ Dual-container Evaluator (Python 3.12, noj_evaluator_sdk)"
 LABEL com.noj.judge.kind="evaluator"
 

--- a/noj-judge/docker/python/Dockerfile
+++ b/noj-judge/docker/python/Dockerfile
@@ -4,7 +4,7 @@
 # 由 noj-judge 在运行时通过绑定挂载注入到 /tmp 目录。
 # 容器内的入口是 judge_command（如 python3 /tmp/evaluate.py）。
 
-FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
+FROM python:3.12-slim@sha256:a249c9f47e05708dd367f3fe8ada03cf347390fad66fb8b0518c0ef55ae3cb84
 LABEL org.opencontainers.image.description="Neuro OJ Python 3 Judge Environment"
 
 # 评测脚本不需要额外依赖——所有依赖由 evaluate.py 自行管理。

--- a/noj-judge/docker/solution-ai/Dockerfile
+++ b/noj-judge/docker/solution-ai/Dockerfile
@@ -8,7 +8,7 @@
 # 入口：noj-judge 通过 docker exec 启动 `python3 -m noj_solution_sdk.host --entry <file>`
 # 容器默认 cmd 设为 sleep infinity（容器本身不主动跑东西，由 exec 注入 host 进程）。
 
-FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
+FROM python:3.12-slim@sha256:a249c9f47e05708dd367f3fe8ada03cf347390fad66fb8b0518c0ef55ae3cb84
 LABEL org.opencontainers.image.description="Neuro OJ Dual-container Solution AI (Python 3.12, CPU torch, noj_solution_sdk)"
 LABEL com.noj.judge.kind="solution"
 

--- a/noj-judge/docker/solution-python/Dockerfile
+++ b/noj-judge/docker/solution-python/Dockerfile
@@ -9,7 +9,7 @@
 # 入口：noj-judge 通过 docker exec 启动 `python3 -m noj_solution_sdk.host --entry <file>`
 # 容器默认 cmd 设为 sleep infinity（容器本身不主动跑东西，由 exec 注入 host 进程）。
 
-FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
+FROM python:3.12-slim@sha256:a249c9f47e05708dd367f3fe8ada03cf347390fad66fb8b0518c0ef55ae3cb84
 LABEL org.opencontainers.image.description="Neuro OJ Dual-container Solution (Python 3.12, noj_solution_sdk)"
 LABEL com.noj.judge.kind="solution"
 

--- a/noj-llm-gateway/Dockerfile
+++ b/noj-llm-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-2.9.5
+FROM denoland/deno:alpine-2.9.5@sha256:7ef8943fede9b4ec021465dcadb98c9cefeef7121ae7eb2369fbd5bd354d27f8
 LABEL org.opencontainers.image.description="Neuro OJ LLM Gateway (Deno + Hono)"
 
 WORKDIR /app

--- a/noj-ui/Dockerfile
+++ b/noj-ui/Dockerfile
@@ -8,7 +8,7 @@
 # 平台：linux/amd64（公测阶段只支持 amd64）。
 
 # ── Builder：安装依赖并编译单二进制 ────────────────────────────────
-FROM denoland/deno:debian-2.9.5 AS builder
+FROM denoland/deno:debian-2.9.5@sha256:5d46f925d213e9adaf18a0664b291fe973c91ba7b929572877610dcaaf09ee2b AS builder
 
 WORKDIR /build
 
@@ -33,7 +33,7 @@ RUN deno run -A scripts/patch-monaco-workers.mjs
 RUN deno task compile 2>&1 || { echo "ERROR: noj-ui compile failed" >&2; exit 1; }
 
 # ── Runtime：只保留二进制 ───────────────────────────────────────────
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:5ae3c39ebd15e229dcedd5cee596b2497182493d41ff162e824ba13fc1b2b867
 
 # ca-certificates：HTTPS 出站；wget：healthcheck
 RUN apt-get update \

--- a/openspec/changes/immutable-image-release/.openspec.yaml
+++ b/openspec/changes/immutable-image-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/immutable-image-release/design.md
+++ b/openspec/changes/immutable-image-release/design.md
@@ -1,0 +1,69 @@
+## Context
+
+当前 `.github/workflows/release.yml` 在六个镜像上直接同时推送版本标签和 `latest`，生产 Compose 又把 `latest` 作为默认值。仓库已经有生产 Dockerfile、生产 Compose、部署脚本和备份恢复脚本，但缺少“候选构建 → 安全门禁 → 正式标签 → 发布验证”的闭环。相关既有要求见 `openspec/specs/production-release-pipeline/spec.md`，本变更对其中的可变标签行为进行修改。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 让正式 Release 标签只指向已扫描、已生成 SBOM、已签名并已验证的镜像 digest。
+- 固定生产构建和基础设施镜像的内容摘要，阻止无意的上游 tag 漂移。
+- 让部署脚本拒绝缺少版本、使用 `latest` 或格式明显非法的生产版本。
+- 在 GitHub Actions 中自动验证六个正式镜像的 digest、签名、来源证明和最小运行能力。
+- 保留现有升级前备份和数据卷策略，并把回滚动作写成可执行文档。
+
+**Non-Goals:**
+
+- 不实现 Kubernetes、蓝绿发布、自动扩缩容或云厂商专用发布平台。
+- 不自动执行生产环境数据库降级迁移；数据库迁移必须保持向前兼容或由运维人工恢复备份。
+- 不把开发/E2E 镜像改造成生产发布物；只覆盖生产 Release 工作流和生产 Compose 使用的镜像。
+- 不承诺在没有真实生产主机的本地环境完成一次生产回滚演练；CI 只验证回滚输入和脚本护栏。
+
+## Decisions
+
+### 1. 使用候选标签隔离安全门禁与正式发布
+
+每个矩阵任务先构建并推送唯一候选标签，例如 `0.1.2-build.<run_id>-<attempt>`。候选构建启用 BuildKit 的 provenance/SBOM attestations；随后使用 Trivy 扫描，并用 Cosign keyless 签名候选 digest、附加可验证的 SBOM attestation。全部矩阵任务成功后，再由验证任务把同一 digest 创建为正式 Release tag。
+
+选择候选标签而非先推正式标签再扫描，是为了避免扫描失败后留下看似可部署的正式镜像。正式标签只作为 digest 的可读别名，不能重新构建或重新打包。
+
+### 2. 使用 GitHub OIDC 的 keyless 签名与 provenance
+
+Release workflow 请求 `id-token: write`，通过 Cosign Fulcio/Rekor 完成 keyless 签名，并使用 GitHub Actions provenance attestation 绑定仓库、工作流和 commit。部署侧和发布验证侧按仓库及 Release workflow 身份验证证书身份，避免把私钥写入仓库或长期保存到生产主机。
+
+替代方案是维护 Cosign 私钥并通过 GitHub Secret 注入；该方案需要密钥轮换和泄露响应，且长期密钥本身成为新的高价值秘密，因此不采用。
+
+### 3. 以不可变 Release tag 作为生产 Compose 输入
+
+`NOJ_VERSION` 改为必填，并拒绝 `latest`/`beta`/空值。当前仓库的生产部署以 Release tag 作为人类可操作的版本标识；发布工作流记录并验证该 tag 对应 digest，部署文档要求先完成签名验证。后续若需要严格 digest 锁定，可在不改变服务拓扑的情况下将 Compose 输入扩展为每个服务的 digest 引用。
+
+不把 Compose 改成单一全局 digest 变量，因为六个服务的 digest 不同，且会显著降低人工回滚时的可读性；版本 tag + 发布清单已经满足本变更的不可变 Release tag 要求。
+
+### 4. 固定生产基础镜像 digest
+
+生产 Dockerfile 的 builder/runtime 基础镜像以及生产 Compose 的 Nginx、PostgreSQL、Redis、MinIO 和 `mc` 镜像均使用平台支持 `linux/amd64` 的 digest。digest 更新作为显式依赖升级，必须通过构建和安全扫描后再合入。
+
+### 5. 把配置检查和发布验证做成独立脚本
+
+新增无外部服务依赖的 shell 检查，扫描生产 Dockerfile、Compose 和 release workflow 的关键约束（无生产 `latest` 回退、基础镜像 digest、必填版本）。发布验证脚本负责从 GHCR 拉取实际版本 tag，检查 digest、Cosign 签名和基础容器命令；复杂的依赖服务健康检查仍由现有 staging acceptance 负责。
+
+## Risks / Trade-offs
+
+- [GHCR 或 Sigstore 暂时不可用] → 正式 Release 会失败；候选镜像可保留用于重试，不创建正式部署标签。
+- [Trivy 将未修复高危漏洞作为门禁] → 上游基础镜像更新可能阻塞发布；允许通过版本化、可审计的 ignore 配置处理明确误报，不允许全局关闭门禁。
+- [Release tag 仍可能被仓库管理员手工移动] → GitHub 分支/标签保护与发布流程必须限制重写；部署前验证签名身份和发布清单，发现 digest 不匹配即拒绝。
+- [基础镜像 digest 更新成本增加] → 通过定期依赖更新任务和单独的镜像升级 PR 管理，避免隐式漂移。
+- [数据库迁移无法自动回滚] → 升级前强制备份，文档要求向前兼容迁移；失败回滚只切换应用镜像，数据恢复由人工按备份流程执行。
+- [本地 Docker 环境无法访问真实 GHCR/Sigstore] → 本地验证覆盖 Compose 配置、版本护栏和脚本逻辑；真实镜像签名/发布验证由 GitHub Actions 执行。
+
+## Migration Plan
+
+1. 合入工作流、基础镜像 digest、Compose 版本护栏和部署脚本测试。
+2. 创建一个测试 Release，确认六个候选镜像均完成扫描、SBOM、签名和 provenance，再生成正式版本标签。
+3. 在 staging 使用该版本的签名验证结果启动 Compose，执行健康检查和基础 smoke test。
+4. 记录当前生产版本和镜像 digest；升级前执行现有备份脚本。
+5. 若升级失败，将 `NOJ_VERSION` 切换为上一版本，重新执行部署并按数据库兼容性说明决定是否恢复数据。
+
+## Open Questions
+
+- Sigstore 的证书身份过滤条件需要在仓库实际组织/工作流名称确定后，在部署平台的验证命令中固定；这不改变仓库内的发布流程和验收标准。

--- a/openspec/changes/immutable-image-release/proposal.md
+++ b/openspec/changes/immutable-image-release/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+当前发布工作流虽然可以构建并推送生产镜像，但仍允许 `latest` 作为部署回退标签，且没有把漏洞扫描、SBOM、签名证明和发布后验证组成强制门禁。这样会削弱镜像来源追溯、构建可复现性和故障回滚能力；随着生产部署脚本已经具备基础升级/备份能力，现在补齐发布供应链是合适的时机。
+
+## What Changes
+
+- 将生产镜像发布改为使用经过校验的不可变 Release tag，并禁止生产 Compose 默认使用 `latest`。
+- 固定生产 Dockerfile 和生产 Compose 中仍然漂移的基础镜像 digest。
+- 在 Release workflow 中生成并发布 SBOM，执行镜像漏洞扫描，并在扫描失败时阻断发布。
+- 使用 Cosign keyless 签名和 GitHub OIDC provenance，使镜像可追溯到仓库、Release 和源码 commit。
+- 对实际推送的镜像执行 manifest/digest 校验、拉取验证和最小容器健康检查。
+- 为部署脚本增加版本格式校验、升级前后版本记录和可操作的回滚提示；明确数据库迁移不可自动回滚的兼容性边界。
+- 更新生产部署文档与发布规范，记录镜像验证、升级和回滚流程。
+
+## Capabilities
+
+### New Capabilities
+
+- `production-image-supply-chain`: 定义生产镜像的可追溯构建、SBOM、漏洞门禁、签名证明和发布后验证。
+
+### Modified Capabilities
+
+- `production-release-pipeline`: 将 Release 标签、生产 Compose 镜像引用、发布验证和升级/回滚要求从可变标签行为改为不可变发布行为。
+
+## Impact
+
+- 修改 `.github/workflows/release.yml`，新增镜像元数据、SBOM、Trivy 扫描、Cosign 签名/证明和发布后校验步骤。
+- 修改 `docker-compose.prod.yml`、生产 Dockerfile 及必要的环境模板，移除生产镜像对 `latest` 的默认依赖并固定基础镜像 digest。
+- 修改 `scripts/deploy/deploy.sh` 和生产部署文档，强化版本检查、升级记录及回滚操作说明。
+- 新增仓库内发布链路测试，验证 workflow/Compose 配置不会重新引入可变生产标签。
+- 不引入 Kubernetes、云厂商专用服务或自动化数据库降级迁移；真实生产升级/回滚演练仍需部署环境执行。

--- a/openspec/changes/immutable-image-release/specs/production-image-supply-chain/spec.md
+++ b/openspec/changes/immutable-image-release/specs/production-image-supply-chain/spec.md
@@ -1,0 +1,68 @@
+## Purpose
+
+为 Neuro OJ 生产镜像建立可复现、可审计且默认拒绝不安全产物的发布供应链，使运维能够确认镜像来源、内容摘要、漏洞状态、SBOM 与签名证明，并安全地执行升级和回滚。
+
+## ADDED Requirements
+
+### Requirement: 候选镜像通过安全门禁后才能发布正式标签
+
+Release 工作流 MUST 先为每个生产镜像生成唯一候选标签并推送候选镜像，随后完成漏洞扫描、SBOM 生成和签名。只有所有门禁成功后，工作流才可以将已验证的同一镜像 digest 发布为 Release 版本标签；工作流 MUST NOT 将扫描前的镜像直接发布为正式生产标签。
+
+#### Scenario: 安全门禁通过后发布版本标签
+
+- **WHEN** GitHub Release 触发镜像发布且所有候选镜像通过扫描、SBOM 和签名步骤
+- **THEN** 每个正式版本标签指向扫描时验证过的同一个镜像 digest
+- **THEN** 发布记录包含源码 commit、Release tag 和各镜像 digest
+
+#### Scenario: 漏洞扫描失败阻断正式发布
+
+- **WHEN** 任一候选镜像存在门禁范围内的未豁免高危或严重漏洞
+- **THEN** Release 工作流失败
+- **THEN** 对应正式版本标签不会被创建或更新
+
+### Requirement: 生产镜像具备 SBOM、签名与来源证明
+
+每个正式生产镜像 MUST 关联机器可读 SBOM、Cosign keyless 签名和来源证明。证明 MUST 能够关联到本仓库、构建工作流、Release 版本和源码 commit。生产部署验证 MUST 拒绝无法验证签名或来源的镜像。
+
+#### Scenario: 验证已发布镜像的供应链证明
+
+- **WHEN** 发布验证任务检查一个正式版本镜像
+- **THEN** 镜像 digest 存在 SBOM、有效签名和来源证明
+- **THEN** 签名身份与本仓库的受信 GitHub Actions 工作流匹配
+
+#### Scenario: 供应链证明缺失
+
+- **WHEN** 镜像缺少签名、SBOM 或来源证明之一
+- **THEN** 发布验证失败
+- **THEN** 该镜像不得作为生产部署输入
+
+### Requirement: 生产基础镜像固定内容摘要
+
+生产 Dockerfile 和生产 Compose 使用的基础镜像 MUST 使用经过审查的内容 digest，而不是仅使用可变 tag。应用发布镜像由 Release 版本标签或 digest 标识，不得依赖 `latest`、`beta` 或其他可变通道作为生产默认值。
+
+#### Scenario: 检查生产镜像引用
+
+- **WHEN** CI 检查生产 Dockerfile 和 Compose 文件中的镜像引用
+- **THEN** 基础镜像引用包含 `@sha256:` digest
+- **THEN** 生产应用镜像引用要求显式 Release 版本，不提供 `latest` 默认值
+
+#### Scenario: 发现可变生产引用
+
+- **WHEN** 生产 Compose 或生产 Dockerfile 新增无 digest 的基础镜像，或应用镜像回退到 `latest`
+- **THEN** 配置检查失败并阻止合并或发布
+
+### Requirement: 发布后验证实际镜像
+
+Release 工作流 MUST 对正式版本标签解析出的实际 digest 执行拉取、签名验证和最小容器 smoke test。验证 MUST 覆盖所有发布镜像，并在任一镜像无法拉取、签名不匹配或无法通过 smoke test 时失败。
+
+#### Scenario: 所有正式镜像验证通过
+
+- **WHEN** Release 工作流完成正式标签发布
+- **THEN** 所有发布镜像均可按记录的 digest 拉取
+- **THEN** 所有镜像的签名和来源证明验证通过
+- **THEN** 所有镜像完成对应的最小启动或运行时 smoke test
+
+#### Scenario: 正式标签指向错误 digest
+
+- **WHEN** 正式标签解析出的 digest 与候选镜像记录不一致
+- **THEN** 发布验证失败并报告镜像名称、标签和实际 digest

--- a/openspec/changes/immutable-image-release/specs/production-release-pipeline/spec.md
+++ b/openspec/changes/immutable-image-release/specs/production-release-pipeline/spec.md
@@ -1,0 +1,157 @@
+## MODIFIED Requirements
+
+### Requirement: Release 触发的 ghcr.io 镜像发布
+
+系统 SHALL 提供 GitHub Actions 工作流 `.github/workflows/release.yml`，仅在 GitHub Release 发布（`release: types: [published]`）或手动触发（`workflow_dispatch`）时构建并推送镜像到 ghcr.io。该工作流 SHALL NOT 在普通 push / pull_request 上触发。
+
+工作流 SHALL 构建并推送以下六个镜像到 `ghcr.io/neuro-oj/`：
+
+- `noj-core`
+- `noj-ui`
+- `noj-judge`
+- `noj-llm-gateway`
+- `noj-evaluator-python`
+- `noj-solution-python`
+
+每个镜像 SHALL 先使用唯一候选标签构建并完成供应链门禁，再以当前 Release tag 作为不可变版本标签发布。工作流 MUST NOT 发布或依赖 `latest`、`beta` 等可变标签作为生产部署输入。
+
+#### Scenario: 发布正式 Release
+
+- **WHEN** 维护者发布一个合法版本标签的 GitHub Release
+- **THEN** `release.yml` 被触发并为六个镜像生成唯一候选构建
+- **THEN** 候选镜像通过安全门禁后，六个镜像均发布到对应的 Release 版本标签
+- **THEN** 普通 push / pull_request 不会触发该工作流
+
+#### Scenario: 发布 prerelease
+
+- **WHEN** 维护者发布一个 prerelease Release
+- **THEN** 工作流使用该 Release 的不可变版本标签发布镜像
+- **THEN** 工作流不把 `beta` 或 `latest` 作为生产部署标签
+
+#### Scenario: 手动补发
+
+- **WHEN** 维护者在 Actions 页面手动运行 `release.yml`
+- **THEN** 工作流仅接受合法 Release/tag ref 作为版本标识
+- **THEN** 工作流使用当前 ref/tag 作为版本标签执行相同的安全门禁和发布验证
+
+### Requirement: 生产 Dockerfile
+
+每个服务模块 SHALL 提供生产用 Dockerfile，满足以下要求：
+
+- `noj-core/Dockerfile`：多阶段构建，使用 Deno 2.9.5 与 `deno compile` 产出 API server 与 CLI 两个独立二进制；最终镜像只保留二进制、`drizzle/` 迁移目录与 `data/` 题目数据，不包含源码与 Deno 工具链；通过 `NOJ_PROJECT_ROOT` / `NOJ_MIGRATIONS_DIR` 显式指定运行时路径；以非 root 用户运行 API 服务；所有基础镜像使用 digest 固定。
+- `noj-ui/Dockerfile`：多阶段构建，使用 Deno 2.9.5 与 `deno task compile` 产出单二进制；最终镜像只包含编译后的单二进制与 `ca-certificates`/`wget`，不包含源码、node_modules、开发依赖；以非 root 用户运行；构建期固定 `rolldown@1.2.5` 并运行 `patch-monaco-workers.mjs`；所有基础镜像使用 digest 固定。
+- `noj-judge/Dockerfile`：多阶段构建（builder + runtime），最终镜像只包含 release 二进制与 `ca-certificates`；可通过挂载 Docker socket 与 Docker daemon 通信；所有基础镜像使用 digest 固定。
+- `noj-evaluator-python` / `noj-solution-python`：继续使用现有 SDK 镜像 Dockerfile，但纳入 ghcr 构建发布流程；基础镜像使用 digest 固定。
+- 各模块 SHALL 提供 `.dockerignore`，排除 `node_modules`、`target`、`.deno_cache`、`.env*`、日志、`dist`（除 UI 编译产物外）等不应进入构建上下文的内容。
+- 镜像 SHALL 声明 `HEALTHCHECK`（core/ui/judge 按服务能力提供）。
+- 公测阶段 SHALL 只构建 `linux/amd64` 镜像。
+
+#### Scenario: 构建生产镜像
+
+- **WHEN** CI 使用生产 Dockerfile 构建任一发布镜像
+- **THEN** 所有基础镜像均解析到声明的 digest
+- **THEN** 镜像包含对应运行时所需内容，不包含源码、密钥和构建工具链
+- **THEN** 镜像默认用户和健康检查满足对应模块的生产要求
+
+#### Scenario: 构建 noj-core 生产镜像
+
+- **WHEN** 执行 `docker build -f noj-core/Dockerfile noj-core`
+- **THEN** 镜像包含可运行的 noj-core 服务、迁移 CLI 与健康检查
+- **THEN** 镜像默认用户不是 root
+- **THEN** 镜像内不包含 `.env` 或本地密钥
+
+#### Scenario: 构建 noj-ui 生产镜像
+
+- **WHEN** 执行 `docker build -f noj-ui/Dockerfile noj-ui`
+- **THEN** 最终镜像不包含 `node_modules` 与源码
+- **THEN** 镜像默认用户不是 root
+- **THEN** 镜像可通过 `NUXT_API_BASE` / `NUXT_NOJ_ENV` 等环境变量配置运行时行为
+
+#### Scenario: 构建 noj-judge 生产镜像
+
+- **WHEN** 执行 `docker build -f noj-judge/Dockerfile noj-judge`
+- **THEN** 最终镜像包含 release 二进制，不包含 `target/` 与 Rust 工具链
+- **THEN** 镜像可通过 `REDIS_URL`、`JUDGE_MAX_CONCURRENT_JUDGES` 等环境变量配置
+
+#### Scenario: 基础镜像 digest 漂移
+
+- **WHEN** 生产 Dockerfile 的基础镜像只使用 tag 或 digest 被未经审查地替换
+- **THEN** 供应链配置检查失败
+
+### Requirement: 生产 Docker Compose 配置
+
+系统 SHALL 提供 `docker-compose.prod.yml`，用于公测部署，满足以下要求：
+
+- 所有业务服务镜像来自 `ghcr.io/neuro-oj/*`，版本通过必填的 `NOJ_VERSION` 环境变量控制；`NOJ_VERSION` MUST 是已发布的不可变 Release tag，生产 Compose 不得默认回退到 `latest`。
+- 仅 Nginx 服务对外暴露一个宿主机端口（默认 `8080`，可通过 `NGINX_PORT` 改为 `80`；TLS 由外部边缘终止）；`ui`、`core`、`judge`、`postgres`、`redis`、`minio` 不向宿主机暴露端口。
+- 使用自建 MinIO 作为对象存储，并提供一次性 `minio-init` 服务创建 bucket。
+- 提供 `migrate` 一次性服务（`restart: "no"`）执行数据库迁移/初始化；`core` 依赖其成功完成。
+- 所有敏感配置通过 `.env.prod`（由 `.env.prod.example` 复制）注入，禁止硬编码默认密码。
+- PostgreSQL、Redis、MinIO SHALL 使用用户提供的强密码，未设置时 compose 启动失败。
+- 每个服务 SHALL 配置 `restart: unless-stopped` 与健康检查（除一次性 migrate 外）。
+- `judge` SHALL 挂载 Docker socket、使用 `read_only: true`、`tmpfs: /tmp`、`cap_drop: [ALL]`、`security_opt: [no-new-privileges:true]`，并设置资源限制。
+- `core`、`ui` SHALL 以非 root 用户运行，并设置内存/CPU 限制。
+- 生产 Compose 中的基础设施镜像（Nginx、PostgreSQL、Redis、MinIO 和 `mc`）MUST 使用 digest 固定。
+
+#### Scenario: 使用已发布版本启动生产栈
+
+- **WHEN** 维护者在 `.env.prod` 中填写合法的 `NOJ_VERSION` 并执行生产 Compose
+- **THEN** 业务服务使用该 Release 版本镜像启动
+- **THEN** Compose 配置不会解析到 `latest` 或其他默认可变标签
+- **THEN** 必需密码未设置时 compose 在启动前报错
+
+#### Scenario: 使用 .env.prod 启动生产栈
+
+- **WHEN** 维护者复制 `.env.prod.example` 为 `.env.prod` 并填写真实配置及已发布的 `NOJ_VERSION`
+- **THEN** `docker compose --env-file .env.prod -f docker-compose.prod.yml up -d` 可启动 Nginx/UI/Core/Judge/PostgreSQL/Redis/MinIO
+- **THEN** 只有 Nginx 的 80/443 暴露在宿主机
+- **THEN** 任一必需密码未设置时 compose 在启动前报错
+
+#### Scenario: 未填写生产版本
+
+- **WHEN** `.env.prod` 未设置 `NOJ_VERSION`
+- **THEN** Compose 在启动前报错并拒绝启动
+
+#### Scenario: 升级版本
+
+- **WHEN** 维护者将 `.env.prod` 中 `NOJ_VERSION` 改为另一个已验证的 Release tag 并重新部署
+- **THEN** 业务服务使用新版本镜像重新创建
+- **THEN** 数据卷保持不变
+- **THEN** 部署脚本在升级前创建并校验生产备份
+
+### Requirement: 公测部署文档
+
+系统 SHALL 将公测部署流程写入 `noj-docs/docs/operators/production-deploy.md`，至少包含：
+
+- 前置条件（Docker、域名、外部 TLS 终止、ghcr 访问）。
+- 初始化步骤：复制 `.env.prod.example` → 填写配置 → 设置已验证的 Release `NOJ_VERSION` → 运行 `migrate` → 启动服务。
+- 评测镜像白名单更新：将 `judge_images` 中的镜像更新为 ghcr 全限定名。
+- 日常运维：查看状态、日志、健康检查和当前部署版本/digest。
+- 升级与回滚：只使用已签名验证的 Release tag；升级前备份；失败时恢复上一个已验证版本；明确数据库迁移不自动回滚及兼容性要求。
+- 备份提示：PostgreSQL、Redis、MinIO/S3 数据备份（详细可靠性方案后续补充）。
+
+系统 SHALL 移除 noj-docs 中旧的开发期部署方法（`local-start.md` 及 `devtool.sh` 部署描述），并将运营者文档侧边栏的“本地启动”替换为“生产部署”。
+
+#### Scenario: 按文档完成版本化部署
+
+- **WHEN** 运维按文档使用已验证的 Release tag 部署
+- **THEN** 可完成从空服务器到可访问 HTTPS 公测站点的部署
+- **THEN** 文档包含镜像签名验证、版本记录、升级和回滚步骤
+
+#### Scenario: 按文档执行回滚
+
+- **WHEN** 新版本健康检查或 smoke test 失败
+- **THEN** 运维可按文档切换到上一个已验证 Release tag
+- **THEN** 文档明确数据库迁移兼容性和不可自动降级的风险
+
+#### Scenario: 按文档完成公测部署
+
+- **WHEN** 运维按文档使用已验证的 Release tag 操作
+- **THEN** 可完成从空服务器到可访问 HTTPS 公测站点的部署
+- **THEN** 文档包含评测镜像白名单更新步骤，避免 judge 因镜像不在白名单而拒绝任务
+
+#### Scenario: 运营者文档不再展示旧开发期部署
+
+- **WHEN** 用户打开 noj-docs 运营者文档
+- **THEN** 侧边栏显示“生产部署”而不是“本地启动”
+- **THEN** 不再出现“开发期部署与运维方式尚未成熟”的警示块

--- a/openspec/changes/immutable-image-release/tasks.md
+++ b/openspec/changes/immutable-image-release/tasks.md
@@ -1,0 +1,24 @@
+## 1. 发布供应链工作流
+
+- [x] 1.1 重构 `.github/workflows/release.yml` 的镜像标签计算，校验 Release/tag ref，生成唯一候选标签，并验证六个镜像均使用同一 Release 版本策略；用 YAML/脚本检查确认生产标签不含 `latest` 或 `beta`
+- [x] 1.2 为候选镜像启用 BuildKit provenance/SBOM attestations，并输出候选 digest、源码 commit 和版本到后续步骤；用 workflow 静态检查确认这些输出存在
+- [x] 1.3 增加 Trivy 镜像扫描和版本化误配置入口，确保高危/严重未豁免漏洞返回非零并阻止正式标签创建；用故意失败的扫描配置验证门禁行为
+- [x] 1.4 增加 Cosign keyless 签名、SBOM attestation 和 GitHub OIDC provenance，确保签名目标为候选 digest 而非可变 tag；用 workflow 静态检查确认 `id-token`、`attestations` 和 `packages` 权限最小化声明
+- [x] 1.5 增加正式标签发布后的 digest、签名、来源证明和镜像拉取验证，确保正式标签只指向候选 digest；用独立验证 job 覆盖六个镜像
+- [x] 1.6 为六个生产镜像增加最小 smoke test，验证镜像可拉取、运行用户/关键文件正确且服务入口可执行；在 GitHub Actions 中执行并记录失败镜像
+
+## 2. 镜像与生产部署护栏
+
+- [ ] 2.1 获取并审查生产 Dockerfile 及生产 Compose 基础镜像的 `linux/amd64` digest，更新引用并通过所有生产镜像构建验证
+- [x] 2.2 修改 `docker-compose.prod.yml`，将 `NOJ_VERSION` 改为必填并移除 `latest` 默认值；用 Compose config 测试覆盖缺少版本和合法版本两种场景
+- [x] 2.3 强化 `scripts/deploy/deploy.sh` 的版本校验、当前版本/digest 记录和升级前备份提示；运行现有 `test-deploy.sh` 并增加非法/可变版本用例
+- [x] 2.4 更新生产发布与部署文档，说明签名/SBOM 验证、Release 版本选择、升级前备份、应用回滚和数据库迁移兼容性；通过文档链接和命令审查验证步骤可执行
+
+## 3. 自动化验证与验收
+
+- [x] 3.1 新增仓库级供应链配置检查，覆盖生产 `latest`、未固定基础 digest、Release workflow 关键权限和缺少安全门禁；运行脚本验证通过与故意违规失败两种结果
+- [ ] 3.2 运行 `openspec validate --change immutable-image-release --strict`、YAML 解析、Compose config、部署脚本测试和相关 Dockerfile 构建检查，修复所有可归因于本变更的失败
+- [ ] 3.3 在 GitHub Actions 测试 Release 上完成六镜像发布、签名验证、SBOM/provenance 验证及候选→正式 tag 一致性检查，并保留 digest 清单作为验收记录
+- [ ] 3.4 在 staging 使用已验证 Release tag 执行一次升级和一次回滚演练，记录健康检查、数据卷保持和数据库迁移兼容性结果
+
+> 2.1 与 3.2 的 Dockerfile 构建检查已发起，但本地 Docker Hub 镜像元数据请求因网络 EOF/SSL 错误中断，需由 CI 完成验证；3.3 和 3.4 需要真实 GHCR/Sigstore 发布权限及 staging 环境。

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -10,6 +10,7 @@
 #   bash scripts/deploy/deploy.sh status
 #   bash scripts/deploy/deploy.sh logs [service] [--follow]
 #   bash scripts/deploy/deploy.sh backup
+#   bash scripts/deploy/deploy.sh verify
 #
 # 脚本只封装 docker-compose.prod.yml，不执行 down -v、不删除数据卷，
 # 也不会 source 环境文件，避免环境变量中的特殊字符触发 shell 解析。
@@ -26,6 +27,7 @@ BACKUP_PASSPHRASE_FILE="${NOJ_BACKUP_PASSPHRASE_FILE:-}"
 DOCKER_BIN="${NOJ_DEPLOY_DOCKER_BIN:-docker}"
 DRY_RUN=0
 FOLLOW=0
+declare -a VERIFIED_IMAGE_DIGESTS=()
 
 if [[ -t 1 ]]; then
   GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; RESET='\033[0m'
@@ -54,6 +56,7 @@ Neuro OJ 生产部署工具
   deploy.sh logs [service]           查看最近日志
   deploy.sh logs [service] --follow  持续查看日志
   deploy.sh backup                   创建完整生产备份
+  deploy.sh verify                   校验生产镜像 digest 与 Cosign 签名
 
 选项：
   --env-file FILE       使用指定的生产环境文件
@@ -74,7 +77,7 @@ parse_args() {
   POSITIONAL=()
   while (($# > 0)); do
     case "$1" in
-      install|start|upgrade|stop|status|logs|backup)
+      install|start|upgrade|stop|status|logs|backup|verify)
         if [[ -n "$COMMAND" ]]; then
           POSITIONAL+=("$1")
         else
@@ -263,8 +266,9 @@ check_required_values() {
     printf "  - JUDGE_DOCKER_SOCKET_GID 必须是数字\n" >&2
     missing=1
   }
-  [[ "$(env_value NOJ_VERSION)" != "latest" ]] || {
-    printf "  - NOJ_VERSION 必须使用不可变 Release 标签，不得使用 latest\n" >&2
+  local version="$(env_value NOJ_VERSION)"
+  [[ "$version" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+    printf "  - NOJ_VERSION 必须是不可变 Release 标签（如 v0.1.0 或 0.1.1-rc.1）\n" >&2
     missing=1
   }
   ((missing == 0)) || fail "生产配置校验失败"
@@ -300,8 +304,65 @@ check_dependencies() {
   "$DOCKER_BIN" info >/dev/null 2>&1 || fail "Docker daemon 未运行或当前用户无权限"
   "$DOCKER_BIN" compose version >/dev/null 2>&1 ||
     fail "Docker Compose v2 不可用"
+  if [[ "$(env_value NOJ_ENFORCE_IMAGE_SIGNATURES)" != "false" ]]; then
+    "$DOCKER_BIN" buildx version >/dev/null 2>&1 ||
+      fail "镜像签名校验需要 Docker Buildx"
+  fi
   [[ -f "$COMPOSE_FILE" ]] || fail "找不到生产 Compose 文件：$COMPOSE_FILE"
   ok "Docker daemon 与 Compose 可用"
+}
+
+verify_image_signatures() {
+  [[ "$(env_value NOJ_ENFORCE_IMAGE_SIGNATURES)" != "false" ]] || {
+    warn "NOJ_ENFORCE_IMAGE_SIGNATURES=false，跳过生产镜像签名校验（仅适用于本地测试）"
+    return 0
+  }
+
+  command -v cosign >/dev/null 2>&1 ||
+    fail "生产镜像签名校验需要 cosign；请先安装 Cosign，或仅在本地测试中设置 NOJ_ENFORCE_IMAGE_SIGNATURES=false"
+
+  local version registry identity image digest
+  version="$(env_value NOJ_VERSION)"
+  registry="$(env_value NOJ_IMAGE_REGISTRY)"
+  registry="${registry:-ghcr.io/neuro-oj}"
+  identity="$(env_value NOJ_COSIGN_CERT_IDENTITY_REGEX)"
+  identity="${identity:-^https://github.com/Neuro-OJ/neuro-oj/.github/workflows/release.yml@.*$}"
+  section "校验生产镜像签名"
+
+  local images=(noj-core noj-ui noj-judge noj-llm-gateway noj-evaluator-python noj-solution-python)
+  for image in "${images[@]}"; do
+    local image_name="$image"
+    image="$registry/$image_name:$version"
+    digest="$("$DOCKER_BIN" buildx imagetools inspect "$image" 2>/dev/null |
+      awk '/^Digest:/ {print $2; exit}')"
+    [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+      fail "无法解析生产镜像 digest：$image"
+    cosign verify \
+      --certificate-identity-regexp "$identity" \
+      --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+      "$image@$digest" >/dev/null ||
+      fail "生产镜像 Cosign 签名校验失败：$image@$digest"
+    VERIFIED_IMAGE_DIGESTS+=("$image_name $digest")
+    ok "$image@$digest"
+  done
+}
+
+record_deployment_metadata() {
+  ((DRY_RUN)) && return 0
+  ((${#VERIFIED_IMAGE_DIGESTS[@]} > 0)) || return 0
+
+  mkdir -p "$BACKUP_DIR"
+  local tmp manifest
+  manifest="$BACKUP_DIR/current-deployment.txt"
+  tmp="$(mktemp "$BACKUP_DIR/.current-deployment.XXXXXX")"
+  {
+    printf 'version=%s\n' "$(env_value NOJ_VERSION)"
+    printf 'recorded_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '%s\n' "${VERIFIED_IMAGE_DIGESTS[@]}" | sort
+  } >"$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$manifest"
+  ok "已记录当前部署版本与镜像 digest：$manifest"
 }
 
 check_configuration() {
@@ -317,6 +378,9 @@ check_configuration() {
     "$DOCKER_BIN" compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" config --quiet ||
       fail "Docker Compose 配置无效，请检查环境变量和生产 Compose 文件"
   fi
+  case "$COMMAND" in
+    install|start|upgrade|verify) verify_image_signatures ;;
+  esac
   ok "生产配置检查通过"
 }
 
@@ -352,12 +416,14 @@ install() {
   section "拉取生产镜像"
   run_compose pull
   wait_for_stack
+  record_deployment_metadata
   ok "生产部署完成"
 }
 
 start() {
   prepare_and_check
   wait_for_stack
+  record_deployment_metadata
   ok "生产服务已启动"
 }
 
@@ -367,6 +433,7 @@ upgrade() {
   section "拉取目标版本镜像"
   run_compose pull
   wait_for_stack
+  record_deployment_metadata
   ok "生产服务已升级"
 }
 
@@ -406,6 +473,11 @@ backup() {
   run_backup "手动备份"
 }
 
+verify() {
+  prepare_and_check
+  ok "生产镜像验证完成"
+}
+
 main() {
   parse_args "$@"
   case "$COMMAND" in
@@ -416,6 +488,7 @@ main() {
     status) status ;;
     logs) logs ;;
     backup) backup ;;
+    verify) verify ;;
     *) fail "未知命令：$COMMAND" ;;
   esac
 }

--- a/scripts/deploy/test-deploy.sh
+++ b/scripts/deploy/test-deploy.sh
@@ -30,6 +30,10 @@ if [[ "${NOJ_BACKUP_TEST_FAIL:-}" == "redis" && " $* " == *" redis "* ]]; then
 fi
 if [[ "${1:-}" == "info" ]]; then
   exit 0
+elif [[ "${1:-}" == "buildx" && "${2:-}" == "version" ]]; then
+  exit 0
+elif [[ "${1:-}" == "buildx" && "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+  printf 'Digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'
 elif [[ "${1:-}" == "compose" && " $* " == *" pg_dumpall "* ]]; then
   printf 'CREATE ROLE noj;\n'
 elif [[ "${1:-}" == "compose" && " $* " == *" pg_dump "* ]]; then
@@ -50,6 +54,7 @@ chmod +x "$FAKE_DOCKER"
 
 cat >"$ENV_FILE" <<'EOF'
 NOJ_VERSION=v0.1.0
+NOJ_ENFORCE_IMAGE_SIGNATURES=false
 APP_URL=https://noj.test
 CORS_ALLOWED_ORIGINS=https://noj.test
 TRUSTED_PROXIES=172.28.0.0/16
@@ -85,13 +90,20 @@ printf 'services:\n  fake:\n    image: alpine:3\n' >"$COMPOSE_FILE"
 printf 'test-passphrase\n' >"$PASSPHRASE_FILE"
 chmod 600 "$PASSPHRASE_FILE"
 
-run_deploy() {
+run_deploy_with() {
+  local env_file="$1"
+  shift
   NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" \
   NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
   NOJ_BACKUP_TEST_LOG="$FAKE_LOG" \
   NOJ_BACKUP_PASSPHRASE_FILE="$PASSPHRASE_FILE" \
   NOJ_BACKUP_TEST_FAIL="${NOJ_BACKUP_TEST_FAIL:-}" \
-    bash "$DEPLOY_SCRIPT" "$@" --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE"
+  PATH="$TEST_ROOT:$PATH" \
+    bash "$DEPLOY_SCRIPT" "$@" --env-file "$env_file" --compose-file "$COMPOSE_FILE"
+}
+
+run_deploy() {
+  run_deploy_with "$ENV_FILE" "$@"
 }
 
 [[ "$(bash "$DEPLOY_SCRIPT" --help)" == *"生产部署工具"* ]] || fail "帮助输出缺少工具标题"
@@ -188,6 +200,34 @@ if grep -q 'strong-' "$TEST_ROOT/invalid.err" "$TEST_ROOT/invalid.out"; then
   fail "配置检查输出泄露了 secret"
 fi
 pass "占位配置拒绝与 secret 不泄露"
+
+cp "$ENV_FILE" "$TEST_ROOT/mutable-version.env"
+sed -i.bak 's/NOJ_VERSION=v0.1.0/NOJ_VERSION=latest/' "$TEST_ROOT/mutable-version.env"
+chmod 600 "$TEST_ROOT/mutable-version.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" start --env-file "$TEST_ROOT/mutable-version.env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/mutable-version.out" 2>"$TEST_ROOT/mutable-version.err"; then
+  fail "latest 版本应该被拒绝"
+fi
+grep -q '不可变 Release 标签' "$TEST_ROOT/mutable-version.err" ||
+  fail "latest 版本错误提示缺失"
+pass "可变 Release 标签拒绝"
+
+cat >"$TEST_ROOT/cosign" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TEST_ROOT/cosign"
+cp "$ENV_FILE" "$TEST_ROOT/signed.env"
+sed -i.bak 's/NOJ_ENFORCE_IMAGE_SIGNATURES=false/NOJ_ENFORCE_IMAGE_SIGNATURES=true/' "$TEST_ROOT/signed.env"
+chmod 600 "$TEST_ROOT/signed.env"
+run_deploy_with "$TEST_ROOT/signed.env" start --backup-dir "$TEST_ROOT/signed-backups" \
+  >/dev/null 2>"$TEST_ROOT/signed.err" || fail "合法签名配置的 start 不应失败"
+manifest="$TEST_ROOT/signed-backups/current-deployment.txt"
+[[ -f "$manifest" ]] || fail "成功部署未记录当前版本与镜像 digest"
+grep -q '^version=v0.1.0$' "$manifest" || fail "部署记录缺少版本"
+[[ "$(grep -c '^noj-' "$manifest")" -eq 6 ]] || fail "部署记录未包含六个镜像 digest"
+pass "签名校验与部署 digest 记录"
 
 if run_deploy backup --backup-dir "$TEST_ROOT/backups" >/dev/null 2>"$TEST_ROOT/backup.err"; then
   :

--- a/scripts/release/check-supply-chain.sh
+++ b/scripts/release/check-supply-chain.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# 检查生产镜像发布链路的不可变标签和基础镜像 digest 约束。
+#
+# 该脚本不访问网络，适合在本地和 CI 的发布前检查中运行。
+
+set -Eeuo pipefail
+
+ROOT_DIR="${NOJ_SUPPLY_CHAIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+fail() {
+  printf '[supply-chain] ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+ok() {
+  printf '[supply-chain] ✓ %s\n' "$*"
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "$ROOT_DIR/$path" ]] || fail "找不到文件：$path"
+}
+
+check_dockerfiles() {
+  local file line
+  local files=(
+    noj-core/Dockerfile
+    noj-ui/Dockerfile
+    noj-judge/Dockerfile
+    noj-llm-gateway/Dockerfile
+    noj-judge/docker/evaluator-python/Dockerfile
+    noj-judge/docker/solution-python/Dockerfile
+    noj-judge/docker/python/Dockerfile
+    noj-judge/docker/solution-ai/Dockerfile
+  )
+
+  for file in "${files[@]}"; do
+    require_file "$file"
+    while IFS= read -r line; do
+      [[ "$line" == *'@sha256:'* ]] || fail "$file 存在未固定 digest 的基础镜像：$line"
+    done < <(sed -n '/^[[:space:]]*FROM[[:space:]]/p' "$ROOT_DIR/$file")
+  done
+  ok "生产 Dockerfile 基础镜像均固定 digest"
+}
+
+check_compose() {
+  local file="$ROOT_DIR/docker-compose.prod.yml"
+  require_file "docker-compose.prod.yml"
+
+  grep -q '\${NOJ_VERSION:?NOJ_VERSION is required}' "$file" \
+    || fail "生产 Compose 未将 NOJ_VERSION 设为必填"
+  if grep -Eq 'NOJ_VERSION:-latest|NOJ_VERSION:=latest|:[[:space:]]*latest(["}]|$)' "$file"; then
+    fail "生产 Compose 仍依赖 latest"
+  fi
+
+  local line
+  while IFS= read -r line; do
+    [[ "$line" == *'@sha256:'* ]] || fail "生产 Compose 基础设施镜像未固定 digest：$line"
+  done < <(grep -E '^[[:space:]]*image:[[:space:]]+(nginx|postgres|redis|minio/)' "$file")
+  ok "生产 Compose 不依赖 latest 且基础设施镜像均固定 digest"
+}
+
+check_release_workflow() {
+  local file="$ROOT_DIR/.github/workflows/release.yml"
+  require_file ".github/workflows/release.yml"
+  grep -q 'provenance: mode=max' "$file" || fail "Release workflow 未启用 provenance"
+  grep -q 'sbom: true' "$file" || fail "Release workflow 未启用 BuildKit SBOM"
+  grep -q 'trivy' "$file" || fail "Release workflow 未配置漏洞扫描"
+  grep -q 'cosign' "$file" || fail "Release workflow 未配置镜像签名"
+  if grep -Eq ':[[:space:]]*(latest|beta)(["'"'"'[:space:]]|$)' "$file"; then
+    fail "Release workflow 仍发布 latest/beta 可变标签"
+  fi
+  ok "Release workflow 包含安全门禁且不发布 latest/beta"
+}
+
+check_release_workflow
+check_dockerfiles
+check_compose
+ok "供应链配置检查通过"

--- a/scripts/release/test-supply-chain.sh
+++ b/scripts/release/test-supply-chain.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# 供应链配置检查脚本的正向和负向测试。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-supply-chain-test.XXXXXX")"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+
+cp -R "$ROOT_DIR/.github" "$TEST_ROOT/.github"
+cp -R "$ROOT_DIR/noj-core" "$TEST_ROOT/noj-core"
+cp -R "$ROOT_DIR/noj-ui" "$TEST_ROOT/noj-ui"
+cp -R "$ROOT_DIR/noj-judge" "$TEST_ROOT/noj-judge"
+cp -R "$ROOT_DIR/noj-llm-gateway" "$TEST_ROOT/noj-llm-gateway"
+cp "$ROOT_DIR/docker-compose.prod.yml" "$TEST_ROOT/docker-compose.prod.yml"
+
+NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" >/dev/null ||
+  fail "合法供应链配置检查失败"
+pass "合法供应链配置"
+
+sed -i.bak 's#FROM debian:bookworm-slim@sha256:[0-9a-f]*#FROM debian:bookworm-slim#' \
+  "$TEST_ROOT/noj-core/Dockerfile"
+if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \
+  >/dev/null 2>&1; then
+  fail "未固定基础镜像 digest 未被拒绝"
+fi
+pass "未固定基础镜像拒绝"
+
+sed -i.bak 's#FROM debian:bookworm-slim#FROM debian:bookworm-slim@sha256:5ae3c39eb15e229dcedd5cee596b2497182493d41ff162e824ba13fc1b2b867#' \
+  "$TEST_ROOT/noj-core/Dockerfile"
+sed -i.bak 's#NOJ_VERSION:?NOJ_VERSION is required#NOJ_VERSION:-latest#' \
+  "$TEST_ROOT/docker-compose.prod.yml"
+if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \
+  >/dev/null 2>&1; then
+  fail "latest 生产版本回退未被拒绝"
+fi
+pass "latest 生产版本拒绝"
+
+printf '全部供应链配置测试通过\n'


### PR DESCRIPTION
## 概要

关联 #328，为 Neuro OJ 生产镜像补齐不可变发布、供应链证明和部署回滚护栏。

## 实现内容

- Release workflow 先发布唯一候选 tag，完成 Trivy 高危/严重漏洞门禁、BuildKit SBOM/provenance、Cosign keyless 签名和 GitHub OIDC provenance，再将同一 digest 晋级为正式 Release tag。
- 发布后独立验证六个镜像的 digest、签名、SBOM、来源证明、拉取结果和最小 smoke test。
- 固定生产 Dockerfile 与生产 Compose 基础镜像的 `linux/amd64` digest；生产 Compose 要求显式 `NOJ_VERSION`，不再回退到 `latest`。
- 部署脚本增加 Release 版本格式校验、镜像签名校验、`verify` 命令和成功部署后的版本/digest 清单记录；保留升级前完整备份与失败升级不覆盖当前清单的行为。
- 新增仓库级供应链配置检查和正/负向测试，更新生产部署文档与 OpenSpec 变更。

## 已验证

- `bash scripts/release/test-supply-chain.sh`
- `bash scripts/release/check-supply-chain.sh`
- `bash scripts/deploy/test-deploy.sh`
- `openspec validate immutable-image-release --type change --strict`
- Docker Compose 合法配置与缺少 `NOJ_VERSION` 拒绝场景
- `actionlint`
- `bash -n` 与 `git diff --check`

## 验收说明

- 本地 Dockerfile 完整构建因 Docker Hub 镜像元数据请求出现网络 EOF/SSL 错误未完成，相关构建验证交由 CI。
- 真实 GHCR/Sigstore 六镜像发布和 staging 升级/回滚演练需要 GitHub Actions 与 staging 环境，未在本地伪造完成；OpenSpec tasks 中保留为待验收项。
