### PR TITLE
fix(images): 更新基础镜像安全补丁

### DIFF
--- a/noj-judge/docker/evaluator-python/Dockerfile
+++ b/noj-judge/docker/evaluator-python/Dockerfile
@@ -18,6 +18,11 @@ LABEL com.noj.judge.kind="evaluator"
 # COPY 时跳过外层 noj_evaluator_sdk/，让其内容直接落在 site-packages/noj_evaluator_sdk/
 COPY sdk/evaluator/noj_evaluator_sdk/ /usr/local/lib/python3.12/site-packages/noj_evaluator_sdk/
 
+# 在固定 digest 的基础镜像上安装 Debian 安全更新。
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
 # 验证 SDK 可导入（构建期 sanity check）
 RUN python3 -c "import noj_evaluator_sdk; from noj_evaluator_sdk.runner import SolutionRunner; from noj_evaluator_sdk.result import Result; print('noj_evaluator_sdk OK')"
 

--- a/noj-judge/docker/solution-python/Dockerfile
+++ b/noj-judge/docker/solution-python/Dockerfile
@@ -17,6 +17,11 @@ LABEL com.noj.judge.kind="solution"
 # 跳过外层 noj_solution_sdk/，让其内容直接落在 site-packages/noj_solution_sdk/
 COPY sdk/solution/noj_solution_sdk/ /usr/local/lib/python3.12/site-packages/noj_solution_sdk/
 
+# 在固定 digest 的基础镜像上安装 Debian 安全更新。
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
 # 验证 SDK 可导入（构建期 sanity check）
 RUN python3 -c "import noj_solution_sdk; from noj_solution_sdk.host import main; from noj_solution_sdk.registry import register; print('noj_solution_sdk OK')"
 

--- a/noj-llm-gateway/Dockerfile
+++ b/noj-llm-gateway/Dockerfile
@@ -6,6 +6,9 @@ COPY deno.json .
 COPY deno.lock .
 COPY src/ ./src/
 
+# 在固定 digest 的基础镜像上安装 Alpine 安全更新。
+RUN apk upgrade --no-cache
+
 # 构建期缓存依赖，保证可复现；运行时仍以 lock 为准
 RUN deno cache --lock=deno.lock src/main.ts
 

--- a/openspec/changes/fix-base-image-security-updates/.openspec.yaml
+++ b/openspec/changes/fix-base-image-security-updates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/fix-base-image-security-updates/design.md
+++ b/openspec/changes/fix-base-image-security-updates/design.md
@@ -1,0 +1,37 @@
+## Context
+
+`0.8.0-rc.3` 使用的 Trivy v0.70.0 已正常解析并扫描镜像。失败结果显示 Python 镜像中的 Debian OpenSSL 为 `3.5.6-1~deb13u2`，修复版本为 `3.5.7-1~deb13u2`；LLM Gateway 中 Alpine OpenSSL 为 `3.5.7-r0`，修复版本为 `3.5.8-r0`。基础镜像本身仍需通过 digest 固定以保持供应链可追溯。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 在构建时更新受影响基础系统包，使已知 OpenSSL 修复进入生产镜像。
+- 让静态供应链检查能阻止安全更新步骤被删除。
+- 保持现有容器用户、启动命令和基础镜像 digest 约束。
+
+**Non-Goals:**
+
+- 不降低 Trivy 的 HIGH/CRITICAL 失败门禁。
+- 不通过忽略 CVE、修改严重性或允许扫描失败来解决问题。
+- 不升级应用依赖、语言运行时或 Docker Compose 基础设施镜像；若这些组件有独立漏洞，应单独处理。
+
+## Decisions
+
+- Python Dockerfile 在切换到非 root 用户前执行 `apt-get update`、`apt-get upgrade` 和清理 apt 列表。这样可在保留固定 Python 基础镜像 digest 的同时获取 Debian 安全仓库中的修复包。
+- Alpine Dockerfile 执行 `apk upgrade --no-cache`。该方式直接使用基础镜像声明的 Alpine 仓库更新系统包，并不改变 Deno 版本或基础镜像 digest。
+- 在现有 `scripts/release/check-supply-chain.sh` 中增加针对三份 Dockerfile 的文本检查，并在 `scripts/release/test-supply-chain.sh` 中模拟删除步骤的负向测试。相比构建完整镜像，静态检查更快，适合作为 PR 早期门禁；实际 CVE 是否清除仍由 Release Trivy 扫描确认。
+- 不把安全更新改成动态基础镜像 tag。动态 tag 会削弱现有 digest 可复现性，而构建阶段的包更新已能覆盖当前已确认的安全修复。
+
+## Risks / Trade-offs
+
+- [安全仓库内容会随时间变化，构建结果不完全字节可复现] → 继续固定基础镜像 digest，并让 Release workflow 生成 SBOM；后续可在单独变更中引入快照仓库。
+- [构建需要访问 Debian/Alpine 包仓库] → 构建失败时让发布门禁直接失败，不发布未更新镜像。
+- [未来基础镜像可能已包含更新，额外升级仍增加构建时间] → 保留安全更新步骤，确保基础镜像重建和新漏洞出现时都能获得补丁。
+
+## Migration Plan
+
+1. 修改三份受影响 Dockerfile 和供应链检查。
+2. 在本地运行 Shell、供应链、Dockerfile digest 和 OpenSpec 校验；条件允许时构建受影响镜像并运行 Trivy。
+3. 通过 PR 合并后重新创建下一个 RC，确认所有镜像完成漏洞扫描、SBOM、签名和发布验证。
+4. 如果更新步骤造成兼容性问题，回滚该 PR；回滚会重新暴露当前已知漏洞，因此不能作为最终发布方案。

