### PR TITLE
fix(judge,ci): 统一 Python 镜像安全更新

### DIFF
--- a/noj-judge/docker/evaluator-python/Dockerfile
+++ b/noj-judge/docker/evaluator-python/Dockerfile
@@ -13,15 +13,19 @@ FROM python:3.12-slim@sha256:a249c9f47e05708dd367f3fe8ada03cf347390fad66fb8b0518
 LABEL org.opencontainers.image.description="Neuro OJ Dual-container Evaluator (Python 3.12, noj_evaluator_sdk)"
 LABEL com.noj.judge.kind="evaluator"
 
+# 在固定 digest 的基础镜像上统一安装 Debian 和 Python 工具安全更新。
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && python3 -m pip install --no-cache-dir --upgrade \
+      "setuptools>=78.1.1" \
+      "wheel>=0.46.2" \
+      "jaraco.context>=6.1.0" \
+    && rm -rf /var/lib/apt/lists/*
+
 # 安装 SDK 源码
 # 注：noj-judge/sdk/evaluator/noj_evaluator_sdk/ 是包目录
 # COPY 时跳过外层 noj_evaluator_sdk/，让其内容直接落在 site-packages/noj_evaluator_sdk/
 COPY sdk/evaluator/noj_evaluator_sdk/ /usr/local/lib/python3.12/site-packages/noj_evaluator_sdk/
-
-# 在固定 digest 的基础镜像上安装 Debian 安全更新。
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && rm -rf /var/lib/apt/lists/*
 
 # 验证 SDK 可导入（构建期 sanity check）
 RUN python3 -c "import noj_evaluator_sdk; from noj_evaluator_sdk.runner import SolutionRunner; from noj_evaluator_sdk.result import Result; print('noj_evaluator_sdk OK')"

--- a/noj-judge/docker/solution-ai/Dockerfile
+++ b/noj-judge/docker/solution-ai/Dockerfile
@@ -12,6 +12,15 @@ FROM python:3.12-slim@sha256:a249c9f47e05708dd367f3fe8ada03cf347390fad66fb8b0518
 LABEL org.opencontainers.image.description="Neuro OJ Dual-container Solution AI (Python 3.12, CPU torch, noj_solution_sdk)"
 LABEL com.noj.judge.kind="solution"
 
+# 在固定 digest 的基础镜像上统一安装 Debian 和 Python 工具安全更新。
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && python3 -m pip install --no-cache-dir --upgrade \
+      "setuptools>=78.1.1" \
+      "wheel>=0.46.2" \
+      "jaraco.context>=6.1.0" \
+    && rm -rf /var/lib/apt/lists/*
+
 # 安装 CPU 版 PyTorch 与 CV/ML 常用库
 RUN pip install --no-cache-dir \
     --index-url https://download.pytorch.org/whl/cpu \

--- a/noj-judge/docker/solution-python/Dockerfile
+++ b/noj-judge/docker/solution-python/Dockerfile
@@ -13,14 +13,18 @@ FROM python:3.12-slim@sha256:a249c9f47e05708dd367f3fe8ada03cf347390fad66fb8b0518
 LABEL org.opencontainers.image.description="Neuro OJ Dual-container Solution (Python 3.12, noj_solution_sdk)"
 LABEL com.noj.judge.kind="solution"
 
+# 在固定 digest 的基础镜像上统一安装 Debian 和 Python 工具安全更新。
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && python3 -m pip install --no-cache-dir --upgrade \
+      "setuptools>=78.1.1" \
+      "wheel>=0.46.2" \
+      "jaraco.context>=6.1.0" \
+    && rm -rf /var/lib/apt/lists/*
+
 # 安装 SDK 源码
 # 跳过外层 noj_solution_sdk/，让其内容直接落在 site-packages/noj_solution_sdk/
 COPY sdk/solution/noj_solution_sdk/ /usr/local/lib/python3.12/site-packages/noj_solution_sdk/
-
-# 在固定 digest 的基础镜像上安装 Debian 安全更新。
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && rm -rf /var/lib/apt/lists/*
 
 # 验证 SDK 可导入（构建期 sanity check）
 RUN python3 -c "import noj_solution_sdk; from noj_solution_sdk.host import main; from noj_solution_sdk.registry import register; print('noj_solution_sdk OK')"

--- a/openspec/changes/fix-base-image-security-updates/design.md
+++ b/openspec/changes/fix-base-image-security-updates/design.md
@@ -1,12 +1,13 @@
 ## Context
 
-`0.8.0-rc.3` 使用的 Trivy v0.70.0 已正常解析并扫描镜像。失败结果显示 Python 镜像中的 Debian OpenSSL 为 `3.5.6-1~deb13u2`，修复版本为 `3.5.7-1~deb13u2`；LLM Gateway 中 Alpine OpenSSL 为 `3.5.7-r0`，修复版本为 `3.5.8-r0`。基础镜像本身仍需通过 digest 固定以保持供应链可追溯。
+`0.8.0-rc.3` 使用的 Trivy v0.70.0 已正常解析并扫描镜像。失败结果显示 Python 镜像中的 Debian OpenSSL 为 `3.5.6-1~deb13u2`，修复版本为 `3.5.7-1~deb13u2`；LLM Gateway 中 Alpine OpenSSL 为 `3.5.7-r0`，修复版本为 `3.5.8-r0`。后续 `0.8.1-rc.1` 又发现 `solution-ai` 未覆盖 Debian 更新步骤，同时 Python 基础工具存在可修复漏洞：setuptools 需要至少 `78.1.1`、wheel 需要至少 `0.46.2`，jaraco.context 需要至少 `6.1.0`。基础镜像本身仍需通过 digest 固定以保持供应链可追溯。
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- 在构建时更新受影响基础系统包，使已知 OpenSSL 修复进入生产镜像。
+- 在构建时更新全部 Python 镜像的基础系统包，使已知 OpenSSL 修复进入生产镜像。
+- 在全部 Python 镜像中升级 Python 打包工具，避免基础镜像自带的旧版本随镜像发布。
 - 让静态供应链检查能阻止安全更新步骤被删除。
 - 保持现有容器用户、启动命令和基础镜像 digest 约束。
 
@@ -18,9 +19,9 @@
 
 ## Decisions
 
-- Python Dockerfile 在切换到非 root 用户前执行 `apt-get update`、`apt-get upgrade` 和清理 apt 列表。这样可在保留固定 Python 基础镜像 digest 的同时获取 Debian 安全仓库中的修复包。
+- 三份 Python Dockerfile 在切换到非 root 用户前执行相同的 `apt-get update`、`apt-get upgrade` 和清理 apt 列表，并使用 pip 升级 `setuptools>=78.1.1`、`wheel>=0.46.2`、`jaraco.context>=6.1.0`。这样可在保留固定 Python 基础镜像 digest 的同时获取 Debian 和 Python 工具的修复版本。
 - Alpine Dockerfile 执行 `apk upgrade --no-cache`。该方式直接使用基础镜像声明的 Alpine 仓库更新系统包，并不改变 Deno 版本或基础镜像 digest。
-- 在现有 `scripts/release/check-supply-chain.sh` 中增加针对三份 Dockerfile 的文本检查，并在 `scripts/release/test-supply-chain.sh` 中模拟删除步骤的负向测试。相比构建完整镜像，静态检查更快，适合作为 PR 早期门禁；实际 CVE 是否清除仍由 Release Trivy 扫描确认。
+- 在现有 `scripts/release/check-supply-chain.sh` 中增加针对三份 Python Dockerfile 和 LLM Gateway 的文本检查，并在 `scripts/release/test-supply-chain.sh` 中模拟删除系统更新或 Python 工具升级步骤的负向测试。相比构建完整镜像，静态检查更快，适合作为 PR 早期门禁；实际 CVE 是否清除仍由 Release Trivy 扫描确认。
 - 不把安全更新改成动态基础镜像 tag。动态 tag 会削弱现有 digest 可复现性，而构建阶段的包更新已能覆盖当前已确认的安全修复。
 
 ## Risks / Trade-offs

--- a/openspec/changes/fix-base-image-security-updates/proposal.md
+++ b/openspec/changes/fix-base-image-security-updates/proposal.md
@@ -4,7 +4,8 @@
 
 ## What Changes
 
-- 在 Python 评测镜像构建过程中安装基础 Debian 系统的最新安全更新。
+- 在全部 Python 评测镜像（evaluator、solution、solution-ai）构建过程中安装基础 Debian 系统的最新安全更新。
+- 在全部 Python 评测镜像中升级存在已知高危漏洞的 setuptools、wheel 和 jaraco.context。
 - 在 LLM Gateway 镜像构建过程中安装基础 Alpine 系统的最新安全更新。
 - 保持基础镜像 digest 固定、非 root 运行和现有镜像构建流程不变。
 - 增加回归检查，确保受影响镜像包含基础系统安全更新步骤。
@@ -21,6 +22,6 @@
 
 ## Impact
 
-- 修改 `noj-judge/docker/evaluator-python/Dockerfile`、`noj-judge/docker/solution-python/Dockerfile` 和 `noj-llm-gateway/Dockerfile`。
+- 修改 `noj-judge/docker/evaluator-python/Dockerfile`、`noj-judge/docker/solution-python/Dockerfile`、`noj-judge/docker/solution-ai/Dockerfile` 和 `noj-llm-gateway/Dockerfile`。
 - 修改供应链检查脚本和测试。
 - 构建时间会略有增加；不改变应用运行时 API、部署配置或 Redis/PostgreSQL 数据。

--- a/openspec/changes/fix-base-image-security-updates/specs/base-image-security-updates/spec.md
+++ b/openspec/changes/fix-base-image-security-updates/specs/base-image-security-updates/spec.md
@@ -10,8 +10,9 @@
 
 #### Scenario: Debian 评测镜像构建
 
-- **WHEN** 构建 evaluator 或 solution Python 生产镜像
+- **WHEN** 构建 evaluator、solution 或 solution-ai Python 生产镜像
 - **THEN** 镜像构建应用 Debian 基础系统的安全更新
+- **AND** 镜像中的 setuptools、wheel 和 jaraco.context 使用规范要求的安全版本或更高版本
 - **AND** 镜像继续使用固定 digest 的 Python 基础镜像
 - **AND** 镜像继续以非 root 用户运行
 
@@ -21,6 +22,13 @@
 - **THEN** 镜像构建应用 Alpine 基础系统的安全更新
 - **AND** 镜像继续使用固定 digest 的 Deno 基础镜像
 - **AND** 镜像继续使用现有 Deno 启动命令
+
+#### Scenario: Python 打包工具安全更新
+
+- **WHEN** 构建任一 Python 生产镜像
+- **THEN** setuptools 版本至少为 `78.1.1`
+- **AND** wheel 版本至少为 `0.46.2`
+- **AND** jaraco.context 版本至少为 `6.1.0`
 
 #### Scenario: 安全扫描验证
 
@@ -35,7 +43,8 @@
 #### Scenario: 安全更新步骤存在
 
 - **WHEN** 供应链静态检查运行在当前生产 Dockerfile 上
-- **THEN** 检查确认 Debian 和 Alpine 受影响镜像包含安全更新步骤并通过
+- **THEN** 检查确认三个 Python 镜像和 Alpine 网关包含基础系统安全更新步骤并通过
+- **AND** 检查确认三个 Python 镜像包含 Python 打包工具升级步骤并通过
 
 #### Scenario: 安全更新步骤缺失
 

--- a/openspec/changes/fix-base-image-security-updates/tasks.md
+++ b/openspec/changes/fix-base-image-security-updates/tasks.md
@@ -1,12 +1,15 @@
 ## 1. 镜像安全更新
 
-- [x] 1.1 在 Python evaluator/solution Dockerfile 中加入 Debian 安全包更新并保留固定 digest、非 root 用户，使用 Dockerfile 检查确认
+- [x] 1.1 在三个 Python Dockerfile 中统一加入 Debian 安全包更新并保留固定 digest、非 root 用户，使用 Dockerfile 检查确认
 - [x] 1.2 在 LLM Gateway Dockerfile 中加入 Alpine 安全包更新并保留现有 Deno 启动方式，使用 Dockerfile 检查确认
+- [x] 1.3 在三个 Python Dockerfile 中统一升级 setuptools、wheel 和 jaraco.context 到规范要求的安全版本
 
 ## 2. 供应链回归检查
 
 - [x] 2.1 扩展供应链检查和测试，验证三份受影响 Dockerfile 必须有安全更新步骤，并验证删除步骤会失败
+- [x] 2.2 扩展供应链检查和测试，验证任一 Python Dockerfile 缺少 Python 打包工具升级步骤时会失败
 
 ## 3. 验证
 
 - [x] 3.1 运行 Shell 语法、供应链正负向测试、OpenSpec 严格校验和受影响镜像构建/Trivy 扫描；若本地镜像仓库不可用，记录并依赖 Release workflow 验证
+- [x] 3.2 运行统一安全更新检查；本地 Docker 拉取固定基础镜像时因网络 EOF 未完成构建，依赖 Release workflow 完成真实镜像和 Trivy 验证

--- a/scripts/release/check-supply-chain.sh
+++ b/scripts/release/check-supply-chain.sh
@@ -46,12 +46,25 @@ check_dockerfiles() {
 
 check_base_image_security_updates() {
   local file
-  for file in noj-judge/docker/evaluator-python/Dockerfile noj-judge/docker/solution-python/Dockerfile; do
+  local python_files=(
+    noj-judge/docker/evaluator-python/Dockerfile
+    noj-judge/docker/solution-python/Dockerfile
+    noj-judge/docker/solution-ai/Dockerfile
+  )
+  for file in "${python_files[@]}"; do
     require_file "$file"
     grep -q 'apt-get update' "$ROOT_DIR/$file" \
       || fail "$file 未更新 Debian 软件包索引"
     grep -q 'apt-get upgrade' "$ROOT_DIR/$file" \
       || fail "$file 未安装 Debian 安全更新"
+    grep -q 'python3 -m pip install --no-cache-dir --upgrade' "$ROOT_DIR/$file" \
+      || fail "$file 未升级 Python 打包工具"
+    grep -q 'setuptools>=78.1.1' "$ROOT_DIR/$file" \
+      || fail "$file 未约束 setuptools 安全版本"
+    grep -q 'wheel>=0.46.2' "$ROOT_DIR/$file" \
+      || fail "$file 未约束 wheel 安全版本"
+    grep -q 'jaraco.context>=6.1.0' "$ROOT_DIR/$file" \
+      || fail "$file 未约束 jaraco.context 安全版本"
   done
 
   require_file "noj-llm-gateway/Dockerfile"

--- a/scripts/release/test-supply-chain.sh
+++ b/scripts/release/test-supply-chain.sh
@@ -40,6 +40,22 @@ if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \
 fi
 pass "缺少基础系统安全更新拒绝"
 
+sed -i.bak '/apt-get upgrade -y/d' \
+  "$TEST_ROOT/noj-judge/docker/solution-ai/Dockerfile"
+if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \
+  >/dev/null 2>&1; then
+  fail "solution-ai 缺少 Debian 安全更新的 Dockerfile 未被拒绝"
+fi
+pass "solution-ai 基础系统安全更新拒绝"
+
+sed -i.bak '/setuptools>=78.1.1/d' \
+  "$TEST_ROOT/noj-judge/docker/solution-python/Dockerfile"
+if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \
+  >/dev/null 2>&1; then
+  fail "缺少 Python 打包工具安全更新的 Dockerfile 未被拒绝"
+fi
+pass "Python 打包工具安全更新拒绝"
+
 sed -i.bak 's#aquasecurity/trivy-action@v0.36.0#aquasecurity/trivy-action@v0.28.0#g' \
   "$TEST_ROOT/.github/workflows/release.yml"
 if NOJ_SUPPLY_CHAIN_ROOT="$TEST_ROOT" bash "$SCRIPT_DIR/check-supply-chain.sh" \


### PR DESCRIPTION
## 背景

0.8.1-rc.1 的 Release Images 因 noj-solution-ai 的 3 个 HIGH 漏洞扫描失败：CVE-2026-14456、CVE-2025-47273、CVE-2026-24049。

## 变更

- 三个 Python 生产镜像统一执行 Debian apt 安全更新
- 三个 Python 生产镜像统一升级 setuptools 至 78.1.1 以上
- 统一升级 wheel 至 0.46.2 以上
- 统一升级 jaraco.context 至 6.1.0 以上
- 供应链检查覆盖全部三个 Python 镜像
- 增加 solution-ai 系统更新和 Python 工具缺失的负向回归测试
- 更新 OpenSpec，记录本次覆盖范围补漏

## 验证

- bash -n scripts/release/check-supply-chain.sh scripts/release/test-supply-chain.sh
- bash scripts/release/test-supply-chain.sh
- openspec validate fix-base-image-security-updates --strict
- git diff --check
- 本地 Docker 构建因访问 Docker Hub 基础镜像时网络 EOF 未完成，需由 CI 完成真实构建和 Trivy 验证

合并后请重新发布 0.8.1-rc.1 或下一个 RC，并确认 7 个镜像均通过扫描、签名和发布验证。