### PR TITLE
feat(root): 统一生产安装与 noj 运维入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,14 @@ NOJ 当前持久化数据卷约 66 MiB，生产镜像（含 Evaluator、Solution
 
 ### 一键部署
 
-生产环境推荐直接下载独立安装入口。它会下载指定 Release 到目标目录，并调用生产部署向导：
+生产环境推荐使用仓库根目录的一键安装入口 `setup.sh`。它会临时下载底层安装脚本，下载指定 Release 到目标目录，并调用生产部署向导：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/install.sh \
-  -o noj-install.sh
-bash noj-install.sh --ref <Release 标签> --dir /opt/neuro-oj
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --ref <Release 标签> --dir /opt/neuro-oj
 ```
+
+如需先检查脚本，可先下载 `setup.sh` 再执行；已经有仓库源码时，直接执行下方的 `deploy.sh` 即可。
 
 安装向导会创建并保护 `.env.prod`，生成随机密钥，检查生产配置，拉取镜像并等待服务通过健康检查。Judge 是否启动取决于安装时的选择；没有 Judge 时网站和题库仍可使用，但暂时不能进行代码评测。
 

--- a/README.md
+++ b/README.md
@@ -124,15 +124,13 @@ curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
   bash -s -- --ref <Release 标签> --dir /opt/neuro-oj
 ```
 
-如需先检查脚本，可先下载 `setup.sh` 再执行；已经有仓库源码时，直接执行下方的 `deploy.sh` 即可。
+如需先检查脚本，可先下载 `setup.sh` 再执行；安装完成后，服务启停、更新和管理统一使用
+安装目录中的 `noj` 命令。
 
 安装向导会创建并保护 `.env.prod`，生成随机密钥，检查生产配置，拉取镜像并等待服务通过健康检查。Judge 是否启动取决于安装时的选择；没有 Judge 时网站和题库仍可使用，但暂时不能进行代码评测。
 
-如果已经有仓库源码，不需要再次运行下载入口，可直接在仓库根目录执行：
-
-```bash
-bash scripts/deploy/deploy.sh install
-```
+首次生产安装统一使用 `setup.sh`；安装完成后，服务启停、更新和管理统一使用安装目录中的
+`noj` 命令，不再需要直接调用 bootstrap 或底层部署脚本。
 
 部署完成后，通过配置的域名访问：
 
@@ -144,11 +142,20 @@ bash scripts/deploy/deploy.sh install
 常用运维命令：
 
 ```bash
-bash scripts/deploy/deploy.sh status   # 查看服务状态
-bash scripts/deploy/deploy.sh logs core # 查看 core 日志
-bash scripts/deploy/deploy.sh upgrade  # 升级到 .env.prod 中的版本
-bash scripts/deploy/deploy.sh stop     # 停止服务但保留数据卷
+./noj status                    # 查看服务状态
+./noj logs core                 # 查看 core 日志
+./noj update                    # 升级到 .env.prod 中的 NOJ_VERSION
+./noj stop                      # 停止服务但保留数据卷
+./noj restart                   # 重启服务
+./noj backup                    # 创建完整生产备份
+./noj config check              # 只校验配置和镜像，不改变服务状态
 ```
+
+`./noj` 是生产运维的简化入口，内部支持 `install`，日常使用 `start`、`stop`、`restart`、`update`、
+`status`、`logs`、`backup`、`verify` 和 `config check`。`update` 使用 `.env.prod` 中已经
+配置的 `NOJ_VERSION`，不会自动切换到最新版本，也不会删除数据卷。需要传递高级参数时，
+仍可直接使用 `bash scripts/deploy/deploy.sh <命令> [选项]`。首次通过 `setup.sh` 安装成功后，
+命令会自动注册到 `/usr/local/bin/noj`；若无权限则回退到 `~/.local/bin/noj` 并更新登录 PATH。
 
 更多部署、TLS、备份和升级说明见 [`deploy/README.md`](./deploy/README.md) 和[生产部署文档](./noj-docs/docs/operators/production-deploy.md)。
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -31,21 +31,31 @@ server {
 }
 ```
 
-## 生产部署脚本
+## 首次安装与生产运维
 
-推荐使用仓库根目录的部署入口，脚本会检查生产配置、保护环境文件、复用生产
+推荐使用仓库根目录的 `noj` 入口，脚本会检查生产配置、保护环境文件、复用生产
 Compose、等待健康检查，并且不会删除数据卷：
 
 ```bash
-# 首次执行：创建 .env.prod 和随机密钥；填写提示的人工配置后再次执行
-bash scripts/deploy/deploy.sh install
+# 首次安装：仅使用仓库根目录的 setup.sh
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --dir /opt/neuro-oj
 
 # 日常运维