--- a/openspec/changes/fix-base-image-security-updates/proposal.md
+++ b/openspec/changes/fix-base-image-security-updates/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`0.8.0-rc.3` 的发布流水线已经能够正常执行 Trivy，但三个候选镜像因 OpenSSL 的高危漏洞 CVE-2026-14456 被门禁拦截，且扫描结果显示均已有修复版本。若直接跳过扫描，发布镜像会带着已知可修复漏洞进入用户部署环境。
+
+## What Changes
+
+- 在 Python 评测镜像构建过程中安装基础 Debian 系统的最新安全更新。
+- 在 LLM Gateway 镜像构建过程中安装基础 Alpine 系统的最新安全更新。
+- 保持基础镜像 digest 固定、非 root 运行和现有镜像构建流程不变。
+- 增加回归检查，确保受影响镜像包含基础系统安全更新步骤。
+
+## Capabilities
+
+### New Capabilities
+
+- `base-image-security-updates`: 生产镜像构建必须应用基础系统的安全更新，以便通过高危漏洞发布门禁。
+
+### Modified Capabilities
+
+<!-- 不修改现有用户功能；这是镜像构建安全能力的新增约束。 -->
+
+## Impact
+
+- 修改 `noj-judge/docker/evaluator-python/Dockerfile`、`noj-judge/docker/solution-python/Dockerfile` 和 `noj-llm-gateway/Dockerfile`。
+- 修改供应链检查脚本和测试。
+- 构建时间会略有增加；不改变应用运行时 API、部署配置或 Redis/PostgreSQL 数据。

--- a/openspec/changes/fix-base-image-security-updates/specs/base-image-security-updates/spec.md
+++ b/openspec/changes/fix-base-image-security-updates/specs/base-image-security-updates/spec.md
@@ -1,0 +1,44 @@
+## Purpose
+
+确保生产镜像在固定基础镜像之上应用可用的操作系统安全更新，避免已知且有修复版本的高危漏洞阻止发布或进入用户环境。
+
+## ADDED Requirements
+
+### Requirement: 生产运行时镜像应用基础系统安全更新
+
+受供应链扫描的生产运行时镜像 MUST 在构建阶段应用基础操作系统的可用安全更新，同时 MUST 保留固定基础镜像 digest 和现有运行时行为。
+
+#### Scenario: Debian 评测镜像构建
+
+- **WHEN** 构建 evaluator 或 solution Python 生产镜像
+- **THEN** 镜像构建应用 Debian 基础系统的安全更新
+- **AND** 镜像继续使用固定 digest 的 Python 基础镜像
+- **AND** 镜像继续以非 root 用户运行
+
+#### Scenario: Alpine 网关镜像构建
+
+- **WHEN** 构建 LLM Gateway 生产镜像
+- **THEN** 镜像构建应用 Alpine 基础系统的安全更新
+- **AND** 镜像继续使用固定 digest 的 Deno 基础镜像
+- **AND** 镜像继续使用现有 Deno 启动命令
+
+#### Scenario: 安全扫描验证
+
+- **WHEN** Release workflow 对更新后的候选镜像执行 HIGH/CRITICAL 漏洞扫描
+- **THEN** 已有修复版本的基础系统漏洞不再以当前安装版本出现在扫描结果中
+- **AND** 扫描门禁仍对其它未忽略的 HIGH/CRITICAL 漏洞失败
+
+### Requirement: 安全更新配置回归检查
+
+供应链静态检查 MUST 验证受影响的生产 Dockerfile 包含基础系统安全更新步骤，并继续拒绝未固定 digest 的基础镜像。
+
+#### Scenario: 安全更新步骤存在
+
+- **WHEN** 供应链静态检查运行在当前生产 Dockerfile 上
+- **THEN** 检查确认 Debian 和 Alpine 受影响镜像包含安全更新步骤并通过
+
+#### Scenario: 安全更新步骤缺失
+
+- **WHEN** 任一受影响生产 Dockerfile 删除安全更新步骤
+- **THEN** 供应链静态检查返回非零退出码
+- **AND** CI 在合并前报告镜像安全配置错误

