### PR TITLE
docs(noj-docs): 生产部署文档迁移到 noj-deploy.json / noj-secrets.json

### DIFF
--- a/noj-docs/docs/operators/cli.md
+++ b/noj-docs/docs/operators/cli.md
@@ -7,7 +7,7 @@
 生产环境不直接使用源码或 `deno task`，而是通过 Docker Compose 在 `noj-server` 镜像内执行 CLI：
 
 ```bash
-docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm \
+docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
   --entrypoint /app/bin/noj <子命令>
 ```
 
@@ -15,23 +15,23 @@ docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm \
 
 ```bash
 # 数据库迁移
-docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm \
+docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
   --entrypoint /app/bin/noj db migrate
 
 # 系统基础数据：root + RBAC + 评测镜像白名单 + 标签
-docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm \
+docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
   --entrypoint /app/bin/noj init system
 
-# 管理员引导（从 .env.prod 读取 ADMIN_EMAIL / ADMIN_PASS）
-docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm \
+# 管理员引导（从部署配置或环境变量读取 ADMIN_EMAIL / ADMIN_PASS）
+docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
   --entrypoint /app/bin/noj bootstrap admin
 
 # 构建统一题目包（需要在镜像内包含 data/problems-src）
-docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm \
+docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
   --entrypoint /app/bin/noj problems build
 
 # 导入统一题目包
-docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm \
+docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
   --entrypoint /app/bin/noj problems import
 ```
 

--- a/noj-docs/docs/operators/judge-workers.md
+++ b/noj-docs/docs/operators/judge-workers.md
@@ -246,7 +246,7 @@ docker exec noj-redis redis-cli -a '<REDIS_PASSWORD>' LLEN noj:judge:queue
 
 如果队列持续堆积：
 
-1. 确认 Judge Worker 在线且连接了同一个 Redis（`docker compose ps`）。
+1. 确认 Judge Worker 在线且连接了同一个 Redis（`noj-cli deploy status --dir /opt/neuro-oj`）。
 2. 查看 judge 日志是否有拉取/容器错误。
 3. 检查 Docker daemon 是否可用、评测镜像是否已从 ghcr.io 拉取。
 4. 如负载确实超过单实例能力，按下一节水平扩展。
@@ -262,7 +262,7 @@ docker exec noj-redis redis-cli -a '<REDIS_PASSWORD>' LLEN noj:judge:queue
 
 - 停止实例会进入优雅关闭流程：排空正在执行的 in-flight 任务后再退出，避免提交丢失。
 - 升级步骤：修改 `noj-deploy.json` 中的 `version.noj_server`（或
-  `noj-cli maintain config set version.noj_server v0.1.1`）→
+  `noj-cli maintain config set version.noj_server v0.1.1 --dir /opt/neuro-oj`）→
   `noj-cli deploy up --dir /opt/neuro-oj`。
 - 升级评测镜像后应先在 noj-server 白名单登记，再启动 Worker。
 

--- a/noj-docs/docs/operators/judge-workers.md
+++ b/noj-docs/docs/operators/judge-workers.md
@@ -151,8 +151,8 @@ test "$JUDGE_REQUIRE_ISOLATED_DOCKER" = "true"
 
 # 只应看到独立 daemon socket 和评测缓存，不得出现应用宿主机 socket、
 # /var/lib/docker、/etc 或其他宿主路径。
-docker compose --env-file .env.prod -f docker-compose.prod.yml config
-docker inspect "$(docker compose --env-file .env.prod -f docker-compose.prod.yml ps -q judge)" \
+docker compose -f /opt/neuro-oj/docker-compose.noj.yml config
+docker inspect "$(docker compose -f /opt/neuro-oj/docker-compose.noj.yml ps -q judge)" \
   --format '{{json .Mounts}}'
 ```
 
@@ -217,20 +217,20 @@ noj-server 维护评测镜像白名单（`judgeImages`），并在题目 CRUD / 
 
 ## 健康检查与状态查看
 
-生产环境使用 Docker Compose 管理：
+生产环境使用 noj-cli 管理：
 
 ```bash
 # 查看所有服务状态（含 judge 是否在线）
-docker compose --env-file .env.prod -f docker-compose.prod.yml ps
+noj-cli deploy status --dir /opt/neuro-oj
 
 # 查看 judge 日志
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f --tail=200 judge
+noj-cli maintain logs judge --follow --dir /opt/neuro-oj
 ```
 
 调高日志详细度排查问题（临时覆盖环境变量）：
 
 ```bash
-docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm \
+docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
   -e RUST_LOG=noj_judge=debug judge
 ```
 
@@ -239,9 +239,10 @@ docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm \
 评测任务在 Redis 队列 `noj:judge:queue` 中排队，结果写回 `noj:judge:results`：
 
 ```bash
-docker compose --env-file .env.prod -f docker-compose.prod.yml exec redis \
-  redis-cli -a "$REDIS_PASSWORD" LLEN noj:judge:queue
+docker exec noj-redis redis-cli -a '<REDIS_PASSWORD>' LLEN noj:judge:queue
 ```
+
+密码从 `noj-secrets.json` 的 `secrets.REDIS_PASSWORD` 读取。
 
 如果队列持续堆积：
 
@@ -260,7 +261,9 @@ docker compose --env-file .env.prod -f docker-compose.prod.yml exec redis \
 ## 升级与重启
 
 - 停止实例会进入优雅关闭流程：排空正在执行的 in-flight 任务后再退出，避免提交丢失。
-- 升级步骤：修改 `.env.prod` 中的 `NOJ_VERSION` → `docker compose pull` → `docker compose up -d`。
+- 升级步骤：修改 `noj-deploy.json` 中的 `version.noj_server`（或
+  `noj-cli maintain config set version.noj_server v0.1.1`）→
+  `noj-cli deploy up --dir /opt/neuro-oj`。
 - 升级评测镜像后应先在 noj-server 白名单登记，再启动 Worker。
 
 ## 常见排查方向

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -7,22 +7,10 @@
 
 ### 宝塔等服务器面板
 
-在宝塔等面板环境中，`noj-cli` 不调用面板 API，也不会修改已有站点、证书、反向代理、
-容器或面板配置；按下方“下载 noj-cli 后开始安装”的流程执行即可。
-
-```bash
-curl -fsSL -o noj-cli \
-  https://github.com/Neuro-OJ/neuro-oj/releases/latest/download/noj-cli-linux-amd64
-chmod +x noj-cli
-./noj-cli deploy init --mode prod --dir /opt/neuro-oj
-./noj-cli deploy up --dir /opt/neuro-oj
-```
-
-宝塔兼容模式只复用面板安装的标准 Docker/Compose，不调用面板 API，也不会修改已有
-站点、证书、反向代理、容器或面板配置。前后端 Compose 自带 Nginx，部署完成后请在
-宝塔中将域名反向代理到 `127.0.0.1:NGINX_PORT`，默认端口为 `8080`；如果修改
-`.env.prod` 中的 `NGINX_PORT`，反向代理目标也要同步修改。Judge 仍需使用独立的
-rootless Docker socket，不能改用 `/run/docker.sock` 或 `/var/run/docker.sock`。
+宝塔等服务器面板与普通部署复用同一套 `noj-cli` 流程，不提供面板专用脚本或参数。
+部署完成后只需在面板中将域名反向代理到 `127.0.0.1:NGINX_PORT`（默认 `8080`）；
+Judge 仍需使用独立的 rootless Docker socket，不能改用 `/run/docker.sock` 或
+`/var/run/docker.sock`。
 
 - 一台 Linux 服务器（amd64），已安装 Docker Engine 与 Docker Compose v2。
 - Docker CLI 可用 Buildx；Cosign 不是默认安装条件，只有开启严格镜像签名校验时才需要。
@@ -67,84 +55,71 @@ curl -fsSL -o noj-cli \
 当前 Release 镜像仅发布 `linux/amd64`。ARM64/aarch64 主机请在下载前确认选择了
 对应架构的版本，或在 `noj-cli doctor` 阶段处理架构不匹配提示。
 
-`.env.prod` 中必须填写：
+### 配置模型
 
-| 变量 | 说明 |
-|------|------|
-| `NOJ_VERSION` | 要部署的已签名 Release 标签，如 `v0.1.0`；禁止使用 `latest`/`beta` |
-| `NOJ_ENFORCE_IMAGE_SIGNATURES` | 默认 `false`；设为 `true` 后，启动/升级前校验已启用应用镜像的 Cosign 签名 |
-| `NOJ_COSIGN_CERT_IDENTITY_REGEX` | Cosign 证书身份正则，默认只信任本仓库的 Release workflow |
-| `DOMAIN` | 网站地址，可填域名或服务器 IP，不要写 `https://` |
-| `APP_URL` | 完整应用地址，例如 `https://你的域名` |
-| `NOJ_ALLOW_INSECURE_HTTP` | 临时 HTTP 开关，默认 `false`；正式环境请保持关闭 |
-| `CORS_ALLOWED_ORIGINS` | `https://你的域名` |
-| `TRUSTED_PROXIES` | 可信代理网段，必须与 compose 中 `noj-net` 子网一致（如 `172.28.0.0/16`）；生产必填 |
-| `NUXT_NOJ_ENV` | 前端环境标记，生产环境保持 `production` |
-| `POSTGRES_PASSWORD` | PostgreSQL 强密码 |
-| `REDIS_PASSWORD` | Redis 强密码 |
-| `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` | MinIO 管理员凭据，仅供 `minio-init` 使用 |
-| `S3_ACCESS_KEY` / `S3_SECRET_KEY` | 支持包 bucket 的最小权限应用凭据 |
-| `STORAGE_PROVIDER` / `S3_ENDPOINT` / `S3_BUCKET` | 生产必须使用 S3/MinIO |
-| `S3_REGION` | 可选，默认 `us-east-1` |
-| `S3_FORCE_PATH_STYLE` | 自建 MinIO 通常为 `true` |
-| `JWT_SECRET` / `TFA_ENCRYPTION_KEY` | ≥32 字符随机串 |
-| 首个管理员 | 安装完成后注册的第一个真实用户自动获得管理员权限；已有站点不会因升级自动提权 |
-| `EMAIL_PROVIDER` 及对应凭据 | 可选阿里云、腾讯云或 `disabled`（暂不配置邮件） |
-| `JUDGE_IMAGE_BASE` | 默认 `ghcr.io/neuro-oj/` |
-| `NGINX_PORT` | 容器 Nginx 映射到宿主机的端口，默认 `8080` |
-| `JUDGE_DOCKER_SOCKET` / `JUDGE_DOCKER_SOCKET_GID` | 独立 rootless Docker daemon 的 socket 与组 ID；禁止使用 `/var/run/docker.sock` |
-| `OAUTH_GITHUB_CLIENT_ID` / `OAUTH_GITHUB_CLIENT_SECRET` | 可选；同时填写后启用 GitHub 登录。回调地址为 `APP_URL/api/v1/auth/oauth/github/callback` |
-| `OAUTH_OIDC_ISSUER_URL` / `OAUTH_OIDC_CLIENT_ID` / `OAUTH_OIDC_CLIENT_SECRET` | 可选；同时填写后启用通用 OIDC 登录。回调地址为 `APP_URL/api/v1/auth/oauth/oidc/callback` |
-| `OAUTH_OIDC_NAME` | 可选；OIDC 登录按钮名称，默认 `OIDC` |
-| `JUDGE_ENABLED` | 是否安装和启动评测服务 Judge，默认 `true`；设为 `false` 可跳过 |
-| `JUDGE_DOCKER_SOCKET` / `JUDGE_DOCKER_SOCKET_GID` | `JUDGE_ENABLED=true` 时必填：独立 rootless Docker 服务的 socket 与组 ID；禁止使用 `/var/run/docker.sock` |
-| `NOJ_LLM_SERVICE_TOKEN` | LLM Gateway 服务间鉴权 + eval_token 签发/校验密钥（≥16 字符）；compose 默认始终启动 `llm-gateway`，因此生产**必须填写** |
-| `NOJ_LLM_STORE_KEY` | LLM Gateway 加密 Provider API Key 的信封主密钥（≥16 字符）；compose 默认必填 |
-| `NOJ_LLM_USER_RATE_LIMIT_PER_MINUTE` | 每个用户每 UTC 分钟的 LLM 调用上限；可选，默认 `60`，必须为正整数 |
-| `NOJ_LLM_IP_RATE_LIMIT_PER_MINUTE` | 每个 IP 每 UTC 分钟的 LLM 调用上限；可选，默认 `60`，必须为正整数 |
-| `JUDGE_ALLOW_EVALUATOR_NETWORK` | 是否允许 evaluator 联网；使用 LLM 调用题时必须设为 `true` |
-| `JUDGE_EVALUATOR_NETWORK` | evaluator 联网时加入的 Docker 网络；生产必须指向 `llm-gateway` 所在网络，默认 `noj-net` |
-| `JUDGE_ALLOW_HTTP_S3` | 自建 MinIO 走内网 HTTP 时设为 `true`，允许 judge 通过 HTTP 下载支持包 |
+部署配置统一由 `noj-cli` 管理，**不再使用 `.env.prod`**：
 