-bash scripts/deploy/deploy.sh status
-bash scripts/deploy/deploy.sh logs core
-bash scripts/deploy/deploy.sh backup
-bash scripts/deploy/deploy.sh upgrade
+./noj status
+./noj logs core
+./noj backup
+./noj update
+./noj restart
+./noj config check
 ```
+
+`update` 会按 `.env.prod` 中的 `NOJ_VERSION` 先同步部署文件和 `noj` 命令，再创建并校验完整备份、
+拉取镜像并等待 Compose 健康检查。`stop`、`restart` 和 `update` 都不会删除数据卷。`noj` 支持的部署选项
+会继续传递给底层脚本；需要高级命令或完整参数时仍可执行
+`bash scripts/deploy/deploy.sh <命令> [选项]`。首次安装成功后会优先创建
+`/usr/local/bin/noj` 软链接；没有权限时使用 `~/.local/bin/noj` 并更新登录 PATH，已有同名
+命令不会被覆盖。
 
 镜像拉取由 Docker daemon 负责。若官方源访问不稳定，请在 Docker daemon 配置
 registry mirror 或 HTTP(S) proxy 后重试；评测镜像仍可通过 `JUDGE_IMAGE_BASE`

--- a/noj
+++ b/noj
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# Neuro OJ 生产运维命令入口。
+#
+# 该入口只负责命令路由；配置校验、备份、健康检查和 Docker Compose
+# 生命周期逻辑统一由 scripts/deploy/deploy.sh 实现。
+
+set -Eeuo pipefail
+
+SOURCE_FILE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE_FILE" ]]; do
+  SOURCE_DIR="$(cd -P "$(dirname "$SOURCE_FILE")" && pwd)"
+  SOURCE_FILE="$(readlink "$SOURCE_FILE")"
+  [[ "$SOURCE_FILE" == /* ]] || SOURCE_FILE="$SOURCE_DIR/$SOURCE_FILE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE_FILE")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/scripts/deploy/deploy.sh"
+
+usage() {
+  cat <<'EOF'
+Neuro OJ 生产运维命令
+
+用法：
+  noj <命令> [选项]
+
+常用命令：
+  install                 首次初始化配置并部署
+  start                   启动生产服务
+  stop                    停止服务（保留数据卷）
+  restart                 重启服务（先停止，再启动）
+  update                  按 .env.prod 中的 NOJ_VERSION 升级
+  status                  查看服务状态
+  logs [service]          查看服务日志（支持 --follow）
+  backup                  创建完整生产备份
+  verify                  校验生产镜像和配置
+  config check            只检查生产配置，不改变服务状态
+
+示例：
+  ./noj install
+  ./noj update
+  ./noj status
+  ./noj logs core --follow
+  ./noj backup --passphrase-file /etc/noj/backup-passphrase
+  ./noj config check
+
+说明：
+  update 会先同步对应版本的部署文件和 noj 命令，再执行带备份的服务升级；版本来自 .env.prod。
+  update 不会自动切换到最新版本。
+  install 成功后会自动注册 PATH 命令；优先使用 /usr/local/bin，权限不足时使用 ~/.local/bin。
+  deploy.sh 仍可用于高级选项；noj 会把支持的选项原样传递给它。
+  生产配置默认是 .env.prod，Compose 文件默认是 docker-compose.prod.yml。
+EOF
+}
+
+fail() {
+  printf '✗ %s\n' "$*" >&2
+  exit 2
+}
+
+ok() { printf '✓ %s\n' "$*"; }
+warn() { printf '! %s\n' "$*" >&2; }
+
+link_command() {
+  local bin_dir="$1" command_path="$1/noj" target="$SCRIPT_DIR/noj" existing
+  if [[ -L "$command_path" ]]; then
+    existing="$(readlink "$command_path" 2>/dev/null || true)"
+    [[ "$existing" == "$target" ]] && return 0
+    return 2
+  fi
+  [[ ! -e "$command_path" ]] || return 2
+  mkdir -p "$bin_dir" 2>/dev/null || return 1
+  ln -s "$target" "$command_path" 2>/dev/null || return 1
+}
+
+add_user_path() {
+  local user_home="${HOME:-}" profile path_line
+  [[ -n "$user_home" ]] || return 1
+  profile="$user_home/.profile"
+  path_line='export PATH="$HOME/.local/bin:$PATH"'
+  touch "$profile" 2>/dev/null || return 1
+  if ! grep -Fqx -- "$path_line" "$profile" 2>/dev/null; then
+    printf '\n# Neuro OJ command\n%s\n' "$path_line" >>"$profile" || return 1
+  fi
+}
+
+register_command() {
+  local global_bin="${NOJ_BIN_DIR:-/usr/local/bin}" user_bin user_home link_status
+  if link_command "$global_bin"; then
+    ok "已注册全局命令：$global_bin/noj"
+    return 0
+  else
+    link_status=$?
+    if ((link_status == 2)); then
+      warn "未覆盖已有命令：$global_bin/noj"
+      return 0
+    fi
+  fi
+
+  user_home="${HOME:-}"
+  user_bin="$user_home/.local/bin"
+  if [[ -n "$user_home" ]] && link_command "$user_bin"; then
+    if add_user_path; then
+      ok "已注册用户命令：$user_bin/noj；重新登录后可直接执行 noj"
+    else
+      warn "已创建用户命令：$user_bin/noj，但无法自动更新 PATH，请手动将其加入 PATH"
+    fi
+    return 0
+  else
+    link_status=$?
+    if ((link_status == 2)); then
+      warn "未覆盖已有命令：$user_bin/noj"
+      return 0
+    fi
+  fi
+  warn "无法注册 noj 到 PATH；部署已完成，请手动将 $SCRIPT_DIR/noj 加入 PATH"
+}
+
+require_deploy_script() {
+  [[ -f "$DEPLOY_SCRIPT" ]] ||
+    fail "未找到生产部署脚本：${DEPLOY_SCRIPT}；请在 NOJ 安装目录中执行 noj"
+  [[ -r "$DEPLOY_SCRIPT" ]] || fail "生产部署脚本不可读：$DEPLOY_SCRIPT"
+}
+
+run_deploy() {
+  require_deploy_script
+  bash "$DEPLOY_SCRIPT" "$@"
+}
+
+configured_version() {
+  local env_file="$SCRIPT_DIR/.env.prod" version
+  [[ -f "$env_file" ]] || fail "未找到生产配置：$env_file"
+  version="$(awk '
+    index($0, "NOJ_VERSION=") == 1 { print substr($0, 13); exit }
+  ' "$env_file")"
+  case "$version" in
+    "\""*"\""|"'"*"'") version="${version:1:${#version}-2}" ;;
+  esac
+  [[ -n "$version" ]] || fail "生产配置缺少 NOJ_VERSION：$env_file"
+  printf '%s\n' "$version"
+}
+
+update() {
+  local version sync_dry_run=0
+  local -a sync_args
+  require_deploy_script
+  version="$(configured_version)"
+  [[ -f "$SCRIPT_DIR/scripts/deploy/install.sh" ]] ||
+    fail "未找到部署文件更新脚本：$SCRIPT_DIR/scripts/deploy/install.sh"
+
+  printf '同步生产部署文件：%s\n' "$version"
+  for arg in "$@"; do
+    [[ "$arg" == "--dry-run" ]] && sync_dry_run=1
+  done
+  sync_args=(--ref "$version" --dir "$SCRIPT_DIR" --files-only)
+  ((sync_dry_run)) && sync_args+=(--dry-run)
+  NOJ_BOOTSTRAP_BIN_DIR="${NOJ_BIN_DIR:-/usr/local/bin}" \
+    bash "$SCRIPT_DIR/scripts/deploy/install.sh" "${sync_args[@]}"
+  run_deploy upgrade "$@"
+}
+
+restart() {
+  require_deploy_script
+  bash "$DEPLOY_SCRIPT" stop "$@"
+  bash "$DEPLOY_SCRIPT" start "$@"
+}
+
+main() {
+  local command="${1:-}"
+  if [[ -z "$command" || "$command" == "-h" || "$command" == "--help" || "$command" == "help" ]]; then
+    usage
+    [[ -n "$command" ]] || return 2
+    return 0
+  fi
+  shift
+
+  case "$command" in
+    install|start|stop|status|logs|backup|verify)
+      run_deploy "$command" "$@"
+      [[ "$command" != install ]] || register_command
+      ;;
+    update)
+      update "$@"
+      ;;
+    restart)
+      restart "$@"
+      ;;
+    config)
+      [[ "${1:-}" == "check" ]] || {
+        usage >&2
+        fail "config 目前只支持 check"
+      }
+      shift
+      run_deploy verify "$@"
+      ;;
+    register-command)
+      [[ "${NOJ_INTERNAL_REGISTER:-0}" == 1 ]] || fail "不支持直接调用内部命令"
+      register_command
+      ;;
+    *)
+      usage >&2
+      fail "未知命令：$command"
+      ;;
+  esac
+}
+
+main "$@"

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -11,13 +11,16 @@
 
 ```bash
 # 自动检测（默认）
-bash noj-install.sh --panel auto --ref 0.8.0-rc.1 --dir /opt/neuro-oj
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --panel auto --ref 0.8.0-rc.1 --dir /opt/neuro-oj
 
 # 面板安装路径特殊时，强制显示宝塔兼容提示
-bash noj-install.sh --panel baota --ref 0.8.0-rc.1 --dir /opt/neuro-oj
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --panel baota --ref 0.8.0-rc.1 --dir /opt/neuro-oj
 
 # 关闭面板提示
-bash noj-install.sh --panel none --ref 0.8.0-rc.1 --dir /opt/neuro-oj
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --panel none --ref 0.8.0-rc.1 --dir /opt/neuro-oj
 ```
 
 宝塔兼容模式只复用面板安装的标准 Docker/Compose，不调用面板 API，也不会修改已有
@@ -57,15 +60,8 @@ curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
 如果服务器不能访问 GitHub API，自动获取最新版本会停止安装；请使用上面的 `--ref`
 显式指定版本，或先下载脚本检查后执行。
 
-```bash
-# 只下载一个 bootstrap 脚本；生产环境建议固定到 Release tag
-curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/install.sh \
-  -o noj-install.sh
-chmod +x noj-install.sh
-
-# 下载指定版本源码并调用生产部署入口
-bash noj-install.sh --ref 0.8.0-rc.1 --dir /opt/neuro-oj
-```
+如需人工检查下载内容，可以先下载并检查 `setup.sh`，确认后再执行；
+`scripts/deploy/install.sh` 是 setup.sh 的内部 bootstrap 和旧版本兼容入口，不再作为新安装推荐命令。
 
 首次执行会将源码放入 `/opt/neuro-oj`，随后创建权限为 `600` 的 `.env.prod` 并生成
 部分随机密钥，然后在终端逐项引导填写生产配置。配置网站地址、HTTPS 和邮件服务后，
@@ -91,29 +87,30 @@ bash noj-install.sh --ref 0.8.0-rc.1 --dir /opt/neuro-oj
 ```bash
 sudo vim /opt/neuro-oj/.env.prod
 sudo chmod 600 /opt/neuro-oj/.env.prod
-sudo bash /opt/neuro-oj/scripts/deploy/deploy.sh install
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  sudo bash -s -- --ref 0.8.0-rc.1 --dir /opt/neuro-oj
 ```
 
 bootstrap 默认自动选择最新 Release，可通过 `--ref` 指定其他分支或 Release tag；生产环境应
 使用不可变 Release tag，并让 `--ref` 与 `.env.prod` 中的 `NOJ_VERSION` 保持一致。
 也可以使用 `--download-only` 只获取源码，或使用 `--dry-run` 查看下载计划。目标目录
-非空时 bootstrap 会拒绝覆盖已有 `.env.prod`、备份和部署文件；已有安装请直接执行
-`/opt/neuro-oj/scripts/deploy/deploy.sh upgrade`。
+非空时 bootstrap 会拒绝覆盖已有 `.env.prod`、备份和部署文件；已有安装请进入目录执行
+`/opt/neuro-oj/noj update`。
 
 如果不希望在 shell 中直接执行网络下载内容，可以先保存脚本并人工检查；确认后再运行
-上面的 `sudo bash noj-install.sh ...`。bootstrap 只依赖 Linux 上常见的 Bash、`curl`
+上面的 `setup.sh` 命令。bootstrap 只依赖 Linux 上常见的 Bash、`curl`
 或 `wget`、`tar`，实际服务部署仍需要 Docker Engine 与 Docker Compose v2。
 
 部署前可以先检测宿主机：
 
 ```bash
-bash noj-install.sh check
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | bash -s -- check
 ```
 
 如果缺少基础工具，可让脚本通过当前发行版的包管理器安装：
 
 ```bash
-sudo bash noj-install.sh install-env
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | sudo bash -s -- install-env
 ```
 
 `install-env` 只安装 CA 证书、curl、tar 和 openssl 等基础工具；Docker Engine、Docker
@@ -129,7 +126,8 @@ Linux/CPU 架构、基础工具、Docker/Compose、内存、目标目录磁盘�
 准备完整的 `.env.prod`，否则脚本以非零状态退出：
 
 ```bash
