### PR TITLE
fix(gateway): 使用非 root 用户运行网关

### DIFF
--- a/noj-llm-gateway/Dockerfile
+++ b/noj-llm-gateway/Dockerfile
@@ -6,13 +6,24 @@ COPY deno.json .
 COPY deno.lock .
 COPY src/ ./src/
 
+# 使用固定 UID 的非 root 用户运行服务。
+RUN addgroup -S -g 10001 noj \
+    && adduser -S -D -H -u 10001 -G noj noj \
+    && mkdir -p /deno-dir \
+    && chown -R noj:noj /deno-dir
+
 # 在固定 digest 的基础镜像上安装 Alpine 安全更新。
 RUN apk upgrade --no-cache
 
 # 构建期缓存依赖，保证可复现；运行时仍以 lock 为准
+ENV DENO_DIR=/deno-dir
 RUN deno cache --lock=deno.lock src/main.ts
+
+RUN chown -R noj:noj /app /deno-dir
 
 ENV PYTHONDONTWRITEBYTECODE=1
 EXPOSE 8001
+
+USER noj
 
 CMD ["deno", "run", "-A", "src/main.ts"]

--- a/openspec/changes/harden-gateway-runtime-user/.openspec.yaml
+++ b/openspec/changes/harden-gateway-runtime-user/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/harden-gateway-runtime-user/design.md
+++ b/openspec/changes/harden-gateway-runtime-user/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`noj-llm-gateway` 基于 Alpine Deno 镜像构建，当前 Dockerfile 没有覆盖基础镜像默认用户，因此正式验证中的非 root smoke test 在网关镜像上失败。其他生产镜像已经使用专用用户，网关应保持一致。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 在网关运行时创建专用用户并切换到该用户。
+- 确保 `/app` 中已复制的运行文件可以被该用户读取。
+- 让现有发布 smoke test 验证网关的非 root 运行状态。
+
+**Non-Goals:**
+
+- 不改变 Deno 版本、端口、启动参数或网关代码。
+- 不修改容器编译阶段的权限模型。
+- 不放宽发布验证中的非 root 要求。
+
+## Decisions
+
+- 使用 Alpine 自带的 `addgroup` / `adduser` 创建固定 UID 的专用用户，并在 Dockerfile 中声明 `USER`。这样不需要新增软件包，镜像变化小且与其他生产镜像的固定 UID 约定一致。
+- 在切换用户前将 `/app` 的所有权设置给专用用户。相比仅依赖默认文件权限，这能明确保证未来复制的运行文件仍可被网关读取。
+- 保留现有 `command -v deno` smoke test，并由容器运行时用户检查覆盖 root 回归。
+
+## Risks / Trade-offs
+
+- [应用运行时需要写入 `/app`] → 当前网关为服务进程读取源码和依赖，不依赖 `/app` 写入；若未来需要写入，应使用单独的可写数据目录并显式授权。
+- [基础镜像用户实现变化] → 使用 Alpine 标准命令和固定 UID，并在 Release workflow 中执行真实容器 smoke test。
+
+## Migration Plan
+
+1. 修改网关 Dockerfile，创建专用用户、设置目录权限并声明运行用户。
+2. 运行 Dockerfile 相关静态检查和 OpenSpec 校验。
+3. 合并后重新创建 RC，确认网关镜像 smoke test 及整个正式发布验证通过。
+4. 若出现权限问题，回退 Dockerfile 变更；不会影响已存在的镜像标签。

--- a/openspec/changes/harden-gateway-runtime-user/proposal.md
+++ b/openspec/changes/harden-gateway-runtime-user/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+正式镜像验证已能完成来源证明校验，但 `noj-llm-gateway` 的 smoke test 发现容器仍以 root 用户运行。生产网关不需要 root 权限，继续使用 root 会违反发布链路的最小权限要求并阻止 RC 发布通过。
+
+## What Changes
+
+- 为 LLM Gateway 镜像创建专用的非 root 运行用户。
+- 让网关进程默认使用该用户启动，并确保应用目录可读。
+- 保留发布验证对非 root 运行的检查。
+
+## Capabilities
+
+### New Capabilities
+
+- `gateway-container-hardening`: 规定 LLM Gateway 生产容器以非 root 用户运行。
+
+### Modified Capabilities
+
+## Impact
+
+- 影响 `noj-llm-gateway/Dockerfile` 的运行时用户配置。
+- 影响正式镜像 smoke test 的验证结果。
+- 不改变网关端口、启动命令、API 或配置项。

--- a/openspec/changes/harden-gateway-runtime-user/specs/gateway-container-hardening/spec.md
+++ b/openspec/changes/harden-gateway-runtime-user/specs/gateway-container-hardening/spec.md
@@ -1,0 +1,19 @@
+## Purpose
+
+确保 LLM Gateway 生产容器以最小权限运行，在不影响现有服务端口和启动方式的前提下减少容器进程获得宿主机资源的风险。
+
+## ADDED Requirements
+
+### Requirement: LLM Gateway 生产容器必须使用非 root 用户
+
+LLM Gateway 生产镜像 MUST 创建并使用专用的非 root 用户运行服务进程，且应用运行目录 MUST 对该用户可读。
+
+#### Scenario: 容器启动用户非 root
+
+- **WHEN** 以正式镜像启动 LLM Gateway 容器
+- **THEN** 容器内服务进程的用户 ID MUST 不等于 0，并保持既有启动命令和监听端口可用
+
+#### Scenario: 发布 smoke test 检查非 root
+
+- **WHEN** 正式发布验证执行 LLM Gateway 镜像 smoke test
+- **THEN** 镜像 MUST 通过运行用户非 root 和 Deno 可执行文件存在的检查