-```bash
-# 3) 配置外部 TLS 终止
-# 容器内的 Nginx 不处理 TLS；请在宿主机/云 LB 上配置 HTTPS，
-# 并将解密后的 HTTP 流量转发到本机 ${NGINX_PORT:-8080} 端口（默认 8080）。
-# 示例见 deploy/README.md。
+| 文件 | 权限 | 内容 |
+|---|---|---|
+| `noj-deploy.json` | 644 | 部署类型、版本、组件、全局 env、反向代理 |
+| `noj-secrets.json` | 600 | 数据库/Redis/JWT/OAuth/LLM 等全部密钥 |
 
-# 4) 手动方式：执行一次性初始化（迁移 + 系统数据）
-docker compose --env-file .env.prod -f docker-compose.prod.yml up -d migrate
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs migrate
+`deploy init` 会生成这两个文件并随机填充密钥。之后可用
+`noj-cli maintain config check/show/set` 查看和修改，也可以直接编辑 JSON。
+配置中的环境变量名沿用原 `.env.prod` 的约定，但**不再以 env 文件形式存在**。
 
-# 5) 手动方式：启动全部服务（安装了 Judge 时加上 profile；跳过 Judge 时省略）
-docker compose --env-file .env.prod -f docker-compose.prod.yml --profile judge up -d
-
-# 6) 查看状态
-docker compose --env-file .env.prod -f docker-compose.prod.yml ps
-curl https://你的域名/healthz
-```
-
-使用 noj-cli 时，上述初始化、启动和健康检查由以下命令统一完成：
+### 初始化、启动与健康检查
 
 ```bash
 ./noj-cli deploy init --mode prod --dir /opt/neuro-oj
 ./noj-cli deploy up --dir /opt/neuro-oj
 ./noj-cli deploy status --dir /opt/neuro-oj
+curl https://你的域名/healthz
 ```
 
