### PR TITLE
docs(noj-docs): 补充 rootless Docker 安装方式

### DIFF
--- a/noj-docs/docs/operators/judge-workers.md
+++ b/noj-docs/docs/operators/judge-workers.md
@@ -68,6 +68,63 @@ Docker socket 绕过该限制。
 2. 在应用主机上运行只服务于 judge 的 rootless Docker daemon，并使用独立 Unix
    socket。
 
+### rootless Docker 安装
+
+以下步骤在宿主机上创建仅供 Judge 使用的 rootless Docker daemon。
+
+1. 安装依赖与 rootless 组件（需要已配置 Docker 官方 apt 源）：
+
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y uidmap docker-ce-rootless-extras
+   ```
+
+2. 以准备运行 rootless daemon 的普通用户执行安装：
+
+   ```bash
+   dockerd-rootless-setuptool.sh install
+   ```
+
+   执行成功后会在该用户下创建 `docker-rootless.service`，默认 socket 为：
+
+   ```text
+   /run/user/<uid>/docker.sock
+   ```
+
+   其中 `<uid>` 是当前用户 ID。
+
+3. 创建 NOJ 专用 socket 路径，并让指定组可以访问：
+
+   ```bash
+   sudo mkdir -p /run/noj-judge
+   sudo chown root:<judge-docker-group> /run/noj-judge
+   sudo chmod 0750 /run/noj-judge
+   sudo ln -sf /run/user/<uid>/docker.sock /run/noj-judge/docker.sock
+   ```
+
+   `<judge-docker-group>` 通常是运行 rootless Docker 的用户主组（例如 `1000`）；
+   记下它的 GID，稍后写入 `JUDGE_DOCKER_SOCKET_GID`。
+
+4. 验证能否通过该 socket 访问 rootless daemon：
+
+   ```bash
+   DOCKER_HOST=unix:///run/noj-judge/docker.sock docker info
+   ```
+
+   能看到 daemon 信息且输出中带有 rootless/userns 相关标记即为正常。
+
+5. 在 NOJ 部署配置中填写：
+
+   ```bash
+   JUDGE_DOCKER_SOCKET=/run/noj-judge/docker.sock
+   JUDGE_DOCKER_SOCKET_GID=<judge-docker-group>
+   JUDGE_DOCKER_HOST=unix:///run/noj-judge/docker.sock
+   JUDGE_REQUIRE_ISOLATED_DOCKER=true
+   ```
+
+> 不同发行版的 rootless Docker 安装方式略有差异。Fedora/RHEL 可参考
+> [Rootless mode 官方文档](https://docs.docker.com/engine/security/rootless/)。
+
 生产 Compose 使用以下配置连接该 socket：
 
 ```bash

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -149,7 +149,9 @@ noj-cli maintain verify --dir /opt/neuro-oj
 > 如果启用评测 Worker，不得挂载应用宿主机的 `/var/run/docker.sock`。生产 Compose 要求
 > `JUDGE_DOCKER_SOCKET` 指向只服务于 judge 的 rootless daemon socket，并以非 root
 > 用户运行 Worker；`JUDGE_REQUIRE_ISOLATED_DOCKER=true` 会在错误配置时阻止 Worker
-> 消费评测任务。跳过 Judge 时不需要这些配置。
+> 消费评测任务。rootless Docker 的安装方式见
+> [Judge Worker 运维 - rootless Docker 安装](judge-workers.md#rootless-docker-安装)。
+> 跳过 Judge 时不需要这些配置。
 
 ## 3. 评测镜像白名单
 


### PR DESCRIPTION
## 概述

在 noj-docs 的 Judge Worker 运维文档中补充 rootless Docker 的宿主机安装与配置步骤，并在生产部署文档中添加入口链接。

## 主要变更

- `noj-docs/docs/operators/judge-workers.md`：
  - 新增「rootless Docker 安装」小节
  - Ubuntu/Debian 示例：安装 `uidmap` + `docker-ce-rootless-extras`
  - 使用 `dockerd-rootless-setuptool.sh install` 安装
  - 创建 NOJ 专用 socket 路径 `/run/noj-judge/docker.sock` 并设置组权限
  - 验证命令与 NOJ 环境变量配置
- `noj-docs/docs/operators/production-deploy.md`：
  - 在 Judge 安全说明处链接到上述安装文档

## 验证

- `scripts/verify-md-links.ts` 对本次涉及的 noj-docs 文件无新增链接错误