-bash noj-install.sh --non-interactive --ref 0.8.0-rc.1 --dir /opt/neuro-oj
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --non-interactive --ref 0.8.0-rc.1 --dir /opt/neuro-oj
 ```
 
 `.env.prod` 中必须填写：
@@ -189,10 +187,10 @@ docker compose --env-file .env.prod -f docker-compose.prod.yml ps
 curl https://你的域名/healthz
 ```
 
-使用部署脚本时，上述初始化、启动和健康检查由以下命令统一完成：
+使用安装入口时，上述初始化、启动和健康检查由以下命令统一完成：
 
 ```bash
-bash scripts/deploy/deploy.sh install
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | bash
 ```
 
 部署脚本在 `install`、`start` 和 `upgrade` 前会校验 `NOJ_VERSION` 对应的应用镜像
@@ -304,13 +302,35 @@ bash scripts/staging/acceptance.sh all \
 
 ## 5. 日常运维
 
-推荐使用部署脚本：
+安装完成后，推荐使用安装目录根部的 `noj` 命令统一管理生产服务：
 
 ```bash
-bash scripts/deploy/deploy.sh status
-bash scripts/deploy/deploy.sh logs core
-bash scripts/deploy/deploy.sh logs judge --follow
-bash scripts/deploy/deploy.sh backup --passphrase-file /etc/noj/backup-passphrase
+cd /opt/neuro-oj
+./noj status
+./noj logs core
+./noj restart
+./noj backup
+./noj config check
+```
+
+更新版本前先修改 `.env.prod` 中的 `NOJ_VERSION`，然后执行：
+
+```bash
+./noj update
+```
+
+`update` 会先同步目标 Release 的部署文件和 `noj` 命令，再沿用生产部署脚本的备份、镜像校验和健康检查流程，不会自动选择最新版本，
+也不会删除 Docker 数据卷。`noj` 只是统一命令入口；需要高级选项时仍可使用
+`bash scripts/deploy/deploy.sh <命令> [选项]`。首次部署仅使用 `setup.sh`，成功后会自动
+将命令注册到 `/usr/local/bin/noj`；没有权限时回退到 `~/.local/bin/noj` 并更新登录 PATH。
+
+推荐使用 `noj` 入口：
+
+```bash
+./noj status
+./noj logs core
+./noj logs judge --follow
+./noj backup --passphrase-file /etc/noj/backup-passphrase
 ```
 
 `backup` 会创建包含 PostgreSQL、Redis RDB、MinIO/S3 对象镜像和 GPG 加密
@@ -343,7 +363,7 @@ docker compose --env-file .env.prod -f docker-compose.prod.yml exec redis \
 3. 升级前创建备份并拉取新镜像：
 
 ```bash
-bash scripts/deploy/deploy.sh upgrade
+./noj update
 ```
 
 部署脚本会先校验镜像签名，再创建并校验生产备份，然后拉取镜像并等待 Compose 健康检查。

--- a/openspec/changes/add-noj-cli/.openspec.yaml
+++ b/openspec/changes/add-noj-cli/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/add-noj-cli/design.md
+++ b/openspec/changes/add-noj-cli/design.md
@@ -1,0 +1,73 @@
+## Context
+
+当前生产运维逻辑集中在 `scripts/deploy/deploy.sh`，已经包含配置校验、安装、启动、升级、停止、状态、日志、备份和镜像验证。`setup.sh` 负责远程获取安装脚本，生产安装目录本身还没有统一的短命令入口。详见 proposal.md - Why。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 在生产安装目录提供可执行的根目录 `noj` 命令。
+- 让 `noj start`、`noj stop`、`noj update` 和管理命令复用现有生产脚本的安全逻辑。
+- 提供 `restart` 和 `config check` 两个便捷操作，并正确传播失败退出码。
+- 更新已有安装时同步安装入口脚本，但保留 `.env.prod`、备份目录和 Docker 数据卷。
+- 安装完成后可直接执行 `noj`，优先使用 `/usr/local/bin/noj`，权限不足时回退到用户级 `~/.local/bin/noj` 并更新登录 PATH。
+- `setup.sh` 作为唯一推荐的首次安装入口，内部 bootstrap 完成源码获取后调用目标目录的 `noj install`；`noj update` 先刷新部署文件，再调用 `deploy.sh upgrade`。
+- 通过帮助信息和文档明确命令、参数和数据安全边界。
+
+**Non-Goals:**
+
+- 不重写现有 Compose 编排、备份实现、镜像签名验证或配置解析逻辑。
+- 不自动修改 `NOJ_VERSION` 以追踪最新版本；`noj update` 使用 `.env.prod` 中已经配置的目标版本。
+- 不让 `noj update` 自动选择最新版本；它使用 `.env.prod` 中的 `NOJ_VERSION` 下载同版本部署文件，随后执行升级。
+- 不提供全局系统包安装；仅创建指向当前生产安装目录的 `noj` 软链接，不覆盖已有同名命令。
+- 不把本地开发编排 `scripts/dev/devtool.sh` 与生产 `noj` 命令混为一体。
+
+## Decisions
+
+### 1. 使用根目录 Shell 入口并委托生产脚本
+
+新增根目录可执行文件 `noj`。它根据自身路径计算安装目录，校验 `scripts/deploy/deploy.sh` 存在后再以 `bash` 调用底层脚本。这样从任意当前目录执行绝对路径都能定位正确配置，同时不会复制生产安全逻辑。
+
+命令映射如下：
+
+| `noj` 命令 | 底层行为 |
+| --- | --- |
+| `install` | `deploy.sh install` |
+| `start` | `deploy.sh start` |
+| `stop` | `deploy.sh stop` |
+| `restart` | 先执行 `deploy.sh stop`，成功后执行 `deploy.sh start` |
+| `update` | `deploy.sh upgrade` |
+| `status` | `deploy.sh status` |
+| `logs [service] [--follow]` | `deploy.sh logs ...` |
+| `backup` | `deploy.sh backup` |
+| `verify` | `deploy.sh verify` |
+| `config check` | `deploy.sh verify`，执行无服务变更的配置与镜像检查 |
+
+`upgrade` 保留为底层兼容命令；`update` 只提供更易理解的用户入口，并在调用兼容升级流程前刷新部署文件。
+
+### 2. 只允许已定义的子命令
+
+入口脚本使用显式命令白名单。未知命令、缺失 `config` 子命令或底层脚本缺失时返回非零退出码并显示帮助，避免把任意参数误传给错误的生产操作。已定义命令之后的参数按原样传给底层脚本，以保留 `--env-file`、`--backup-dir`、`--follow` 等现有能力。
+
+### 3. 更新安装目录时同步入口文件
+
+`scripts/deploy/install.sh` 已支持识别已有安装并更新部署文件。扩展该分支，使其同时复制仓库根目录的 `noj` 并恢复可执行权限；`.env.prod`、备份目录和数据卷继续按现有逻辑保留。新安装则随源码归档自然包含该文件。
+
+### 4. 注册标准 PATH 命令
+
+安装流程成功后调用生产安装目录中的 `noj` 自注册入口。默认尝试创建
+`/usr/local/bin/noj -> <安装目录>/noj`；如果当前用户没有写权限，则回退到
+`~/.local/bin/noj`，并在 `~/.profile` 中补充该目录。已有非本项目同名文件或软链接时
+不覆盖，只给出人工处理提示。根目录 `noj` 解析自身软链接后再定位安装目录，确保通过
+`/usr/local/bin/noj` 调用时仍使用正确的生产配置。
+
+### 5. 测试采用无 Docker 的命令路由测试
+
+新增脚本测试使用临时伪造的底层部署脚本，验证路径解析、命令映射、参数透传、`restart` 顺序、`update` 别名、帮助和错误退出码。现有生产部署测试继续覆盖真实配置校验、备份、Compose 和 Docker socket 安全边界；不因新增入口而重复启动生产服务。
+
+## Risks / Trade-offs
+
+- [风险] `noj update` 依赖用户先修改 `.env.prod` 中的 `NOJ_VERSION`，用户可能以为它会自动选择最新版本。→ [缓解] 帮助和 README 明确说明目标版本来源，并保留 `--dry-run` 等底层检查能力。
+- [风险] `restart` 在停止成功、启动失败时会产生服务暂时不可用窗口。→ [缓解] 复用现有健康检查并传播启动失败；正式升级仍使用带备份的 `update`。
+- [风险] 安装目录中的 `noj` 可能因手工复制丢失执行权限。→ [缓解] 安装/更新脚本显式执行 `chmod 755`，帮助文档同时提供 `bash ./noj` 备用调用方式。
+- [风险] 底层脚本未来新增命令但入口白名单未同步。→ [缓解] 在路由测试中覆盖已支持命令，并在文档中把 `noj` 定义为稳定的常用入口，底层脚本仍可用于高级操作。