-部署脚本在 `install`、`start` 和 `upgrade` 前会校验 `NOJ_VERSION` 对应的应用镜像
-digest 与 Cosign keyless 签名；Judge 被跳过时只校验核心、前端和 LLM Gateway 镜像。
-默认信任当前仓库的 Release workflow；如需变更签名身份，
-必须通过受保护的生产配置显式设置 `NOJ_COSIGN_CERT_IDENTITY_REGEX`。可以单独执行：
+### 常用配置项
 
-```bash
-noj-cli maintain verify --dir /opt/neuro-oj
-```
+| 配置项 | 说明 |
+|---|---|
+| `version.noj_server`（对应原 `NOJ_VERSION`） | 要部署的已签名 Release 标签，如 `v0.1.0`；禁止使用 `latest`/`beta` |
+| `env.NOJ_ENFORCE_IMAGE_SIGNATURES` | 默认 `false`；设为 `true` 后，启动/升级前校验已启用应用镜像的 Cosign 签名 |
+| `env.NOJ_COSIGN_CERT_IDENTITY_REGEX` | Cosign 证书身份正则，默认只信任本仓库的 Release workflow |
+| `env.DOMAIN` | 网站地址，可填域名或服务器 IP，不要写 `https://` |
+| `env.APP_URL` | 完整应用地址，例如 `https://你的域名` |
+| `env.NOJ_ALLOW_INSECURE_HTTP` | 临时 HTTP 开关，默认 `false`；正式环境请保持关闭 |
+| `env.CORS_ALLOWED_ORIGINS` | `https://你的域名` |
+| `env.TRUSTED_PROXIES` | 可信代理网段，必须与 compose 中 `noj-net` 子网一致（如 `172.28.0.0/16`）；生产必填 |
+| `env.NUXT_NOJ_ENV` | 前端环境标记，生产环境保持 `production` |
+| `secrets.POSTGRES_PASSWORD` | PostgreSQL 强密码 |
+| `secrets.REDIS_PASSWORD` | Redis 强密码 |
+| `secrets.MINIO_ROOT_USER` / `secrets.MINIO_ROOT_PASSWORD` | MinIO 管理员凭据 |
+| `secrets.S3_ACCESS_KEY` / `secrets.S3_SECRET_KEY` | 支持包 bucket 的最小权限应用凭据 |
+| `env.STORAGE_PROVIDER` / `env.S3_ENDPOINT` / `env.S3_BUCKET` | 生产必须使用 S3/MinIO |
+| `env.S3_REGION` | 可选，默认 `us-east-1` |
+| `env.S3_FORCE_PATH_STYLE` | 自建 MinIO 通常为 `true` |
+| `secrets.JWT_SECRET` / `secrets.TFA_ENCRYPTION_KEY` | ≥32 字符随机串 |
+| 首个管理员 | 安装完成后注册的第一个真实用户自动获得管理员权限；已有站点不会因升级自动提权 |
+| `env.EMAIL_PROVIDER` 及对应凭据 | 可选阿里云、腾讯云或 `disabled`（暂不配置邮件） |
+| `env.JUDGE_IMAGE_BASE` | 默认 `ghcr.io/neuro-oj/` |
+| `env.NGINX_PORT` | 容器 Nginx 映射到宿主机的端口，默认 `8080` |
+| `env.JUDGE_DOCKER_SOCKET` / `env.JUDGE_DOCKER_SOCKET_GID` | 独立 rootless Docker daemon 的 socket 与组 ID；禁止使用 `/var/run/docker.sock` |
+| `secrets.OAUTH_GITHUB_CLIENT_ID` / `secrets.OAUTH_GITHUB_CLIENT_SECRET` | 可选；同时填写后启用 GitHub 登录。回调地址为 `APP_URL/api/v1/auth/oauth/github/callback` |
+| `secrets.OAUTH_OIDC_ISSUER_URL` / `secrets.OAUTH_OIDC_CLIENT_ID` / `secrets.OAUTH_OIDC_CLIENT_SECRET` | 可选；同时填写后启用通用 OIDC 登录。回调地址为 `APP_URL/api/v1/auth/oauth/oidc/callback` |
+| `env.OAUTH_OIDC_NAME` | 可选；OIDC 登录按钮名称，默认 `OIDC` |
+| `components.judge.enabled`（对应原 `JUDGE_ENABLED`） | 是否安装和启动评测服务 Judge，默认 `true`；设为 `false` 可跳过 |
+| `env.JUDGE_DOCKER_SOCKET` / `env.JUDGE_DOCKER_SOCKET_GID` | `components.judge.enabled=true` 时必填：独立 rootless Docker 服务的 socket 与组 ID；禁止使用 `/var/run/docker.sock` |
+| `secrets.NOJ_LLM_SERVICE_TOKEN` | LLM Gateway 服务间鉴权 + eval_token 签发/校验密钥（≥16 字符） |
+| `secrets.NOJ_LLM_STORE_KEY` | LLM Gateway 加密 Provider API Key 的信封主密钥（≥16 字符） |
+| `env.NOJ_LLM_USER_RATE_LIMIT_PER_MINUTE` | 每个用户每 UTC 分钟的 LLM 调用上限；可选，默认 `60`，必须为正整数 |
+| `env.NOJ_LLM_IP_RATE_LIMIT_PER_MINUTE` | 每个 IP 每 UTC 分钟的 LLM 调用上限；可选，默认 `60`，必须为正整数 |
+| `env.JUDGE_ALLOW_EVALUATOR_NETWORK` | 是否允许 evaluator 联网；使用 LLM 调用题时必须设为 `true` |
+| `env.JUDGE_EVALUATOR_NETWORK` | evaluator 联网时加入的 Docker 网络；生产必须指向 `llm-gateway` 所在网络，默认 `noj-net` |
+| `env.JUDGE_ALLOW_HTTP_S3` | 自建 MinIO 走内网 HTTP 时设为 `true`，允许 judge 通过 HTTP 下载支持包 |
 
 镜像签名校验默认关闭，以免阻断普通一键部署；如果需要严格校验，请安装 Cosign 并将
