### PR TITLE
fix(ci): 修复 Trivy 发布扫描动作

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: 扫描候选镜像漏洞
-        uses: aquasecurity/trivy-action@v0.28.0
+        # v0.28.0 会引用不存在的 setup-trivy@v0.2.1，导致任务在构建前直接失败。
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ steps.meta.outputs.candidate }}
           format: table
@@ -129,7 +130,7 @@ jobs:
           exit-code: "1"
 
       - name: 生成候选镜像 SBOM
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ steps.meta.outputs.candidate }}
           format: spdx-json

--- a/openspec/changes/fix-release-trivy-action/.openspec.yaml
+++ b/openspec/changes/fix-release-trivy-action/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/fix-release-trivy-action/design.md
+++ b/openspec/changes/fix-release-trivy-action/design.md
@@ -1,0 +1,36 @@
+## Context
+
+发布工作流当前在两个步骤调用 `aquasecurity/trivy-action@v0.28.0`。该版本的复合动作内部引用不存在的 `aquasecurity/setup-trivy@v0.2.1`，因此在真正构建镜像前即失败。官方后续版本已修复该依赖引用，并支持现有工作流使用的 `image-ref`、`format`、`vuln-type`、`severity`、`ignore-unfixed`、`exit-code` 和 `output` 输入。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 让 Release workflow 能解析并运行 Trivy 漏洞扫描和 SBOM 生成。
+- 继续保留 HIGH/CRITICAL 漏洞门禁与 SBOM 产物。
+- 在本地和 PR 阶段提前发现已知失效的 Trivy Action 引用。
+
+**Non-Goals:**
+
+- 不改变漏洞等级、忽略未修复漏洞或发布签名策略。
+- 不把 Trivy 扫描改成允许失败，也不删除供应链检查。
+- 不修改生产镜像或部署脚本。
+
+## Decisions
+
+- 使用已验证的 `aquasecurity/trivy-action@v0.36.0`，因为它已将内部 `setup-trivy` 引用更新为存在的版本，并保留当前 workflow 所需输入。相比直接使用 `master`，固定版本可复现；相比继续使用 `v0.28.0`，可消除已确认的解析失败。
+- 在 `scripts/release/check-supply-chain.sh` 中增加版本断言，并复用已有的 `scripts/release/test-supply-chain.sh` 执行正向/负向回归检查。这样不需要在 CI 中访问外部仓库，也能阻止已知失效版本重新进入主分支。
+- 版本断言只针对当前已验证版本，不改变其它 Action 的更新策略；后续升级 Trivy 时必须先验证上游复合动作依赖，再同步修改断言和测试。
+
+## Risks / Trade-offs
+
+- [固定版本后不会自动获得后续 Trivy Action 修复] → 由 Dependabot 和后续升级 PR 管理版本，升级时运行供应链测试。
+- [静态检查无法替代 GitHub runner 的真实解析] → 在合并后以 workflow lint 和手动/RC 发布运行做最终验证。
+- [v0.36.0 可能改变 Trivy 默认版本] → 保持现有显式扫描输入，并以 Release workflow 的扫描结果作为发布门禁。
+
+## Migration Plan
+
+1. 更新 Release workflow 和供应链静态检查。
+2. 运行本地 Shell、YAML/actionlint 与 OpenSpec 校验。
+3. 通过 PR 合并后创建新的 RC，确认六个镜像均完成构建、扫描、SBOM、签名和发布。
+4. 如新版本行为不兼容，回滚该 PR 即可恢复上一版本配置；但旧版本仍会触发已知的依赖解析失败。

--- a/openspec/changes/fix-release-trivy-action/proposal.md
+++ b/openspec/changes/fix-release-trivy-action/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`0.8.0-rc.2` 的发布流水线在准备 Trivy 扫描时失败，因为当前固定的 `trivy-action@v0.28.0` 会引用不存在的 `setup-trivy@v0.2.1`。这会阻止应用镜像构建、SBOM 生成和 Release 发布，必须在下一次 RC 前修复。
+
+## What Changes
+
+- 将 Release workflow 使用的 Trivy Action 更新到已验证包含有效 `setup-trivy` 引用的固定版本。
+- 保留漏洞扫描、SBOM 生成和失败门禁，不降低发布安全检查范围。
+- 增加针对 Trivy Action 引用的静态回归检查，避免再次使用已失效的版本或引用。
+
+## Capabilities
+
+### New Capabilities
+
+- `release-supply-chain-scanning`: 发布流水线能够稳定执行 Trivy 漏洞扫描和 SBOM 生成。
+
+### Modified Capabilities
+
+<!-- 仅修复发布工具链实现，不改变面向用户的生产部署需求。 -->
+
+## Impact
+
+- 修改 `.github/workflows/release.yml` 及其 CI 检查。
+- 不修改应用运行时、镜像内容、生产配置或部署命令。
+- 下一次 RC 发布将重新触发镜像构建、扫描、签名和发布流程。