--- a/openspec/changes/add-noj-cli/proposal.md
+++ b/openspec/changes/add-noj-cli/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+当前生产运维需要直接调用较长的 `scripts/deploy/deploy.sh` 路径，并且版本更新使用 `upgrade` 命令，首次使用者不容易记忆。统一的 `noj` 命令可以降低启动、停止、更新和日常管理的操作成本，同时复用现有部署脚本已经实现的配置校验、备份、镜像签名验证和健康检查。
+
+## What Changes
+
+- 新增仓库根目录的 `noj` 命令入口，支持生产服务的常用生命周期操作。
+- 提供 `install`、`start`、`stop`、`restart`、`update`、`status`、`logs`、`backup`、`verify` 和 `config` 管理命令。
+- `update` 使用现有生产升级流程，继续执行升级前备份、镜像校验、数据库迁移和健康检查，并保留现有 `deploy.sh upgrade` 兼容入口。
+- `setup.sh` 是唯一推荐的首次安装入口；安装完成后，`noj update` 负责同步目标 Release 的部署文件、CLI 和生产镜像，再执行安全升级。
+- 命令自动定位仓库根目录，默认使用 `.env.prod` 和 `docker-compose.prod.yml`，支持将部署脚本已有的相关选项继续传递下去。
+- 安装成功后将 `noj` 注册到标准 PATH 目录；若无权限，则安装到用户级 `~/.local/bin` 并在登录配置中补充 PATH，拒绝覆盖已有同名命令。
+- 更新部署文档、命令帮助和脚本测试，明确失败时的退出码与不会删除数据卷的安全边界。
+
+## Capabilities
+
+### New Capabilities
+
+- `production-cli`: 提供统一的 `noj` 生产运维命令及其生命周期、诊断和配置管理子命令。
+
+### Modified Capabilities
+
+- `openspec/specs/production-deployment`: 将 `noj` 作为生产部署入口，并补充 `update`、`restart` 和配置检查命令的行为要求，同时保留现有脚本兼容性。
+
+## Impact
+
+- 新增根目录可执行脚本及其参数解析、路径定位和命令转发逻辑。
+- 复用并可能小幅调整 `scripts/deploy/deploy.sh` 的命令接口，不引入新的运行时依赖。
+- 更新 `README.md`、生产部署文档和脚本测试。
+- 不修改数据库 Schema，不改变 Compose 服务、数据卷或现有部署安全边界。

--- a/openspec/changes/add-noj-cli/specs/production-cli/spec.md
+++ b/openspec/changes/add-noj-cli/specs/production-cli/spec.md
@@ -1,0 +1,104 @@
+## Purpose
+
+为生产部署提供一个统一、可发现且安全的 `noj` 命令入口，让运营者可以用一致的命令完成服务生命周期、版本更新、状态诊断、日志查看、备份和配置检查。
+
+## ADDED Requirements
+
+### Requirement: 统一生产命令入口
+
+系统 SHALL 在生产安装目录提供可执行的 `noj` 命令入口，并默认使用该目录下的 `.env.prod` 与 `docker-compose.prod.yml`。命令 SHALL 从任意当前工作目录解析自身所在的安装目录，不得依赖调用者当前目录。
+
+#### Scenario: 显示帮助
+
+- **WHEN** 用户执行 `noj help` 或 `noj --help`
+- **THEN** 系统展示所有支持的子命令、常用参数和默认配置文件位置，并返回退出码 0
+
+#### Scenario: 从其他目录执行
+
+- **WHEN** 用户在生产安装目录之外执行 `/opt/neuro-oj/noj status`
+- **THEN** 系统仍使用 `/opt/neuro-oj/.env.prod` 和 `/opt/neuro-oj/docker-compose.prod.yml` 执行状态查询
+
+### Requirement: 安装后加入 PATH
+
+生产安装成功后，系统 SHALL 注册一个指向当前安装目录 `noj` 文件的命令链接，使用户
+可以直接执行 `noj <命令>`。系统 SHALL 优先使用 `/usr/local/bin/noj`；当前用户无权限时
+可以使用 `~/.local/bin/noj` 并在用户登录 PATH 配置中补充该目录。系统 SHALL 拒绝覆盖
+已有非本项目同名命令或链接。
+
+#### Scenario: 注册全局命令
+
+- **WHEN** 用户以有权限的方式完成生产安装
+- **THEN** `/usr/local/bin/noj` 指向该安装目录中的 `noj`，且通过该路径执行时仍能定位原安装目录
+
+#### Scenario: 无全局目录权限
+
+- **WHEN** 用户无法写入 `/usr/local/bin`
+- **THEN** 系统尝试创建 `~/.local/bin/noj` 并补充登录 PATH；若用户级目录也不可用，安装仍保留已完成的部署并给出手动处理提示
+
+#### Scenario: 不覆盖同名命令
+
+- **WHEN** PATH 目标位置已经存在非当前安装的文件或链接
+- **THEN** 系统不覆盖该目标，给出警告，并保留当前安装结果
+
+### Requirement: 生命周期与更新命令
+
+`noj` SHALL 提供 `install`、`start`、`stop`、`restart` 和 `update` 子命令。`update` SHALL 使用与现有生产升级入口相同的安全流程，包括升级前备份、镜像校验、必要迁移和健康检查；`stop` 和 `restart` SHALL 保留持久化数据卷。
+
+#### Scenario: 启动和停止服务
+
+- **WHEN** 用户执行 `noj start` 或 `noj stop`
+- **THEN** 系统分别启动或停止生产 Compose 服务，校验失败或 Compose 失败时返回非零退出码，并且 `stop` 不删除数据卷
+
+#### Scenario: 重启服务
+
+- **WHEN** 用户执行 `noj restart`
+- **THEN** 系统安全停止并重新启动生产服务，复用现有配置和数据卷，并在启动健康检查失败时返回非零退出码
+
+#### Scenario: 更新生产版本
+
+- **WHEN** 用户修改 `.env.prod` 中的 `NOJ_VERSION` 后执行 `noj update`
+- **THEN** 系统先按 `NOJ_VERSION` 同步部署文件和 `noj` 命令，再创建并校验备份，校验目标镜像，拉取目标版本，执行必要迁移并等待健康检查；任一阶段失败时返回非零退出码且不得宣称升级成功
+
+### Requirement: 唯一首次安装入口
+
+新用户 SHALL 使用仓库根目录的 `setup.sh` 完成首次安装；安装完成后，日常启停、升级和管理
+SHALL 使用安装目录中的 `noj`。`scripts/deploy/install.sh` 可以保留为 setup.sh 的内部
+bootstrap 和旧版本兼容入口，但不得作为新安装文档的推荐入口。
+
+#### Scenario: setup 委托 noj 初始化
+
+- **WHEN** 用户通过 `setup.sh` 完成源码下载
+- **THEN** bootstrap 将生产初始化和首次服务部署委托给目标目录的 `noj install`，并在成功后注册 PATH 命令
+
+#### Scenario: noj update 同步部署文件
+
+- **WHEN** 用户执行 `noj update`
+- **THEN** 系统按 `.env.prod` 的 `NOJ_VERSION` 更新部署脚本和 `noj` 文件，再执行原有带备份的 `deploy.sh upgrade` 流程
+
+### Requirement: 运维管理与诊断
+
+`noj` SHALL 提供 `status`、`logs`、`backup`、`verify` 和 `config check` 管理命令。管理命令 SHALL 复用现有部署安全检查，不得输出 `.env.prod` 中的 secret 明文。
+
+#### Scenario: 查看状态与日志
+
+- **WHEN** 用户执行 `noj status` 或 `noj logs [service] [--follow]`
+- **THEN** 系统展示生产 Compose 的服务状态或指定服务日志，并返回底层命令的退出码
+
+#### Scenario: 创建备份与校验镜像
+
+- **WHEN** 用户执行 `noj backup` 或 `noj verify`
+- **THEN** 系统分别创建受限权限的生产备份或校验已配置版本的生产镜像，并在失败时返回非零退出码
+
+#### Scenario: 检查配置
+
+- **WHEN** 用户执行 `noj config check`
+- **THEN** 系统检查生产配置、secret 文件权限、Compose 配置、Judge 隔离 Docker socket 和必要外部依赖，但不启动、停止、更新服务，也不修改生产配置
+
+### Requirement: 兼容与安全边界
+
+新命令 SHALL 复用既有 `scripts/deploy/deploy.sh` 的行为，保留 `deploy.sh upgrade` 等旧入口可用；新命令不得执行 `down -v`、删除生产数据卷、自动挂载应用宿主机 Docker socket 或在输出中泄露 secret。
+
+#### Scenario: 底层命令失败传播
+
+- **WHEN** 被转发的生产操作失败
+- **THEN** `noj` 返回非零退出码，并保留底层脚本的可执行错误信息