-`NOJ_ENFORCE_IMAGE_SIGNATURES=true`，然后执行 `noj-cli maintain verify --dir /opt/neuro-oj`。
-成功启动或升级后，脚本会在 `backups/current-deployment.txt` 记录当前 Release 版本和已启用
-应用镜像的 digest；升级失败时不会覆盖上一份成功部署记录。
+`env.NOJ_ENFORCE_IMAGE_SIGNATURES=true`，然后执行 `noj-cli maintain verify --dir /opt/neuro-oj`。
+`noj-cli deploy up` 会按 Compose 拉取新镜像并等待健康检查；当前版本与镜像 digest
+由 noj-cli 记录在部署目录中。
 
 > 如果启用评测 Worker，不得挂载应用宿主机的 `/var/run/docker.sock`。生产 Compose 要求
 > `JUDGE_DOCKER_SOCKET` 指向只服务于 judge 的 rootless daemon socket，并以非 root
@@ -176,10 +151,9 @@ ghcr.io/neuro-oj/noj-solution-ai       all_versions  solution
 
 ## 3.5 LLM Gateway 部署
 
-`docker-compose.prod.yml` 默认启动 `llm-gateway` 容器，并让 core 通过
-`http://llm-gateway:8001` 访问。由于 compose 对 `NOJ_LLM_SERVICE_TOKEN` 和
-`NOJ_LLM_STORE_KEY` 使用 `${...:?}` 必填校验，即使不使用 LLM 调用题也必须
-在 `.env.prod` 中填写这两个密钥。
+noj-cli 生成的部署默认启动 `llm-gateway` 容器，并让 core 通过
+`http://llm-gateway:8001` 访问。即使不使用 LLM 调用题，也必须在
+`noj-secrets.json` 中填写 `NOJ_LLM_SERVICE_TOKEN` 和 `NOJ_LLM_STORE_KEY`。
 
 使用 LLM 调用题时：
 
