### PR TITLE
feat(judge): 添加独立 Judge 一键部署

### DIFF
--- a/noj-docs/docs/operators/judge-workers.md
+++ b/noj-docs/docs/operators/judge-workers.md
@@ -9,6 +9,49 @@ Evaluator + Solution 双容器（用后即毁），并把结果写回 Redis。
 
 支持多个 Judge Worker 实例水平扩展：所有实例消费同一个 Redis 队列，互不冲突。
 
+## 独立节点一键部署
+
+如果评测节点不运行 noj-core、noj-ui 或完整源码仓库，可以只下载部署脚本，然后由脚本
+生成独立 Compose 配置：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/judge-install.sh \
+  | bash -s -- install --dir /srv/noj-judge
+```
+
+首次执行会引导填写以下配置：
+
+- `NOJ_VERSION`：不可变 Release 版本，例如 `v0.1.0`；
+- `REDIS_URL`：与 noj-core 相同的 Redis 地址、数据库和认证信息；
+- `JUDGE_QUEUE` / `RESULT_QUEUE`：必须与 noj-core 使用的队列名称一致；
+- `JUDGE_DOCKER_SOCKET` / `JUDGE_DOCKER_SOCKET_GID`：只服务于 Judge 的 rootless
+  Docker daemon Unix socket 及其组 ID。
+
+部署前必须准备专用 rootless Docker daemon。脚本会检查 Linux、Docker、Compose、Redis、
+磁盘/内存、镜像架构和 socket 权限，但不会自动安装或替换 Docker daemon，也不会修改
+宿主机 systemd、subuid/subgid。`/var/run/docker.sock`、`/run/docker.sock`、TCP/HTTP
+Docker endpoint 都会被拒绝。
+
+管理独立 Worker：
+
+```bash
+bash /srv/noj-judge/judge-install.sh check
+bash /srv/noj-judge/judge-install.sh status
+bash /srv/noj-judge/judge-install.sh logs --follow
+bash /srv/noj-judge/judge-install.sh stop
+bash /srv/noj-judge/judge-install.sh upgrade --version v0.1.1
+```
+
+也可以在目标机只下载指定 ref 的脚本，审阅后再执行：
+
+```bash
+bash /srv/noj-judge/judge-install.sh download --ref v0.1.0 --dir /srv/noj-judge
+```
+
+当前生产 Release 镜像由发布流水线提供 `linux/amd64`。ARM64 主机必须先确认所选
+版本发布了对应 manifest；否则脚本会在启动前提示架构不匹配，不能通过回退到宿主机
+Docker socket 绕过该限制。
+
 ### 评测并发上限
 
 单个 Worker 同时执行的评测任务数由 `JUDGE_MAX_CONCURRENT_JUDGES` 控制，默认值为

--- a/openspec/changes/judge-standalone-deploy/.openspec.yaml
+++ b/openspec/changes/judge-standalone-deploy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/judge-standalone-deploy/design.md
+++ b/openspec/changes/judge-standalone-deploy/design.md
@@ -1,0 +1,90 @@
+## Context
+
+当前生产 Compose 将 core、UI、Judge 和基础设施编排在同一份项目中。虽然现有文档
+已经规定 Judge 必须使用专用 rootless Docker daemon，但独立评测节点仍需要手工复制
+镜像配置、Redis 参数和 socket 权限，容易导致 Worker 连错队列或误用宿主机
+`/var/run/docker.sock`。PR #374 只回滚了原有的整套下载部署入口，没有提供独立 Judge
+部署能力，因此本变更从 `main` 单独实现一条可审计的 Linux Worker 路径。
+
+## Goals / Non-Goals
+
+### Goals
+
+- 通过单个 Bash 入口完成 Judge 部署所需的下载、检测、配置和生命周期管理。
+- 支持 core 与 Judge 分机部署，使用外部 Redis 和现有队列名称。
+- 默认只接受专用 Unix Docker socket，并在启动前校验 socket 权限与镜像架构。
+- 保留配置和缓存，支持安全重复启动与版本升级。
+- 为交互式人工部署和自动化非交互部署提供同一套校验逻辑。
+
+### Non-Goals
+
+- 不改变 noj-judge Rust 代码、Redis 消息格式、core API 或评测协议。
+- 不默认安装 Docker、不替换系统 Docker daemon、不自动创建 rootless daemon，避免
+  脚本在未知主机上修改权限、subuid/subgid 或 systemd 用户服务。
+- 不提供将应用宿主机 `/var/run/docker.sock` 代理给 Worker 的兼容模式。
+- 不在本变更中增加 ARM64 发布镜像；脚本只负责在启动前给出明确架构提示。
+
+## Decisions
+
+### 1. 使用独立 Compose 项目运行发布镜像
+
+脚本生成最小的 Judge Compose 文件，默认运行
+`ghcr.io/neuro-oj/noj-judge:${NOJ_VERSION}`，而不是在目标机编译 Rust。这样部署
+机器只需要 Docker、Compose 和专用 socket，升级只需替换镜像版本。Compose project
+name 固定为 `noj-judge-standalone`，避免 `down` 或状态操作影响其他项目。
+
+### 2. Redis 作为唯一外部业务依赖
+
+配置使用完整的 `REDIS_URL`，不绑定 Compose 内部的 Redis 服务名。任务队列、结果
+队列和必要的 Judge 运行参数显式写入配置文件，以确保独立节点能与 core 对接。脚本
+只做连通性探测，不尝试初始化或清空 Redis。
+
+### 3. 默认要求预先准备隔离 socket
+
+脚本检查专用 Unix socket 的存在、类型和 GID，并把它只读挂载到 Worker。对于
+`/var/run/docker.sock`、`/run/docker.sock`、TCP 和 HTTP endpoint 直接失败。rootless
+daemon 的创建涉及发行版包、用户会话、subuid/subgid 和 systemd，脚本只输出针对性
+引导，避免把高权限主机变更隐藏在“一键”命令中。
+
+### 4. 配置文件严格收敛权限
+
+配置文件使用 `0600`，交互式秘密输入关闭回显；状态和日志只展示脱敏摘要。脚本
+不把 Redis 密码或 Registry 凭据拼接到命令输出中，也不把配置复制到镜像或评测
+容器的工作目录。
+
+### 5. 分层检查镜像架构
+
+脚本优先用 Docker manifest 检查目标 Worker 镜像是否包含当前架构；无法访问 registry
+时保留 Docker pull 的真实错误，并提示网络、认证或架构问题。当前 Release 工作流
+发布 `linux/amd64`，因此 ARM64 主机在可确认时应在启动前失败，而不是创建重启循环。
+
+### 6. 下载入口与部署入口分离
+
+远程 `install.sh` 只负责安全下载指定 ref 的仓库归档并转交给本地 Judge 入口；
+`--download-only` 不执行 Docker 操作。这样用户可以审阅下载内容、固定 ref 后再
+部署，也能在没有完整源码 checkout 的机器上使用脚本。
+
+## Risks / Tradeoffs
+
+| 风险 | 取舍与缓解 |
+| --- | --- |
+| 目标主机没有隔离 rootless daemon | 安全优先，安装前明确失败并给出准备步骤；不回退到宿主机 socket |
+| 外部 Redis 延迟或 TLS/认证配置错误 | 安装前做连接检查，失败时不启动；不修改 Redis 数据 |
+| GHCR 无法访问或架构不匹配 | 启动前做 manifest/pull 检查，输出版本和架构提示 |
+| 低配评测节点资源不足 | 检查磁盘/内存，默认并发保持与现有 Judge 一致，允许用户调整 |
+| Compose 环境变量包含特殊字符 | 使用独立 env 文件和生成的 Compose 配置，状态输出脱敏 |
+| 一键脚本权限过大 | 不自动安装/替换 Docker，不删除数据，不接受共享 host socket |
+
+## Migration
+
+现有整套生产部署不需要迁移。新增脚本默认写入用户指定的独立目录，并使用不同的
+Compose project name。迁移现有 Worker 时，运维人员先为新节点准备同一 Redis、队列和
+镜像白名单，再启动独立 Worker，确认无害样例评测成功后停止旧 Worker。回滚只需将
+`NOJ_VERSION` 改回上一个 Release 并执行升级，不触碰 core 数据库或 Redis 队列。
+
+## Open Questions
+
+- ARM64 发布镜像是否要在单独变更中扩展 `.github/workflows/release.yml` 的 platforms；
+  本变更不提前假设该发布策略。
+- 是否需要为 rootless daemon 提供发行版专属安装向导；本变更先保留明确检测和文档
+  指引，避免覆盖不同发行版的系统管理策略。

--- a/openspec/changes/judge-standalone-deploy/proposal.md
+++ b/openspec/changes/judge-standalone-deploy/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+当前生产部署脚本默认将 `noj-judge` 与 core、UI 一起启动，评测节点无法在没有完整应用仓库的机器上独立扩容。Judge 还需要 Redis 连接、Docker API 和独立的 rootless Docker socket，手工配置容易误挂载宿主机 socket，阻断评测隔离。
+
+## What Changes
+
+- 新增可独立下载的 Linux Judge 部署入口，支持固定 Release ref、目标目录和下载后执行。
+- 增加 Judge 主机环境检测：Linux、CPU 架构、Docker daemon、Compose、Redis 连通性、独立 Docker socket、磁盘和内存。
+- 增加交互式配置引导，填写 Redis、队列、工作目录、并发数和独立 Docker socket。
+- 检测并引导用户准备独立 rootless Docker daemon；默认不替换现有 Docker daemon，避免
+  未经确认修改宿主机权限和 systemd 配置。
+- 提供独立 Docker Compose 项目的启动、停止、状态、日志和升级入口。
+- 拒绝使用 `/var/run/docker.sock` 作为 Judge 沙箱 socket，并保留非交互模式供自动化部署。
+- 增加离线 smoke test、Linux VM 验证说明和故障排查文档。
+
+## Capabilities
+
+### New Capabilities
+
+- `judge-standalone-deploy`: 独立 Judge Worker 的下载、配置、环境检测和服务生命周期管理。
+
+### Modified Capabilities
+
+无。独立部署脚本复用现有 Judge 的 Docker 隔离契约，不改变评测协议或运行时安全规则。
+
+## Impact
+
+- 影响 `scripts/deploy/`、Judge 运维文档和部署脚本测试；不修改 Judge 镜像构建流程。
+- 不修改 core API、Redis 消息格式或 Judge 评测协议。
+- 目标主机仍需要预先创建只服务于 Judge 的 rootless Docker daemon；脚本负责检测、提示和
+  校验，不默认自动修改宿主机 systemd、subuid/subgid 或 Docker 运行时权限。

--- a/openspec/changes/judge-standalone-deploy/specs/judge-standalone-deploy/spec.md
+++ b/openspec/changes/judge-standalone-deploy/specs/judge-standalone-deploy/spec.md
@@ -1,0 +1,132 @@
+## Purpose
+
+为没有完整 Neuro OJ 应用仓库的 Linux 评测节点提供可重复的 noj-judge 独立部署入口，
+让运维人员能够完成版本下载、环境检查、配置生成和 Worker 生命周期管理，同时保持
+现有 Redis 队列协议与 Docker 沙箱安全边界不变。
+
+## ADDED Requirements
+
+### Requirement: Standalone Linux entrypoint
+
+部署入口 MUST 支持从仓库下载指定 ref 的部署脚本或归档，并在目标目录生成仅供
+noj-judge 使用的运行文件。入口 MUST 支持显式指定仓库、ref 和目标目录；重复执行
+不得覆盖用户现有的配置文件或运行数据，除非用户显式请求升级。
+
+#### Scenario: Download only the entrypoint
+
+- **WHEN** 用户通过远程脚本请求下载模式并指定目标目录
+- **THEN** 脚本只下载并校验部署内容，不启动服务、不修改 Docker daemon，也不写入
+  目标目录之外的文件
+
+#### Scenario: Upgrade an existing worker
+
+- **WHEN** 目标目录已有配置且用户执行升级
+- **THEN** 脚本保留配置和缓存数据，更新 Worker 镜像版本或运行文件，并在启动前
+  显示将要使用的版本
+
+#### Scenario: Unsafe target is rejected
+
+- **WHEN** 目标目录不是空目录且用户未选择升级或覆盖配置
+- **THEN** 脚本终止并说明如何显式继续，不删除目录中的文件
+
+### Requirement: Environment detection before deployment
+
+部署入口 MUST 在启动前检查 Linux 系统、受支持的 CPU 架构、Docker daemon、Docker
+Compose、目标工作目录权限、可用磁盘和内存。脚本 MUST 检查配置的 Redis 地址是否可
+连通，并检查配置的 Docker socket 存在、为 Unix socket 且不是 `/var/run/docker.sock`
+或 `/run/docker.sock`。检查失败时 MUST 在启动 Worker 前退出并给出修复提示。
+
+#### Scenario: Missing Docker tooling
+
+- **WHEN** 目标机缺少 Docker daemon 或 Docker Compose
+- **THEN** `check` 和部署命令报告缺失项，并且部署命令不拉起 Worker
+
+#### Scenario: ARM64 image is unavailable
+
+- **WHEN** 目标机架构为 `aarch64`/`arm64` 且所选 Worker 镜像没有对应架构
+- **THEN** 脚本在启动前报告当前镜像架构限制和可选方案，不创建会持续重启的容器
+
+#### Scenario: Shared host socket is selected
+
+- **WHEN** 用户把 Judge Docker socket 配置为 `/var/run/docker.sock` 或 `/run/docker.sock`
+- **THEN** 脚本拒绝配置，并要求用户提供专用 rootless Docker daemon 的 Unix socket
+
+### Requirement: Guided and non-interactive configuration
+
+首次部署 MUST 通过交互式提示引导用户填写 Worker 版本、Redis URL、任务队列、结果
+队列、工作目录、并发数、镜像前缀、专用 Docker socket 和 socket GID。Redis URL 中
+的密码、Registry token 等敏感值 MUST 使用隐藏输入或环境变量传入，不能回显到终端、
+日志或测试输出。脚本 MUST 支持非交互模式，并在缺少必填项时失败且列出缺失配置。
+
+#### Scenario: First install prompts for required values
+
+- **WHEN** 用户在没有配置文件的目录执行安装
+- **THEN** 脚本逐项提示必填配置，确认后以仅属主可读的权限写入配置文件
+
+#### Scenario: Non-interactive install is complete
+
+- **WHEN** 用户使用 `--non-interactive` 并提供全部必填环境变量
+- **THEN** 脚本不读取终端输入，生成等价配置并继续执行环境检查
+
+#### Scenario: Secret is not echoed
+
+- **WHEN** 用户输入包含密码的 Redis URL 或 Registry 凭据
+- **THEN** 终端输出、配置检查摘要和失败日志均不打印该秘密的原文
+
+### Requirement: Isolated Docker endpoint contract
+
+独立部署生成的 Worker 配置 MUST 启用 `JUDGE_REQUIRE_ISOLATED_DOCKER=true`，使用
+专用 Unix Docker endpoint，并将该 endpoint 以只读 socket 挂载给非 root Worker。脚本
+MUST 不自动挂载应用宿主机 Docker socket，不接受 TCP/HTTP Docker endpoint，也不得把
+Redis、缓存或 Worker 配置写入 Judge 沙箱容器的宿主机敏感路径。
+
+#### Scenario: Dedicated rootless socket is ready
+
+- **WHEN** 配置的专用 Unix socket 存在且当前 Worker 用户可访问
+- **THEN** 脚本通过 Compose 启动 Worker，并保留隔离模式配置
+
+#### Scenario: Socket is missing or inaccessible
+
+- **WHEN** 专用 socket 不存在、不是 socket 文件或 socket GID/权限不匹配
+- **THEN** 脚本报告 rootless daemon 和组权限的修复方向，并在修复前不启动 Worker
+
+### Requirement: Safe worker lifecycle
+
+部署入口 MUST 提供 `install`、`start`、`stop`、`status`、`logs` 和 `upgrade` 操作，
+并使用固定的 Compose project name 或等价唯一标识避免误操作其他应用。`stop` 和
+`upgrade` MUST 保留 Redis 中的任务、配置文件及 Judge 缓存；脚本不得提供默认删除
+持久化数据的清理动作。启动失败时 MUST 返回非零状态并保留日志供排查。
+
+#### Scenario: Repeated start is idempotent
+
+- **WHEN** Worker 已运行且用户再次执行 `start`
+- **THEN** 脚本不创建重复项目，报告现有服务状态
+
+#### Scenario: Status exposes readiness
+
+- **WHEN** 用户执行 `status`
+- **THEN** 脚本显示 Worker 容器状态、使用的版本、Redis/Compose 配置摘要和隔离
+  socket 检查结果，但不显示秘密
+
+#### Scenario: Stop preserves work
+
+- **WHEN** 用户执行 `stop`
+- **THEN** Worker 停止但配置、缓存和 Redis 中的任务不被删除
+
+### Requirement: Deployment verification guidance
+
+部署入口和运维文档 MUST 提供首次启动后的最小验证步骤，包括 Docker PING、Redis
+队列连接、无害样例评测、日志和升级回滚检查。文档 MUST 明确说明独立 Judge 节点
+仍需与 noj-core 使用同一个 Redis 和队列名称，并说明当前发布镜像不支持的架构。
+
+#### Scenario: Operator verifies a new worker
+
+- **WHEN** Worker 首次启动成功
+- **THEN** 运维人员可以按文档检查隔离 socket、队列长度和一条无害评测结果，再
+  扩容其他 Worker
+
+#### Scenario: Operator diagnoses a failed check
+
+- **WHEN** 环境检查或 Worker 启动失败
+- **THEN** 文档能将问题归类到 Docker、Compose、Redis、socket 权限、镜像架构或
+  队列配置，并给出下一步操作

--- a/openspec/changes/judge-standalone-deploy/tasks.md
+++ b/openspec/changes/judge-standalone-deploy/tasks.md
@@ -1,0 +1,17 @@
+## 1. 部署入口与配置
+
+- [x] 1.1 新增独立 Judge Linux 部署脚本，支持下载指定仓库 ref、目标目录、`--download-only` 和安全的重复执行，并用离线测试验证不会覆盖既有配置
+- [x] 1.2 实现交互式与非交互式配置生成，覆盖版本、Redis、队列、工作目录、并发、镜像前缀、专用 Docker socket 和 socket GID，并验证配置文件权限为 `0600` 且敏感值不出现在输出中
+- [x] 1.3 生成最小化的独立 Compose 配置，固定 project name、非 root Worker、只读专用 socket 挂载、缓存卷和现有 Judge 安全环境变量，并用 `docker compose config` 验证渲染结果
+
+## 2. 环境检查与生命周期
+
+- [x] 2.1 实现 Linux、架构、Docker daemon、Docker Compose、资源、目录权限和专用 Unix socket 检查，并验证缺失依赖或共享 host socket 会在启动前失败
+- [x] 2.2 实现 Redis 连通性与 Worker 镜像架构检查，验证 ARM64/无 manifest 场景给出可操作提示且不创建重启循环
+- [x] 2.3 实现 `install`、`start`、`stop`、`status`、`logs` 和 `upgrade`，验证重复启动幂等、停止保留配置/缓存、升级保留配置且失败返回非零状态
+
+## 3. 文档与回归验证
+
+- [x] 3.1 更新部署脚本索引和 Judge 运维文档，说明独立节点、Redis/队列契约、rootless socket 准备、架构限制、首次 smoke test、升级和回滚
+- [x] 3.2 新增不依赖真实生产资源的脚本测试，覆盖帮助、下载模式、配置脱敏、参数校验、共享 socket 拒绝和生命周期命令调用
+- [x] 3.3 运行 Shell 静态检查、脚本测试、OpenSpec 严格校验和相关 Rust/Compose 校验，并记录 Debian/Ubuntu 虚拟机上的可执行性结果

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,8 @@ scripts/
 | **单脚本下载并部署**                     | `bash scripts/deploy/install.sh --ref v0.1.0 --dir /opt/neuro-oj` |
 | **检测 Linux 部署环境**                  | `bash scripts/deploy/install.sh check`                           |
 | **安装基础部署工具**                     | `sudo bash scripts/deploy/install.sh install-env`                |
+| **独立 Judge 一键部署**                   | `curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/judge-install.sh \| bash -s -- install --dir /srv/noj-judge` |
+| **检查独立 Judge 环境**                   | `bash /srv/noj-judge/judge-install.sh check`                      |
 | **启动/停止生产服务**                    | `bash scripts/deploy/deploy.sh start` / `stop`                   |
 | **升级生产版本**                         | `bash scripts/deploy/deploy.sh upgrade`                          |
 | **查看生产状态/日志**                    | `bash scripts/deploy/deploy.sh status` / `logs [service]`        |

--- a/scripts/deploy/judge-install.sh
+++ b/scripts/deploy/judge-install.sh
@@ -1,0 +1,648 @@
+#!/usr/bin/env bash
+#
+# Neuro OJ 独立 Judge Worker 部署入口。
+#
+# 远程一键入口：
+#   curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/judge-install.sh \
+#     | bash -s -- install --dir /srv/noj-judge
+#
+# 该脚本只管理 noj-judge，不安装或替换宿主机 Docker daemon，且禁止使用共享的
+# /var/run/docker.sock。rootless Docker daemon 应由运维人员按目标发行版预先准备。
+
+set -Eeuo pipefail
+
+SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
+DOCKER_BIN="${NOJ_JUDGE_DOCKER_BIN:-docker}"
+CURL_BIN="${NOJ_JUDGE_CURL_BIN:-curl}"
+PROJECT_NAME="noj-judge-standalone"
+DEFAULT_REPO="https://github.com/Neuro-OJ/neuro-oj"
+REPO_URL="${NOJ_JUDGE_REPO:-$DEFAULT_REPO}"
+REF="${NOJ_JUDGE_REF:-main}"
+TARGET_DIR="${NOJ_JUDGE_DIR:-/srv/noj-judge}"
+ENV_FILE=""
+COMPOSE_FILE=""
+COMMAND=""
+NON_INTERACTIVE=0
+DOWNLOAD_ONLY=0
+DRY_RUN=0
+FOLLOW=0
+VERSION_OVERRIDE=""
+POSITIONAL=()
+
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; RESET='\033[0m'
+else
+  GREEN=''; YELLOW=''; RED=''; RESET=''
+fi
+
+ok() { printf "%b✓%b %s\n" "$GREEN" "$RESET" "$*"; }
+warn() { printf "%b!%b %s\n" "$YELLOW" "$RESET" "$*" >&2; }
+fail() {
+  printf "%b✗%b %s\n" "$RED" "$RESET" "$*" >&2
+  exit 1
+}
+section() { printf "\n== %s ==\n" "$*"; }
+
+usage() {
+  cat <<'EOF'
+Neuro OJ 独立 Judge Worker 部署工具
+
+用法：
+  judge-install.sh install       首次配置并启动独立 Judge
+  judge-install.sh install-env   检查部署依赖并输出 rootless 准备指引
+  judge-install.sh check         检查配置、Redis、Docker socket 和镜像架构
+  judge-install.sh start         启动 Judge（保留现有容器）
+  judge-install.sh stop          停止 Judge（保留配置、缓存和 Redis 任务）
+  judge-install.sh status        查看 Judge 状态和脱敏配置摘要
+  judge-install.sh logs [--follow]
+                                查看 Judge 日志
+  judge-install.sh upgrade       拉取配置中的版本并升级
+  judge-install.sh download      只从仓库下载本部署脚本
+
+选项：
+  --dir DIR              Judge 运行目录（默认 /srv/noj-judge）
+  --env-file FILE        配置文件（默认 DIR/.env.judge）
+  --compose-file FILE    Compose 文件（默认 DIR/docker-compose.judge.yml）
+  --repo URL             GitHub 仓库地址（download 使用）
+  --ref REF              仓库分支、标签或提交（download 使用，默认 main）
+  --version VERSION      install/upgrade 使用的 Release 版本
+  --non-interactive      不读取终端输入，必填项从环境变量或配置文件读取
+  --download-only        只下载部署脚本，不执行 Docker 操作
+  --dry-run              只显示动作，不修改服务
+  -h, --help             显示帮助
+
+首次 install 的非交互环境变量：
+  NOJ_VERSION REDIS_URL JUDGE_DOCKER_SOCKET JUDGE_DOCKER_SOCKET_GID
+  JUDGE_QUEUE RESULT_QUEUE WORK_DIR JUDGE_MAX_CONCURRENT_JUDGES
+  JUDGE_IMAGE_PREFIX JUDGE_IMAGE_REGISTRY JUDGE_UID JUDGE_GID
+
+安全约束：
+  - 必须使用专用 Unix rootless Docker socket；禁止 /var/run/docker.sock 和 /run/docker.sock
+  - 不自动安装、替换或配置 Docker daemon
+  - 配置文件权限必须为 600 或 400；密码不会在提示和状态摘要中回显
+EOF
+}
+
+parse_args() {
+  while (($# > 0)); do
+    case "$1" in
+      install|install-env|check|start|stop|status|logs|upgrade|download)
+        [[ -z "$COMMAND" ]] || fail "只能指定一个操作：$COMMAND"
+        COMMAND="$1"
+        ;;
+      --dir)
+        (($# >= 2)) || fail "--dir 需要一个目录路径"
+        TARGET_DIR="$2"; shift
+        ;;
+      --dir=*) TARGET_DIR="${1#*=}" ;;
+      --env-file)
+        (($# >= 2)) || fail "--env-file 需要一个文件路径"
+        ENV_FILE="$2"; shift
+        ;;
+      --env-file=*) ENV_FILE="${1#*=}" ;;
+      --compose-file)
+        (($# >= 2)) || fail "--compose-file 需要一个文件路径"
+        COMPOSE_FILE="$2"; shift
+        ;;
+      --compose-file=*) COMPOSE_FILE="${1#*=}" ;;
+      --repo)
+        (($# >= 2)) || fail "--repo 需要仓库地址"
+        REPO_URL="$2"; shift
+        ;;
+      --repo=*) REPO_URL="${1#*=}" ;;
+      --ref)
+        (($# >= 2)) || fail "--ref 需要分支、标签或提交"
+        REF="$2"; shift
+        ;;
+      --ref=*) REF="${1#*=}" ;;
+      --version)
+        (($# >= 2)) || fail "--version 需要 Release 版本"
+        VERSION_OVERRIDE="$2"; shift
+        ;;
+      --version=*) VERSION_OVERRIDE="${1#*=}" ;;
+      --non-interactive) NON_INTERACTIVE=1 ;;
+      --download-only) DOWNLOAD_ONLY=1 ;;
+      --dry-run) DRY_RUN=1 ;;
+      --follow|-f) FOLLOW=1 ;;
+      -h|--help) usage; exit 0 ;;
+      --) shift; POSITIONAL+=("$@"); break ;;
+      *) POSITIONAL+=("$1") ;;
+    esac
+    shift
+  done
+  [[ -n "$COMMAND" ]] || { usage; exit 2; }
+  [[ -n "$ENV_FILE" ]] || ENV_FILE="$TARGET_DIR/.env.judge"
+  [[ -n "$COMPOSE_FILE" ]] || COMPOSE_FILE="$TARGET_DIR/docker-compose.judge.yml"
+}
+
+env_value() {
+  local key="$1" value=""
+  if [[ -f "$ENV_FILE" ]]; then
+    value="$(awk -v key="$key" '
+      index($0, key "=") == 1 { print substr($0, length(key) + 2); exit }
+    ' "$ENV_FILE")"
+    case "$value" in
+      \"*\") value="${value:1:${#value}-2}" ;;
+      \'*\') value="${value:1:${#value}-2}" ;;
+    esac
+  fi
+  if [[ -z "$value" ]]; then
+    value="$(printenv "$key" 2>/dev/null || true)"
+  fi
+  printf '%s\n' "$value"
+}
+
+set_env_value() {
+  local key="$1" value="$2" tmp
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE"
+  [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || fail "$key 不能包含换行"
+  tmp="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+  if ! awk -v key="$key" -v value="$value" '
+    BEGIN { found = 0 }
+    index($0, key "=") == 1 { print key "=" value; found = 1; next }
+    { print }
+    END { if (!found) print key "=" value }
+  ' "$ENV_FILE" >"$tmp"; then
+    rm -f "$tmp"
+    fail "更新配置失败"
+  fi
+  chmod 600 "$tmp"
+  mv "$tmp" "$ENV_FILE"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "缺少依赖：$1"
+}
+
+is_version() {
+  [[ "$1" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]
+}
+
+is_placeholder() {
+  local value="$1"
+  [[ -z "$value" ]] && return 0
+  case "$value" in
+    *change-me*|*changeme*|*example*|*placeholder*|*replace-me*|*your-*|latest|main|xxx*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+stat_mode() {
+  local path="$1"
+  stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path" 2>/dev/null
+}
+
+stat_gid() {
+  local path="$1"
+  stat -c '%g' "$path" 2>/dev/null || stat -f '%g' "$path" 2>/dev/null
+}
+
+ensure_target_dir() {
+  if [[ -e "$TARGET_DIR" && ! -d "$TARGET_DIR" ]]; then
+    fail "目标路径不是目录：$TARGET_DIR"
+  fi
+  if [[ ! -d "$TARGET_DIR" ]]; then
+    ((DRY_RUN)) || mkdir -p "$TARGET_DIR"
+  fi
+}
+
+validate_existing_target() {
+  [[ -d "$TARGET_DIR" ]] || return 0
+  if [[ ! -f "$ENV_FILE" && ! -f "$COMPOSE_FILE" ]]; then
+    if find "$TARGET_DIR" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+      fail "目标目录非空但没有本工具配置；请指定新目录，或先明确清理后再安装：$TARGET_DIR"
+    fi
+  fi
+}
+
+prompt_value() {
+  local key="$1" label="$2" default_value="${3:-}" secret="${4:-0}" value
+  value="$(env_value "$key")"
+  [[ -n "$value" ]] && { printf '%s\n' "$value"; return 0; }
+  ((NON_INTERACTIVE)) && fail "非交互安装缺少必填配置：$key"
+  if [[ "$secret" == 1 ]]; then
+    read -r -s -p "$label${default_value:+ [$default_value]}：" value
+    printf '\n' >&2
+  else
+    read -r -p "$label${default_value:+ [$default_value]}：" value
+  fi
+  value="${value:-$default_value}"
+  [[ -n "$value" ]] || fail "$key 不能为空"
+  [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || fail "$key 不能包含换行"
+  printf '%s\n' "$value"
+}
+
+initialize_env() {
+  section "配置独立 Judge"
+  ensure_target_dir
+  validate_existing_target
+  if [[ -f "$ENV_FILE" ]]; then
+    chmod 600 "$ENV_FILE"
+    ok "保留已有配置：$ENV_FILE"
+    [[ -n "$VERSION_OVERRIDE" ]] && set_env_value NOJ_VERSION "$VERSION_OVERRIDE"
+    return 0
+  fi
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将创建配置：$ENV_FILE"
+    return 0
+  fi
+
+  umask 077
+  local version redis_url socket socket_gid queue result work_dir concurrency prefix registry uid gid
+  version="$VERSION_OVERRIDE"
+  [[ -n "$version" ]] || version="$(prompt_value NOJ_VERSION "NOJ_VERSION（Release 版本）")"
+  redis_url="$(prompt_value REDIS_URL "Redis URL（密码输入不回显）" "" 1)"
+  queue="$(prompt_value JUDGE_QUEUE "任务队列" "noj:judge:queue")"
+  result="$(prompt_value RESULT_QUEUE "结果队列" "noj:judge:results")"
+  work_dir="$(prompt_value WORK_DIR "Worker 容器工作目录" "/tmp/noj-judge")"
+  concurrency="$(prompt_value JUDGE_MAX_CONCURRENT_JUDGES "最大并发评测数" "2")"
+  prefix="$(prompt_value JUDGE_IMAGE_PREFIX "评测镜像前缀" "noj-")"
+  registry="$(prompt_value JUDGE_IMAGE_REGISTRY "Worker 镜像仓库" "ghcr.io/neuro-oj")"
+  socket="$(prompt_value JUDGE_DOCKER_SOCKET "专用 rootless Docker socket" "/run/noj-judge/docker.sock")"
+  socket_gid="$(prompt_value JUDGE_DOCKER_SOCKET_GID "Docker socket GID" "10001")"
+  uid="$(prompt_value JUDGE_UID "Worker UID" "10001")"
+  gid="$(prompt_value JUDGE_GID "Worker GID" "10001")"
+
+  cat >"$ENV_FILE" <<EOF
+NOJ_VERSION=$version
+REDIS_URL=$redis_url
+JUDGE_QUEUE=$queue
+RESULT_QUEUE=$result
+WORK_DIR=$work_dir
+JUDGE_MAX_CONCURRENT_JUDGES=$concurrency
+JUDGE_IMAGE_PREFIX=$prefix
+JUDGE_IMAGE_REGISTRY=$registry
+JUDGE_DOCKER_SOCKET=$socket
+JUDGE_DOCKER_SOCKET_GID=$socket_gid
+JUDGE_DOCKER_HOST=unix:///run/noj-judge/docker.sock
+JUDGE_REQUIRE_ISOLATED_DOCKER=true
+JUDGE_UID=$uid
+JUDGE_GID=$gid
+JUDGE_CPU_LIMIT_MILLICORES=1000
+JUDGE_MAX_EVALUATOR_TIME_MS=300000
+JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS=60000
+JUDGE_COMMAND_WHITELIST=python3,deno,node,bash,sh
+JUDGE_ALLOW_EVALUATOR_NETWORK=false
+JUDGE_EVALUATOR_NETWORK=bridge
+JUDGE_ALLOW_HTTP_S3=false
+SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT=60
+SUPPORT_CACHE_DIR=/tmp/noj-judge/support-cache
+SUPPORT_CACHE_MAX_ITEMS=500
+SUPPORT_CACHE_MAX_MB=2048
+EOF
+  chmod 600 "$ENV_FILE"
+  ok "已创建配置：$ENV_FILE"
+}
+
+write_compose() {
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将生成 Compose 配置：$COMPOSE_FILE"
+    return 0
+  fi
+  umask 077
+  cat >"$COMPOSE_FILE" <<'EOF'
+services:
+  judge:
+    image: "${JUDGE_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-judge:${NOJ_VERSION:?NOJ_VERSION is required}"
+    environment:
+      REDIS_URL: "${REDIS_URL:?REDIS_URL is required}"
+      JUDGE_QUEUE: "${JUDGE_QUEUE:-noj:judge:queue}"
+      RESULT_QUEUE: "${RESULT_QUEUE:-noj:judge:results}"
+      WORK_DIR: "${WORK_DIR:-/tmp/noj-judge}"
+      JUDGE_MAX_CONCURRENT_JUDGES: "${JUDGE_MAX_CONCURRENT_JUDGES:-2}"
+      JUDGE_CPU_LIMIT_MILLICORES: "${JUDGE_CPU_LIMIT_MILLICORES:-1000}"
+      JUDGE_MAX_EVALUATOR_TIME_MS: "${JUDGE_MAX_EVALUATOR_TIME_MS:-300000}"
+      JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS: "${JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS:-60000}"
+      JUDGE_IMAGE_PREFIX: "${JUDGE_IMAGE_PREFIX:-noj-}"
+      JUDGE_COMMAND_WHITELIST: "${JUDGE_COMMAND_WHITELIST:-python3,deno,node,bash,sh}"
+      JUDGE_ALLOW_EVALUATOR_NETWORK: "${JUDGE_ALLOW_EVALUATOR_NETWORK:-false}"
+      JUDGE_EVALUATOR_NETWORK: "${JUDGE_EVALUATOR_NETWORK:-bridge}"
+      JUDGE_ALLOW_HTTP_S3: "${JUDGE_ALLOW_HTTP_S3:-false}"
+      JUDGE_DOCKER_HOST: "${JUDGE_DOCKER_HOST:-unix:///run/noj-judge/docker.sock}"
+      JUDGE_REQUIRE_ISOLATED_DOCKER: "true"
+      SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT: "${SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT:-60}"
+      SUPPORT_CACHE_DIR: "${SUPPORT_CACHE_DIR:-/tmp/noj-judge/support-cache}"
+      SUPPORT_CACHE_MAX_ITEMS: "${SUPPORT_CACHE_MAX_ITEMS:-500}"
+      SUPPORT_CACHE_MAX_MB: "${SUPPORT_CACHE_MAX_MB:-2048}"
+    volumes:
+      - "${JUDGE_DOCKER_SOCKET:?JUDGE_DOCKER_SOCKET is required}:/run/noj-judge/docker.sock:ro"
+      - judge-cache:/tmp/noj-judge
+    user: "${JUDGE_UID:-10001}:${JUDGE_GID:-10001}"
+    group_add:
+      - "${JUDGE_DOCKER_SOCKET_GID:?JUDGE_DOCKER_SOCKET_GID is required}"
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+volumes:
+  judge-cache:
+    name: noj-judge-standalone-cache
+EOF
+  chmod 600 "$COMPOSE_FILE"
+  ok "已生成 Compose 配置：$COMPOSE_FILE"
+}
+
+check_base_environment() {
+  section "检查主机环境"
+  [[ "$(uname -s)" == "Linux" ]] || fail "独立 Judge 部署目前只支持 Linux"
+  local machine arch
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64|amd64) arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+    *) fail "不支持的 CPU 架构：${machine}（当前支持 x86_64/amd64 与 ARM64）" ;;
+  esac
+  require_command "$DOCKER_BIN"
+  "$DOCKER_BIN" info >/dev/null 2>&1 || fail "Docker daemon 未运行或当前用户无权限"
+  "$DOCKER_BIN" compose version >/dev/null 2>&1 || fail "Docker Compose v2 不可用"
+  ok "Linux/${arch}、Docker daemon 和 Compose 可用"
+  if [[ -d "$TARGET_DIR" ]]; then
+    local available_kb memory_kb
+    available_kb="$(df -Pk "$TARGET_DIR" | awk 'NR==2 {print $4}')"
+    [[ "$available_kb" =~ ^[0-9]+$ ]] || fail "无法读取目标目录磁盘空间：$TARGET_DIR"
+    ((available_kb >= 5242880)) || warn "目标目录可用空间少于 5 GiB，评测镜像和缓存可能不足"
+    if [[ -r /proc/meminfo ]]; then
+      memory_kb="$(awk '/MemAvailable:/ {print $2; exit}' /proc/meminfo)"
+      [[ "$memory_kb" =~ ^[0-9]+$ ]] && ((memory_kb >= 524288)) ||
+        warn "可用内存少于 512 MiB，建议降低 Judge 并发"
+    fi
+  fi
+}
+
+check_config_values() {
+  local key value missing=0
+  local required=(NOJ_VERSION REDIS_URL JUDGE_QUEUE RESULT_QUEUE WORK_DIR
+    JUDGE_MAX_CONCURRENT_JUDGES JUDGE_IMAGE_PREFIX JUDGE_IMAGE_REGISTRY
+    JUDGE_DOCKER_SOCKET JUDGE_DOCKER_SOCKET_GID JUDGE_UID JUDGE_GID)
+  for key in "${required[@]}"; do
+    value="$(env_value "$key")"
+    if is_placeholder "$value"; then
+      printf "  - %s 未配置或仍是占位值\n" "$key" >&2
+      missing=1
+    fi
+  done
+  ((missing == 0)) || fail "Judge 配置未完成，请修复上面的配置项"
+  is_version "$(env_value NOJ_VERSION)" || fail "NOJ_VERSION 必须是不可变 Release 标签，如 v0.1.0"
+  [[ "$(env_value JUDGE_MAX_CONCURRENT_JUDGES)" =~ ^[1-9][0-9]*$ ]] ||
+    fail "JUDGE_MAX_CONCURRENT_JUDGES 必须是正整数"
+  [[ "$(env_value JUDGE_DOCKER_SOCKET_GID)" =~ ^[0-9]+$ ]] ||
+    fail "JUDGE_DOCKER_SOCKET_GID 必须是数字"
+  [[ "$(env_value JUDGE_UID)" =~ ^[0-9]+$ && "$(env_value JUDGE_GID)" =~ ^[0-9]+$ ]] ||
+    fail "JUDGE_UID 和 JUDGE_GID 必须是数字"
+  [[ "$(env_value JUDGE_DOCKER_HOST)" == unix:///* ]] ||
+    fail "JUDGE_DOCKER_HOST 必须使用 unix:// endpoint"
+  [[ "$(env_value JUDGE_DOCKER_HOST)" == unix:///run/noj-judge/docker.sock ]] ||
+    fail "JUDGE_DOCKER_HOST 必须为容器内专用 endpoint：unix:///run/noj-judge/docker.sock"
+  [[ "$(env_value JUDGE_REQUIRE_ISOLATED_DOCKER)" == true ]] ||
+    fail "JUDGE_REQUIRE_ISOLATED_DOCKER 必须为 true"
+}
+
+check_socket() {
+  local socket_path socket_gid socket_mode configured_gid
+  socket_path="$(env_value JUDGE_DOCKER_SOCKET)"
+  case "$socket_path" in
+    /var/run/docker.sock|/run/docker.sock)
+      fail "禁止使用应用宿主机 Docker socket：${socket_path}；请准备专用 rootless socket"
+      ;;
+  esac
+  [[ "$socket_path" == /* ]] || fail "JUDGE_DOCKER_SOCKET 必须是绝对路径"
+  [[ "$socket_path" != *:* ]] || fail "JUDGE_DOCKER_SOCKET 必须是本机 Unix socket 路径"
+  [[ -S "$socket_path" ]] || fail "专用 Docker socket 不存在或不是 Unix socket：${socket_path}"
+  [[ -r "$socket_path" && -w "$socket_path" ]] ||
+    fail "当前用户无法读写专用 Docker socket：${socket_path}"
+  socket_gid="$(stat_gid "$socket_path")"
+  configured_gid="$(env_value JUDGE_DOCKER_SOCKET_GID)"
+  [[ "$socket_gid" == "$configured_gid" ]] ||
+    fail "Docker socket GID=${socket_gid} 与配置 JUDGE_DOCKER_SOCKET_GID=${configured_gid} 不一致"
+  socket_mode="$(stat_mode "$socket_path")"
+  DOCKER_HOST="unix://${socket_path}" "$DOCKER_BIN" info >/dev/null 2>&1 ||
+    fail "专用 rootless Docker daemon 不可连接：${socket_path}"
+  ok "专用 rootless Docker socket 可用（GID=${socket_gid}，权限=${socket_mode}）"
+}
+
+redis_host() {
+  local url="$(env_value REDIS_URL)"
+  url="${url#*://}"
+  url="${url#*@}"
+  url="${url%%/*}"
+  url="${url%%:*}"
+  printf '%s\n' "${url:-未知主机}"
+}
+
+check_redis() {
+  local url="$(env_value REDIS_URL)"
+  [[ "$url" =~ ^rediss?:// ]] || fail "REDIS_URL 必须使用 redis:// 或 rediss://"
+  section "检查 Redis"
+  if command -v redis-cli >/dev/null 2>&1; then
+    redis-cli -u "$url" ping >/dev/null 2>&1 ||
+      fail "Redis 连接失败：$(redis_host)（密码不会显示）"
+  else
+    REDIS_URL="$url" "$DOCKER_BIN" run --rm --network host -e REDIS_URL redis:7-alpine \
+      sh -c 'redis-cli -u "$REDIS_URL" ping' >/dev/null 2>&1 ||
+      fail "Redis 连接失败：$(redis_host)；系统未安装 redis-cli，已尝试使用临时 Redis 客户端"
+  fi
+  ok "Redis 可连接：$(redis_host)"
+}
+
+image_name() {
+  printf '%s/noj-judge:%s\n' "$(env_value JUDGE_IMAGE_REGISTRY)" "$(env_value NOJ_VERSION)"
+}
+
+local_image_arch() {
+  "$DOCKER_BIN" image inspect "$(image_name)" --format '{{.Architecture}}' 2>/dev/null || true
+}
+
+check_image_architecture() {
+  local machine expected image details inspect_file local_image_arch_value
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64|amd64) expected=amd64 ;;
+    aarch64|arm64) expected=arm64 ;;
+    *) return 1 ;;
+  esac
+  image="$(image_name)"
+  local_image_arch_value="$(local_image_arch)"
+  if [[ -n "$local_image_arch_value" ]]; then
+    [[ "$local_image_arch_value" == "$expected" ]] ||
+      fail "本地 Worker 镜像架构为 ${local_image_arch_value}，当前主机需要 ${expected}：${image}"
+    ok "Worker 镜像已存在且架构匹配：${expected}"
+    return 0
+  fi
+  inspect_file="$(mktemp "${TMPDIR:-/tmp}/noj-judge-image-inspect.XXXXXX")"
+  if "$DOCKER_BIN" buildx imagetools inspect "$image" >"$inspect_file" 2>/dev/null; then
+    details="$(<"$inspect_file")"
+    rm -f "$inspect_file"
+    grep -Eiq "linux/${expected}|Architecture:[[:space:]]+${expected}" <<<"$details" ||
+      fail "Worker 镜像没有当前主机架构 linux/${expected}：${image}"
+    ok "Worker 镜像 manifest 包含 linux/${expected}"
+  else
+    rm -f "$inspect_file"
+    warn "无法预先读取 Worker manifest，将由 docker pull 报告网络、认证或架构错误：${image}"
+  fi
+}
+
+check_configuration() {
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE，请先执行 install"
+  [[ -f "$COMPOSE_FILE" ]] || fail "找不到 Compose 配置：$COMPOSE_FILE，请先执行 install"
+  local mode
+  mode="$(stat_mode "$ENV_FILE")"
+  [[ "$mode" == 600 || "$mode" == 400 ]] ||
+    fail "配置文件权限必须为 600 或 400：$ENV_FILE"
+  check_config_values
+  check_socket
+  if ((DRY_RUN)); then
+    ok "[dry-run] 跳过 Redis、镜像和 Compose 实际连接检查"
+  else
+    check_redis
+    check_image_architecture
+    "$DOCKER_BIN" compose --project-name "$PROJECT_NAME" --env-file "$ENV_FILE" \
+      -f "$COMPOSE_FILE" config --quiet || fail "独立 Judge Compose 配置无效"
+  fi
+  ok "Judge 配置检查通过"
+}
+
+run_compose() {
+  if ((DRY_RUN)); then
+    printf '[dry-run] docker compose --project-name %s --env-file %s -f %s' \
+      "$PROJECT_NAME" "$ENV_FILE" "$COMPOSE_FILE"
+    printf ' %s\n' "$*"
+    return 0
+  fi
+  "$DOCKER_BIN" compose --project-name "$PROJECT_NAME" --env-file "$ENV_FILE" \
+    -f "$COMPOSE_FILE" "$@"
+}
+
+download_script() {
+  require_command "$CURL_BIN"
+  [[ "$REPO_URL" =~ ^https://github\.com/[^/]+/[^/]+/?$ ]] ||
+    fail "--repo 目前只支持 https://github.com/组织/仓库"
+  local slug url tmp download_dir
+  slug="${REPO_URL#https://github.com/}"
+  slug="${slug%/}"
+  slug="${slug%.git}"
+  url="https://raw.githubusercontent.com/$slug/$REF/scripts/deploy/judge-install.sh"
+  download_dir="$TARGET_DIR"
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将下载部署脚本：$url -> $download_dir/judge-install.sh"
+    return 0
+  fi
+  [[ -d "$download_dir" ]] || { ((DRY_RUN)) || mkdir -p "$download_dir"; }
+  tmp="$(mktemp "${download_dir}/.judge-install.XXXXXX")"
+  if ! "$CURL_BIN" -fsSL --retry 3 "$url" -o "$tmp"; then
+    rm -f "$tmp"
+    fail "下载部署脚本失败，请检查仓库、ref 和网络：$url"
+  fi
+  bash -n "$tmp" || { rm -f "$tmp"; fail "下载内容不是有效 Bash 脚本：$url"; }
+  chmod 700 "$tmp"
+  mv "$tmp" "$download_dir/judge-install.sh"
+  ok "已下载部署脚本：$download_dir/judge-install.sh"
+}
+
+install_env() {
+  section "检查 Judge 部署依赖"
+  [[ "$(uname -s)" == Linux ]] || fail "独立 Judge 部署目前只支持 Linux"
+  require_command "$CURL_BIN"
+  require_command "$DOCKER_BIN"
+  "$DOCKER_BIN" info >/dev/null 2>&1 || fail "Docker daemon 未运行或当前用户无权限"
+  "$DOCKER_BIN" compose version >/dev/null 2>&1 || fail "Docker Compose v2 不可用"
+  ok "Docker daemon 与 Compose 可用"
+  cat <<'EOF'
+
+请确认已准备以下隔离条件：
+  1. 只服务于 Judge 的 rootless Docker daemon；
+  2. 独立 Unix socket（例如 /run/noj-judge/docker.sock）；
+  3. Worker 用户的 UID/GID 及 socket group 权限；
+  4. 与 noj-core 使用同一 Redis、任务队列和结果队列。
+
+本工具不会自动安装或替换 Docker daemon，也不会把 /var/run/docker.sock 提供给 Judge。
+EOF
+}
+
+install_worker() {
+  initialize_env
+  write_compose
+  check_base_environment
+  check_configuration
+  section "启动独立 Judge"
+  run_compose pull
+  run_compose up -d --remove-orphans
+  ok "独立 Judge 已启动（Compose project: ${PROJECT_NAME}）"
+}
+
+start_worker() {
+  check_base_environment
+  check_configuration
+  run_compose up -d --remove-orphans
+  ok "独立 Judge 已启动"
+}
+
+upgrade_worker() {
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE，请先执行 install"
+  [[ -n "$VERSION_OVERRIDE" ]] && set_env_value NOJ_VERSION "$VERSION_OVERRIDE"
+  write_compose
+  check_base_environment
+  check_configuration
+  section "升级独立 Judge"
+  run_compose pull
+  run_compose up -d --remove-orphans
+  ok "独立 Judge 已升级；配置、缓存和 Redis 任务已保留"
+}
+
+status_worker() {
+  check_base_environment
+  check_configuration
+  printf '版本：%s\n' "$(env_value NOJ_VERSION)"
+  printf 'Redis 主机：%s\n' "$(redis_host)"
+  printf '任务队列：%s\n' "$(env_value JUDGE_QUEUE)"
+  printf '结果队列：%s\n' "$(env_value RESULT_QUEUE)"
+  printf 'Docker socket：%s\n' "$(env_value JUDGE_DOCKER_SOCKET)"
+  run_compose ps
+}
+
+logs_worker() {
+  check_base_environment
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE，请先执行 install"
+  local args=(logs --tail=200)
+  ((FOLLOW)) && args+=(--follow)
+  run_compose "${args[@]}"
+}
+
+stop_worker() {
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE，请先执行 install"
+  run_compose stop
+  ok "独立 Judge 已停止；配置、缓存和 Redis 任务已保留"
+}
+
+main() {
+  parse_args "$@"
+  if ((DOWNLOAD_ONLY)) || [[ "$COMMAND" == download ]]; then
+    download_script
+    exit 0
+  fi
+  case "$COMMAND" in
+    install-env) install_env ;;
+    install)
+      initialize_env
+      write_compose
+      check_base_environment
+      check_configuration
+      run_compose pull
+      run_compose up -d --remove-orphans
+      ok "独立 Judge 已启动（Compose project: ${PROJECT_NAME}）"
+      ;;
+    check) check_base_environment; check_configuration ;;
+    start) start_worker ;;
+    stop) stop_worker ;;
+    status) status_worker ;;
+    logs) logs_worker ;;
+    upgrade) upgrade_worker ;;
+    download) download_script ;;
+  esac
+}
+
+main "$@"

--- a/scripts/deploy/test-judge-install.sh
+++ b/scripts/deploy/test-judge-install.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# 独立 Judge 部署脚本的离线安全边界测试。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/judge-install.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-judge-install-test.XXXXXX")"
+FAKE_DOCKER="$TEST_ROOT/fake-docker"
+FAKE_CURL="$TEST_ROOT/fake-curl"
+FAKE_UNAME="$TEST_ROOT/uname"
+DOCKER_LOG="$TEST_ROOT/docker.log"
+TARGET_DIR="$TEST_ROOT/target"
+ENV_FILE="$TARGET_DIR/.env.judge"
+SOCKET="$TEST_ROOT/isolated-docker.sock"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+
+cat >"$FAKE_DOCKER" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$*" >>"${NOJ_JUDGE_TEST_LOG:?}"
+case "${1:-}" in
+  info) exit 0 ;;
+  compose)
+    [[ "${2:-}" == version ]] && exit 0
+    exit 0
+    ;;
+  image)
+    exit 1
+    ;;
+  buildx)
+    printf 'Name: fake\nPlatform: linux/amd64\n'
+    exit 0
+    ;;
+  run)
+    printf 'PONG\n'
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$FAKE_DOCKER"
+
+cat >"$FAKE_CURL" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+output=""
+while (($# > 0)); do
+  if [[ "$1" == -o ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]] || exit 2
+cp "${NOJ_JUDGE_SOURCE_SCRIPT:?}" "$output"
+EOF
+chmod +x "$FAKE_CURL"
+
+cat >"$FAKE_UNAME" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == -m ]]; then
+  printf '%s\n' "${NOJ_JUDGE_TEST_ARCH:-x86_64}"
+else
+  printf 'Linux\n'
+fi
+EOF
+chmod +x "$FAKE_UNAME"
+
+mkdir -p "$TARGET_DIR"
+python3 - "$SOCKET" <<'PY'
+import socket
+import sys
+
+sock = socket.socket(socket.AF_UNIX)
+sock.bind(sys.argv[1])
+sock.listen(1)
+PY
+chmod 660 "$SOCKET"
+SOCKET_GID="$(stat -c '%g' "$SOCKET" 2>/dev/null || stat -f '%g' "$SOCKET")"
+
+cat >"$ENV_FILE" <<EOF
+NOJ_VERSION=v0.1.0
+REDIS_URL=redis://:secret-password@redis.test.local:6379/0
+JUDGE_QUEUE=noj:judge:queue
+RESULT_QUEUE=noj:judge:results
+WORK_DIR=/tmp/noj-judge
+JUDGE_MAX_CONCURRENT_JUDGES=2
+JUDGE_IMAGE_PREFIX=noj-
+JUDGE_IMAGE_REGISTRY=ghcr.io/neuro-oj
+JUDGE_DOCKER_SOCKET=$SOCKET
+JUDGE_DOCKER_SOCKET_GID=$SOCKET_GID
+JUDGE_DOCKER_HOST=unix:///run/noj-judge/docker.sock
+JUDGE_REQUIRE_ISOLATED_DOCKER=true
+JUDGE_UID=10001
+JUDGE_GID=10001
+EOF
+chmod 600 "$ENV_FILE"
+
+run_judge() {
+  NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+  NOJ_JUDGE_CURL_BIN="$FAKE_CURL" \
+  NOJ_JUDGE_TEST_LOG="$DOCKER_LOG" \
+  NOJ_JUDGE_SOURCE_SCRIPT="$DEPLOY_SCRIPT" \
+  PATH="$TEST_ROOT:$PATH" \
+    bash "$DEPLOY_SCRIPT" "$@" --dir "$TARGET_DIR"
+}
+
+[[ "$(bash "$DEPLOY_SCRIPT" --help)" == *"独立 Judge Worker 部署工具"* ]] ||
+  fail "帮助输出缺少工具标题"
+pass "帮助输出"
+
+DOWNLOAD_DIR="$TEST_ROOT/download"
+NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+NOJ_JUDGE_CURL_BIN="$FAKE_CURL" \
+NOJ_JUDGE_TEST_LOG="$DOCKER_LOG" \
+NOJ_JUDGE_SOURCE_SCRIPT="$DEPLOY_SCRIPT" \
+PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" download --dir "$DOWNLOAD_DIR" --ref test-ref >/dev/null
+[[ -x "$DOWNLOAD_DIR/judge-install.sh" ]] || fail "download 未生成可执行脚本"
+bash -n "$DOWNLOAD_DIR/judge-install.sh" || fail "下载脚本不是有效 Bash"
+pass "仅下载脚本"
+
+run_judge install >/dev/null
+[[ -f "$TARGET_DIR/docker-compose.judge.yml" ]] || fail "install 未生成 Compose 文件"
+grep -q 'JUDGE_REQUIRE_ISOLATED_DOCKER: "true"' "$TARGET_DIR/docker-compose.judge.yml" ||
+  fail "Compose 未启用隔离 Docker"
+grep -q ':ro"' "$TARGET_DIR/docker-compose.judge.yml" || fail "Docker socket 未以只读方式挂载"
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  docker compose --project-name noj-judge-standalone-test --env-file "$ENV_FILE" \
+    -f "$TARGET_DIR/docker-compose.judge.yml" config --quiet ||
+    fail "实际 Docker Compose 无法渲染独立 Judge 配置"
+fi
+if grep -q 'secret-password' "$DOCKER_LOG"; then fail "Docker 命令日志泄露 Redis 密码"; fi
+pass "配置生成、Compose 安全项和 secret 脱敏"
+
+run_judge start >/dev/null || fail "重复 start 不应失败"
+run_judge status >/dev/null || fail "status 不应失败"
+run_judge logs >/dev/null || fail "logs 不应失败"
+run_judge stop >/dev/null || fail "stop 不应失败"
+grep -q 'compose.*stop' "$DOCKER_LOG" || fail "stop 未调用 Compose stop"
+pass "生命周期命令和重复启动"
+
+run_judge upgrade --version v0.2.0 >/dev/null || fail "upgrade 不应失败"
+grep -q '^NOJ_VERSION=v0.2.0$' "$ENV_FILE" || fail "upgrade 未更新版本"
+pass "升级保留配置"
+
+cp "$ENV_FILE" "$TEST_ROOT/unsafe.env"
+sed -i.bak 's#JUDGE_DOCKER_SOCKET=.*#JUDGE_DOCKER_SOCKET=/var/run/docker.sock#' "$TEST_ROOT/unsafe.env"
+chmod 600 "$TEST_ROOT/unsafe.env"
+if run_judge check --env-file "$TEST_ROOT/unsafe.env" >/dev/null 2>"$TEST_ROOT/unsafe.err"; then
+  fail "共享 Docker socket 应该被拒绝"
+fi
+grep -q '禁止使用应用宿主机 Docker socket' "$TEST_ROOT/unsafe.err" ||
+  fail "共享 socket 错误提示缺失"
+pass "共享 Docker socket 拒绝"
+
+cp "$ENV_FILE" "$TEST_ROOT/missing.env"
+sed -i.bak "s#JUDGE_DOCKER_SOCKET=.*#JUDGE_DOCKER_SOCKET=$TEST_ROOT/missing.sock#" "$TEST_ROOT/missing.env"
+chmod 600 "$TEST_ROOT/missing.env"
+if run_judge check --env-file "$TEST_ROOT/missing.env" >/dev/null 2>"$TEST_ROOT/missing.err"; then
+  fail "缺失 Docker socket 应该被拒绝"
+fi
+grep -q '不是 Unix socket' "$TEST_ROOT/missing.err" || fail "缺失 socket 错误提示缺失"
+pass "专用 Docker socket 存在性检查"
+
+if NOJ_JUDGE_TEST_ARCH=aarch64 run_judge check >/dev/null 2>"$TEST_ROOT/arm64.err"; then
+  fail "ARM64 无匹配镜像 manifest 时应该被拒绝"
+fi
+grep -q 'linux/arm64' "$TEST_ROOT/arm64.err" || fail "ARM64 架构错误提示缺失"
+pass "ARM64 镜像架构门禁"
+
+if NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" NOJ_JUDGE_TEST_LOG="$DOCKER_LOG" PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install --dir "$TEST_ROOT/non-interactive" --non-interactive \
+  >"$TEST_ROOT/non-interactive.out" 2>"$TEST_ROOT/non-interactive.err"; then
+  fail "非交互模式缺少配置时应该失败"
+fi
+grep -q 'NOJ_VERSION' "$TEST_ROOT/non-interactive.err" || fail "非交互缺失配置提示缺少"
+pass "非交互必填配置门禁"
+
+if grep -q 'secret-password' "$TARGET_DIR/docker-compose.judge.yml" "$DOCKER_LOG"; then
+  fail "部署产物或 Docker 日志泄露了 Redis 密码"
+fi
+pass "最终 secret 泄露检查"
+
+printf '全部独立 Judge 部署脚本测试通过\n'


### PR DESCRIPTION
## 概要

新增 Linux 独立 noj-judge Worker 的一键部署入口，支持在不部署 core/UI/完整源码仓库的评测节点上完成下载、环境检测、交互配置和 Compose 生命周期管理。

## 主要变更

- 新增 `scripts/deploy/judge-install.sh`：
  - 支持 `install`、`install-env`、`check`、`start`、`stop`、`status`、`logs`、`upgrade`；
  - 支持从 GitHub 指定 ref 只下载部署脚本；
  - 支持交互式和 `--non-interactive` 配置；
  - 配置文件权限固定为 `600`，状态和检查输出不显示 Redis 密码；
  - 生成固定 Compose project 的最小 Judge 配置，使用非 root Worker、只读专用 socket、缓存卷和既有安全变量。
- 启动前检查 Linux/架构、Docker/Compose、资源、Redis、专用 Unix socket、socket GID 和 Worker 镜像 manifest。
- 明确拒绝 `/var/run/docker.sock`、`/run/docker.sock` 以及 TCP/HTTP Docker endpoint。
- 更新 Judge 运维文档和脚本索引。
- 新增离线安全边界测试，并覆盖 ARM64 无匹配镜像场景。
- 增加 OpenSpec 提案、设计、规范和任务清单。

## 安全与范围

- 不修改 noj-judge Rust 代码、core API、Redis 消息格式或评测协议。
- 不自动安装或替换宿主机 Docker daemon，不自动修改 systemd、subuid/subgid；部署前需要准备只服务于 Judge 的 rootless Docker daemon。
- 当前生产 Release 工作流发布 `linux/amd64`；ARM64 主机在无对应 manifest 时会在启动前失败，不会回退到共享宿主机 socket。

## 验证

- `bash -n scripts/deploy/judge-install.sh scripts/deploy/test-judge-install.sh`
- `bash scripts/deploy/test-judge-install.sh`
- `bash scripts/deploy/test-deploy.sh`
- `bash scripts/deploy/test-backup.sh`
- `openspec validate judge-standalone-deploy --strict`
- 实际 Docker Compose 配置渲染
- Debian 13 ARM64 虚拟机：`install-env` 成功；非交互安装在专用 socket 缺失时提前失败，未执行 `pull`/`up`。