--- a/openspec/changes/add-noj-cli/specs/production-deployment/spec.md
+++ b/openspec/changes/add-noj-cli/specs/production-deployment/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: 生产生命周期命令
+
+部署入口 MUST 提供 `install`、`start`、`upgrade`、`stop`、`status`、`logs`、`restart`、`update`、`backup`、`verify` 和 `config check` 命令，并默认使用 `docker-compose.prod.yml` 与 `.env.prod`。其中 `update` 是 `upgrade` 的用户友好别名；命令失败时 MUST 返回非零退出码。仓库根目录的 `noj` 命令 SHALL 作为这些生产操作的统一入口，同时保留 `scripts/deploy/deploy.sh` 的兼容调用方式。
+
+#### Scenario: 启动生产服务
+
+- **WHEN** 用户执行 `start` 或 `noj start`
+- **THEN** 系统校验配置后启动生产 Compose 中的服务，并报告 Compose 操作结果
+
+#### Scenario: 安全停止服务
+
+- **WHEN** 用户执行 `stop` 或 `noj stop`
+- **THEN** 系统停止生产服务但保留 PostgreSQL、Redis、MinIO、题目包和 judge 缓存数据卷
+
+#### Scenario: 重启生产服务
+
+- **WHEN** 用户执行 `noj restart`
+- **THEN** 系统安全停止并重新启动生产服务，复用已有配置和数据卷，并在健康检查失败时返回非零退出码
+
+#### Scenario: 查看服务状态和日志
+
+- **WHEN** 用户执行 `status`、`logs [service]`、`noj status` 或 `noj logs [service]`
+- **THEN** 系统展示生产 Compose 的服务状态或指定服务日志，并且不输出环境文件中的 secret 值
+
+#### Scenario: 更新生产版本
+
+- **WHEN** 用户修改 `NOJ_VERSION` 后执行 `upgrade` 或 `noj update`
+- **THEN** 系统先完成生产备份和镜像校验，再拉取目标版本、执行必要迁移并等待健康检查通过后报告升级完成
+
+#### Scenario: 检查生产配置
+
+- **WHEN** 用户执行 `noj config check`
+- **THEN** 系统检查生产必填项、secret 文件权限、Compose 配置、必要的 Judge Docker socket 和外部依赖，但不启动、停止或更新服务

--- a/openspec/changes/add-noj-cli/tasks.md
+++ b/openspec/changes/add-noj-cli/tasks.md
@@ -1,0 +1,28 @@
+## 1. 统一命令入口
+
+- [x] 1.1 新增根目录可执行 `noj` 脚本，解析自身所在的生产安装目录并在底层部署脚本缺失时返回清晰错误；使用 `bash -n noj` 和 `./noj --help` 验证
+- [x] 1.2 实现 `install`、`start`、`stop`、`update`、`status`、`logs`、`backup`、`verify` 命令映射，并透传底层参数；使用伪造部署脚本测试每个命令的转发和退出码
+- [x] 1.3 实现 `restart` 和 `config check`，验证停止/启动顺序、配置检查不改变服务状态，并验证失败时返回非零退出码
+
+## 2. 安装与更新集成
+
+- [x] 2.1 扩展已有安装更新流程，使 `scripts/deploy/install.sh` 更新生产部署文件时同步复制根目录 `noj` 并恢复执行权限；使用临时安装目录测试新安装和已有安装更新均保留 `.env.prod`
+- [x] 2.2 确认旧的 `scripts/deploy/deploy.sh upgrade`、`install` 和其他既有命令保持兼容；运行现有 `scripts/deploy/test-deploy.sh` 并验证原命令行为不变
+
+## 3. 文档与测试
+
+- [x] 3.1 为 `noj` 增加无 Docker 的命令路由测试，覆盖帮助、未知命令、参数透传、`restart`、`update` 和配置检查；运行新增测试脚本并检查断言通过
+- [x] 3.2 更新 README、生产部署文档和 scripts 索引，说明 `./noj` 的常用命令、版本来源、数据卷安全边界和高级命令兼容入口；运行 Markdown 链接检查
+- [x] 3.3 执行 Shell 语法检查、OpenSpec 校验和相关部署脚本测试，确认没有 secret 输出、数据卷删除或宿主机 Docker socket 自动挂载行为
+
+## 4. PATH 注册
+
+- [x] 4.1 使 `noj install` 和 bootstrap 安装成功后自动注册标准 PATH 命令，解析软链接定位真实安装目录，拒绝覆盖同名命令
+- [x] 4.2 扩展无 Docker 测试，覆盖全局 PATH 注册、用户级 PATH 回退、重复注册和同名命令保护
+- [x] 4.3 更新帮助与生产部署文档，说明直接执行 `noj` 的生效条件及权限不足时的处理方式；完成 Shell 语法和 OpenSpec 校验
+
+## 5. 统一安装与更新入口
+
+- [x] 5.1 将 setup.sh 定义为唯一推荐首次安装入口，并让内部 bootstrap 将首次部署委托给目标目录的 `noj install`，保留旧脚本兼容
+- [x] 5.2 让 `noj update` 按 `.env.prod` 的 `NOJ_VERSION` 同步部署文件和 CLI，再执行原有带备份的生产升级流程，并支持 `--dry-run`
+- [x] 5.3 更新所有生产安装/升级文档和脚本索引，补充无 Docker 测试覆盖 setup 委托与 update 同步；完成回归测试

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,6 +3,9 @@
 Neuro OJ 仓库根目录的脚本统一存放点。所有脚本以 `bash scripts/<dir>/<name>.sh`
 方式调用。
 