@@ -267,31 +241,32 @@ GPG 加密配置的完整快照，产物为单个 `snapshot-<timestamp>.nojbacku
 
 ```bash
 # 查看服务状态
-docker compose --env-file .env.prod -f docker-compose.prod.yml ps
+noj-cli deploy status --dir /opt/neuro-oj
 
 # 查看日志
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f --tail=200 server
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f --tail=200 judge
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f --tail=200 llm-gateway
+noj-cli maintain logs server --dir /opt/neuro-oj
+noj-cli maintain logs judge --follow --dir /opt/neuro-oj
+noj-cli maintain logs llm_gateway --dir /opt/neuro-oj
 
 # 健康检查（通过外部 TLS 终止后的地址）
 curl https://你的域名/healthz
 
-# 队列积压（需要进入 redis 容器或使用 redis-cli）
-docker compose --env-file .env.prod -f docker-compose.prod.yml exec redis \
-  redis-cli -a "$REDIS_PASSWORD" LLEN noj:judge:queue
+# 队列积压（密码从 noj-secrets.json 读取）
+docker exec noj-redis redis-cli -a '<REDIS_PASSWORD>' LLEN noj:judge:queue
 ```
 
 ## 6. 升级
 
 1. 在 GitHub 发布新 Release（如 `v0.1.1`）。Release workflow 会先构建候选镜像，
    完成漏洞扫描、SBOM、签名和来源证明后，才创建正式版本标签。
-2. 确认 Release workflow 的全部镜像验证成功；固定版本部署可在服务器修改 `.env.prod` 中的
-   `NOJ_VERSION=v0.1.1`。
+2. 确认 Release workflow 的全部镜像验证成功；固定版本部署可在服务器修改
+   `noj-deploy.json` 中的 `version.noj_server=v0.1.1`（或执行
+   `noj-cli maintain config set version.noj_server v0.1.1`）。
 3. 升级前创建备份，然后更新配置并重新部署：
 
 ```bash
 noj-cli maintain backup create --dir /opt/neuro-oj
+noj-cli maintain config set version.noj_server v0.1.1
 noj-cli deploy up --dir /opt/neuro-oj
 ```
 
@@ -300,8 +275,11 @@ noj-cli deploy up --dir /opt/neuro-oj
 
 ## 7. 回滚
 
-- 确认上一版本 Release 仍可拉取且签名有效，将 `.env.prod` 的 `NOJ_VERSION` 改回上一版本，
-  执行 `noj-cli maintain verify --dir /opt/neuro-oj` 后再执行 `noj-cli deploy up --dir /opt/neuro-oj`。
+- 确认上一版本 Release 仍可拉取且签名有效，将 `noj-deploy.json` 的
+  `version.noj_server` 改回上一版本（或执行
+  `noj-cli maintain config set version.noj_server <上一版本>`），
+  再执行 `noj-cli maintain verify --dir /opt/neuro-oj` 和
+  `noj-cli deploy up --dir /opt/neuro-oj`。
 - 数据库 schema 采用只追加迁移，**不自动回滚**；如需回退 schema，请人工评估并备份后操作。
 - 评测镜像也按 Release tag 发布，回滚时需要把 `judge_images` 白名单指向旧 tag（若使用 `all_versions` 则无需改白名单，只需题目/系统设置中的镜像 tag 指向旧版本）。
 
@@ -312,7 +290,8 @@ noj-cli deploy up --dir /opt/neuro-oj
 
 ### 8.1 初始化口令与创建快照
 
-备份口令只保存在仓库外的受限文件中，不要写入 `.env.prod` 或提交到 Git：
+备份口令只保存在仓库外的受限文件中，不要写入 `noj-deploy.json` / `noj-secrets.json`
+或提交到 Git：
 
 ```bash
 sudo install -d -m 700 /etc/noj