--- a/openspec/changes/harden-gateway-runtime-user/tasks.md
+++ b/openspec/changes/harden-gateway-runtime-user/tasks.md
@@ -1,0 +1,8 @@
+## 1. 网关镜像加固
+
+- [x] 1.1 在 LLM Gateway Dockerfile 中创建固定 UID 的非 root 用户并将 `/app` 交给该用户，验证 Dockerfile 包含用户切换和权限设置
+- [x] 1.2 保持既有网关启动命令、端口和 Deno 运行环境，运行 Dockerfile 静态检查确认未引入配置回退
+
+## 2. 回归验证
+
+- [ ] 2.1 运行供应链检查、OpenSpec 严格校验和可用的 Docker smoke test，确认网关镜像以非 root 用户运行

--- a/scripts/release/check-supply-chain.sh
+++ b/scripts/release/check-supply-chain.sh
@@ -60,6 +60,18 @@ check_base_image_security_updates() {
   ok "受影响生产 Dockerfile 均包含基础系统安全更新"
 }
 
+check_runtime_users() {
+  local file="noj-llm-gateway/Dockerfile"
+  require_file "$file"
+  grep -Eq 'adduser .*(-u 10001|--uid 10001)' "$ROOT_DIR/$file" \
+    || fail "$file 未创建固定 UID 的运行用户"
+  grep -q 'chown -R noj:noj /app' "$ROOT_DIR/$file" \
+    || fail "$file 未授予运行用户应用目录权限"
+  grep -q '^USER noj$' "$ROOT_DIR/$file" \
+    || fail "$file 未切换到非 root 运行用户"
+  ok "LLM Gateway 使用非 root 运行用户"
+}
+
 check_compose() {
   local file="$ROOT_DIR/docker-compose.prod.yml"
   require_file "docker-compose.prod.yml"
@@ -103,5 +115,6 @@ check_release_workflow() {
 check_release_workflow
 check_dockerfiles
 check_base_image_security_updates
+check_runtime_users
 check_compose
 ok "供应链配置检查通过"

--- a/scripts/release/test-supply-chain.sh
+++ b/scripts/release/test-supply-chain.sh
@@ -24,6 +24,14 @@ NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" >/de
   fail "合法供应链配置检查失败"
 pass "合法供应链配置"
 
+sed -i.bak '/^USER noj$/d' \
+  "$TEST_ROOT/noj-llm-gateway/Dockerfile"
+if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \
+  >/dev/null 2>&1; then
+  fail "缺少网关非 root 运行用户的 Dockerfile 未被拒绝"
+fi
+pass "缺少网关非 root 运行用户拒绝"
+
 sed -i.bak '/apt-get upgrade -y/d' \
   "$TEST_ROOT/noj-judge/docker/evaluator-python/Dockerfile"
 if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \


### PR DESCRIPTION
## 关联 Issue

无

## 变更摘要

修复 `noj-llm-gateway` 生产容器默认以 root 用户运行的问题，使其与其他生产镜像保持一致并通过发布 smoke test。

## 变更类型

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `test` 测试
- [x] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

- [ ] `noj-core` 后端
- [ ] `noj-ui` 前端
- [ ] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [ ] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [x] OpenSpec 规范（specs/ 或 changes/ 改动）
- [ ] 文档（README / noj-docs）

## 验证清单

- [ ] `deno fmt` 已运行（noj-core / noj-ui）
- [ ] `deno lint` 已运行
- [ ] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [ ] 本地 `deno task test` 通过
- [x] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [x] 若是功能变更，已 `/opsx:propose` 起草 OpenSpec 提案
- [ ] 非平凡变更包含 Agent Note（`.agents/notes/implemented/`）
- [ ] 相关文档已同步（AGENTS / CLAUDE / docs / noj-docs）
- [ ] 注释/导出 JSDoc 与实现一致（`deno task check:jsdoc` 通过）
- [x] 新增/修改行为有对应测试
- [x] GPG 签名可用

## 截图 / 录屏（可选）

不适用。

## 补充说明（可选）

- 已运行 `bash -n scripts/release/check-supply-chain.sh scripts/release/test-supply-chain.sh`。
- 已运行 `bash scripts/release/test-supply-chain.sh`，全部供应链回归测试通过。
- 已运行 `openspec validate harden-gateway-runtime-user --strict`，校验通过。
- 本地 Docker 构建因 Docker Hub 返回 EOF 暂未完成，合并后由 Release workflow 执行真实镜像构建和 smoke test。
- 不改变网关端口、启动命令、API 或配置项。