+生产环境的日常运维推荐从仓库根目录执行 `./noj`；它是 `scripts/deploy/deploy.sh` 的
+安全简化入口。
+
 ## 目录结构
 
 ```
@@ -20,6 +23,8 @@ scripts/
 │   ├── install.sh          #   可独立下载的源码获取与部署 bootstrap
 │   ├── deploy.sh          #   生产安装、启动、升级、停止、备份入口
 │   ├── backup.sh          #   PostgreSQL/Redis/MinIO/S3 全量快照、校验、恢复与演练
+│   ├── test-install.sh     #   不依赖网络和 Docker 的安装更新测试
+│   ├── test-noj.sh         #   noj 命令路由测试
 │   ├── test-deploy.sh     #   不依赖真实生产资源的部署脚本测试
 │   └── test-backup.sh     #   不依赖真实 Docker 的备份与恢复安全边界测试
 │
@@ -41,25 +46,26 @@ scripts/
 
 | 我想...                                  | 使用                                                            |
 | ---------------------------------------- | --------------------------------------------------------------- |
+| **生产运维统一入口**                     | `./noj <install\|start\|stop\|restart\|update\|status\|logs\|backup\|verify>` |
+| **只检查生产配置**                       | `./noj config check`                                            |
 | **首次启动整套开发环境**                 | `bash scripts/dev/devtool.sh install-deps && bash scripts/dev/devtool.sh init-env && bash scripts/dev/devtool.sh start` |
 | **查看当前运行状态**                     | `bash scripts/dev/devtool.sh status`（加 `--json` 结构化输出）  |
 | **停止所有模块**                         | `bash scripts/dev/devtool.sh stop`                              |
 | **单模块启动**                           | `bash scripts/dev/devtool.sh start <core\|ui\|judge\|infra>`    |
 | **单模块重启**                           | `bash scripts/dev/devtool.sh stop <core\|ui\|judge> && bash scripts/dev/devtool.sh start <core\|ui\|judge>` |
 | **更新环境变量模板（保留自定义）**       | `bash scripts/dev/devtool.sh init-env --merge`                  |
-| **首次生产部署**                         | `bash scripts/deploy/deploy.sh install`                          |
 | **一条命令安装整套 NOJ**                  | `curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh \| bash` |
 | **固定版本安装**                          | `curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh \| bash -s -- --ref 0.8.0-rc.1 --dir /opt/neuro-oj` |
-| **单脚本下载并部署**                     | `bash scripts/deploy/install.sh --dir /opt/neuro-oj`             |
+| **兼容旧版本的单脚本下载部署**            | `bash scripts/deploy/install.sh --dir /opt/neuro-oj`             |
 | **宝塔兼容部署**                         | `bash scripts/deploy/install.sh --panel baota --ref v0.1.0 --dir /opt/neuro-oj` |
 | **检测 Linux 部署环境**                  | `bash scripts/deploy/install.sh check`                           |
 | **安装基础部署工具**                     | `sudo bash scripts/deploy/install.sh install-env`                |
 | **独立 Judge 一键部署**                   | `curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/judge-install.sh \| bash -s -- install --dir /srv/noj-judge` |
 | **检查独立 Judge 环境**                   | `bash /srv/noj-judge/judge-install.sh check`                      |
-| **启动/停止生产服务**                    | `bash scripts/deploy/deploy.sh start` / `stop`                   |
-| **升级生产版本**                         | `bash scripts/deploy/deploy.sh upgrade`                          |
-| **查看生产状态/日志**                    | `bash scripts/deploy/deploy.sh status` / `logs [service]`        |
-| **创建完整生产备份**                     | `bash scripts/deploy/deploy.sh backup`                          |
+| **启动/停止生产服务**                    | `./noj start` / `./noj stop`                                     |
+| **升级生产版本**                         | `./noj update`                                                   |
+| **查看生产状态/日志**                    | `./noj status` / `./noj logs [service]`                          |
+| **创建完整生产备份**                     | `./noj backup`                                                   |
 | **校验/恢复演练快照**                    | `bash scripts/deploy/backup.sh verify <snapshot>` / `drill <snapshot>` |
 | **执行 staging 验收**                    | `bash scripts/staging/acceptance.sh all --env-file .env.staging` |
 | **仅检查 staging 配置**                  | `bash scripts/staging/acceptance.sh check --env-file .env.staging` |
@@ -92,12 +98,12 @@ cd noj-judge && cargo run
 然后进入环境检测、配置向导和生产部署。需要复现或固定版本时，在命令后增加
 `--ref 0.8.0-rc.1`。安装完成后打开网站注册第一个用户，该用户会自动获得管理员权限。
 
-`scripts/deploy/install.sh` 可以从仓库中单独下载后执行。它也会自动选择最新 Release，只获取源码并调用
-下载后的 `deploy.sh`，目标目录非空时会拒绝覆盖；已有安装请直接进入目标目录执行
-`deploy.sh upgrade`。
+`setup.sh` 是唯一推荐的首次安装入口，会获取内部 bootstrap、完成源码安装并调用目标目录中的
+`noj install`。`scripts/deploy/install.sh` 仅作为 setup.sh 的内部实现和旧版本兼容入口；已有安装
+的更新、启停和管理请统一使用 `./noj update`、`./noj start`、`./noj status` 等命令。
 
-在单脚本模式下可先执行 `bash noj-install.sh check` 检查 Linux、架构、基础工具、Docker
-Compose、内存、磁盘和端口。`sudo bash noj-install.sh install-env` 只会通过系统包管理器
+兼容入口模式下可执行 `bash scripts/deploy/install.sh check` 检查 Linux、架构、基础工具、Docker
+Compose、内存、磁盘和端口。`sudo bash scripts/deploy/install.sh install-env` 只会通过系统包管理器
 安装 `ca-certificates`、`curl`、`tar` 和 `openssl`；Docker Engine、Compose plugin、Cosign
 和 Judge rootless Docker daemon 不由脚本自动安装。Cosign 只在主动开启镜像签名校验时需要。
 

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 #
-# Neuro OJ 独立下载与生产部署入口。
+# Neuro OJ 内部 bootstrap 与旧版本兼容入口。
 #
-# 此文件可以单独下载后执行，不依赖当前工作目录或本地 Git 仓库：
-#   curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/install.sh \
-#     -o noj-install.sh
-#   bash noj-install.sh --ref 0.8.0-rc.1 --dir /opt/neuro-oj
+# 新用户请使用 setup.sh；此文件保留用于旧版本兼容和 setup.sh 的内部引导，不依赖当前
+# 工作目录或本地 Git 仓库。
 #
 # Bootstrap 只负责获取源码；生产 Compose、配置校验和服务生命周期仍由
 # 下载后的 scripts/deploy/deploy.sh 负责。
@@ -26,6 +24,7 @@ PANEL_ROOT="${NOJ_BOOTSTRAP_PANEL_ROOT:-/www/server/panel}"
 PANEL_COMMAND="${NOJ_BOOTSTRAP_PANEL_COMMAND:-/usr/bin/bt}"
 COMMAND=""
 DOWNLOAD_ONLY=0
+FILES_ONLY=0
 DRY_RUN=0
 NON_INTERACTIVE=0
 TEMP_ROOT=""
@@ -52,17 +51,17 @@ usage() {
   cat <<'EOF'
 Neuro OJ Linux 独立下载部署工具
 
+新用户请使用仓库根目录的 setup.sh；本脚本作为 setup.sh 的内部 bootstrap，并保留旧版本兼容。
+
 用法：
   install.sh [check|install-env|install] [选项] [-- <deploy.sh 参数>]
 
 示例：
-  curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/install.sh \
-    -o noj-install.sh
-  bash noj-install.sh --dir /opt/neuro-oj
-  bash noj-install.sh --ref 0.8.0-rc.1 --dir /opt/neuro-oj
-  bash noj-install.sh check
-  sudo bash noj-install.sh install-env
-  bash noj-install.sh --ref 0.8.0-rc.1 --dir /opt/neuro-oj -- --dry-run
+  curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh \
+    -o noj-setup.sh
+  bash noj-setup.sh --dir /opt/neuro-oj
+  bash scripts/deploy/install.sh check       # 旧版本兼容检查
+  sudo bash scripts/deploy/install.sh install-env
 
 命令：
   check                  检测 Linux、基础工具、Docker/Compose、资源和端口
@@ -76,6 +75,7 @@ Neuro OJ Linux 独立下载部署工具
   --port PORT            检测宿主机端口（默认 8080）
   --panel MODE           面板模式：auto（默认）、baota 或 none
   --download-only        只下载源码，不执行生产部署
+  --files-only            只更新安装目录中的部署文件和 noj 命令（内部兼容选项）
   --dry-run              只显示下载计划，不下载、不写文件、不启动服务
   --non-interactive      首次配置不询问，配置不完整时直接失败
   -h, --help             显示帮助
@@ -143,6 +143,7 @@ parse_args() {
         ;;
       --panel=*) PANEL_MODE="${1#*=}"; PANEL_MODE_SET=1 ;;
       --download-only) DOWNLOAD_ONLY=1 ;;
+      --files-only) FILES_ONLY=1 ;;
       --dry-run) DRY_RUN=1 ;;
       --non-interactive) NON_INTERACTIVE=1 ;;
       -h|--help) usage; exit 0 ;;
@@ -233,7 +234,7 @@ docker_install_hint() {
 Docker Engine 或 Docker Compose v2 不可用。
 请按照发行版官方文档安装 Docker Engine 和 Compose plugin：
   https://docs.docker.com/engine/install/
-安装后重新执行：bash noj-install.sh check
+安装后重新执行：bash scripts/deploy/install.sh check
 EOF
 }
 
@@ -408,7 +409,7 @@ install_env() {
     return 0
   fi
   [[ "${EUID:-$(id -u)}" -eq 0 ]] ||
-    fail "install-env 需要 root 权限，请使用 sudo bash noj-install.sh install-env"
+    fail "install-env 需要 root 权限，请使用 sudo bash scripts/deploy/install.sh install-env"
   case "$package_manager" in
     apt-get) apt-get update; apt-get install -y ca-certificates curl tar openssl ;;
     dnf|yum) "$package_manager" install -y ca-certificates curl tar openssl ;;
@@ -527,6 +528,10 @@ install_source() {
       cp -a "$source_dir/.env.prod.example" "$TARGET_DIR/"
     mkdir -p "$TARGET_DIR/scripts/deploy"
     cp -a "$source_dir/scripts/deploy/." "$TARGET_DIR/scripts/deploy/"
+    if [[ -f "$source_dir/noj" ]]; then
+      cp -a "$source_dir/noj" "$TARGET_DIR/noj"
+      chmod 755 "$TARGET_DIR/noj"
+    fi
     if [[ -d "$source_dir/deploy" ]]; then
       mkdir -p "$TARGET_DIR/deploy"
       cp -a "$source_dir/deploy/." "$TARGET_DIR/deploy/"
@@ -545,11 +550,12 @@ install_source() {
 }
 
 run_deploy() {
-  local status
+  local status deploy_entry
   ((NON_INTERACTIVE)) && DEPLOY_ARGS+=(--non-interactive)
   ((PANEL_MODE_SET)) && DEPLOY_ARGS+=(--panel "$PANEL_MODE")
-  ((DOWNLOAD_ONLY)) && {
-    ok "仅下载模式完成，未启动生产服务"
+  ((DOWNLOAD_ONLY || FILES_ONLY)) && {
+    ((FILES_ONLY)) && ok "部署文件和 noj 命令已更新，未重启生产服务"
+    ((DOWNLOAD_ONLY)) && ok "仅下载模式完成，未启动生产服务"
     return 0
   }
   if ((DRY_RUN)); then
@@ -557,13 +563,19 @@ run_deploy() {
     return 0
   fi
 
+  deploy_entry="$TARGET_DIR/scripts/deploy/deploy.sh"
+  if [[ -f "$TARGET_DIR/noj" ]]; then
+    deploy_entry="$TARGET_DIR/noj"
+  fi
   set +e
   if ((${#DEPLOY_ARGS[@]} > 0)); then
+    NOJ_BIN_DIR="${NOJ_BOOTSTRAP_BIN_DIR:-/usr/local/bin}" \
     NOJ_DEPLOY_DEFAULT_VERSION="$REF" \
-      bash "$TARGET_DIR/scripts/deploy/deploy.sh" install "${DEPLOY_ARGS[@]}"
+      bash "$deploy_entry" install "${DEPLOY_ARGS[@]}"
   else
+    NOJ_BIN_DIR="${NOJ_BOOTSTRAP_BIN_DIR:-/usr/local/bin}" \
     NOJ_DEPLOY_DEFAULT_VERSION="$REF" \
-      bash "$TARGET_DIR/scripts/deploy/deploy.sh" install
+      bash "$deploy_entry" install
   fi
   status=$?
   set -e
@@ -572,6 +584,19 @@ run_deploy() {
     return "$status"
   fi
   ok "生产部署完成"
+}
+
+register_noj_command() {
+  ((DOWNLOAD_ONLY || DRY_RUN)) && return 0
+  [[ -f "$TARGET_DIR/noj" ]] || {
+    warn "当前源码未包含 noj 命令，跳过 PATH 注册"
+    return 0
+  }
+  chmod 755 "$TARGET_DIR/noj"
+  NOJ_INTERNAL_REGISTER=1 \
+  NOJ_BIN_DIR="${NOJ_BOOTSTRAP_BIN_DIR:-/usr/local/bin}" \
+    bash "$TARGET_DIR/noj" register-command ||
+    warn "无法自动注册 noj 到 PATH；部署已完成，请手动将 $TARGET_DIR/noj 加入 PATH"
 }
 
 main() {
@@ -597,6 +622,7 @@ main() {
       printf '下载地址：%s\n' "$ARCHIVE_URL"
       install_source
       run_deploy
+      register_noj_command
       ;;
     *)
       fail "未知命令：$COMMAND"
@@ -604,4 +630,6 @@ main() {
   esac
 }
 
-main "$@"
+if [[ "${NOJ_BOOTSTRAP_SOURCE_ONLY:-0}" != "1" ]]; then
+  main "$@"
+fi

--- a/scripts/deploy/test-install.sh
+++ b/scripts/deploy/test-install.sh
@@ -5,6 +5,7 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_SCRIPT="$SCRIPT_DIR/install.sh"
+SOURCE_NOJ="$SCRIPT_DIR/../../noj"
 TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-bootstrap-test.XXXXXX")"
 FAKE_BIN="$TEST_ROOT/bin"
 ARCHIVE="$TEST_ROOT/source.tar.gz"
@@ -19,6 +20,8 @@ fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
 
 mkdir -p "$FAKE_BIN" "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/scripts/deploy"
 printf 'target\n' >"$TEST_ROOT/source/noj-neuro-oj-v0.1.0/AGENTS.md"
+cp "$SOURCE_NOJ" "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/noj"
+chmod 755 "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/noj"
 ln -s AGENTS.md "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/CLAUDE.md"
 cat >"$TEST_ROOT/source/noj-neuro-oj-v0.1.0/scripts/deploy/deploy.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -113,6 +116,7 @@ export PATH="$FAKE_BIN:$PATH"
 export NOJ_BOOTSTRAP_ARCHIVE="$ARCHIVE"
 export NOJ_BOOTSTRAP_DOWNLOAD_LOG="$DOWNLOAD_LOG"
 export NOJ_BOOTSTRAP_DEPLOY_LOG="$DEPLOY_LOG"
+export NOJ_BOOTSTRAP_BIN_DIR="$TEST_ROOT/noj-bin"
 
 bash "$INSTALL_SCRIPT" --help >/dev/null
 pass "帮助输出"
@@ -189,7 +193,8 @@ set -e
 grep -q '使用 --ref' "$TEST_ROOT/api-fail.err" || fail "最新 Release 获取失败提示缺少显式版本建议"
 pass "最新 Release 获取失败"
 
-NOJ_BOOTSTRAP_API_FAIL=1 bash "$INSTALL_SCRIPT" --ref v0.1.0 --dir "$TEST_ROOT/explicit-ref" >/dev/null
+NOJ_BOOTSTRAP_API_FAIL=1 NOJ_BOOTSTRAP_BIN_DIR="$TEST_ROOT/explicit-bin" \
+  bash "$INSTALL_SCRIPT" --ref v0.1.0 --dir "$TEST_ROOT/explicit-ref" >/dev/null
 pass "显式版本跳过 Release 查询"
 
 download_only_dir="$TEST_ROOT/download-only"
@@ -197,6 +202,7 @@ rm -f "$DEPLOY_LOG"
 bash "$INSTALL_SCRIPT" --download-only --repo https://example.com/repo --ref v0.1.0 \
   --dir "$download_only_dir" >/dev/null
 [[ -f "$download_only_dir/scripts/deploy/deploy.sh" ]] || fail "下载模式缺少部署脚本"
+[[ -x "$download_only_dir/noj" ]] || fail "下载模式缺少可执行 noj 命令"
 [[ ! -e "$DEPLOY_LOG" ]] || fail "download-only 启动了部署"
 [[ -z "$(find "$TEST_ROOT" -maxdepth 1 -type d -name 'noj-bootstrap.*' -print -quit)" ]] ||
   fail "下载完成后未清理临时目录"
@@ -207,6 +213,8 @@ bash "$INSTALL_SCRIPT" --repo https://example.com/repo --ref v0.1.0 --dir "$depl
   --env-file /tmp/example.env --backup-dir /tmp/backups >/dev/null
 [[ "$(cat "$DEPLOY_LOG")" == 'install --env-file /tmp/example.env --backup-dir /tmp/backups' ]] ||
   fail "部署参数未正确传递"
+[[ -L "$NOJ_BOOTSTRAP_BIN_DIR/noj" ]] || fail "安装后未注册 PATH 命令"
+cmp -s "$NOJ_BOOTSTRAP_BIN_DIR/noj" "$deploy_dir/noj" || fail "PATH 命令未指向安装目录"
 pass "部署入口与参数传递"
 
 resume_dir="$TEST_ROOT/resume"
@@ -218,10 +226,14 @@ printf 'services:\n  fake:\n    image: alpine:3\n' >"$resume_dir/docker-compose.
 printf 'NOJ_VERSION=v0.1.0\nADMIN_PASS=keep-this-secret\n' >"$resume_dir/.env.prod"
 mkdir -p "$resume_dir/backups"
 printf 'keep\n' >"$resume_dir/backups/marker.txt"
+printf 'old-noj\n' >"$resume_dir/noj"
+chmod 600 "$resume_dir/noj"
 bash "$INSTALL_SCRIPT" --panel baota --dir "$resume_dir" >/dev/null
 grep -q 'install --panel baota' "$DEPLOY_LOG" || fail "已有 NOJ 安装未继续执行 deploy.sh"
 grep -q '^ADMIN_PASS=keep-this-secret$' "$resume_dir/.env.prod" || fail "续装覆盖了生产配置"
 [[ "$(cat "$resume_dir/backups/marker.txt")" == keep ]] || fail "续装覆盖了备份目录"
+cmp -s "$resume_dir/noj" "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/noj" || fail "续装未更新 noj 命令"
+[[ -x "$resume_dir/noj" ]] || fail "续装后 noj 命令不可执行"
 pass "已有 NOJ 安装保留配置并继续部署"
 
 panel_deploy_dir="$TEST_ROOT/panel-deploy"

--- a/scripts/deploy/test-noj.sh
+++ b/scripts/deploy/test-noj.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# noj 命令入口的无 Docker 路由测试。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_NOJ="$SCRIPT_DIR/../../noj"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-cli-test.XXXXXX")"
+NORMALIZED_TEST_ROOT="$(cd -P "$TEST_ROOT" && pwd)"
+LOG_FILE="$TEST_ROOT/route.log"
+COMMAND_BIN="$TEST_ROOT/commands"
+UPDATE_LOG="$TEST_ROOT/update.log"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+
+mkdir -p "$TEST_ROOT/scripts/deploy"
+cp "$SOURCE_NOJ" "$TEST_ROOT/noj"
+chmod 755 "$TEST_ROOT/noj"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -Eeuo pipefail' \
+  'printf "%s\n" "$*" >>"${NOJ_FAKE_LOG:?}"' \
+  'if [[ "${NOJ_FAKE_EXIT:-0}" != 0 ]]; then exit "$NOJ_FAKE_EXIT"; fi' \
+  >"$TEST_ROOT/scripts/deploy/deploy.sh"
+chmod 755 "$TEST_ROOT/scripts/deploy/deploy.sh"
+printf '%s\n' 'NOJ_VERSION=v-test' >"$TEST_ROOT/.env.prod"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -Eeuo pipefail' \
+  'printf "%s\n" "$*" >>"${NOJ_UPDATE_LOG:?}"' \
+  >"$TEST_ROOT/scripts/deploy/install.sh"
+chmod 755 "$TEST_ROOT/scripts/deploy/install.sh"
+
+run_noj() {
+  NOJ_BIN_DIR="${NOJ_BIN_DIR:-$COMMAND_BIN}" \
+  NOJ_FAKE_LOG="$LOG_FILE" NOJ_UPDATE_LOG="$UPDATE_LOG" NOJ_FAKE_EXIT="${NOJ_FAKE_EXIT:-0}" \
+    "$TEST_ROOT/noj" "$@"
+}
+
+assert_last_route() {
+  local expected="$1" actual
+  actual="$(tail -n 1 "$LOG_FILE")"
+  [[ "$actual" == "$expected" ]] ||
+    fail "路由错误：期望 [$expected]，实际 [$actual]"
+}
+
+: >"$LOG_FILE"
+[[ "$(run_noj --help)" == *"Neuro OJ 生产运维命令"* ]] || fail "帮助输出缺少标题"
+[[ ! -s "$LOG_FILE" ]] || fail "帮助命令不应调用部署脚本"
+pass "帮助命令"
+
+for command in install start stop status logs backup verify; do
+  : >"$LOG_FILE"
+  run_noj "$command" --env-file /tmp/noj-test.env
+  assert_last_route "$command --env-file /tmp/noj-test.env"
+done
+[[ -L "$COMMAND_BIN/noj" ]] || fail "install 未注册 PATH 命令"
+cmp -s "$COMMAND_BIN/noj" "$TEST_ROOT/noj" || fail "PATH 命令未指向当前安装"
+pass "基础命令路由与参数透传"
+
+: >"$LOG_FILE"
+run_noj install
+[[ -L "$COMMAND_BIN/noj" ]] || fail "重复注册破坏了 PATH 命令"
+pass "PATH 命令重复注册"
+
+ln -s "$TEST_ROOT/noj" "$TEST_ROOT/linked-noj"
+: >"$LOG_FILE"
+NOJ_BIN_DIR="$TEST_ROOT/linked-commands" NOJ_FAKE_LOG="$LOG_FILE" NOJ_FAKE_EXIT=0 \
+  "$TEST_ROOT/linked-noj" status
+assert_last_route "status"
+pass "软链接调用定位安装目录"
+
+: >"$LOG_FILE"
+: >"$UPDATE_LOG"
+run_noj update --dry-run
+assert_last_route "upgrade --dry-run"
+grep -Fqx -- "--ref v-test --dir $NORMALIZED_TEST_ROOT --files-only --dry-run" "$UPDATE_LOG" ||
+  fail "update 未先同步配置版本的部署文件"
+pass "update 同步部署文件并升级服务"
+
+: >"$LOG_FILE"
+run_noj update --env-file /tmp/noj-test.env --dry-run
+assert_last_route "upgrade --env-file /tmp/noj-test.env --dry-run"
+pass "update 路由到 upgrade"
+
+: >"$LOG_FILE"
+run_noj restart --env-file /tmp/noj-test.env
+[[ "$(sed -n '1p' "$LOG_FILE")" == "stop --env-file /tmp/noj-test.env" ]] || fail "restart 未先停止服务"
+[[ "$(sed -n '2p' "$LOG_FILE")" == "start --env-file /tmp/noj-test.env" ]] || fail "restart 未再启动服务"
+pass "restart 顺序"
+
+: >"$LOG_FILE"
+run_noj config check --env-file /tmp/noj-test.env
+assert_last_route "verify --env-file /tmp/noj-test.env"
+pass "config check 路由"
+
+: >"$LOG_FILE"
+if run_noj unknown >/dev/null 2>&1; then
+  fail "未知命令应返回非零退出码"
+fi
+[[ ! -s "$LOG_FILE" ]] || fail "未知命令不应调用部署脚本"
+pass "未知命令"
+
+: >"$LOG_FILE"
+if NOJ_FAKE_EXIT=17 run_noj status >/dev/null 2>&1; then
+  fail "底层部署脚本失败时 noj 应返回非零退出码"
+fi
+pass "底层退出码透传"
+
+mkdir -p "$TEST_ROOT/conflict-bin"
+printf 'existing command\n' >"$TEST_ROOT/conflict-bin/noj"
+NOJ_BIN_DIR="$TEST_ROOT/conflict-bin" run_noj install >"$TEST_ROOT/conflict.out" 2>&1 ||
+  fail "PATH 冲突不应导致已完成安装失败"
+grep -q '未覆盖已有命令' "$TEST_ROOT/conflict.out" || fail "PATH 冲突未给出保护提示"
+pass "已有同名命令保护"
+
+printf 'not a directory\n' >"$TEST_ROOT/blocked-bin"
+HOME="$TEST_ROOT/fallback-home" \
+NOJ_BIN_DIR="$TEST_ROOT/blocked-bin/subdir" run_noj install >"$TEST_ROOT/fallback.out" 2>&1 ||
+  fail "全局目录不可写时不应导致已完成安装失败"
+[[ -L "$TEST_ROOT/fallback-home/.local/bin/noj" ]] || fail "全局目录不可用时未回退用户目录"
+grep -Fqx 'export PATH="$HOME/.local/bin:$PATH"' "$TEST_ROOT/fallback-home/.profile" ||
+  fail "用户目录回退时未补充登录 PATH"
+pass "用户级 PATH 回退"
+
+mv "$TEST_ROOT/scripts/deploy/deploy.sh" "$TEST_ROOT/scripts/deploy/deploy.sh.missing"
+if run_noj status >"$TEST_ROOT/missing.out" 2>&1; then
+  fail "缺少部署脚本时 noj 应返回非零退出码"
+fi
+grep -q '未找到生产部署脚本' "$TEST_ROOT/missing.out" || fail "缺少部署脚本时错误提示不清晰"
+pass "部署脚本缺失提示"
+
+printf 'noj CLI 路由测试通过\n'

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# Neuro OJ 用户一键安装入口。
+# Neuro OJ 唯一公开的一键安装入口。
 #
 # 推荐用法：
 #   curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | bash
 #
-# 入口只下载固定仓库 main 分支中的 bootstrap；实际安装逻辑仍由 bootstrap 从
-# 最新 Release 获取，用户也可以传入 --ref 固定版本。
+# setup.sh 只负责获取内部 bootstrap 并完成首次安装；安装完成后的服务启停、更新
+# 和管理统一使用安装目录中的 noj 命令。
 
 set -Eeuo pipefail
 
@@ -18,14 +18,12 @@ trap cleanup EXIT
 if command -v curl >/dev/null 2>&1; then
   curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
     --retry 3 --connect-timeout 15 --output "$tmp_file" "$BOOTSTRAP_URL" || {
-    printf '无法下载 NOJ 安装程序。可以先下载后检查：curl -fsSL %s -o noj-install.sh\n' \
-      "$BOOTSTRAP_URL" >&2
+    printf '无法下载 NOJ 安装程序。请检查网络，或先下载 setup.sh 后人工检查再执行。\n' >&2
     exit 1
   }
 elif command -v wget >/dev/null 2>&1; then
   wget --https-only --tries=3 --timeout=20 --quiet --output-document="$tmp_file" "$BOOTSTRAP_URL" || {
-    printf '无法下载 NOJ 安装程序。可以先下载后检查：wget -O noj-install.sh %s\n' \
-      "$BOOTSTRAP_URL" >&2
+    printf '无法下载 NOJ 安装程序。请检查网络，或先下载 setup.sh 后人工检查再执行。\n' >&2
     exit 1
   }
 else


### PR DESCRIPTION
## 变更

- 保留 setup.sh 作为唯一推荐的首次安装入口
- 新增根目录 noj CLI，支持 install、start、stop、restart、status、logs、update、backup、verify、config check
- noj install 自动注册 PATH；noj update 同步版本文件后执行带备份、迁移和健康检查的升级
- 保留 scripts/deploy/install.sh 作为 setup.sh 内部 bootstrap 和旧版本兼容入口
- 更新 README、生产部署文档和脚本说明
- 补充 OpenSpec 变更记录以及无 Docker 的安装/CLI 回归测试

## 安全与兼容

- 不覆盖已有的同名 noj 命令
- 不删除 .env.prod、备份文件或 Docker 数据卷
- 兼容旧安装目录，旧版本没有 noj 时回退到 deploy.sh
- 未纳入工作区中已有的 noj-ui 和 .agents 未提交修改

## 验证

- bash -n setup.sh noj scripts/deploy/install.sh scripts/deploy/test-noj.sh scripts/deploy/test-install.sh
- scripts/deploy/test-noj.sh
- scripts/deploy/test-install.sh
- scripts/deploy/test-deploy.sh
- scripts/deploy/test-backup.sh
- openspec validate add-noj-cli --strict
- git diff --check

提交已使用 GPG 签名。