@@ -355,8 +334,8 @@ Compose 服务必须已经停止。建议恢复到单独主机或单独数据卷
   和异地对象存储，不能只依赖本脚本。
 - RTO 由 PostgreSQL 数据量、对象数量和网络决定。每月至少在隔离环境跑一次实际
   `restore --confirm`，记录从快照开始到健康检查通过的耗时，作为真实 RTO 基线。
-- 建议由 systemd timer、cron 或外部调度平台执行 `backup.sh create`，并对非零退出码、
-  磁盘空间不足、`verify` 失败和恢复演练失败发送告警。备份目录应同步到与生产主机
-  不同故障域的加密存储。
+- 建议由 systemd timer、cron 或外部调度平台执行
+  `noj-cli maintain backup create`，并对非零退出码、磁盘空间不足、`verify`
+  失败和恢复演练失败发送告警。备份目录应同步到与生产主机不同故障域的加密存储。
 
 密钥轮换和失效步骤见[生产密钥轮换 Runbook](./production-secrets.md)。

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -8,7 +8,7 @@
 ### 宝塔等服务器面板
 
 宝塔等服务器面板与普通部署复用同一套 `noj-cli` 流程，不提供面板专用脚本或参数。
-部署完成后只需在面板中将域名反向代理到 `127.0.0.1:NGINX_PORT`（默认 `8080`）；
+部署完成后只需在面板中将域名反向代理到 `127.0.0.1:<env.NGINX_PORT>`（默认 `8080`）；
 Judge 仍需使用独立的 rootless Docker socket，不能改用 `/run/docker.sock` 或
 `/var/run/docker.sock`。
 
@@ -261,12 +261,12 @@ docker exec noj-redis redis-cli -a '<REDIS_PASSWORD>' LLEN noj:judge:queue
    完成漏洞扫描、SBOM、签名和来源证明后，才创建正式版本标签。
 2. 确认 Release workflow 的全部镜像验证成功；固定版本部署可在服务器修改
    `noj-deploy.json` 中的 `version.noj_server=v0.1.1`（或执行
-   `noj-cli maintain config set version.noj_server v0.1.1`）。
+   `noj-cli maintain config set version.noj_server v0.1.1 --dir /opt/neuro-oj`）。
 3. 升级前创建备份，然后更新配置并重新部署：
 
 ```bash
 noj-cli maintain backup create --dir /opt/neuro-oj
-noj-cli maintain config set version.noj_server v0.1.1
+noj-cli maintain config set version.noj_server v0.1.1 --dir /opt/neuro-oj
 noj-cli deploy up --dir /opt/neuro-oj
 ```
 

--- a/noj-docs/docs/operators/production-secrets.md
+++ b/noj-docs/docs/operators/production-secrets.md
@@ -1,11 +1,11 @@
 # 生产密钥轮换 Runbook
 
-本文档适用于 Docker Compose 生产部署。推荐使用 secrets manager 将值注入容器环境；推荐使用 secrets manager，或将密钥写入 `noj-secrets.json`（权限 600），不得提交 Git、打入镜像或写入日志。
+本文档适用于 Docker Compose 生产部署。推荐使用 secrets manager 将值注入容器环境；未接入 secrets manager 时，可将密钥写入 `noj-secrets.json`（权限 600），不得提交 Git、打入镜像或写入日志。
 
 ## 部署前检查
 
 ```bash
-chmod 600 noj-secrets.json
+chmod 600 /opt/neuro-oj/noj-secrets.json
 cd noj-core
     deno task check:prod  # 可选；生产一键部署不依赖 Deno
 cd ..
@@ -17,7 +17,7 @@ docker compose -f /opt/neuro-oj/docker-compose.noj.yml config >/dev/null
 ## S3/MinIO 应用凭据轮换
 
 1. 生成新的 `S3_ACCESS_KEY` 和 `S3_SECRET_KEY`，确保它们与 `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` 不同。
-2. 在维护窗口更新 `noj-secrets.json`，运行 `docker compose config` 和 `deno task check:prod`。
+2. 在维护窗口更新 `noj-secrets.json`，运行 `docker compose -f /opt/neuro-oj/docker-compose.noj.yml config` 和 `deno task check:prod`。
 3. 执行 `minio-init`，让目标 bucket 的应用策略和新用户生效：
 
    ```bash