--- a/openspec/changes/fix-release-trivy-action/specs/release-supply-chain-scanning/spec.md
+++ b/openspec/changes/fix-release-trivy-action/specs/release-supply-chain-scanning/spec.md
@@ -1,0 +1,37 @@
+## Purpose
+
+确保生产镜像发布时的漏洞扫描和 SBOM 生成能够在 GitHub Actions 中实际执行，并在工具引用失效时尽早阻止发布。
+
+## ADDED Requirements
+
+### Requirement: Release 使用可用且固定的 Trivy 扫描动作
+
+Release workflow MUST 使用已验证存在、且其依赖引用可解析的固定 Trivy Action 版本；漏洞扫描和 SBOM 生成 MUST 继续对每个生产镜像执行。
+
+#### Scenario: 发布流水线准备扫描
+
+- **WHEN** GitHub Release 触发镜像发布流水线
+- **THEN** Trivy Action 的引用能够被 GitHub Actions 解析
+- **AND** 流水线对每个候选生产镜像执行漏洞扫描
+- **AND** 流水线为每个候选生产镜像生成 SBOM
+
+#### Scenario: 高危漏洞扫描失败
+
+- **WHEN** Trivy 扫描发现未忽略的 HIGH 或 CRITICAL 漏洞
+- **THEN** 对应镜像的发布门禁失败
+- **AND** 该镜像不得进入正式发布阶段
+
+### Requirement: 发布配置回归检查
+
+供应链静态检查 MUST 校验 Release workflow 使用已验证的 Trivy Action 引用，防止已知不可解析的版本回归。
+
+#### Scenario: 已知有效的 Trivy 引用
+
+- **WHEN** 静态供应链检查运行在当前 Release workflow 上
+- **THEN** 检查确认 Trivy Action 引用符合已验证版本约束并通过
+
+#### Scenario: 回归到失效引用
+
+- **WHEN** Release workflow 恢复使用已知会引用不存在依赖的 Trivy Action 版本
+- **THEN** 静态供应链检查返回非零退出码
+- **AND** CI 在合并前报告供应链配置错误

--- a/openspec/changes/fix-release-trivy-action/tasks.md
+++ b/openspec/changes/fix-release-trivy-action/tasks.md
@@ -1,0 +1,11 @@
+## 1. Release workflow
+
+- [x] 1.1 将 `.github/workflows/release.yml` 中漏洞扫描和 SBOM 步骤更新到已验证可用的固定 Trivy Action 版本，并确认现有扫描输入保持不变
+
+## 2. 供应链回归检查
+
+- [x] 2.1 在 `scripts/release/check-supply-chain.sh` 增加 Trivy Action 版本约束，并在 `scripts/release/test-supply-chain.sh` 增加有效/失效引用测试
+
+## 3. 验证
+
+- [x] 3.1 运行 Shell 语法、供应链正负向测试、OpenSpec 严格校验和 workflow/actionlint 检查，并记录结果

--- a/scripts/release/check-supply-chain.sh
+++ b/scripts/release/check-supply-chain.sh
@@ -67,6 +67,14 @@ check_release_workflow() {
   grep -q 'provenance: mode=max' "$file" || fail "Release workflow 未启用 provenance"
   grep -q 'sbom: true' "$file" || fail "Release workflow 未启用 BuildKit SBOM"
   grep -q 'trivy' "$file" || fail "Release workflow 未配置漏洞扫描"
+  local trivy_refs
+  trivy_refs="$(grep -E '^[[:space:]]*uses:[[:space:]]+aquasecurity/trivy-action@' "$file" || true)"
+  [[ "$(printf '%s\n' "$trivy_refs" | sed '/^$/d' | wc -l | tr -d ' ')" == "2" ]] \
+    || fail "Release workflow 必须配置两个 Trivy 步骤"
+  while IFS= read -r line; do
+    [[ "$line" == *'aquasecurity/trivy-action@v0.36.0'* ]] \
+      || fail "Release workflow 使用了未经验证的 Trivy Action 版本：$line"
+  done <<< "$trivy_refs"
   grep -q 'cosign' "$file" || fail "Release workflow 未配置镜像签名"
   if grep -Eq ':[[:space:]]*(latest|beta)(["'"'"'[:space:]]|$)' "$file"; then
     fail "Release workflow 仍发布 latest/beta 可变标签"

--- a/scripts/release/test-supply-chain.sh
+++ b/scripts/release/test-supply-chain.sh
@@ -24,6 +24,14 @@ NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" >/de
   fail "合法供应链配置检查失败"
 pass "合法供应链配置"
 
+sed -i.bak 's#aquasecurity/trivy-action@v0.36.0#aquasecurity/trivy-action@v0.28.0#g' \
+  "$TEST_ROOT/.github/workflows/release.yml"
+if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \
+  >/dev/null 2>&1; then
+  fail "已知失效的 Trivy Action 引用未被拒绝"
+fi
+pass "失效 Trivy Action 引用拒绝"
+
 sed -i.bak 's#FROM debian:bookworm-slim@sha256:[0-9a-f]*#FROM debian:bookworm-slim#' \
   "$TEST_ROOT/noj-core/Dockerfile"
 if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \


### PR DESCRIPTION
## 变更说明

- 将 Release workflow 的 Trivy Action 从会引用不存在依赖的 v0.28.0 更新到已验证可用的 v0.36.0
- 保留漏洞扫描、高危漏洞门禁和 SBOM 生成
- 增加供应链静态检查，阻止已知失效版本回归

## 验证

- bash -n scripts/release/*.sh
- bash scripts/release/test-supply-chain.sh
- openspec validate fix-release-trivy-action --strict
- actionlint v1.7.12

修复 0.8.0-rc.2 发布流水线在 Trivy 初始化阶段失败的问题。