--- a/openspec/changes/fix-base-image-security-updates/tasks.md
+++ b/openspec/changes/fix-base-image-security-updates/tasks.md
@@ -1,0 +1,12 @@
+## 1. 镜像安全更新
+
+- [x] 1.1 在 Python evaluator/solution Dockerfile 中加入 Debian 安全包更新并保留固定 digest、非 root 用户，使用 Dockerfile 检查确认
+- [x] 1.2 在 LLM Gateway Dockerfile 中加入 Alpine 安全包更新并保留现有 Deno 启动方式，使用 Dockerfile 检查确认
+
+## 2. 供应链回归检查
+
+- [x] 2.1 扩展供应链检查和测试，验证三份受影响 Dockerfile 必须有安全更新步骤，并验证删除步骤会失败
+
+## 3. 验证
+
+- [x] 3.1 运行 Shell 语法、供应链正负向测试、OpenSpec 严格校验和受影响镜像构建/Trivy 扫描；若本地镜像仓库不可用，记录并依赖 Release workflow 验证

--- a/scripts/release/check-supply-chain.sh
+++ b/scripts/release/check-supply-chain.sh
@@ -44,6 +44,22 @@ check_dockerfiles() {
   ok "生产 Dockerfile 基础镜像均固定 digest"
 }
 
+check_base_image_security_updates() {
+  local file
+  for file in noj-judge/docker/evaluator-python/Dockerfile noj-judge/docker/solution-python/Dockerfile; do
+    require_file "$file"
+    grep -q 'apt-get update' "$ROOT_DIR/$file" \
+      || fail "$file 未更新 Debian 软件包索引"
+    grep -q 'apt-get upgrade' "$ROOT_DIR/$file" \
+      || fail "$file 未安装 Debian 安全更新"
+  done
+
+  require_file "noj-llm-gateway/Dockerfile"
+  grep -q 'apk upgrade --no-cache' "$ROOT_DIR/noj-llm-gateway/Dockerfile" \
+    || fail "noj-llm-gateway/Dockerfile 未安装 Alpine 安全更新"
+  ok "受影响生产 Dockerfile 均包含基础系统安全更新"
+}
+
 check_compose() {
   local file="$ROOT_DIR/docker-compose.prod.yml"
   require_file "docker-compose.prod.yml"
@@ -84,5 +100,6 @@ check_release_workflow() {
 
 check_release_workflow
 check_dockerfiles
+check_base_image_security_updates
 check_compose
 ok "供应链配置检查通过"

--- a/scripts/release/test-supply-chain.sh
+++ b/scripts/release/test-supply-chain.sh
@@ -24,6 +24,14 @@ NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" >/de
   fail "合法供应链配置检查失败"
 pass "合法供应链配置"
 
+sed -i.bak '/apt-get upgrade -y/d' \
+  "$TEST_ROOT/noj-judge/docker/evaluator-python/Dockerfile"
+if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \
+  >/dev/null 2>&1; then
+  fail "缺少 Debian 安全更新的 Dockerfile 未被拒绝"
+fi
+pass "缺少基础系统安全更新拒绝"
+
 sed -i.bak 's#aquasecurity/trivy-action@v0.36.0#aquasecurity/trivy-action@v0.28.0#g' \
   "$TEST_ROOT/.github/workflows/release.yml"
 if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \


### PR DESCRIPTION
## 变更说明

- 修复 0.8.0-rc.3 扫描发现的 OpenSSL CVE-2026-14456
- Python evaluator/solution 镜像构建时更新 Debian 安全包
- LLM Gateway 镜像构建时更新 Alpine 安全包
- 增加供应链回归检查，防止删除安全更新步骤

## 验证

- bash -n scripts/release/*.sh
- bash scripts/release/test-supply-chain.sh
- openspec validate fix-base-image-security-updates --strict
- 已尝试本地 Docker 构建；因当前 Docker Hub 请求 EOF 无法拉取基础镜像，待 Release workflow 完成实际构建与 Trivy 验证

rc.3 已确认 Trivy 动作正常，失败原因为三个候选镜像中的 OpenSSL 高危漏洞。