--- a/noj-docs/docs/operators/production-secrets.md
+++ b/noj-docs/docs/operators/production-secrets.md
@@ -1,15 +1,15 @@
 # 生产密钥轮换 Runbook
 
-本文档适用于 Docker Compose 生产部署。推荐使用 secrets manager 将值注入容器环境；若暂时使用 `.env.prod`，文件必须由部署用户持有并设置为 `chmod 600`，不得提交 Git、打入镜像或写入日志。
+本文档适用于 Docker Compose 生产部署。推荐使用 secrets manager 将值注入容器环境；推荐使用 secrets manager，或将密钥写入 `noj-secrets.json`（权限 600），不得提交 Git、打入镜像或写入日志。
 
 ## 部署前检查
 
 ```bash
-chmod 600 .env.prod
+chmod 600 noj-secrets.json
 cd noj-core
     deno task check:prod  # 可选；生产一键部署不依赖 Deno
 cd ..
-docker compose --env-file .env.prod -f docker-compose.prod.yml config >/dev/null
+docker compose -f /opt/neuro-oj/docker-compose.noj.yml config >/dev/null
 ```
 
 检查命令只输出配置键名和错误原因，不输出 secret 值。生产环境禁止已知占位符、mock 邮件 Provider 和 local 存储。
@@ -17,11 +17,11 @@ docker compose --env-file .env.prod -f docker-compose.prod.yml config >/dev/null
 ## S3/MinIO 应用凭据轮换
 
 1. 生成新的 `S3_ACCESS_KEY` 和 `S3_SECRET_KEY`，确保它们与 `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` 不同。
-2. 在维护窗口更新 `.env.prod`，运行 `docker compose config` 和 `deno task check:prod`。
+2. 在维护窗口更新 `noj-secrets.json`，运行 `docker compose config` 和 `deno task check:prod`。
 3. 执行 `minio-init`，让目标 bucket 的应用策略和新用户生效：
 
    ```bash
-   docker compose --env-file .env.prod -f docker-compose.prod.yml up --no-deps minio-init
+   docker compose -f /opt/neuro-oj/docker-compose.noj.yml up --no-deps minio-init
    ```
 
 4. 重启 `server` 和 `judge`，提交一个小型支持包题目验证读写和评测交付。


### PR DESCRIPTION
## 概述

将 noj-docs 中的生产部署/运维文档从 `.env.prod` 迁移到 `noj-deploy.json` + `noj-secrets.json` 配置模型，与 noj-cli 的实际管理方式保持一致。

## 主要变更

- `noj-docs/docs/operators/production-deploy.md`
  - 删除 `.env.prod` 配置表与手工 `docker compose --env-file .env.prod` 步骤
  - 新增「配置模型」：明确使用 `noj-deploy.json`（644）+ `noj-secrets.json`（600）
  - 常用配置项改为 JSON 路径/字段（`version.noj_server`、`env.*`、`secrets.*`、`components.judge.enabled`）
  - 升级/回滚改为 `noj-cli maintain config set version.noj_server ...`
  - 日常运维命令统一为 `noj-cli deploy status / maintain logs / maintain backup`
  - 宝塔面板段落收敛为与普通部署复用同一流程，不重复描述
- `noj-docs/docs/operators/judge-workers.md`
  - 移除 `.env.prod` 命令，改用 noj-cli / `docker-compose.noj.yml` / `docker exec noj-redis`
- `noj-docs/docs/operators/cli.md`
  - 移除 `--env-file .env.prod`，改用 noj-cli 生成的 `docker-compose.noj.yml`
- `noj-docs/docs/operators/production-secrets.md`
  - 密钥轮换 Runbook 改为面向 `noj-secrets.json`

## 验证

- `grep .env.prod noj-docs`：仅剩“不再使用 .env.prod”的说明
- `scripts/verify-md-links.ts`：本次涉及的 noj-docs 文件无新增链接错误
