### PR TITLE
feat(root): 恢复一键部署并拆分 noj-cli 发布

### DIFF
--- a/.agents/notes/implemented/feature/2026-09-02-restore-legacy-deploy-entrypoint.md
+++ b/.agents/notes/implemented/feature/2026-09-02-restore-legacy-deploy-entrypoint.md
@@ -1,0 +1,30 @@
+# Agent Note: 恢复独立的一键部署入口
+
+Status: implemented
+
+## Problem
+
+将 `noj-cli` 作为 GitHub Release 二进制和唯一生产入口后，安装依赖缺失的 Release 资产，
+并且旧版用户熟悉的 `setup.sh`、`noj`、生产配置和 Judge 部署流程被移除。新旧配置模型和服务命名
+同时存在时，用户无法直接判断应该使用哪套部署方式。
+
+## Decision
+
+恢复 `setup.sh`、根目录 `noj`、`scripts/deploy/` 生产脚本、独立 Judge 安装脚本和 `.env.prod`
+配置流程。生产 Compose 恢复 `core` 服务名，同时兼容当前已发布的 `noj-server` 镜像，`noj` 负责安装、升级、备份、诊断和
+卸载。保留 `noj-cli/` 源码目录供独立开发和测试，但从 Release workflow 移除 CLI/Server 二进制
+构建与上传任务；Release 只发布生产 Docker 镜像。
+
+## Alternatives considered
+
+- 继续让 `noj-cli` 作为唯一入口：安装路径短，但依赖二进制 Release 资产，旧配置和已有部署无法平滑复用。
+- 完全删除 `noj-cli`：能减少维护面，但会丢失已有 CLI 实验代码和后续可复用的部署编排实现。
+- 同时维护两套生产入口：短期有少量文档和测试维护成本，但能兼容已有用户并降低迁移风险，因此采用该方案，
+  并明确 `noj` 是生产入口、`noj-cli` 是源码工具。
+
+## Consequences
+
+- 空服务器可以继续使用一条 `curl ... setup.sh | bash` 命令完成部署，不依赖 CLI Release 资产。
+- 旧版 `.env.prod`、数据卷、备份和 Judge 配置可以继续使用；升级和回滚命令保持稳定。
+- `noj-cli` 的二进制安装方式不再有效，CLI 使用者需要从源码目录通过 Deno 运行。
+- Release workflow 的镜像命名与生产 Compose 保持一致，发布验证不再依赖 `noj-cli` 或 `noj-server` Release 资产。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@
 # 触发条件：GitHub Release published 或 workflow_dispatch。
 # 普通 push / pull_request 不发布生产镜像。
 # 每次 Release 构建并推送 7 个镜像，平台为 linux/amd64（公测阶段只支持 amd64）。
+# noj-cli 仅作为源码项目维护，不作为 GitHub Release 二进制资产发布。
 # =============================================================================
 
 name: Release Images
@@ -218,77 +219,6 @@ jobs:
           path: release-${{ matrix.name }}.txt
           if-no-files-found: error
           retention-days: 90
-
-  build-binaries:
-    name: 构建并发布 noj-server / noj-cli 二进制
-    needs: supply-chain-check
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: write
-    steps:
-      - name: 检出代码
-        uses: actions/checkout@v4
-
-      - name: 设置 Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: 2.x
-
-      - name: 计算 Release 版本
-        id: meta
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-          version="${{ github.event.release.tag_name || github.ref_name }}"
-          if [[ ! "$version" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::版本必须是合法 Release tag（例如 v0.1.0 或 0.1.1-rc.1）：$version"
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: 编译 noj-cli
-        run: |
-          cd noj-cli
-          deno task build:cli
-          test -x bin/noj-cli-linux-amd64
-
-      - name: 编译 noj-server
-        run: |
-          cd noj-core
-          bash scripts/build-server.sh
-          test -x bin/noj-server
-
-      - name: 整理发布产物与 SHA-256
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-          mkdir -p dist
-          cp noj-cli/bin/noj-cli-linux-amd64 dist/noj-cli-linux-amd64
-          cp noj-core/bin/noj-server dist/noj-server-linux-amd64
-          chmod +x dist/noj-cli-linux-amd64 dist/noj-server-linux-amd64
-          (cd dist && sha256sum noj-cli-linux-amd64 noj-server-linux-amd64 > SHA256SUMS.txt)
-          (cd dist && sha256sum noj-cli-linux-amd64 | awk '{print $1}' > noj-cli-linux-amd64.sha256)
-          (cd dist && sha256sum noj-server-linux-amd64 | awk '{print $1}' > noj-server-linux-amd64.sha256)
-          ls -lh dist
-
-      - name: 冒烟测试 noj-cli
-        run: ./dist/noj-cli-linux-amd64 version
-
-      - name: 上传二进制到 GitHub Release
-        if: github.event_name == 'release'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -Eeuo pipefail
-          tag="${{ github.event.release.tag_name }}"
-          gh release upload "$tag" \
-            dist/noj-cli-linux-amd64 \
-            dist/noj-cli-linux-amd64.sha256 \
-            dist/noj-server-linux-amd64 \
-            dist/noj-server-linux-amd64.sha256 \
-            dist/SHA256SUMS.txt \
-            --clobber
 
   verify-release:
     name: 验证正式 Release 镜像

--- a/README.md
+++ b/README.md
@@ -117,24 +117,25 @@ NOJ 当前持久化数据卷约 66 MiB，生产镜像（含 Evaluator、Solution
 
 ### 一键部署
 
-生产环境推荐直接下载 `noj-cli` 二进制作为唯一安装入口，由 `noj-cli` 完成环境
-检测（doctor）与生产部署（deploy init / deploy up）：
+生产环境推荐使用仓库根目录的一键安装入口 `setup.sh`。它会下载部署脚本，
+自动检查环境、引导填写配置并启动生产服务：
 
 ```bash
-# 下载最新版 noj-cli（GitHub Release 资产）
-curl -fsSL -o noj-cli \
-  https://github.com/Neuro-OJ/neuro-oj/releases/latest/download/noj-cli-linux-amd64
-chmod +x noj-cli
+# 一键安装（默认自动选择最新 Release）
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --dir /opt/neuro-oj
 
-# 环境检测
-./noj-cli doctor
-
-# 初始化并部署（示例）
-./noj-cli deploy init --mode prod --dir /opt/neuro-oj
-./noj-cli deploy up --dir /opt/neuro-oj
+# 也可以固定版本，例如 v0.8.1
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --ref v0.8.1 --dir /opt/neuro-oj
 ```
 
-安装完成后，服务启停、更新和管理统一使用 `noj-cli` 命令。
+安装脚本会在前面先检查 Linux、Docker、Compose、磁盘、端口等环境；首次安装会创建
+`.env.prod` 并用简单中文提示填写网站地址、HTTP/HTTPS、邮件服务和 Judge。邮件可以跳过，
+首个注册用户自动成为管理员。已存在的安装目录会保留配置并继续更新，不会因为目录非空而停止。
+
+安装完成后，服务启停、升级、备份和日志统一使用 `noj` 命令；`noj-cli` 是独立的源码工具，
+不作为 GitHub Release 二进制资产发布。
 
 部署完成后，通过配置的域名访问：
 
@@ -146,19 +147,20 @@ chmod +x noj-cli
 常用运维命令：
 
 ```bash
-noj-cli doctor                      # 环境检测
-noj-cli deploy status               # 查看服务状态
-noj-cli maintain logs server        # 查看 server 日志
-noj-cli deploy restart              # 重启服务
-noj-cli deploy down                 # 停止服务但保留数据卷
-noj-cli deploy up                   # 再次启动
-noj-cli maintain backup create      # 创建生产备份
-noj-cli maintain config check       # 只校验配置，不改变服务状态
+noj check                            # 检查部署环境
+noj status                           # 查看服务状态
+noj logs core                        # 查看 core 日志
+noj restart                          # 重启服务
+noj stop                             # 停止服务但保留数据卷
+noj update --latest                  # 升级到最新稳定 Release
+noj backup                           # 创建生产备份
+noj config check                     # 只校验配置，不改变服务状态
 ```
 
-`noj-cli` 是统一部署与运维入口，覆盖 `doctor`、`deploy`、`maintain`、`run-server`
-与 `version`。`noj-cli` 不提供升级/卸载子命令；配置变更与数据管理见
-`noj-cli maintain config` 与 `noj-cli maintain reset`。
+`noj` 同时保留 `install`、`start`、`stop`、`upgrade`、`update`、`status`、`logs`、`backup`、
+`verify`、`config check` 和 `uninstall`。需要高级参数时可直接运行
+`bash scripts/deploy/deploy.sh <命令>`。如果需要使用 `noj-cli`，请从 `noj-cli/` 源码目录
+通过 Deno 运行；它与生产一键部署相互独立。
 
 更多部署、TLS、备份和升级说明见 [`deploy/README.md`](./deploy/README.md) 和[生产部署文档](./noj-docs/docs/operators/production-deploy.md)。
 
@@ -211,7 +213,7 @@ noj-docs          用户、运营者和出题人文档
 
 - 提交长时间处于 `Pending`：确认 Judge Worker 已启动，并且连接了与 `noj-core` 相同的 Redis；队列和日志排查方法见[Judge Worker 运维文档](./noj-docs/docs/operators/judge-workers.md)。
 - 评测镜像不存在：确认评测镜像已发布、已加入 `judge_images` 白名单，并检查 Judge Worker 的镜像前缀配置。
-- 生产服务启动失败：执行 `noj-cli doctor`、`noj-cli deploy status` 和 `noj-cli maintain logs <service>` 查看状态与日志。
+- 生产服务启动失败：执行 `noj check`、`noj status` 和 `noj logs <service>` 查看状态与日志。
 - 密码重置邮件不可用：检查 `EMAIL_PROVIDER` 及对应凭据；暂时不配置邮件时可以使用 `disabled`，但密码找回功能不可用。
 
 更多常见问题见[常见问题](./noj-docs/docs/intro/faq.md)。

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -33,28 +33,26 @@ server {
 
 ## 首次安装与生产运维
 
-推荐直接下载 `noj-cli` 二进制作为唯一安装入口，由 `noj-cli` 完成环境检测与生产部署：
+推荐使用仓库根目录的 `setup.sh` 一键安装入口。脚本会先检查环境，再下载部署文件并引导完成生产配置：
 
 ```bash
-# 首次安装：下载 noj-cli（GitHub Release 资产）
-curl -fsSL -o noj-cli \
-  https://github.com/Neuro-OJ/neuro-oj/releases/latest/download/noj-cli-linux-amd64
-chmod +x noj-cli
+# 首次安装
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --dir /opt/neuro-oj
 
 # 日常运维
-./noj-cli doctor
-./noj-cli deploy status --dir /opt/neuro-oj
-./noj-cli maintain logs --dir /opt/neuro-oj server
-./noj-cli maintain backup create --dir /opt/neuro-oj
-./noj-cli deploy restart --dir /opt/neuro-oj
-./noj-cli deploy down --dir /opt/neuro-oj
-./noj-cli deploy up --dir /opt/neuro-oj
-./noj-cli maintain config check --dir /opt/neuro-oj
+noj status
+noj logs core
+noj backup
+noj restart
+noj stop
+noj start
+noj config check
 ```
 
-`noj-cli` 不提供升级/卸载子命令；配置变更与数据管理见 `noj-cli maintain config`
-与 `noj-cli maintain reset`。`deploy down` 不会删除数据卷；`maintain reset` 默认
-只清数据，`--include-deploy-configs` 才连配置一起清。
+`noj update` 按 `.env.prod` 中的版本升级，`noj update --latest` 获取最新稳定版本。
+`noj uninstall` 默认保留数据卷，`noj uninstall --all --yes` 才会执行完全删除。
+`noj-cli` 与 `noj` 分开维护，仅作为源码工具使用，不从 GitHub Release 下载。
 
 镜像拉取由 Docker daemon 负责。若官方源访问不稳定，请在 Docker daemon 配置
 registry mirror 或 HTTP(S) proxy 后重试；评测镜像仍可通过 `JUDGE_IMAGE_BASE`

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,11 +5,11 @@
 #   vim .env.prod
 #   docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
 #
-# 仅 Nginx 容器对外暴露 HTTP 端口（TLS 由外部边缘终止）；server/judge/db/redis/minio 不暴露到宿主机。
+# 仅 Nginx 容器对外暴露 HTTP 端口（TLS 由外部边缘终止）；core/judge/db/redis/minio 不暴露到宿主机。
 # 镜像从 NOJ_IMAGE_REGISTRY 拉取，版本由 NOJ_VERSION 控制。
 name: noj-prod
 
-x-server-env: &server-env
+x-core-env: &core-env
   NOJ_ENV: production
   NOJ_PROJECT_ROOT: /app
   NOJ_MIGRATIONS_DIR: /app/drizzle
@@ -55,7 +55,7 @@ services:
         /app/bin/noj db migrate &&
         /app/bin/noj init system
     environment:
-      <<: *server-env
+      <<: *core-env
     depends_on:
       postgres:
         condition: service_healthy
@@ -65,11 +65,11 @@ services:
       - noj-net
     restart: "no"
 
-  # ── 服务端 API（noj-server） ─────────────────────────────────────
-  server:
+  # ── 核心 API ──────────────────────────────────────────────────────
+  core:
     image: "${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-server:${NOJ_VERSION:?NOJ_VERSION is required}"
     environment:
-      <<: *server-env
+      <<: *core-env
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -105,13 +105,13 @@ services:
   ui:
     image: "${NOJ_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-ui:${NOJ_VERSION:?NOJ_VERSION is required}"
     environment:
-      NUXT_API_BASE: http://server:8000
+      NUXT_API_BASE: http://core:8000
       NUXT_NOJ_ENV: ${NUXT_NOJ_ENV:-production}
       NUXT_ALLOW_INSECURE_HTTP: ${NOJ_ALLOW_INSECURE_HTTP:-false}
       NODE_ENV: ${NODE_ENV:-production}
       PORT: "3000"
     depends_on:
-      server:
+      core:
         condition: service_healthy
     expose:
       - "3000"

--- a/noj
+++ b/noj
@@ -1,0 +1,457 @@
+#!/usr/bin/env bash
+#
+# Neuro OJ 生产运维命令入口。
+#
+# 该入口只负责命令路由；配置校验、备份、健康检查和 Docker Compose
+# 生命周期逻辑统一由 scripts/deploy/deploy.sh 实现。
+
+set -Eeuo pipefail
+
+SOURCE_FILE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE_FILE" ]]; do
+  SOURCE_DIR="$(cd -P "$(dirname "$SOURCE_FILE")" && pwd)"
+  SOURCE_FILE="$(readlink "$SOURCE_FILE")"
+  [[ "$SOURCE_FILE" == /* ]] || SOURCE_FILE="$SOURCE_DIR/$SOURCE_FILE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE_FILE")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/scripts/deploy/deploy.sh"
+
+usage() {
+  cat <<'EOF'
+Neuro OJ 生产运维命令
+
+用法：
+  noj <命令> [选项]
+
+常用命令：
+  install                 首次初始化配置并部署
+  check                   检查 Linux、Docker、Compose、磁盘和端口
+  start                   启动生产服务
+  stop                    停止服务（保留数据卷）
+  restart                 重启服务（先停止，再启动）
+  uninstall [--yes]      删除容器、网络和本地镜像（保留数据卷）
+  uninstall --all        完全删除 NOJ 及全部数据（不可恢复）
+  update                  按 .env.prod 中的 NOJ_VERSION 升级
+  update --latest         升级到最新稳定 Release（不含 RC/预发布）
+  status                  查看服务状态
+  logs [service]          查看服务日志（支持 --follow）
+  backup                  创建完整生产备份
+  verify                  校验生产镜像和配置
+  config check            只检查生产配置，不改变服务状态
+
+示例：
+  ./noj install
+  ./noj update
+  ./noj update --latest
+  ./noj status
+  ./noj logs core --follow
+  ./noj backup --passphrase-file /etc/noj/backup-passphrase
+  ./noj config check
+  ./noj uninstall
+  ./noj uninstall --all
+
+说明：
+  update 会先同步对应版本的部署文件和 noj 命令，再执行带备份的服务升级；默认版本来自 .env.prod。
+  update --latest 会查询最新稳定 Release；当前已是最新版本时不重启服务、不创建升级备份。
+  首次 install 或 upgrade 会自动准备 /etc/noj/backup-passphrase；也可通过 --passphrase-file 指定已有口令文件。
+  uninstall 会要求输入 UNINSTALL 确认；自动化环境请使用 uninstall --yes。它不会删除数据卷、配置、备份或部署目录。
+  uninstall --all 会要求输入 DELETE ALL 确认；自动化环境请使用 uninstall --all --yes。它会删除当前安装目录和全部数据，且不可恢复。
+  install 成功后会自动注册 PATH 命令；优先使用 /usr/local/bin，权限不足时使用 ~/.local/bin。
+  deploy.sh 仍可用于高级选项；noj 会把支持的选项原样传递给它。
+  生产配置默认是 .env.prod，Compose 文件默认是 docker-compose.prod.yml。
+EOF
+}
+
+fail() {
+  printf '✗ %s\n' "$*" >&2
+  exit 2
+}
+
+ok() { printf '✓ %s\n' "$*"; }
+warn() { printf '! %s\n' "$*" >&2; }
+
+link_command() {
+  local bin_dir="$1" command_path="$1/noj" target="$SCRIPT_DIR/noj" existing
+  if [[ -L "$command_path" ]]; then
+    existing="$(readlink "$command_path" 2>/dev/null || true)"
+    [[ "$existing" == "$target" ]] && return 0
+    return 2
+  fi
+  [[ ! -e "$command_path" ]] || return 2
+  mkdir -p "$bin_dir" 2>/dev/null || return 1
+  ln -s "$target" "$command_path" 2>/dev/null || return 1
+}
+
+add_user_path() {
+  local user_home="${HOME:-}" profile path_line
+  [[ -n "$user_home" ]] || return 1
+  profile="$user_home/.profile"
+  path_line='export PATH="$HOME/.local/bin:$PATH"'
+  touch "$profile" 2>/dev/null || return 1
+  if ! grep -Fqx -- "$path_line" "$profile" 2>/dev/null; then
+    printf '\n# Neuro OJ command\n%s\n' "$path_line" >>"$profile" || return 1
+  fi
+}
+
+register_command() {
+  local global_bin="${NOJ_BIN_DIR:-/usr/local/bin}" user_bin user_home link_status
+  if link_command "$global_bin"; then
+    ok "已注册全局命令：$global_bin/noj"
+    return 0
+  else
+    link_status=$?
+    if ((link_status == 2)); then
+      warn "未覆盖已有命令：$global_bin/noj"
+      return 0
+    fi
+  fi
+
+  user_home="${HOME:-}"
+  user_bin="$user_home/.local/bin"
+  if [[ -n "$user_home" ]] && link_command "$user_bin"; then
+    if add_user_path; then
+      ok "已注册用户命令：$user_bin/noj；重新登录后可直接执行 noj"
+    else
+      warn "已创建用户命令：$user_bin/noj，但无法自动更新 PATH，请手动将其加入 PATH"
+    fi
+    return 0
+  else
+    link_status=$?
+    if ((link_status == 2)); then
+      warn "未覆盖已有命令：$user_bin/noj"
+      return 0
+    fi
+  fi
+  warn "无法注册 noj 到 PATH；部署已完成，请手动将 $SCRIPT_DIR/noj 加入 PATH"
+}
+
+symlink_points_to_current_install() {
+  local command_path="$1" target target_dir target_name resolved
+  [[ -L "$command_path" ]] || return 1
+  target="$(readlink "$command_path" 2>/dev/null || true)"
+  [[ -n "$target" ]] || return 1
+  if [[ "$target" == /* ]]; then
+    resolved="$target"
+  else
+    target_dir="$(cd -P "$(dirname "$command_path")" && cd -P "$(dirname "$target")" && pwd)"
+    target_name="$(basename "$target")"
+    resolved="$target_dir/$target_name"
+  fi
+  [[ "$resolved" == "$SCRIPT_DIR/noj" ]]
+}
+
+unregister_command() {
+  local command_path removed=0
+  local -a command_paths=()
+  [[ -n "${NOJ_BIN_DIR:-}" ]] && command_paths+=("$NOJ_BIN_DIR/noj")
+  command_paths+=("/usr/local/bin/noj")
+  [[ -n "${HOME:-}" ]] && command_paths+=("$HOME/.local/bin/noj")
+  for command_path in "${command_paths[@]}"; do
+    [[ -L "$command_path" ]] || continue
+    symlink_points_to_current_install "$command_path" || continue
+    rm -f -- "$command_path" || fail "无法移除 PATH 命令软链接：$command_path"
+    ok "已移除 PATH 命令：$command_path"
+    removed=1
+  done
+  ((removed)) || warn "未找到指向当前安装目录的 PATH 命令软链接"
+}
+
+remove_install_directory() {
+  [[ -d "$SCRIPT_DIR" && ! -L "$SCRIPT_DIR" ]] ||
+    fail "当前安装目录不存在或不是普通目录：$SCRIPT_DIR"
+  [[ -f "$SCRIPT_DIR/noj" && -f "$DEPLOY_SCRIPT" && -f "$SCRIPT_DIR/docker-compose.prod.yml" ]] ||
+    fail "当前目录不是完整的 NOJ 安装目录，拒绝完全删除：$SCRIPT_DIR"
+  [[ ! -e "$SCRIPT_DIR/.git" ]] ||
+    fail "检测到 Git 工作区，拒绝删除源码目录；请在生产安装目录执行 uninstall --all"
+  [[ "$SCRIPT_DIR" != / && "$SCRIPT_DIR" != "." && "$SCRIPT_DIR" != ".." ]] ||
+    fail "拒绝删除危险安装路径：$SCRIPT_DIR"
+  rm -rf -- "$SCRIPT_DIR" || fail "无法删除 NOJ 安装目录：$SCRIPT_DIR"
+  ok "已删除 NOJ 安装目录：$SCRIPT_DIR"
+}
+
+require_deploy_script() {
+  [[ -f "$DEPLOY_SCRIPT" ]] ||
+    fail "未找到生产部署脚本：${DEPLOY_SCRIPT}；请在 NOJ 安装目录中执行 noj"
+  [[ -r "$DEPLOY_SCRIPT" ]] || fail "生产部署脚本不可读：$DEPLOY_SCRIPT"
+}
+
+run_deploy() {
+  require_deploy_script
+  bash "$DEPLOY_SCRIPT" "$@"
+}
+
+run_bootstrap_check() {
+  local bootstrap="$SCRIPT_DIR/scripts/deploy/install.sh"
+  [[ -f "$bootstrap" ]] || fail "未找到环境检查脚本：$bootstrap"
+  bash "$bootstrap" check "$@"
+}
+
+run_files_sync() {
+  local bootstrap status
+  bootstrap="$(mktemp "${TMPDIR:-/tmp}/noj-update-bootstrap.XXXXXX")" ||
+    fail "无法创建更新 bootstrap 临时文件"
+  if ! cp -- "$SCRIPT_DIR/scripts/deploy/install.sh" "$bootstrap"; then
+    rm -f -- "$bootstrap"
+    fail "无法准备更新 bootstrap 临时文件"
+  fi
+  chmod 700 "$bootstrap"
+  set +e
+  NOJ_BOOTSTRAP_BIN_DIR="${NOJ_BIN_DIR:-/usr/local/bin}" \
+    bash "$bootstrap" "$@"
+  status=$?
+  set -e
+  rm -f -- "$bootstrap"
+  return "$status"
+}
+
+configured_version() {
+  local env_file="${1:-$SCRIPT_DIR/.env.prod}" version
+  [[ -f "$env_file" ]] || fail "未找到生产配置：$env_file"
+  version="$(awk '
+    index($0, "NOJ_VERSION=") == 1 { print substr($0, 13); exit }
+  ' "$env_file")"
+  case "$version" in
+    "\""*"\""|"'"*"'") version="${version:1:${#version}-2}" ;;
+  esac
+  [[ -n "$version" ]] || fail "生产配置缺少 NOJ_VERSION：$env_file"
+  printf '%s\n' "$version"
+}
+
+json_field() {
+  local key="$1"
+  awk -v key="$key" '
+    {
+      pattern = "\\\"" key "\\\"[[:space:]]*:[[:space:]]*"
+      if (match($0, pattern)) {
+        value = substr($0, RSTART + RLENGTH)
+        sub(/[,}].*$/, "", value)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+        gsub(/^\"|\"$/, "", value)
+        print value
+        exit
+      }
+    }
+  '
+}
+
+validate_release_tag() {
+  local version="$1"
+  [[ "$version" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    fail "GitHub Release 不是稳定版本标签：${version}；请使用固定版本升级 RC/预发布版本"
+}
+
+latest_release_version() {
+  local repository metadata_url metadata tag draft prerelease
+  repository="${NOJ_UPDATE_REPOSITORY:-https://github.com/Neuro-OJ/neuro-oj}"
+  repository="${repository%/}"
+  if [[ -n "${NOJ_UPDATE_API_URL:-}" ]]; then
+    metadata_url="$NOJ_UPDATE_API_URL"
+  else
+    [[ "$repository" =~ ^https://github\.com/([^/]+/[^/]+)$ ]] ||
+      fail "无法自动获取最新版本；请使用 NOJ_UPDATE_API_URL 或固定版本升级"
+    metadata_url="https://api.github.com/repos/${BASH_REMATCH[1]}/releases/latest"
+  fi
+  [[ "$metadata_url" == https://* ]] ||
+    fail "最新版本 API 地址必须使用 HTTPS"
+
+  printf '正在获取最新稳定 Release\n' >&2
+  if command -v curl >/dev/null 2>&1; then
+    metadata="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+      --retry 3 --connect-timeout 15 --header 'Accept: application/vnd.github+json' \
+      --header 'User-Agent: neuro-oj-updater' "$metadata_url")" ||
+      fail "无法获取最新稳定 Release，请检查网络，或使用固定版本重试"
+  elif command -v wget >/dev/null 2>&1; then
+    metadata="$(wget --https-only --tries=3 --timeout=20 --quiet \
+      --header='Accept: application/vnd.github+json' --header='User-Agent: neuro-oj-updater' \
+      -O - "$metadata_url")" ||
+      fail "无法获取最新稳定 Release，请检查网络，或使用固定版本重试"
+  else
+    fail "需要 curl 或 wget 才能查询最新稳定 Release"
+  fi
+
+  tag="$(json_field tag_name <<<"$metadata")"
+  draft="$(json_field draft <<<"$metadata")"
+  prerelease="$(json_field prerelease <<<"$metadata")"
+  [[ -n "$tag" && "$draft" == false && "$prerelease" == false ]] ||
+    fail "GitHub 返回的最新 Release 无效或仍是预发布版本"
+  validate_release_tag "$tag"
+  printf '%s\n' "$tag"
+}
+
+write_config_version() {
+  local env_file="$1" version="$2" temp_file
+  temp_file="$(mktemp "${env_file}.version.XXXXXX")" ||
+    fail "无法创建版本配置暂存文件"
+  if ! awk -v version="$version" '
+    BEGIN { found = 0 }
+    index($0, "NOJ_VERSION=") == 1 {
+      print "NOJ_VERSION=" version
+      found = 1
+      next
+    }
+    { print }
+    END { if (!found) print "NOJ_VERSION=" version }
+  ' "$env_file" >"$temp_file"; then
+    rm -f -- "$temp_file"
+    fail "写入版本配置暂存文件失败"
+  fi
+  chmod 600 "$temp_file"
+  mv -- "$temp_file" "$env_file" || fail "写入版本配置暂存文件失败"
+}
+
+update() {
+  local latest=0 version current env_file="$SCRIPT_DIR/.env.prod"
+  local sync_dry_run=0 stage_file="" status
+  local -a original_args=("$@")
+  local -a sync_args=()
+  local -a deploy_args=()
+  require_deploy_script
+
+  while (($# > 0)); do
+    case "$1" in
+      --latest)
+        latest=1
+        ;;
+      --env-file)
+        (($# >= 2)) || fail "--env-file 需要一个文件路径"
+        env_file="$2"
+        shift
+        ;;
+      --env-file=*)
+        env_file="${1#*=}"
+        ;;
+      *)
+        deploy_args+=("$1")
+        ;;
+    esac
+    shift
+  done
+
+  if (( !latest )); then
+    version="$(configured_version "$env_file")"
+    sync_args=(--ref "$version" --dir "$SCRIPT_DIR" --files-only)
+    for arg in "${original_args[@]}"; do
+      [[ "$arg" == "--dry-run" ]] && sync_dry_run=1
+    done
+    ((sync_dry_run)) && sync_args+=(--dry-run)
+    printf '同步生产部署文件：%s\n' "$version"
+    run_files_sync "${sync_args[@]}"
+    run_deploy upgrade "${original_args[@]}"
+    return 0
+  fi
+
+  current="$(configured_version "$env_file")"
+  version="$(latest_release_version)"
+  printf '当前生产版本：%s\n' "$current"
+  printf '最新稳定版本：%s\n' "$version"
+  if [[ "$version" == "$current" ]]; then
+    ok "当前已经是最新稳定 Release，无需升级"
+    return 0
+  fi
+
+  [[ -f "$SCRIPT_DIR/scripts/deploy/install.sh" ]] ||
+    fail "未找到部署文件更新脚本：$SCRIPT_DIR/scripts/deploy/install.sh"
+
+  stage_file="$(mktemp "${env_file}.latest.XXXXXX")" ||
+    fail "无法创建版本配置暂存文件"
+  if ! cp -- "$env_file" "$stage_file"; then
+    rm -f -- "$stage_file"
+    fail "无法复制生产配置到暂存文件"
+  fi
+  write_config_version "$stage_file" "$version"
+
+  for arg in "${original_args[@]}"; do
+    [[ "$arg" == "--dry-run" ]] && sync_dry_run=1
+  done
+  sync_args=(--ref "$version" --dir "$SCRIPT_DIR" --files-only)
+  ((sync_dry_run)) && sync_args+=(--dry-run)
+  printf '同步生产部署文件：%s\n' "$version"
+  if run_files_sync "${sync_args[@]}"; then
+    :
+  else
+    status=$?
+    rm -f -- "$stage_file"
+    return "$status"
+  fi
+
+  deploy_args+=(--env-file "$stage_file")
+  if run_deploy upgrade "${deploy_args[@]}"; then
+    if ((sync_dry_run)); then
+      rm -f -- "$stage_file"
+      ok "[dry-run] 将升级到最新稳定 Release：$version"
+      return 0
+    fi
+    chmod 600 "$stage_file"
+    mv -- "$stage_file" "$env_file" || fail "升级成功但无法提交生产版本配置"
+    ok "已升级到最新稳定 Release：$version"
+  else
+    status=$?
+    rm -f -- "$stage_file"
+    return "$status"
+  fi
+}
+
+restart() {
+  require_deploy_script
+  bash "$DEPLOY_SCRIPT" stop "$@"
+  bash "$DEPLOY_SCRIPT" start "$@"
+}
+
+main() {
+  local command="${1:-}"
+  if [[ -z "$command" || "$command" == "-h" || "$command" == "--help" || "$command" == "help" ]]; then
+    usage
+    [[ -n "$command" ]] || return 2
+    return 0
+  fi
+  shift
+
+  case "$command" in
+    check)
+      run_bootstrap_check "$@"
+      ;;
+    install|start|stop|status|logs|backup|verify)
+      run_deploy "$command" "$@"
+      [[ "$command" != install ]] || register_command
+      ;;
+    uninstall)
+      run_deploy uninstall "$@"
+      local arg dry_run=0
+      local remove_all=0
+      for arg in "$@"; do
+        [[ "$arg" == --dry-run ]] && dry_run=1
+        [[ "$arg" == --all ]] && remove_all=1
+      done
+      if (( !dry_run )); then
+        unregister_command
+        if ((remove_all)); then
+          remove_install_directory
+        fi
+      fi
+      ;;
+    update)
+      update "$@"
+      ;;
+    restart)
+      restart "$@"
+      ;;
+    config)
+      [[ "${1:-}" == "check" ]] || {
+        usage >&2
+        fail "config 目前只支持 check"
+      }
+      shift
+      run_deploy verify "$@"
+      ;;
+    register-command)
+      [[ "${NOJ_INTERNAL_REGISTER:-0}" == 1 ]] || fail "不支持直接调用内部命令"
+      register_command
+      ;;
+    *)
+      usage >&2
+      fail "未知命令：$command"
+      ;;
+  esac
+}
+
+main "$@"

--- a/noj-cli/README.md
+++ b/noj-cli/README.md
@@ -29,18 +29,17 @@ P5 补充：`deploy up` 与 `run-server` 在 process 模式且未配置 `dev_com
 （SHA-256），缓存到 `<install_dir>/bin/`；`deploy init` 会尝试解析最新版本号，
 网络不可用时回退到内置默认版本。
 
-## 安装
+## 使用边界
 
-`noj-cli` 是唯一安装入口，直接下载 GitHub Release 二进制即可：
+生产服务器请使用仓库根目录的 `setup.sh` 和 `noj`，不要依赖 `noj-cli` Release
+二进制。`noj-cli` 保留在仓库中，作为独立的 Deno/TypeScript 源码工具开发和测试：
 
 ```bash
-curl -fsSL -o noj-cli \
-  https://github.com/Neuro-OJ/neuro-oj/releases/latest/download/noj-cli-linux-amd64
-chmod +x noj-cli
-./noj-cli doctor
+cd noj-cli
+deno run -A src/cli.ts doctor
 ```
 
-固定版本时把 `releases/latest` 换成 `releases/download/vX.Y.Z`。
+它不会作为 GitHub Release 二进制资产发布，也不承担旧版 `noj` 的兼容入口。
 
 ## 用法
 

--- a/noj-docs/docs/operators/cli.md
+++ b/noj-docs/docs/operators/cli.md
@@ -1,13 +1,14 @@
-# CLI 初始化
+# 服务端 CLI 初始化
 
-`noj-server` 镜像内包含编译后的管理 CLI（`/app/bin/noj`），用于数据库迁移、系统初始化、管理员引导与题目包操作。
+这里的 CLI 是 `noj-server` 镜像内置的服务端管理命令（`/app/bin/noj`），用于数据库迁移、系统初始化、管理员引导与题目包操作。
+它与仓库中的 `noj-cli` 源码工具相互独立；`noj-cli` 不作为 GitHub Release 二进制发布。
 
 ## 生产环境执行方式
 
-生产环境不直接使用源码或 `deno task`，而是通过 Docker Compose 在 `noj-server` 镜像内执行 CLI：
+生产环境不直接使用源码或 `deno task`，而是通过部署目录中的 Docker Compose，在 `noj-server` 镜像内执行 CLI：
 
 ```bash
-docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
+docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml run --rm \
   --entrypoint /app/bin/noj <子命令>
 ```
 
@@ -15,23 +16,23 @@ docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
 
 ```bash
 # 数据库迁移
-docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
+docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml run --rm \
   --entrypoint /app/bin/noj db migrate
 
 # 系统基础数据：root + RBAC + 评测镜像白名单 + 标签
-docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
+docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml run --rm \
   --entrypoint /app/bin/noj init system
 
 # 管理员引导（从部署配置或环境变量读取 ADMIN_EMAIL / ADMIN_PASS）
-docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
+docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml run --rm \
   --entrypoint /app/bin/noj bootstrap admin
 
 # 构建统一题目包（需要在镜像内包含 data/problems-src）
-docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
+docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml run --rm \
   --entrypoint /app/bin/noj problems build
 
 # 导入统一题目包
-docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
+docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml run --rm \
   --entrypoint /app/bin/noj problems import
 ```
 

--- a/noj-docs/docs/operators/index.md
+++ b/noj-docs/docs/operators/index.md
@@ -16,7 +16,7 @@
 
 - PostgreSQL：持久化用户、题目、提交、结果和配置。
 - Redis：评测任务队列、结果队列和 core/judge RPC。
-- noj-server：Deno + Hono 后端。
+- noj-core：Deno + Hono 后端。
 - noj-ui：Nuxt 前端。
 - noj-judge：Rust + Docker Judge Worker。
 - noj-llm-gateway：LLM 调用网关（Provider Key 托管、eval_token、限流/额度与用量审计）。

--- a/noj-docs/docs/operators/judge-workers.md
+++ b/noj-docs/docs/operators/judge-workers.md
@@ -11,33 +11,32 @@ Evaluator + Solution 双容器（用后即毁），并把结果写回 Redis。
 
 ## 独立节点部署
 
-如果评测节点不运行 noj-server、noj-ui 或完整源码仓库，可以使用 `noj-cli` 在独立目录
-初始化一份只启用 judge 组件的部署配置：
+如果评测节点不运行 noj-core、noj-ui 或完整源码仓库，可以使用仓库提供的 Judge 安装脚本
+在独立目录初始化 Worker：
 
 ```bash
-cd noj-cli
-deno run -A src/cli.ts deploy init --mode prod --dir /srv/noj-judge
-# 编辑 /srv/noj-judge/noj-deploy.json，只保留 judge 组件并填写 Redis / Docker socket 配置
-deno run -A src/cli.ts deploy up --dir /srv/noj-judge
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/judge-install.sh \
+  -o judge-install.sh
+bash judge-install.sh install --dir /srv/noj-judge
 ```
 
 首次配置需要填写：
 
-- `NOJ_VERSION` / `version.noj_server`：不可变 Release 版本，例如 `v0.1.0`；
-- `REDIS_URL`：与 noj-server 相同的 Redis 地址、数据库和认证信息；
-- `JUDGE_QUEUE` / `RESULT_QUEUE`：必须与 noj-server 使用的队列名称一致；
+- `NOJ_VERSION`：不可变 Release 版本，例如 `v0.1.0`；
+- `REDIS_URL`：与 noj-core 相同的 Redis 地址、数据库和认证信息；
+- `JUDGE_QUEUE` / `RESULT_QUEUE`：必须与 noj-core 使用的队列名称一致；
 - `JUDGE_DOCKER_SOCKET` / `JUDGE_DOCKER_SOCKET_GID`：只服务于 Judge 的 rootless
   Docker daemon Unix socket 及其组 ID。
 
 管理独立 Worker：
 
 ```bash
-noj-cli deploy status --dir /srv/noj-judge
-noj-cli maintain logs --dir /srv/noj-judge
-noj-cli deploy down --dir /srv/noj-judge
+bash /srv/noj-judge/judge-install.sh status
+bash /srv/noj-judge/judge-install.sh logs
+bash /srv/noj-judge/judge-install.sh stop
 ```
 
-> 旧版 `scripts/deploy/judge-install.sh` 已移除，统一使用 `noj-cli`。
+Judge 安装脚本与主站部署脚本相互独立；它不会安装或替换主站的 `noj` 命令。
 
 当前生产 Release 镜像由发布流水线提供 `linux/amd64`。ARM64 主机必须先确认所选
 版本发布了对应 manifest；否则部署会在启动前提示架构不匹配，不能通过回退到宿主机
@@ -151,8 +150,8 @@ test "$JUDGE_REQUIRE_ISOLATED_DOCKER" = "true"
 
 # 只应看到独立 daemon socket 和评测缓存，不得出现应用宿主机 socket、
 # /var/lib/docker、/etc 或其他宿主路径。
-docker compose -f /opt/neuro-oj/docker-compose.noj.yml config
-docker inspect "$(docker compose -f /opt/neuro-oj/docker-compose.noj.yml ps -q judge)" \
+docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml config
+docker inspect "$(docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml ps -q judge)" \
   --format '{{json .Mounts}}'
 ```
 
@@ -184,13 +183,13 @@ cd noj-judge
 ```
 
 生产部署时，`init system` 会根据 `JUDGE_IMAGE_BASE`（默认 `ghcr.io/neuro-oj/`）写入
-ghcr 全限定镜像名；若需要手工确认，见[生产部署](production-deploy.md#3-评测镜像白名单)。
+ghcr 全限定镜像名；若需要手工确认，见[生产部署](production-deploy.md#3-配置说明)。
 
 `noj-evaluator-python` 与 `noj-solution-python` 基于 `python:3.12-slim`，不预装题目专用依赖，题目依赖由出题人在 evaluator 中自行管理；`noj-solution-ai` 额外内置 CPU 版 PyTorch、torchvision 与常用 CV/ML 依赖。
 
 ## 镜像白名单
 
-noj-server 维护评测镜像白名单（`judgeImages`），并在题目 CRUD / 调度阶段完成校验。Judge Worker 侧还会按 `JUDGE_IMAGE_PREFIX` / `JUDGE_COMMAND_WHITELIST` 对 MQ 消息做一次纵深复验，不再通过 Redis RPC 拉取白名单。
+noj-core 维护评测镜像白名单（`judgeImages`），并在题目 CRUD / 调度阶段完成校验。Judge Worker 侧还会按 `JUDGE_IMAGE_PREFIX` / `JUDGE_COMMAND_WHITELIST` 对 MQ 消息做一次纵深复验，不再通过 Redis RPC 拉取白名单。
 
 镜像规则包含：
 
@@ -217,20 +216,20 @@ noj-server 维护评测镜像白名单（`judgeImages`），并在题目 CRUD / 
 
 ## 健康检查与状态查看
 
-生产环境使用 noj-cli 管理：
+生产环境使用 `noj` 或 Judge 脚本管理：
 
 ```bash
 # 查看所有服务状态（含 judge 是否在线）
-noj-cli deploy status --dir /opt/neuro-oj
+bash /opt/neuro-oj/noj status
 
 # 查看 judge 日志
-noj-cli maintain logs judge --follow --dir /opt/neuro-oj
+bash /opt/neuro-oj/noj logs judge --follow
 ```
 
 调高日志详细度排查问题（临时覆盖环境变量）：
 
 ```bash
-docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
+docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml run --rm \
   -e RUST_LOG=noj_judge=debug judge
 ```
 
@@ -242,11 +241,11 @@ docker compose -f /opt/neuro-oj/docker-compose.noj.yml run --rm \
 docker exec noj-redis redis-cli -a '<REDIS_PASSWORD>' LLEN noj:judge:queue
 ```
 
-密码从 `noj-secrets.json` 的 `secrets.REDIS_PASSWORD` 读取。
+密码从 `/opt/neuro-oj/.env.prod` 的 `REDIS_PASSWORD` 读取。
 
 如果队列持续堆积：
 
-1. 确认 Judge Worker 在线且连接了同一个 Redis（`noj-cli deploy status --dir /opt/neuro-oj`）。
+1. 确认 Judge Worker 在线且连接了同一个 Redis（`noj status`）。
 2. 查看 judge 日志是否有拉取/容器错误。
 3. 检查 Docker daemon 是否可用、评测镜像是否已从 ghcr.io 拉取。
 4. 如负载确实超过单实例能力，按下一节水平扩展。
@@ -261,10 +260,8 @@ docker exec noj-redis redis-cli -a '<REDIS_PASSWORD>' LLEN noj:judge:queue
 ## 升级与重启
 
 - 停止实例会进入优雅关闭流程：排空正在执行的 in-flight 任务后再退出，避免提交丢失。
-- 升级步骤：修改 `noj-deploy.json` 中的 `version.noj_server`（或
-  `noj-cli maintain config set version.noj_server v0.1.1 --dir /opt/neuro-oj`）→
-  `noj-cli deploy up --dir /opt/neuro-oj`。
-- 升级评测镜像后应先在 noj-server 白名单登记，再启动 Worker。
+- 升级步骤：修改 `.env.prod` 中的 `NOJ_VERSION` → `noj update`。
+- 升级评测镜像后应先在 noj-core 白名单登记，再启动 Worker。
 
 ## 常见排查方向
 

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -1,341 +1,149 @@
 # 生产部署（公测）
 
-> 本文档面向公测（Public Beta）部署。当前方案为单机 Docker Compose + ghcr.io 镜像，
-> 数据库高可用、监控告警、日志聚合等可靠性/可观测性能力后续版本补充。
+本文档介绍 Linux 服务器上的一键部署方式。生产服务使用 Docker Compose 和
+`ghcr.io/neuro-oj/` 镜像；`noj` 负责部署运维，`noj-cli` 是独立的源码工具，不参与生产安装。
 
 ## 1. 前置条件
 
+- Linux amd64 服务器，至少 2 vCPU、2 GiB Swap 和 5 GiB 可用磁盘空间。
+- Docker Engine 和 Docker Compose v2，当前用户可以运行 Docker。
+- `curl` 或 `wget`、`tar`、`openssl`、CA 证书。
+- 能够访问 GitHub 源码地址和 `ghcr.io/neuro-oj/` 镜像；网络受限时请先配置 Docker 镜像源或代理。
+- 正式网站建议准备域名和 HTTPS 证书；临时测试可使用服务器 IP 和 HTTP。
+
 ### 宝塔等服务器面板
 
-宝塔等服务器面板与普通部署复用同一套 `noj-cli` 流程，不提供面板专用脚本或参数。
-部署完成后只需在面板中将域名反向代理到 `127.0.0.1:<env.NGINX_PORT>`（默认 `8080`）；
-Judge 仍需使用独立的 rootless Docker socket，不能改用 `/run/docker.sock` 或
-`/var/run/docker.sock`。
+安装脚本会自动识别宝塔面板，只给出反向代理提示，不调用面板 API，也不会修改已有站点、证书
+或其他容器。部署完成后，在面板中把域名反向代理到 `127.0.0.1:8080`；如修改了
+`NGINX_PORT`，请使用修改后的端口。启用 Judge 时仍必须使用独立的 rootless Docker socket，
+不能填写 `/run/docker.sock` 或 `/var/run/docker.sock`。
 
-- 一台 Linux 服务器（amd64），已安装 Docker Engine 与 Docker Compose v2。
-- Docker CLI 可用 Buildx；Cosign 不是默认安装条件，只有开启严格镜像签名校验时才需要。
-- Deno 2.x（可选，仅用于部署前运行 `noj-server` 的配置检查命令；一键生产部署不依赖 Deno）。
-- 一个已解析到服务器的域名。
-- 外部 TLS 终止（宿主机 Nginx / Caddy / 云负载均衡），负责 HTTPS → 容器 HTTP 端口。
-- 能够访问 `ghcr.io/neuro-oj/` 镜像；私有镜像还需要配置相应凭据。
+## 2. 一键安装
 
-## 2. 初始化
-
-### 推荐：下载 noj-cli 后开始安装
-
-NOJ 的唯一安装入口是 `noj-cli` 二进制。直接从 GitHub Releases 下载，然后交给
-`noj-cli` 完成环境检测（doctor）与生产部署（deploy init / deploy up）：
+直接复制以下命令到服务器控制台：
 
 ```bash
-# 下载最新版 noj-cli
-curl -fsSL -o noj-cli \
-  https://github.com/Neuro-OJ/neuro-oj/releases/latest/download/noj-cli-linux-amd64
-chmod +x noj-cli
-
-# 环境检测
-./noj-cli doctor
-
-# 初始化并部署（示例目录 /opt/neuro-oj）
-./noj-cli deploy init --mode prod --dir /opt/neuro-oj
-./noj-cli deploy up --dir /opt/neuro-oj
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --dir /opt/neuro-oj
 ```
 
-固定版本时把 `releases/latest` 换成 `releases/download/vX.Y.Z`，例如：
+脚本会按以下顺序执行：
+
+1. 检查 Linux、CPU 架构、Docker、Compose、磁盘和端口。
+2. 下载指定版本的部署文件；未指定版本时自动选择最新 Release。
+3. 首次创建 `.env.prod`，用简单提示询问网站地址、HTTP/HTTPS、邮件服务和是否安装 Judge。
+4. 用户确认写入配置后，拉取镜像、执行数据库迁移并等待健康检查。
+
+可选参数：
 
 ```bash
-curl -fsSL -o noj-cli \
-  https://github.com/Neuro-OJ/neuro-oj/releases/download/v0.1.0/noj-cli-linux-amd64
+# 固定版本，便于回滚
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- --ref v0.8.1 --dir /opt/neuro-oj
+
+# 只检查环境，不下载源码
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- check
+
+# 只安装基础工具；Docker Engine 仍需按发行版方式安装
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
+  bash -s -- install-env
 ```
 
-安装完成后打开网站注册第一个真实用户，该用户会自动获得管理员权限，不需要再执行额外
-的提权命令。已有站点的用户和管理员权限不会因为升级改变。
+重复执行时，如果目标目录已经是 NOJ 安装目录，脚本会保留 `.env.prod`、备份和数据卷并继续执行；
+不会因为目录非空而停止。其他非空目录会拒绝覆盖。若之前配置过，脚本开头会询问是否继续使用；
+选择重新填写时只在最后确认后写入正式配置。
 
-`setup.sh`、`scripts/deploy/*.sh` 与根目录 `noj` 旧命令均已移除，统一使用 `noj-cli`。
+安装完成后打开网站注册第一个用户，该用户自动成为管理员，不需要填写管理员邮箱或密码。
+邮件服务可以选择“暂不配置”，不影响网站启动，但密码找回邮件不可用。Judge 可以在安装时跳过，
+之后补充独立 Docker socket 后再启用。
 
-当前 Release 镜像仅发布 `linux/amd64`。ARM64/aarch64 主机请在下载前确认选择了
-对应架构的版本，或在 `noj-cli doctor` 阶段处理架构不匹配提示。
+## 3. 配置说明
 
-### 配置模型
-
-部署配置统一由 `noj-cli` 管理，**不再使用 `.env.prod`**：
-
-| 文件 | 权限 | 内容 |
-|---|---|---|
-| `noj-deploy.json` | 644 | 部署类型、版本、组件、全局 env、反向代理 |
-| `noj-secrets.json` | 600 | 数据库/Redis/JWT/OAuth/LLM 等全部密钥 |
-
-`deploy init` 会生成这两个文件并随机填充密钥。之后可用
-`noj-cli maintain config check/show/set` 查看和修改，也可以直接编辑 JSON。
-配置中的环境变量名沿用原 `.env.prod` 的约定，但**不再以 env 文件形式存在**。
-
-### 初始化、启动与健康检查
-
-```bash
-./noj-cli deploy init --mode prod --dir /opt/neuro-oj
-./noj-cli deploy up --dir /opt/neuro-oj
-./noj-cli deploy status --dir /opt/neuro-oj
-curl https://你的域名/healthz
-```
-
-### 常用配置项
+配置文件位于 `/opt/neuro-oj/.env.prod`，权限应为 `600`。常用配置如下：
 
 | 配置项 | 说明 |
 |---|---|
-| `version.noj_server`（对应原 `NOJ_VERSION`） | 要部署的已签名 Release 标签，如 `v0.1.0`；禁止使用 `latest`/`beta` |
-| `env.NOJ_ENFORCE_IMAGE_SIGNATURES` | 默认 `false`；设为 `true` 后，启动/升级前校验已启用应用镜像的 Cosign 签名 |
-| `env.NOJ_COSIGN_CERT_IDENTITY_REGEX` | Cosign 证书身份正则，默认只信任本仓库的 Release workflow |
-| `env.DOMAIN` | 网站地址，可填域名或服务器 IP，不要写 `https://` |
-| `env.APP_URL` | 完整应用地址，例如 `https://你的域名` |
-| `env.NOJ_ALLOW_INSECURE_HTTP` | 临时 HTTP 开关，默认 `false`；正式环境请保持关闭 |
-| `env.CORS_ALLOWED_ORIGINS` | `https://你的域名` |
-| `env.TRUSTED_PROXIES` | 可信代理网段，必须与 compose 中 `noj-net` 子网一致（如 `172.28.0.0/16`）；生产必填 |
-| `env.NUXT_NOJ_ENV` | 前端环境标记，生产环境保持 `production` |
-| `secrets.POSTGRES_PASSWORD` | PostgreSQL 强密码 |
-| `secrets.REDIS_PASSWORD` | Redis 强密码 |
-| `secrets.MINIO_ROOT_USER` / `secrets.MINIO_ROOT_PASSWORD` | MinIO 管理员凭据 |
-| `secrets.S3_ACCESS_KEY` / `secrets.S3_SECRET_KEY` | 支持包 bucket 的最小权限应用凭据 |
-| `env.STORAGE_PROVIDER` / `env.S3_ENDPOINT` / `env.S3_BUCKET` | 生产必须使用 S3/MinIO |
-| `env.S3_REGION` | 可选，默认 `us-east-1` |
-| `env.S3_FORCE_PATH_STYLE` | 自建 MinIO 通常为 `true` |
-| `secrets.JWT_SECRET` / `secrets.TFA_ENCRYPTION_KEY` | ≥32 字符随机串 |
-| 首个管理员 | 安装完成后注册的第一个真实用户自动获得管理员权限；已有站点不会因升级自动提权 |
-| `env.EMAIL_PROVIDER` 及对应凭据 | 可选阿里云、腾讯云或 `disabled`（暂不配置邮件） |
-| `env.JUDGE_IMAGE_BASE` | 默认 `ghcr.io/neuro-oj/` |
-| `env.NGINX_PORT` | 容器 Nginx 映射到宿主机的端口，默认 `8080` |
-| `env.JUDGE_DOCKER_SOCKET` / `env.JUDGE_DOCKER_SOCKET_GID` | 独立 rootless Docker daemon 的 socket 与组 ID；禁止使用 `/var/run/docker.sock` |
-| `secrets.OAUTH_GITHUB_CLIENT_ID` / `secrets.OAUTH_GITHUB_CLIENT_SECRET` | 可选；同时填写后启用 GitHub 登录。回调地址为 `APP_URL/api/v1/auth/oauth/github/callback` |
-| `secrets.OAUTH_OIDC_ISSUER_URL` / `secrets.OAUTH_OIDC_CLIENT_ID` / `secrets.OAUTH_OIDC_CLIENT_SECRET` | 可选；同时填写后启用通用 OIDC 登录。回调地址为 `APP_URL/api/v1/auth/oauth/oidc/callback` |
-| `env.OAUTH_OIDC_NAME` | 可选；OIDC 登录按钮名称，默认 `OIDC` |
-| `components.judge.enabled`（对应原 `JUDGE_ENABLED`） | 是否安装和启动评测服务 Judge，默认 `true`；设为 `false` 可跳过 |
-| `env.JUDGE_DOCKER_SOCKET` / `env.JUDGE_DOCKER_SOCKET_GID` | `components.judge.enabled=true` 时必填：独立 rootless Docker 服务的 socket 与组 ID；禁止使用 `/var/run/docker.sock` |
-| `secrets.NOJ_LLM_SERVICE_TOKEN` | LLM Gateway 服务间鉴权 + eval_token 签发/校验密钥（≥16 字符） |
-| `secrets.NOJ_LLM_STORE_KEY` | LLM Gateway 加密 Provider API Key 的信封主密钥（≥16 字符） |
-| `env.NOJ_LLM_USER_RATE_LIMIT_PER_MINUTE` | 每个用户每 UTC 分钟的 LLM 调用上限；可选，默认 `60`，必须为正整数 |
-| `env.NOJ_LLM_IP_RATE_LIMIT_PER_MINUTE` | 每个 IP 每 UTC 分钟的 LLM 调用上限；可选，默认 `60`，必须为正整数 |
-| `env.JUDGE_ALLOW_EVALUATOR_NETWORK` | 是否允许 evaluator 联网；使用 LLM 调用题时必须设为 `true` |
-| `env.JUDGE_EVALUATOR_NETWORK` | evaluator 联网时加入的 Docker 网络；生产必须指向 `llm-gateway` 所在网络，默认 `noj-net` |
-| `env.JUDGE_ALLOW_HTTP_S3` | 自建 MinIO 走内网 HTTP 时设为 `true`，允许 judge 通过 HTTP 下载支持包 |
+| `NOJ_VERSION` | 要使用的 Release 标签，例如 `v0.8.1`；不要填写 `latest` |
+| `DOMAIN` | 网站地址，只填写域名或服务器 IP，不要写 `http://`/`https://` |
+| `APP_URL` | 网站完整地址，例如 `http://1.2.3.4` 或 `https://oj.example.com` |
+| `CORS_ALLOWED_ORIGINS` | 通常与 `APP_URL` 相同 |
+| `POSTGRES_PASSWORD` / `REDIS_PASSWORD` | 数据库和 Redis 强密码 |
+| `JWT_SECRET` / `TFA_ENCRYPTION_KEY` | 至少 32 个字符的随机密钥 |
+| `EMAIL_PROVIDER` | `aliyun`、`tencent` 或 `disabled`；可直接跳过 |
+| `JUDGE_ENABLED` | 是否启动 Judge，默认 `true` |
+| `JUDGE_DOCKER_SOCKET` | Judge 专用 rootless Docker socket；禁止使用宿主机默认 socket |
+| `NGINX_PORT` | 对外端口，默认 `8080` |
+| `NOJ_ENFORCE_IMAGE_SIGNATURES` | 默认 `false`；只有主动开启时才需要 Cosign |
 
-镜像签名校验默认关闭，以免阻断普通一键部署；如果需要严格校验，请安装 Cosign 并将
-`env.NOJ_ENFORCE_IMAGE_SIGNATURES=true`，然后执行 `noj-cli maintain verify --dir /opt/neuro-oj`。
-`noj-cli deploy up` 会按 Compose 拉取新镜像并等待健康检查；当前版本与镜像 digest
-由 noj-cli 记录在部署目录中。
+容器内 Nginx 只处理 HTTP。使用 HTTPS 时，应在宝塔、宿主机 Nginx、Caddy 或云负载均衡中终止 TLS，
+再转发到 `127.0.0.1:8080`。脚本不会自动申请或安装证书。
 
-> 如果启用评测 Worker，不得挂载应用宿主机的 `/var/run/docker.sock`。生产 Compose 要求
-> `JUDGE_DOCKER_SOCKET` 指向只服务于 judge 的 rootless daemon socket，并以非 root
-> 用户运行 Worker；`JUDGE_REQUIRE_ISOLATED_DOCKER=true` 会在错误配置时阻止 Worker
-> 消费评测任务。rootless Docker 的安装方式见
-> [Judge Worker 运维 - rootless Docker 安装](judge-workers.md#rootless-docker-安装)。
-> 跳过 Judge 时不需要这些配置。
+## 4. 日常运维
 
-## 3. 评测镜像白名单
-
-生产初始化时 `init system` 会根据 `JUDGE_IMAGE_BASE` 写入 ghcr 全限定镜像名
-（例如 `ghcr.io/neuro-oj/noj-evaluator-python`）。
-
-如果是从旧数据库升级，或需要手工确认，请通过管理后台或 SQL 检查 `judge_images`：
-
-```sql
-SELECT image, mode, kind FROM judge_images ORDER BY kind;
-```
-
-应包含：
-
-```text
-ghcr.io/neuro-oj/noj-evaluator-python  all_versions  evaluator
-ghcr.io/neuro-oj/noj-solution-python   all_versions  solution
-ghcr.io/neuro-oj/noj-solution-ai       all_versions  solution
-```
-
-产物提交题使用 `noj-solution-python` 或 `noj-solution-ai` 运行 zip 产物；发布前应确认相应镜像已推送并被加入白名单。
-
-## 3.5 LLM Gateway 部署
-
-noj-cli 生成的部署默认启动 `llm-gateway` 容器，并让 core 通过
-`http://llm-gateway:8001` 访问。即使不使用 LLM 调用题，也必须在
-`noj-secrets.json` 中填写 `NOJ_LLM_SERVICE_TOKEN` 和 `NOJ_LLM_STORE_KEY`。
-
-使用 LLM 调用题时：
-
-- 必须设置 `NOJ_LLM_SERVICE_TOKEN` 与 `NOJ_LLM_STORE_KEY`，且 `NOJ_LLM_SERVICE_TOKEN`
-  与 noj-core 保持一致。
-- 必须开启 evaluator 联网：`JUDGE_ALLOW_EVALUATOR_NETWORK=true`。
-- `JUDGE_EVALUATOR_NETWORK` 必须指向 `llm-gateway` 所在网络（compose 中为 `noj-net`），
-  否则 evaluator 容器无法解析 `http://llm-gateway:8001`。
-- 在管理后台「LLM Providers」配置上游 OpenAI 兼容服务；Provider Key 仅加密存储在数据库。
-
-用户和 IP 分钟限流分别由 `NOJ_LLM_USER_RATE_LIMIT_PER_MINUTE` 与
-`NOJ_LLM_IP_RATE_LIMIT_PER_MINUTE` 配置，缺失时均为每 UTC 分钟 60 次。
-配置必须是正整数，并在 `llm-gateway` 重启后生效；其它日/月调用量、Token 和费用配额不受影响。
-
-密钥轮换：
-
-- 轮换 `NOJ_LLM_SERVICE_TOKEN` 会让所有未过期 eval_token 失效，需同步更新 noj-server 与 gateway。
-- 轮换 `NOJ_LLM_STORE_KEY` 后，需要用新主密钥重新加密所有 Provider Key。
-
-## 4. staging 验收门禁
-
-生产候选版本必须先在 staging 使用与生产相同的 Compose 文件和七类镜像完成验收，
-再进入 Release。验收脚本要求工作树洁净，默认只接受 `main`、`release/*` 或版本
-标签；生产验收不得使用 `latest` 作为版本标识。
-
-准备验收环境文件：
+安装目录默认为 `/opt/neuro-oj`，可以直接执行：
 
 ```bash
-cp scripts/staging/env.example .env.staging
-chmod 600 .env.staging
-vim .env.staging
+noj check                 # 检查部署环境
+noj status                # 查看服务状态
+noj logs core             # 查看 core 日志
+noj logs judge --follow   # 持续查看 Judge 日志
+noj start                 # 启动服务
+noj stop                  # 停止服务但保留数据
+noj restart               # 重启服务
+noj backup                # 创建备份
+noj verify                # 校验配置和镜像
+noj config check          # 只检查配置，不改变服务
 ```
 
-其中 `STAGING_BASE_URL` 必须是已经配置好外部 TLS 终止和反向代理的 HTTPS 地址，
-`STAGING_CORS_ORIGIN` 必须与浏览器实际来源一致。执行完整验收：
+如果 `noj` 尚未加入 PATH，也可以在安装目录执行 `./noj`，或直接调用：
 
 ```bash
-bash scripts/staging/acceptance.sh all \
-  --env-file .env.staging \
-  --artifact-dir artifacts/staging/$(grep '^NOJ_VERSION=' .env.staging | cut -d= -f2)
+cd /opt/neuro-oj
+bash scripts/deploy/deploy.sh status
 ```
 
-脚本会构建并启动 `noj-server`、`noj-ui`、`noj-judge`、`noj-llm-gateway`、
-`noj-evaluator-python`、`noj-solution-python`、`noj-solution-ai` 七类生产镜像，然后依次验证：
+## 5. 升级与回滚
 
-- Compose 健康检查、`/healthz`、HTTPS、CORS，以及 `HttpOnly`/`Secure`/`SameSite=Lax` Cookie；
-- 管理员登录与强制改密、普通用户登录、TFA 启用与登录；
-- 题包导入、S3/MinIO 支持包下载、真实代码提交与完整评测；
-- 提交 SSE 推送和管理员重测。
-
-失败时不会自动清理 staging 服务，并将 `compose ps`、最近 500 行服务日志、Docker
-信息和版本元数据写入报告目录；修复后应重新执行完整验收。成功时默认停止服务但保留
-数据卷，调试时可加 `--keep-stack` 保留服务。仅本地调试允许使用 `--allow-http`。
-
-发布前人工确认清单：
-
-1. staging 验收报告为成功，且包含候选提交、镜像仓库/版本和数据库迁移结果。
-2. 失败日志与已知限制已归档，未遗留未处理的队列、容器或数据问题。
-3. 已创建并验证 GPG 签名的提交或版本标签。
-4. 发布负责人完成手工批准后，才执行 GitHub Release 和生产升级。
-
-## 5. 日常运维
-
-安装完成后，推荐使用 `noj-cli` 命令统一管理生产服务：
+固定版本升级：
 
 ```bash
-noj-cli doctor
-noj-cli deploy status
-noj-cli maintain logs server
-noj-cli maintain logs judge --follow
-noj-cli deploy restart
-noj-cli deploy down
-noj-cli deploy up
-noj-cli maintain backup create --passphrase-file /etc/noj/backup-passphrase
-noj-cli maintain config check
+cd /opt/neuro-oj
+sed -i 's/^NOJ_VERSION=.*/NOJ_VERSION=v0.8.1/' .env.prod
+noj update
 ```
 
-`noj-cli` 不提供升级/卸载子命令；配置变更与数据管理见 `noj-cli maintain config`
-与 `noj-cli maintain reset`。`deploy down` 不会删除数据卷；`maintain reset` 默认
-只清数据，`--include-deploy-configs` 才连配置一起清。首次安装直接下载
-`noj-cli` 二进制即可，没有 `setup.sh` 薄引导。
-
-`maintain backup create` 会创建包含 PostgreSQL、Redis RDB、MinIO/S3 对象镜像和
-GPG 加密配置的完整快照，产物为单个 `snapshot-<timestamp>.nojbackup`。
+自动升级到最新稳定 Release：
 
 ```bash
-# 查看服务状态
-noj-cli deploy status --dir /opt/neuro-oj
-
-# 查看日志
-noj-cli maintain logs server --dir /opt/neuro-oj
-noj-cli maintain logs judge --follow --dir /opt/neuro-oj
-noj-cli maintain logs llm_gateway --dir /opt/neuro-oj
-
-# 健康检查（通过外部 TLS 终止后的地址）
-curl https://你的域名/healthz
-
-# 队列积压（密码从 noj-secrets.json 读取）
-docker exec noj-redis redis-cli -a '<REDIS_PASSWORD>' LLEN noj:judge:queue
+noj update --latest
 ```
 
-## 6. 升级
+升级前会创建并校验备份，拉取镜像，执行数据库迁移并等待健康检查；不会删除数据卷。若失败，
+先查看 `noj status` 和 `noj logs`，再把 `NOJ_VERSION` 改回上一个已验证版本并执行 `noj update`。
+数据库迁移只追加，不会自动回滚，因此跨大版本升级前必须确认迁移兼容性。
 
-1. 在 GitHub 发布新 Release（如 `v0.1.1`）。Release workflow 会先构建候选镜像，
-   完成漏洞扫描、SBOM、签名和来源证明后，才创建正式版本标签。
-2. 确认 Release workflow 的全部镜像验证成功；固定版本部署可在服务器修改
-   `noj-deploy.json` 中的 `version.noj_server=v0.1.1`（或执行
-   `noj-cli maintain config set version.noj_server v0.1.1 --dir /opt/neuro-oj`）。
-3. 升级前创建备份，然后更新配置并重新部署：
+## 6. 卸载
 
 ```bash
-noj-cli maintain backup create --dir /opt/neuro-oj
-noj-cli maintain config set version.noj_server v0.1.1 --dir /opt/neuro-oj
-noj-cli deploy up --dir /opt/neuro-oj
+# 删除容器、网络和本地镜像，保留配置和数据卷
+noj uninstall
+
+# 明确删除全部数据和安装目录（不可恢复）
+noj uninstall --all --yes
 ```
 
-`deploy up` 会按 Compose 拉取新镜像并等待健康检查；数据库迁移由 `migrate` 一次性服务执行。
-升级前必须确认新版本迁移与旧版本应用兼容，并先完成备份。
+普通卸载要求输入 `UNINSTALL`，不会删除 PostgreSQL、Redis、MinIO、Judge 缓存、备份或配置。
+完全删除要求输入 `DELETE ALL` 或使用 `--yes`，执行前请确认备份已保存到其他位置。
 
-## 7. 回滚
+## 7. noj-cli 的边界
 
-- 确认上一版本 Release 仍可拉取且签名有效，将 `noj-deploy.json` 的
-  `version.noj_server` 改回上一版本（或执行
-  `noj-cli maintain config set version.noj_server <上一版本>`），
-  再执行 `noj-cli maintain verify --dir /opt/neuro-oj` 和
-  `noj-cli deploy up --dir /opt/neuro-oj`。
-- 数据库 schema 采用只追加迁移，**不自动回滚**；如需回退 schema，请人工评估并备份后操作。
-- 评测镜像也按 Release tag 发布，回滚时需要把 `judge_images` 白名单指向旧 tag（若使用 `all_versions` 则无需改白名单，只需题目/系统设置中的镜像 tag 指向旧版本）。
-
-如果新版本已经执行了不兼容的数据库迁移，不能只切换应用镜像；必须停止服务、确认备份
-可恢复后，按备份恢复流程处理数据，再启动上一版本。
-
-## 8. 备份提示
-
-### 8.1 初始化口令与创建快照
-
-备份口令只保存在仓库外的受限文件中，不要写入 `noj-deploy.json` / `noj-secrets.json`
-或提交到 Git：
+`noj-cli` 位于仓库的 `noj-cli/` 目录，使用 Deno 从源码运行，供实验性部署编排和运维功能开发：
 
 ```bash
-sudo install -d -m 700 /etc/noj
-openssl rand -hex 32 | sudo tee /etc/noj/backup-passphrase >/dev/null
-sudo chmod 600 /etc/noj/backup-passphrase
-
-export NOJ_BACKUP_PASSPHRASE_FILE=/etc/noj/backup-passphrase
-noj-cli maintain backup create --dir /opt/neuro-oj --backup-dir /srv/noj/backups
+cd noj-cli
+deno run -A src/cli.ts --help
 ```
 
-每次快照都会生成 SHA-256 清单、PostgreSQL dump 结构清单、迁移状态和 `SUCCESS`
-标记；默认保留 30 天，默认要求备份目录至少有 1GiB 可用空间。可通过
-`NOJ_BACKUP_RETENTION_DAYS` 和 `NOJ_BACKUP_MIN_FREE_MB` 调整。
-
-### 8.2 校验、恢复与恢复演练
-
-```bash
-snapshot=/srv/noj/backups/snapshot-YYYYMMDD-HHMMSS
-noj-cli maintain backup verify "$snapshot" --dir /opt/neuro-oj
-noj-cli maintain backup drill "$snapshot" --dir /opt/neuro-oj --report /srv/noj/restore-drill.txt
-```
-
-`drill` 不会触碰当前生产数据，只验证解密、校验和、PostgreSQL 结构、Redis RDB
-以及对象镜像。周期性演练应在隔离部署目录中执行实际恢复：
-
-```bash
-noj-cli maintain backup restore "$snapshot" --dir /opt/neuro-oj --confirm
-```
-
-恢复会覆盖目标数据库、Redis 数据和对象存储，因此必须显式 `--confirm`，且目标
-Compose 服务必须已经停止。建议恢复到单独主机或单独数据卷，人工检查后再启动业务
-服务；脚本不会执行 `down -v`，也不会删除生产数据卷。
-
-### 8.3 RPO/RTO 与自动化
-
-- 默认快照是 PostgreSQL 完整逻辑备份；Redis 使用 RDB，评测队列属于可恢复的瞬态
-  数据，故障后允许重新提交或重新入队。
-- 可按 6 小时执行一次 `backup`，将业务 RPO 目标设为不超过 6 小时；实际 RPO 取决于
-  调度器是否成功完成并收到告警。需要分钟级 RPO 时，应额外配置 PostgreSQL WAL/PITR
-  和异地对象存储，不能只依赖本脚本。
-- RTO 由 PostgreSQL 数据量、对象数量和网络决定。每月至少在隔离环境跑一次实际
-  `restore --confirm`，记录从快照开始到健康检查通过的耗时，作为真实 RTO 基线。
-- 建议由 systemd timer、cron 或外部调度平台执行
-  `noj-cli maintain backup create`，并对非零退出码、磁盘空间不足、`verify`
-  失败和恢复演练失败发送告警。备份目录应同步到与生产主机不同故障域的加密存储。
-
-密钥轮换和失效步骤见[生产密钥轮换 Runbook](./production-secrets.md)。
+它与生产 `noj` 脚本分开维护，Release workflow 只发布生产 Docker 镜像，不构建或上传
+`noj-cli` 二进制资产。因此生产安装不会依赖 GitHub Release 中的 CLI 文件。

--- a/noj-docs/docs/operators/production-secrets.md
+++ b/noj-docs/docs/operators/production-secrets.md
@@ -1,15 +1,13 @@
 # 生产密钥轮换 Runbook
 
-本文档适用于 Docker Compose 生产部署。推荐使用 secrets manager 将值注入容器环境；未接入 secrets manager 时，可将密钥写入 `noj-secrets.json`（权限 600），不得提交 Git、打入镜像或写入日志。
+本文档适用于 Docker Compose 生产部署。未接入 secrets manager 时，将密钥写入 `/opt/neuro-oj/.env.prod`（权限 600），不得提交 Git、打入镜像或写入日志。
 
 ## 部署前检查
 
 ```bash
-chmod 600 /opt/neuro-oj/noj-secrets.json
-cd noj-core
-    deno task check:prod  # 可选；生产一键部署不依赖 Deno
-cd ..
-docker compose -f /opt/neuro-oj/docker-compose.noj.yml config >/dev/null
+chmod 600 /opt/neuro-oj/.env.prod
+docker compose --env-file /opt/neuro-oj/.env.prod \
+  -f /opt/neuro-oj/docker-compose.prod.yml config >/dev/null
 ```
 
 检查命令只输出配置键名和错误原因，不输出 secret 值。生产环境禁止已知占位符、mock 邮件 Provider 和 local 存储。
@@ -17,14 +15,15 @@ docker compose -f /opt/neuro-oj/docker-compose.noj.yml config >/dev/null
 ## S3/MinIO 应用凭据轮换
 
 1. 生成新的 `S3_ACCESS_KEY` 和 `S3_SECRET_KEY`，确保它们与 `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` 不同。
-2. 在维护窗口更新 `noj-secrets.json`，运行 `docker compose -f /opt/neuro-oj/docker-compose.noj.yml config` 和 `deno task check:prod`。
+2. 在维护窗口更新 `/opt/neuro-oj/.env.prod`，运行 `noj config check`。
 3. 执行 `minio-init`，让目标 bucket 的应用策略和新用户生效：
 
    ```bash
-   docker compose -f /opt/neuro-oj/docker-compose.noj.yml up --no-deps minio-init
+   docker compose --env-file /opt/neuro-oj/.env.prod \
+     -f /opt/neuro-oj/docker-compose.prod.yml up --no-deps minio-init
    ```
 
-4. 重启 `server` 和 `judge`，提交一个小型支持包题目验证读写和评测交付。
+4. 重启 `core` 和 `judge`，提交一个小型支持包题目验证读写和评测交付。
 5. 确认新凭据可用后，在 MinIO 管理侧撤销旧应用用户；root 凭据只保留给受限运维操作。
 
 应用策略只允许目标 bucket 的列举、读取、写入、删除和位置查询，不授予 MinIO 管理权限或其他 bucket 权限。使用 `mc admin policy info` 和一次实际读写验证记录结果。
@@ -33,10 +32,10 @@ docker compose -f /opt/neuro-oj/docker-compose.noj.yml config >/dev/null
 
 1. 在邮件服务商创建新的 API 凭据，并确认发件域名/地址已验证。
 2. 更新对应的 `ALIBABA_*` 或 `TENCENT_*` 配置，保留 `EMAIL_PROVIDER` 不变。
-3. 运行生产配置检查并重启 `server`，执行密码重置邮件 smoke test。
+3. 运行 `noj config check` 并重启 `core`，执行密码重置邮件 smoke test。
 4. 确认新凭据发送成功后，撤销旧凭据。
 
-`EMAIL_PROVIDER=mock` 在生产环境会阻止 server 启动。
+`EMAIL_PROVIDER=mock` 在生产环境会阻止 core 启动。
 
 ## Redis、PostgreSQL 和管理员凭据
 
@@ -51,7 +50,7 @@ Redis/PostgreSQL 凭据轮换可能造成短暂不可用；应在维护窗口执
 
 - 轮换 `JWT_SECRET` 会使既有 JWT 会话失效，用户需要重新登录。
 - 轮换 `TFA_ENCRYPTION_KEY` 可能使已保存的 TOTP secret 无法解密；除非已完成 TFA 数据迁移方案，否则不得直接替换。
-- 轮换前必须完成数据库和配置备份，并记录影响范围；回滚时恢复旧 secret 后重启 `server`。
+- 轮换前必须完成数据库和配置备份，并记录影响范围；回滚时恢复旧配置后重启 `core`。
 
 ## LLM Gateway 与 BYOK 密钥
 
@@ -62,4 +61,4 @@ Redis/PostgreSQL 凭据轮换可能造成短暂不可用；应在维护窗口执
 
 ## 回滚与记录
 
-每次轮换记录时间、变更人、受影响服务、旧凭据撤销时间和 smoke test 结果。出现失败时先停止继续撤销旧凭据，恢复上一份受限配置并重启服务；不得通过把 MinIO root 凭据注入 server 来绕过故障。
+每次轮换记录时间、变更人、受影响服务、旧凭据撤销时间和 smoke test 结果。出现失败时先停止继续撤销旧凭据，恢复上一份受限配置并重启服务；不得通过把 MinIO root 凭据注入 core 来绕过故障。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,23 +1,21 @@
 # scripts/ — 脚本总览
 
-Neuro OJ 仓库根目录的脚本统一存放点。部署与运维入口已统一为 `noj-cli`，
-旧版 `setup.sh`、`scripts/deploy/*.sh`、`scripts/dev/devtool.sh` 与根目录
-`noj` 命令已移除。
+Neuro OJ 仓库根目录的脚本统一存放点。部署与运维入口恢复为 `setup.sh` 与 `noj`；
+`noj-cli` 保留为独立源码工具，不参与 GitHub Release 二进制发布。
 
-## 唯一安装/部署/运维入口
+## 安装、部署与运维入口
 
-`noj-cli` 是唯一入口：直接下载二进制，然后由它完成 doctor、deploy、maintain 等。
+首次部署使用 `setup.sh`，日常运维使用安装目录中的 `noj`：
 
 ```bash
-# 下载并运行 noj-cli（生产/安装）
-curl -fsSL -o noj-cli \
-  https://github.com/Neuro-OJ/neuro-oj/releases/latest/download/noj-cli-linux-amd64
-chmod +x noj-cli
-./noj-cli doctor
-./noj-cli deploy init --mode prod --dir /opt/neuro-oj
-./noj-cli deploy up --dir /opt/neuro-oj
-./noj-cli maintain logs
-./noj-cli maintain backup create
+# 一键安装
+curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | bash
+
+# 日常运维
+noj status
+noj logs core
+noj update --latest
+noj backup
 ```
 
 从源码运行（开发/测试）：
@@ -34,7 +32,7 @@ scripts/
 ├── README.md              # 本文件(索引)
 ├── check-all.ts           # 本地全量检查入口
 ├── check-ci.ts            # CI 仓库级门禁入口
-├── deploy/                # 仅保留 noj-cli 相关校验门禁（TypeScript）
+├── deploy/                # 生产部署、备份、Judge 与回归测试脚本
 │   ├── verify-build-server.ts
 │   └── verify-compose-server.ts
 ├── staging/               # 生产候选版本验收门禁
@@ -46,20 +44,19 @@ scripts/
 
 | 我想...                                  | 使用                                                            |
 | ---------------------------------------- | --------------------------------------------------------------- |
-| **下载 noj-cli（唯一安装入口）**          | `curl -fsSL -o noj-cli https://github.com/Neuro-OJ/neuro-oj/releases/latest/download/noj-cli-linux-amd64 && chmod +x noj-cli` |
-| **环境检测**                             | `cd noj-cli && deno run -A src/cli.ts doctor`                   |
-| **初始化部署配置**                       | `cd noj-cli && deno run -A src/cli.ts deploy init --mode dev\|prod --dir /opt/neuro-oj` |
-| **启动/停止/重启/状态**                  | `noj-cli deploy up\|down\|restart\|status --dir /opt/neuro-oj`   |
-| **查看日志**                             | `noj-cli maintain logs [server,ui,...] [--follow]`               |
-| **创建/校验/恢复备份**                   | `noj-cli maintain backup create\|verify\|restore\|drill`         |
-| **重置部署**                             | `noj-cli maintain reset --confirm`                               |
-| **直接运行 noj-server**                  | `noj-cli run-server --dir /opt/neuro-oj`                         |
+| **一键安装**                            | `curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh \| bash` |
+| **环境检测**                            | `noj check`                                                      |
+| **启动/停止/重启/状态**                  | `noj start\|stop\|restart\|status`                              |
+| **查看日志**                            | `noj logs [core,ui,...] [--follow]`                              |
+| **升级**                                | `noj update [--latest]`                                         |
+| **创建/校验备份**                        | `noj backup` / `noj verify`                                     |
+| **源码运行 noj-cli**                    | `cd noj-cli && deno run -A src/cli.ts --help`                    |
 | **执行 staging 验收**                    | `bash scripts/staging/acceptance.sh all --env-file .env.staging` |
 | **跑跨模块 E2E 测试**                    | `bash scripts/e2e/run-all.sh`                                   |
 
 ## 与原 `deno task` / `cargo run` 的关系
 
-`noj-cli` 负责部署编排与运维；需要前台运行/调试单个模块时仍推荐直接使用：
+需要前台运行/调试单个模块时仍推荐直接使用：
 
 ```bash
 cd noj-core  && deno task dev

--- a/scripts/deploy/backup.sh
+++ b/scripts/deploy/backup.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+# Neuro OJ 生产数据备份、校验、恢复和恢复演练工具。
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env.prod"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.prod.yml"
+BACKUP_DIR="$REPO_ROOT/backups"
+PASSPHRASE_FILE="${NOJ_BACKUP_PASSPHRASE_FILE:-}"
+DOCKER_BIN="${NOJ_BACKUP_DOCKER_BIN:-docker}"
+RETENTION_DAYS="${NOJ_BACKUP_RETENTION_DAYS:-30}"
+MIN_FREE_MB="${NOJ_BACKUP_MIN_FREE_MB:-1024}"
+PROJECT_NAME="${NOJ_BACKUP_PROJECT_NAME:-}"
+COMMAND=""
+SNAPSHOT=""
+CONFIRM=0
+RESTORE_ENV=""
+DRILL_REPORT=""
+CREATE_TEMP=""
+VERIFY_TEMP=""
+
+cleanup_temporary_files() {
+  [[ -z "$CREATE_TEMP" || ! -e "$CREATE_TEMP" ]] || rm -rf -- "$CREATE_TEMP"
+  [[ -z "$VERIFY_TEMP" || ! -e "$VERIFY_TEMP" ]] || rm -f -- "$VERIFY_TEMP"
+}
+
+trap cleanup_temporary_files EXIT
+
+ok() { printf '[backup] ✓ %s\n' "$*"; }
+warn() { printf '[backup] ⚠ %s\n' "$*" >&2; }
+die() { printf '[backup] ✗ %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Neuro OJ 生产备份工具
+
+用法：
+  backup.sh create [选项]             创建完整快照
+  backup.sh verify SNAPSHOT [选项]    校验快照完整性
+  backup.sh restore SNAPSHOT [选项]   恢复到已停止的 Compose 环境
+  backup.sh drill SNAPSHOT [选项]     执行非破坏性的恢复演练校验
+
+选项：
+  --env-file FILE          生产环境文件（默认 .env.prod）
+  --compose-file FILE      生产 Compose 文件
+  --backup-dir DIR         快照根目录（默认 ./backups）
+  --passphrase-file FILE   GPG 对称加密口令文件（权限必须为 600/400）
+  --retention-days DAYS    保留天数（默认 30）
+  --min-free-mb MB         最低可用磁盘空间（默认 1024 MB）
+  --confirm                确认 restore 会覆盖目标数据
+  --restore-env FILE       将加密环境文件恢复到新文件（目标不得已存在）
+  --report FILE            drill 报告文件
+  -h, --help               显示帮助
+
+环境变量：
+  NOJ_BACKUP_PASSPHRASE_FILE  默认 GPG 口令文件
+  NOJ_BACKUP_RETENTION_DAYS   默认快照保留天数
+  NOJ_BACKUP_MIN_FREE_MB      默认最低可用空间
+EOF
+}
+
+env_value() {
+  local key="$1" value
+  [[ -f "$ENV_FILE" ]] || return 0
+  value="$(awk -v key="$key" '
+    index($0, key "=") == 1 { print substr($0, length(key) + 2); exit }
+  ' "$ENV_FILE")"
+  case "$value" in
+    '"'*'"'|"'"*"'"*) value="${value:1:${#value}-2}" ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+compose() {
+  local args=(compose --env-file "$ENV_FILE" --file "$COMPOSE_FILE")
+  if [[ -n "$PROJECT_NAME" ]]; then
+    args+=(--project-name "$PROJECT_NAME")
+  fi
+  "$DOCKER_BIN" "${args[@]}" "$@"
+}
+
+file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
+}
+
+check_secret_file() {
+  [[ -f "$1" ]] || die "GPG 口令文件不存在：$1"
+  local mode
+  mode="$(file_mode "$1")"
+  [[ "$mode" == "600" || "$mode" == "400" ]] ||
+    die "GPG 口令文件权限必须为 600 或 400：$1"
+}
+
+check_env() {
+  [[ -f "$ENV_FILE" ]] || die "生产环境文件不存在：$ENV_FILE"
+  local mode
+  mode="$(file_mode "$ENV_FILE")"
+  [[ "$mode" == "600" || "$mode" == "400" ]] ||
+    die "生产环境文件权限必须为 600 或 400：$ENV_FILE"
+  [[ -f "$COMPOSE_FILE" ]] || die "生产 Compose 文件不存在：$COMPOSE_FILE"
+  command -v "$DOCKER_BIN" >/dev/null 2>&1 || die "找不到 Docker CLI：$DOCKER_BIN"
+  "$DOCKER_BIN" info >/dev/null 2>&1 || die "Docker daemon 不可用"
+  compose config --quiet || die "Docker Compose 配置无效"
+}
+
+check_numbers() {
+  [[ "$RETENTION_DAYS" =~ ^[0-9]+$ ]] || die "保留天数必须是非负整数"
+  [[ "$MIN_FREE_MB" =~ ^[0-9]+$ ]] || die "最低可用空间必须是非负整数"
+}
+
+check_free_space() {
+  mkdir -p "$BACKUP_DIR"
+  chmod 700 "$BACKUP_DIR"
+  local available_kb
+  available_kb="$(df -Pk "$BACKUP_DIR" | awk 'NR == 2 { print $4 }')"
+  [[ "$available_kb" =~ ^[0-9]+$ ]] || die "无法读取备份目录可用空间"
+  ((available_kb >= MIN_FREE_MB * 1024)) ||
+    die "备份目录可用空间不足：需要至少 ${MIN_FREE_MB}MB"
+}
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    die "需要 sha256sum 或 shasum"
+  fi
+}
+
+gpg_encrypt() {
+  command -v gpg >/dev/null 2>&1 || die "创建加密环境备份需要 gpg"
+  gpg --batch --yes --pinentry-mode loopback \
+    --passphrase-file "$PASSPHRASE_FILE" \
+    --symmetric --cipher-algo AES256 \
+    --output "$1" "$ENV_FILE" >/dev/null 2>&1 || die "生产环境文件加密失败"
+}
+
+gpg_decrypt() {
+  command -v gpg >/dev/null 2>&1 || die "校验加密环境备份需要 gpg"
+  gpg --batch --yes --pinentry-mode loopback \
+    --passphrase-file "$PASSPHRASE_FILE" \
+    --decrypt --output "$2" "$1" >/dev/null 2>&1 || die "生产环境文件解密失败"
+}
+
+record_migration_status() {
+  local user db schema
+  user="$(env_value POSTGRES_USER)"; user="${user:-noj}"
+  db="$(env_value POSTGRES_DB)"; db="${db:-noj}"
+  schema="$(compose exec -T postgres psql -U "$user" -d "$db" -Atqc \
+    "SELECT to_regclass('drizzle.__drizzle_migrations')" 2>/dev/null || true)"
+  if [[ -n "$schema" && "$schema" != "" ]]; then
+    compose exec -T postgres psql -U "$user" -d "$db" -Atqc \
+      "SELECT hash || ':' || created_at::text FROM drizzle.__drizzle_migrations ORDER BY created_at" \
+      2>/dev/null || printf 'migration-status-unavailable\n'
+  else
+    printf 'not-initialized\n'
+  fi
+}
+
+write_checksums() {
+  local root="$1" file digest
+  : > "$root/sha256sums.txt"
+  while IFS= read -r file; do
+    digest="$(sha256 "$root/$file")"
+    printf '%s  %s\n' "$digest" "$file" >> "$root/sha256sums.txt"
+  done < <(cd "$root" && find . -type f ! -name 'sha256sums.txt' -print | sed 's#^./##' | LC_ALL=C sort)
+}
+
+prune_old_snapshots() {
+  local old
+  while IFS= read -r -d '' old; do
+    rm -rf -- "$old"
+    ok "已清理过期快照：$old"
+  done < <(find "$BACKUP_DIR" -mindepth 1 -maxdepth 1 -type d \
+    -name 'snapshot-*' -mtime "+$RETENTION_DAYS" -print0)
+}
+
+create_snapshot() {
+  check_env
+  check_numbers
+  [[ -n "$PASSPHRASE_FILE" ]] || die "create 必须提供 --passphrase-file 或 NOJ_BACKUP_PASSPHRASE_FILE"
+  check_secret_file "$PASSPHRASE_FILE"
+  check_free_space
+
+  local timestamp final temp index=1
+  timestamp="$(date '+%Y%m%d-%H%M%S')"
+  final="$BACKUP_DIR/snapshot-$timestamp"
+  while [[ -e "$final" ]]; do
+    final="$BACKUP_DIR/snapshot-$timestamp-$index"
+    index=$((index + 1))
+  done
+  temp="$BACKUP_DIR/.snapshot-$timestamp-$$.tmp"
+  mkdir -m 700 "$temp"
+  CREATE_TEMP="$temp"
+
+  local pg_user pg_db redis_file
+  pg_user="$(env_value POSTGRES_USER)"; pg_user="${pg_user:-noj}"
+  pg_db="$(env_value POSTGRES_DB)"; pg_db="${pg_db:-noj}"
+
+  compose exec -T postgres pg_dump -U "$pg_user" -d "$pg_db" -Fc > "$temp/postgres.dump" \
+    || die "PostgreSQL 备份失败"
+  [[ -s "$temp/postgres.dump" ]] || die "PostgreSQL 备份为空"
+  compose exec -T postgres pg_dumpall -U "$pg_user" --globals-only --no-role-passwords > "$temp/postgres-globals.sql" \
+    || die "PostgreSQL 全局对象备份失败"
+  compose exec -T postgres pg_restore --list < "$temp/postgres.dump" > "$temp/postgres.restore-list" \
+    || die "PostgreSQL 备份结构校验失败"
+
+  redis_file="$temp/redis.rdb"
+  compose exec -T redis sh -c \
+    'REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning --rdb -' > "$redis_file" \
+    || die "Redis RDB 备份失败"
+  [[ -s "$redis_file" ]] || die "Redis RDB 备份为空"
+  compose exec -T redis sh -c \
+    'REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning INFO persistence' \
+    > "$temp/redis-persistence.txt" || die "Redis 持久化状态读取失败"
+
+  mkdir -m 700 "$temp/minio"
+  compose run --rm --no-deps --entrypoint /bin/sh -v "$temp/minio:/backup:rw" minio-init -c \
+    'set -eu; for i in $(seq 1 30); do mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 && break; sleep 2; done; mc mirror --preserve "local/$S3_BUCKET" /backup' \
+    || die "MinIO/S3 对象备份失败"
+
+  gpg_encrypt "$temp/env.prod.gpg"
+  cat > "$temp/manifest.json" <<EOF
+{
+  "format_version": 1,
+  "created_at": "$(date -u '+%Y-%m-%dT%H:%M:%SZ')",
+  "postgres_database": "$pg_db",
+  "redis_policy": "RDB snapshot; judge queue is recoverable transient data",
+  "object_storage": "MinIO/S3 mirror",
+  "postgres_backup_mode": "logical-full",
+  "incremental_policy": "MinIO mirror is incremental; PostgreSQL WAL/PITR requires external infrastructure",
+  "rpo": "snapshot interval configured by scheduler",
+  "rto": "restore duration depends on database and object volume",
+  "retention_days": $RETENTION_DAYS
+}
+EOF
+  printf '%s\n' "$(record_migration_status)" > "$temp/migration-status.txt"
+  write_checksums "$temp"
+  printf 'success\n' > "$temp/SUCCESS"
+  chmod -R go-rwx "$temp"
+  mv "$temp" "$final"
+  CREATE_TEMP=""
+  verify_snapshot "$final"
+  prune_old_snapshots
+  ok "完整生产快照已创建：$final"
+  ok "PostgreSQL、Redis、MinIO/S3 和加密环境文件均已写入"
+}
+
+validate_snapshot_path() {
+  [[ -d "$1" ]] || die "快照目录不存在：$1"
+  [[ "$(basename "$1")" == snapshot-* ]] || die "只允许校验 snapshot-* 快照目录"
+  [[ "$1" != */..* && "$1" != */.snapshot-* ]] || die "非法快照路径"
+}
+
+verify_snapshot() {
+  local snapshot="$1"
+  validate_snapshot_path "$snapshot"
+  local snapshot_mode
+  snapshot_mode="$(file_mode "$snapshot")"
+  [[ "$snapshot_mode" == "700" ]] || die "快照目录权限必须为 700：$snapshot"
+  [[ -n "$PASSPHRASE_FILE" ]] || die "verify 必须提供 --passphrase-file 或 NOJ_BACKUP_PASSPHRASE_FILE"
+  check_secret_file "$PASSPHRASE_FILE"
+  [[ -f "$snapshot/sha256sums.txt" ]] || die "快照缺少 sha256sums.txt"
+  [[ -f "$snapshot/SUCCESS" ]] || die "快照缺少成功标记"
+
+  local line expected file actual temp
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    expected="${line%%  *}"
+    file="${line#*  }"
+    [[ "$file" != "$line" && "$file" != /* && "$file" != *".."* ]] || die "校验清单包含非法路径"
+    [[ -f "$snapshot/$file" ]] || die "快照文件缺失：$file"
+    actual="$(sha256 "$snapshot/$file")"
+    [[ "$actual" == "$expected" ]] || die "SHA-256 校验失败：$file"
+  done < "$snapshot/sha256sums.txt"
+  [[ -s "$snapshot/postgres.restore-list" ]] || die "PostgreSQL dump 结构清单为空"
+  [[ -s "$snapshot/redis.rdb" ]] || die "Redis RDB 为空"
+  [[ -d "$snapshot/minio" ]] || die "MinIO/S3 快照目录缺失"
+
+  temp="$(mktemp)"
+  VERIFY_TEMP="$temp"
+  gpg_decrypt "$snapshot/env.prod.gpg" "$temp"
+  [[ -s "$temp" ]] || die "加密环境文件解密结果为空"
+  rm -f "$temp"
+  VERIFY_TEMP=""
+  ok "快照校验通过：$snapshot"
+}
+
+ensure_stopped() {
+  local running
+  running="$(compose ps --status running -q 2>/dev/null || true)"
+  [[ -z "$running" ]] || die "恢复前必须停止 Compose 服务；请先执行 deploy.sh stop"
+}
+
+restore_env_file() {
+  [[ -n "$RESTORE_ENV" ]] || return 0
+  [[ ! -e "$RESTORE_ENV" ]] || die "恢复环境文件目标已存在，为避免覆盖请先移走：$RESTORE_ENV"
+  gpg_decrypt "$SNAPSHOT/env.prod.gpg" "$RESTORE_ENV"
+  chmod 600 "$RESTORE_ENV"
+  ok "加密环境文件已恢复：$RESTORE_ENV"
+}
+
+restore_snapshot() {
+  validate_snapshot_path "$SNAPSHOT"
+  [[ "$CONFIRM" == "1" ]] || die "restore 会覆盖目标数据，必须显式提供 --confirm"
+  verify_snapshot "$SNAPSHOT"
+  check_env
+  ensure_stopped
+  restore_env_file
+
+  local pg_user pg_db
+  pg_user="$(env_value POSTGRES_USER)"; pg_user="${pg_user:-noj}"
+  pg_db="$(env_value POSTGRES_DB)"; pg_db="${pg_db:-noj}"
+  compose up -d --wait --wait-timeout 180 postgres redis minio || die "恢复前数据服务启动失败"
+
+  compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" < "$SNAPSHOT/postgres-globals.sql" \
+    || die "PostgreSQL 全局对象恢复失败"
+  compose exec -T postgres pg_restore --clean --if-exists --no-owner --exit-on-error \
+    -U "$pg_user" -d "$pg_db" - < "$SNAPSHOT/postgres.dump" \
+    || die "PostgreSQL 数据恢复失败"
+
+  compose stop redis || die "停止 Redis 失败"
+  compose run --rm --no-deps --entrypoint /bin/sh redis -c \
+    'set -eu; rm -rf /data/appendonlydir /data/dump.rdb; cat > /data/dump.rdb' < "$SNAPSHOT/redis.rdb" \
+    || die "写入 Redis RDB 失败"
+  compose up -d --wait --wait-timeout 180 redis || die "恢复后 Redis 启动失败"
+
+  compose run --rm --no-deps --entrypoint /bin/sh -v "$SNAPSHOT/minio:/restore:ro" minio-init -c \
+    'set -eu; for i in $(seq 1 30); do mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 && break; sleep 2; done; mc mirror --overwrite --remove /restore "local/$S3_BUCKET"' \
+    || die "MinIO/S3 对象恢复失败"
+  compose stop postgres redis minio >/dev/null || true
+  ok "快照恢复完成；数据服务已停止，请人工检查后再启动业务服务"
+}
+
+drill_snapshot() {
+  validate_snapshot_path "$SNAPSHOT"
+  verify_snapshot "$SNAPSHOT"
+  local report="${DRILL_REPORT:-$SNAPSHOT/restore-drill.txt}"
+  {
+    printf 'result=verified\n'
+    printf 'snapshot=%s\n' "$SNAPSHOT"
+    printf 'next_step=restore --confirm in an isolated Compose project\n'
+    printf 'postgres=logical dump structure verified\n'
+    printf 'redis=RDB payload and persistence metadata verified\n'
+    printf 'minio=object mirror directory verified\n'
+    printf 'env=GPG decryption verified\n'
+    printf 'warning=PostgreSQL incremental/PITR requires external WAL archive infrastructure\n'
+  } > "$report"
+  chmod 600 "$report"
+  ok "恢复演练校验通过，报告已写入：$report"
+}
+
+parse_args() {
+  [[ "$#" -gt 0 ]] || { usage; exit 2; }
+  if [[ "$1" == "-h" || "$1" == "--help" ]]; then usage; exit 0; fi
+  COMMAND="$1"
+  shift
+  if [[ "$COMMAND" == "verify" || "$COMMAND" == "restore" || "$COMMAND" == "drill" ]]; then
+    [[ "$#" -gt 0 ]] || die "$COMMAND 需要 SNAPSHOT 参数"
+    SNAPSHOT="$1"
+    shift
+  fi
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --env-file) [[ "$#" -ge 2 ]] || die "--env-file 缺少参数"; ENV_FILE="$2"; shift 2 ;;
+      --compose-file) [[ "$#" -ge 2 ]] || die "--compose-file 缺少参数"; COMPOSE_FILE="$2"; shift 2 ;;
+      --backup-dir) [[ "$#" -ge 2 ]] || die "--backup-dir 缺少参数"; BACKUP_DIR="$2"; shift 2 ;;
+      --passphrase-file) [[ "$#" -ge 2 ]] || die "--passphrase-file 缺少参数"; PASSPHRASE_FILE="$2"; shift 2 ;;
+      --retention-days) [[ "$#" -ge 2 ]] || die "--retention-days 缺少参数"; RETENTION_DAYS="$2"; shift 2 ;;
+      --min-free-mb) [[ "$#" -ge 2 ]] || die "--min-free-mb 缺少参数"; MIN_FREE_MB="$2"; shift 2 ;;
+      --project-name) [[ "$#" -ge 2 ]] || die "--project-name 缺少参数"; PROJECT_NAME="$2"; shift 2 ;;
+      --confirm) CONFIRM=1; shift ;;
+      --restore-env) [[ "$#" -ge 2 ]] || die "--restore-env 缺少参数"; RESTORE_ENV="$2"; shift 2 ;;
+      --report) [[ "$#" -ge 2 ]] || die "--report 缺少参数"; DRILL_REPORT="$2"; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "未知选项：$1" ;;
+    esac
+  done
+}
+
+parse_args "$@"
+case "$COMMAND" in
+  create) create_snapshot ;;
+  verify) verify_snapshot "$SNAPSHOT" ;;
+  restore) restore_snapshot ;;
+  drill) drill_snapshot ;;
+  help) usage ;;
+  *) die "未知命令：$COMMAND" ;;
+esac

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,0 +1,1154 @@
+#!/usr/bin/env bash
+#
+# Neuro OJ 生产部署入口。
+#
+# 用法：
+#   bash scripts/deploy/deploy.sh install
+#   bash scripts/deploy/deploy.sh start
+#   bash scripts/deploy/deploy.sh upgrade
+#   bash scripts/deploy/deploy.sh stop
+#   bash scripts/deploy/deploy.sh uninstall --yes
+#   bash scripts/deploy/deploy.sh status
+#   bash scripts/deploy/deploy.sh logs [service] [--follow]
+#   bash scripts/deploy/deploy.sh backup
+#   bash scripts/deploy/deploy.sh verify
+#
+# 脚本只封装 docker-compose.prod.yml，不执行 down -v、不删除数据卷，
+# 也不会 source 环境文件，避免环境变量中的特殊字符触发 shell 解析。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env.prod"
+ENV_TEMPLATE="$REPO_ROOT/.env.prod.example"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.prod.yml"
+BACKUP_DIR="$REPO_ROOT/backups"
+BACKUP_PASSPHRASE_FILE="${NOJ_BACKUP_PASSPHRASE_FILE:-}"
+DEFAULT_BACKUP_PASSPHRASE_FILE="/etc/noj/backup-passphrase"
+DOCKER_BIN="${NOJ_DEPLOY_DOCKER_BIN:-docker}"
+PANEL_MODE="${NOJ_DEPLOY_PANEL:-auto}"
+PANEL_NAME="none"
+PANEL_ROOT="${NOJ_DEPLOY_PANEL_ROOT:-/www/server/panel}"
+PANEL_COMMAND="${NOJ_DEPLOY_PANEL_COMMAND:-/usr/bin/bt}"
+TTY_PATH="${NOJ_DEPLOY_TTY_PATH:-/dev/tty}"
+DRY_RUN=0
+FOLLOW=0
+INTERACTIVE=1
+UNINSTALL_CONFIRMED=0
+UNINSTALL_ALL=0
+INCLUDE_ALL_PROFILES=0
+[[ "${NOJ_DEPLOY_NON_INTERACTIVE:-0}" == "1" ]] && INTERACTIVE=0
+declare -a VERIFIED_IMAGE_DIGESTS=()
+CONFIG_STAGE_FILE=""
+CONFIG_TARGET_FILE=""
+
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; RESET='\033[0m'
+else
+  GREEN=''; YELLOW=''; RED=''; RESET=''
+fi
+
+ok() { printf "%b✓%b %s\n" "$GREEN" "$RESET" "$*"; }
+warn() { printf "%b!%b %s\n" "$YELLOW" "$RESET" "$*" >&2; }
+fail() {
+  printf "%b✗%b %s\n" "$RED" "$RESET" "$*" >&2
+  exit 1
+}
+section() { printf "\n== %s ==\n" "$*"; }
+
+has_interactive_tty() {
+  [[ -r "$TTY_PATH" && -w "$TTY_PATH" ]] || return 1
+  (exec 3<>"$TTY_PATH") 2>/dev/null
+}
+
+read_prompt() {
+  local prompt="$1" secret="${2:-0}" value
+  if has_interactive_tty; then
+    printf '%s' "$prompt" >"$TTY_PATH"
+    if [[ "$secret" == 1 ]]; then
+      IFS= read -r -s value <"$TTY_PATH" || fail "读取配置输入失败"
+      printf '\n' >"$TTY_PATH"
+    else
+      IFS= read -r value <"$TTY_PATH" || fail "读取配置输入失败"
+    fi
+  elif [[ "$secret" == 1 ]]; then
+    IFS= read -r -s -p "$prompt" value || fail "读取配置输入失败"
+    printf '\n' >&2
+  else
+    IFS= read -r -p "$prompt" value || fail "读取配置输入失败"
+  fi
+  PROMPT_VALUE="$value"
+}
+
+usage() {
+  cat <<'EOF'
+Neuro OJ 生产部署工具
+
+用法：
+  deploy.sh install                  首次初始化配置并部署
+  deploy.sh start                    启动生产服务
+  deploy.sh upgrade                  拉取 NOJ_VERSION 并升级服务
+  deploy.sh stop                     停止服务（保留数据卷）
+  deploy.sh uninstall [--yes]       删除容器、网络和本地镜像（保留数据卷）
+  deploy.sh uninstall --all --yes   删除 NOJ 栈及全部数据（不可恢复）
+  deploy.sh status                   查看服务状态
+  deploy.sh logs [service]           查看最近日志
+  deploy.sh logs [service] --follow  持续查看日志
+  deploy.sh backup                   创建完整生产备份
+  deploy.sh verify                   校验生产镜像 digest 与 Cosign 签名
+
+选项：
+  --env-file FILE       使用指定的生产环境文件
+  --compose-file FILE   使用指定的 Compose 文件
+  --backup-dir DIR      指定备份目录（默认 ./backups）
+  --passphrase-file FILE
+                        GPG 备份口令文件（默认读取 NOJ_BACKUP_PASSPHRASE_FILE）
+  --panel MODE           面板模式：auto（默认）、baota 或 none
+  --dry-run             只检查并显示将执行的操作，不修改服务或文件
+  --non-interactive     首次初始化不询问，配置不完整时直接失败
+  --yes, -y             仅用于 uninstall，跳过明确确认提示
+  -h, --help            显示帮助
+
+环境变量：
+  NOJ_DEPLOY_DOCKER_BIN  仅用于测试，指定 Docker CLI 路径
+  NOJ_DEPLOY_PANEL       面板模式（默认 auto）
+EOF
+}
+
+parse_args() {
+  COMMAND=""
+  POSITIONAL=()
+  while (($# > 0)); do
+    case "$1" in
+      install|start|upgrade|stop|uninstall|status|logs|backup|verify)
+        if [[ -n "$COMMAND" ]]; then
+          POSITIONAL+=("$1")
+        else
+          COMMAND="$1"
+        fi
+        ;;
+      --env-file)
+        (($# >= 2)) || fail "--env-file 需要一个文件路径"
+        ENV_FILE="$2"
+        shift
+        ;;
+      --env-file=*) ENV_FILE="${1#*=}" ;;
+      --compose-file)
+        (($# >= 2)) || fail "--compose-file 需要一个文件路径"
+        COMPOSE_FILE="$2"
+        shift
+        ;;
+      --compose-file=*) COMPOSE_FILE="${1#*=}" ;;
+      --backup-dir)
+        (($# >= 2)) || fail "--backup-dir 需要一个目录路径"
+        BACKUP_DIR="$2"
+        shift
+        ;;
+      --backup-dir=*) BACKUP_DIR="${1#*=}" ;;
+      --passphrase-file)
+        (($# >= 2)) || fail "--passphrase-file 需要一个文件路径"
+        BACKUP_PASSPHRASE_FILE="$2"
+        shift
+        ;;
+      --passphrase-file=*) BACKUP_PASSPHRASE_FILE="${1#*=}" ;;
+      --panel)
+        (($# >= 2)) || fail "--panel 需要 auto、baota 或 none"
+        PANEL_MODE="$2"
+        shift
+        ;;
+      --panel=*) PANEL_MODE="${1#*=}" ;;
+      --follow|-f) FOLLOW=1 ;;
+      --dry-run) DRY_RUN=1 ;;
+      --non-interactive) INTERACTIVE=0 ;;
+      --yes|-y) UNINSTALL_CONFIRMED=1 ;;
+      --all) UNINSTALL_ALL=1 ;;
+      -h|--help) usage; exit 0 ;;
+      --) shift; POSITIONAL+=("$@"); break ;;
+      *) POSITIONAL+=("$1") ;;
+    esac
+    shift
+  done
+  [[ -n "$COMMAND" ]] || { usage; exit 2; }
+  case "$PANEL_MODE" in
+    auto|baota|none) ;;
+    *) fail "--panel 只能是 auto、baota 或 none：$PANEL_MODE" ;;
+  esac
+}
+
+env_value() {
+  local key="$1" value
+  [[ -f "$ENV_FILE" ]] || return 0
+  value="$(awk -v key="$key" '
+    index($0, key "=") == 1 { print substr($0, length(key) + 2); exit }
+  ' "$ENV_FILE")"
+  case "$value" in
+    "\""*"\""|"'"*"'") value="${value:1:${#value}-2}" ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+is_exit_word() {
+  case "$1" in
+    exit|EXIT|quit|QUIT|cancel|CANCEL|q|Q|取消) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+set_env_value() {
+  local key="$1" value="$2" tmp
+  tmp="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+  if ! awk -v key="$key" -v value="$value" '
+    BEGIN { found = 0 }
+    index($0, key "=") == 1 {
+      print key "=" value
+      found = 1
+      next
+    }
+    { print }
+    END { if (!found) print key "=" value }
+  ' "$ENV_FILE" >"$tmp"; then
+    rm -f "$tmp"
+    fail "更新生产配置失败"
+  fi
+  chmod 600 "$tmp"
+  mv "$tmp" "$ENV_FILE"
+}
+
+generate_secret() {
+  command -v openssl >/dev/null 2>&1 ||
+    fail "首次初始化需要 openssl，用于生成随机密钥"
+  openssl rand -hex 32 | tr -d '\n'
+}
+
+prompt_text() {
+  local label="$1" default_value="${2:-}" value
+  while :; do
+    if [[ -n "$default_value" ]]; then
+      read_prompt "$label [$default_value]: "
+      value="$PROMPT_VALUE"
+      value="${value:-$default_value}"
+    else
+      read_prompt "$label: "
+      value="$PROMPT_VALUE"
+    fi
+    if [[ -n "$value" && "$value" != *$'\n'* && "$value" != *$'\r'* ]]; then
+      PROMPT_VALUE="$value"
+      return 0
+    fi
+    warn "该配置不能为空，请重新输入"
+  done
+}
+
+prompt_secret() {
+  local label="$1" value
+  while :; do
+    read_prompt "$label: " 1
+    value="$PROMPT_VALUE"
+    if [[ -n "$value" ]]; then
+      PROMPT_VALUE="$value"
+      return 0
+    fi
+    warn "该配置不能为空，请重新输入"
+  done
+}
+
+prompt_yes_no() {
+  local label="$1" default="${2:-y}" answer
+  while :; do
+    if [[ "$default" == y ]]; then
+      read_prompt "$label [Y/n]: "
+    else
+      read_prompt "$label [y/N]: "
+    fi
+    answer="${PROMPT_VALUE:-$default}"
+    case "$answer" in
+      y|Y|yes|YES) return 0 ;;
+      n|N|no|NO) return 1 ;;
+      *) warn "请输入 Y 或 N" ;;
+    esac
+  done
+}
+
+current_config_value() {
+  local key="$1" value
+  value="$(env_value "$key")"
+  if is_placeholder "$value"; then
+    value=""
+  fi
+  if [[ "$key" == DOMAIN ]] && is_exit_word "$value"; then
+    value=""
+  fi
+  printf '%s\n' "$value"
+}
+
+config_prompt_value() {
+  local key="$1" reset_existing="${2:-0}"
+  if ((reset_existing)); then
+    return 0
+  fi
+  current_config_value "$key"
+}
+
+cleanup_config_staging() {
+  if [[ -n "$CONFIG_STAGE_FILE" && -f "$CONFIG_STAGE_FILE" ]]; then
+    rm -f "$CONFIG_STAGE_FILE"
+  fi
+  if [[ -n "$CONFIG_TARGET_FILE" ]]; then
+    ENV_FILE="$CONFIG_TARGET_FILE"
+  fi
+  CONFIG_STAGE_FILE=""
+  CONFIG_TARGET_FILE=""
+}
+
+trap cleanup_config_staging EXIT
+
+begin_config_staging() {
+  [[ -f "$ENV_FILE" ]] || fail "找不到用于暂存的生产配置：$ENV_FILE"
+  CONFIG_TARGET_FILE="$ENV_FILE"
+  CONFIG_STAGE_FILE="$(mktemp "${ENV_FILE}.staging.XXXXXX")" ||
+    fail "无法创建临时配置文件"
+  if ! cp "$CONFIG_TARGET_FILE" "$CONFIG_STAGE_FILE"; then
+    cleanup_config_staging
+    fail "无法复制生产配置到临时文件"
+  fi
+  chmod 600 "$CONFIG_STAGE_FILE"
+  ENV_FILE="$CONFIG_STAGE_FILE"
+}
+
+commit_config_staging() {
+  local staged_file="$CONFIG_STAGE_FILE" target_file="$CONFIG_TARGET_FILE"
+  [[ -n "$staged_file" && -n "$target_file" && -f "$staged_file" ]] ||
+    fail "找不到待写入的临时配置"
+  chmod 600 "$staged_file"
+  mv "$staged_file" "$target_file" || fail "写入生产配置失败"
+  ENV_FILE="$target_file"
+  CONFIG_STAGE_FILE=""
+  CONFIG_TARGET_FILE=""
+}
+
+cancel_config_staging() {
+  cleanup_config_staging
+}
+
+email_provider_prompt_label() {
+  case "$1" in
+    aliyun) printf '邮件服务（当前已配置阿里云；回车继续使用，输入 skip 暂不配置）\n' ;;
+    tencent) printf '邮件服务（当前已配置腾讯云；回车继续使用，输入 skip 暂不配置）\n' ;;
+    *) printf '邮件服务（可选阿里云/腾讯云；直接回车暂不配置）\n' ;;
+  esac
+}
+
+is_ipv4_address() {
+  local address="$1" octet
+  local -a octets=()
+  [[ "$address" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] || return 1
+  IFS=. read -r -a octets <<<"$address"
+  for octet in "${octets[@]}"; do
+    ((10#$octet <= 255)) || return 1
+  done
+}
+
+is_site_address() {
+  local address="$1"
+  if is_ipv4_address "$address"; then
+    return 0
+  fi
+  [[ "$address" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?$ ]] &&
+    [[ "$address" == *.* ]]
+}
+
+detect_default_ipv4() {
+  local candidate route_info
+  candidate="${NOJ_DEPLOY_DEFAULT_IP:-}"
+  if is_ipv4_address "$candidate" && [[ "$candidate" != 127.* ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  if command -v ip >/dev/null 2>&1; then
+    route_info="$(ip -4 route get 1.1.1.1 2>/dev/null || true)"
+    candidate="$(awk '{ for (i = 1; i <= NF; i++) if ($i == "src") { print $(i + 1); exit } }' <<<"$route_info")"
+    if is_ipv4_address "$candidate" && [[ "$candidate" != 127.* ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  fi
+
+  if command -v hostname >/dev/null 2>&1; then
+    while IFS= read -r candidate; do
+      if is_ipv4_address "$candidate" && [[ "$candidate" != 127.* ]]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    done < <(hostname -I 2>/dev/null | tr ' ' '\n')
+  fi
+}
+
+configuration_needs_interactive_input() {
+  local key value
+  for key in NOJ_VERSION DOMAIN APP_URL EMAIL_PROVIDER JUDGE_ENABLED; do
+    value="$(current_config_value "$key")"
+    is_placeholder "$value" && return 0
+  done
+  case "$(env_value EMAIL_PROVIDER)" in
+    aliyun)
+      for key in ALIBABA_ACCESS_KEY_ID ALIBABA_ACCESS_KEY_SECRET ALIBABA_FROM_EMAIL; do
+        value="$(current_config_value "$key")"
+        is_placeholder "$value" && return 0
+      done
+      ;;
+    tencent)
+      for key in TENCENT_SECRET_ID TENCENT_SECRET_KEY TENCENT_FROM_EMAIL TENCENT_REGION; do
+        value="$(current_config_value "$key")"
+        is_placeholder "$value" && return 0
+      done
+      ;;
+  esac
+  if judge_enabled; then
+    for key in JUDGE_DOCKER_SOCKET JUDGE_DOCKER_SOCKET_GID; do
+      value="$(current_config_value "$key")"
+      is_placeholder "$value" && return 0
+    done
+  fi
+  return 1
+}
+
+confirm_reuse_config() {
+  printf '检测到先前生产配置：%s\n' "$ENV_FILE"
+  if prompt_yes_no '是否使用先前配置？（Y=保留，N=重新填写）' y; then
+    ok "将使用先前配置"
+    return 0
+  fi
+  warn "将进入配置向导重新填写"
+  return 1
+}
+
+configure_env_interactive() {
+  local version domain app_url email_provider socket_path socket_gid key
+  local judge_default judge_install
+  local current_value current_app_url detected_ip default_domain ssl_default email_prompt_label
+  local email_provider_reused=0
+  local reset_existing="${1:-0}"
+
+  begin_config_staging
+  section "填写生产配置"
+  cat <<'EOF'
+请按提示填写网站和服务配置。邮件密钥不会显示在屏幕上，也不会被脚本打印。
+“网站地址”是域名或服务器 IP；脚本会根据 HTTPS 选择自动生成浏览器访问地址。
+评测服务连接位置一般保持默认即可；邮件服务可以选择“暂不配置”，以后再补充。
+如果暂时没有独立的评测 Docker 服务，可以选择跳过 Judge，网站和题库仍可先部署。
+安装完成后请立即打开网站注册第一个用户；第一个注册用户会自动获得管理员权限。
+EOF
+
+  current_value="$(config_prompt_value NOJ_VERSION "$reset_existing")"
+  prompt_text "安装版本（例如 v0.8.0-rc.1）" "$current_value"
+  version="$PROMPT_VALUE"
+  set_env_value NOJ_VERSION "$version"
+
+  current_value="$(config_prompt_value DOMAIN "$reset_existing")"
+  detected_ip="$(detect_default_ipv4)"
+  default_domain="${current_value:-$detected_ip}"
+  prompt_text "网站地址（域名或服务器 IP，不要写 https://；可直接回车使用检测到的 IP）" "$default_domain"
+  domain="$PROMPT_VALUE"
+  is_site_address "$domain" ||
+    fail "网站地址必须是域名或服务器 IP，例如 oj.example.com 或 192.0.2.10"
+  set_env_value DOMAIN "$domain"
+  if is_ipv4_address "$domain"; then
+    warn "当前使用服务器 IP；正式环境仍需 HTTPS，建议以后换成域名并配置证书"
+  fi
+
+  current_app_url="$(config_prompt_value APP_URL "$reset_existing")"
+  if [[ "$current_app_url" == http://* ]]; then
+    ssl_default=n
+  else
+    ssl_default=y
+  fi
+  if prompt_yes_no '是否使用 HTTPS（证书需在宝塔或反向代理中配置）' "$ssl_default"; then
+    set_env_value NOJ_ALLOW_INSECURE_HTTP "false"
+    app_url="https://$domain"
+  else
+    set_env_value NOJ_ALLOW_INSECURE_HTTP "true"
+    app_url="http://$domain"
+    warn "已选择临时 HTTP；登录信息可能被窃取，正式使用前请配置 HTTPS"
+  fi
+  set_env_value APP_URL "$app_url"
+  set_env_value CORS_ALLOWED_ORIGINS "$app_url"
+
+  current_value="$(config_prompt_value EMAIL_PROVIDER "$reset_existing")"
+  while :; do
+    email_prompt_label="$(email_provider_prompt_label "$current_value")"
+    prompt_text "$email_prompt_label" "${current_value:-disabled}"
+    email_provider="$PROMPT_VALUE"
+    case "$email_provider" in
+      aliyun|tencent) break ;;
+      disabled|skip|none|跳过|暂不配置) email_provider=disabled; break ;;
+      *) warn "请输入 aliyun、tencent，或选择暂不配置" ;;
+    esac
+  done
+  if [[ "$reset_existing" != 1 && "$current_value" == "$email_provider" ]] &&
+    [[ "$email_provider" == aliyun || "$email_provider" == tencent ]]; then
+    email_provider_reused=1
+  fi
+  set_env_value EMAIL_PROVIDER "$email_provider"
+  if [[ "$email_provider" == aliyun ]]; then
+    if ((email_provider_reused)) && [[ -n "$(current_config_value ALIBABA_ACCESS_KEY_ID)" ]] &&
+      ! is_placeholder "$(current_config_value ALIBABA_ACCESS_KEY_ID)"; then
+      :
+    else
+      prompt_secret "阿里云 Access Key ID"
+      set_env_value ALIBABA_ACCESS_KEY_ID "$PROMPT_VALUE"
+    fi
+    if ((email_provider_reused)) && [[ -n "$(current_config_value ALIBABA_ACCESS_KEY_SECRET)" ]] &&
+      ! is_placeholder "$(current_config_value ALIBABA_ACCESS_KEY_SECRET)"; then
+      :
+    else
+      prompt_secret "阿里云 Access Key Secret"
+      set_env_value ALIBABA_ACCESS_KEY_SECRET "$PROMPT_VALUE"
+    fi
+    current_value="$(config_prompt_value ALIBABA_FROM_EMAIL "$reset_existing")"
+    if ((email_provider_reused)) && [[ -n "$current_value" ]] && ! is_placeholder "$current_value"; then
+      :
+    else
+      prompt_text "阿里云发件邮箱" "$current_value"
+      set_env_value ALIBABA_FROM_EMAIL "$PROMPT_VALUE"
+    fi
+  elif [[ "$email_provider" == tencent ]]; then
+    if ((email_provider_reused)) && [[ -n "$(current_config_value TENCENT_SECRET_ID)" ]] &&
+      ! is_placeholder "$(current_config_value TENCENT_SECRET_ID)"; then
+      :
+    else
+      prompt_secret "腾讯云 Secret ID"
+      set_env_value TENCENT_SECRET_ID "$PROMPT_VALUE"
+    fi
+    if ((email_provider_reused)) && [[ -n "$(current_config_value TENCENT_SECRET_KEY)" ]] &&
+      ! is_placeholder "$(current_config_value TENCENT_SECRET_KEY)"; then
+      :
+    else
+      prompt_secret "腾讯云 Secret Key"
+      set_env_value TENCENT_SECRET_KEY "$PROMPT_VALUE"
+    fi
+    current_value="$(config_prompt_value TENCENT_FROM_EMAIL "$reset_existing")"
+    if ((email_provider_reused)) && [[ -n "$current_value" ]] && ! is_placeholder "$current_value"; then
+      :
+    else
+      prompt_text "腾讯云发件邮箱" "$current_value"
+      set_env_value TENCENT_FROM_EMAIL "$PROMPT_VALUE"
+    fi
+    current_value="$(config_prompt_value TENCENT_REGION "$reset_existing")"
+    if ((email_provider_reused)) && [[ -n "$current_value" ]] && ! is_placeholder "$current_value"; then
+      :
+    else
+      prompt_text "腾讯云 Region" "${current_value:-ap-guangzhou}"
+      set_env_value TENCENT_REGION "$PROMPT_VALUE"
+    fi
+  else
+    for key in ALIBABA_ACCESS_KEY_ID ALIBABA_ACCESS_KEY_SECRET ALIBABA_FROM_EMAIL \
+      TENCENT_SECRET_ID TENCENT_SECRET_KEY TENCENT_FROM_EMAIL TENCENT_REGION; do
+      set_env_value "$key" ""
+    done
+    warn "已跳过邮件服务；密码找回邮件暂时不可用，可稍后在后台配置"
+  fi
+
+  current_value="$(config_prompt_value JUDGE_ENABLED "$reset_existing")"
+  case "$current_value" in
+    false|FALSE|no|NO|0|off|OFF) judge_default=n ;;
+    *) judge_default=y ;;
+  esac
+  if prompt_yes_no '是否安装评测服务 Judge（没有评测 Docker 服务也可以跳过）' "$judge_default"; then
+    judge_install=true
+  else
+    judge_install=false
+    warn "已跳过 Judge；当前部署暂时不能进行代码评测，准备好后可再次启用"
+  fi
+  set_env_value JUDGE_ENABLED "$judge_install"
+
+  if [[ "$judge_install" == true ]]; then
+    current_value="$(config_prompt_value JUDGE_DOCKER_SOCKET "$reset_existing")"
+    prompt_text "评测服务连接位置（一般直接回车）" \
+      "${current_value:-/run/noj-judge/docker.sock}"
+    socket_path="$PROMPT_VALUE"
+    set_env_value JUDGE_DOCKER_SOCKET "$socket_path"
+    if [[ -e "$socket_path" ]]; then
+      socket_gid="$(stat -c '%g' "$socket_path" 2>/dev/null || stat -f '%g' "$socket_path" 2>/dev/null || printf '10001')"
+    else
+      socket_gid="10001"
+    fi
+    current_value="$(config_prompt_value JUDGE_DOCKER_SOCKET_GID "$reset_existing")"
+    prompt_text "评测服务连接编号（一般直接回车）" "${current_value:-$socket_gid}"
+    [[ "$PROMPT_VALUE" =~ ^[0-9]+$ ]] || fail "Judge Docker socket GID 必须是数字"
+    set_env_value JUDGE_DOCKER_SOCKET_GID "$PROMPT_VALUE"
+  else
+    ok "已跳过 Judge 配置"
+  fi
+  ok "配置已暂存，尚未写入正式配置"
+  if prompt_yes_no '是否写入配置？（Y=写入并继续部署，N=取消）' y; then
+    commit_config_staging
+    ok "配置已写入，正在继续校验和启动服务"
+  else
+    cancel_config_staging
+    warn "已取消本次部署，正式配置未修改"
+    return 1
+  fi
+}
+
+initialize_env() {
+  section "初始化生产配置"
+  [[ -f "$ENV_TEMPLATE" ]] || fail "找不到生产配置模板：$ENV_TEMPLATE"
+  if [[ -e "$ENV_FILE" ]]; then
+    [[ -f "$ENV_FILE" ]] || fail "生产配置路径不是普通文件：$ENV_FILE"
+    chmod 600 "$ENV_FILE"
+    ok "保留已有配置：$ENV_FILE"
+    if ((INTERACTIVE)) && has_interactive_tty; then
+      if confirm_reuse_config; then
+        if configuration_needs_interactive_input; then
+          warn "先前配置尚未填写完整，将进入补齐向导"
+          configure_env_interactive || return 1
+        fi
+      else
+        configure_env_interactive 1 || return 1
+      fi
+    fi
+    return 0
+  fi
+
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将从 $ENV_TEMPLATE 创建 $ENV_FILE"
+    return 0
+  fi
+
+  umask 077
+  cp "$ENV_TEMPLATE" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+
+  local key value
+  for key in \
+    POSTGRES_PASSWORD \
+    REDIS_PASSWORD \
+    MINIO_ROOT_PASSWORD \
+    S3_SECRET_KEY \
+    JWT_SECRET \
+    TFA_ENCRYPTION_KEY \
+    NOJ_LLM_SERVICE_TOKEN \
+    NOJ_LLM_STORE_KEY; do
+    value="$(generate_secret)"
+    set_env_value "$key" "$value"
+  done
+  if [[ -n "${NOJ_DEPLOY_DEFAULT_VERSION:-}" ]]; then
+    set_env_value NOJ_VERSION "$NOJ_DEPLOY_DEFAULT_VERSION"
+  fi
+  set_env_value MINIO_ROOT_USER "nojminio$(openssl rand -hex 6)"
+  set_env_value S3_ACCESS_KEY "nojs3$(openssl rand -hex 6)"
+
+  ok "已创建并保护 $ENV_FILE"
+  if ((INTERACTIVE)) && has_interactive_tty; then
+        configure_env_interactive 1 || return 1
+    return 0
+  fi
+  warn "当前没有可交互终端，无法引导填写生产配置"
+  warn "请编辑 ${ENV_FILE}，填写安装版本、网站地址、HTTPS 选项、邮件服务和是否安装 Judge"
+  warn "如果安装 Judge，还要填写评测服务连接位置"
+  warn "填写完成后重新执行：bash scripts/deploy/deploy.sh install"
+  warn "自动化场景可显式使用 --non-interactive，让未完成配置直接失败"
+  exit 2
+}
+
+check_file_permissions() {
+  local mode
+  mode="$(stat -c '%a' "$ENV_FILE" 2>/dev/null || stat -f '%Lp' "$ENV_FILE" 2>/dev/null || true)"
+  [[ -n "$mode" ]] || fail "无法读取生产配置文件权限：$ENV_FILE"
+  if [[ "$mode" != "600" && "$mode" != "400" ]]; then
+    fail "生产配置文件权限必须为 600 或 400：$ENV_FILE"
+  fi
+}
+
+is_placeholder() {
+  local value="$1"
+  [[ -z "$value" ]] && return 0
+  case "$value" in
+    *change-me*|*change-this*|*changeme*|*example*|*placeholder*|*replace-me*|*your-*|test|xxx*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+judge_enabled() {
+  case "$(env_value JUDGE_ENABLED)" in
+    false|FALSE|no|NO|0|off|OFF) return 1 ;;
+    ""|true|TRUE|yes|YES|1|on|ON) return 0 ;;
+    *) fail "JUDGE_ENABLED 必须是 true 或 false" ;;
+  esac
+}
+
+check_required_values() {
+  local key value
+  local required_keys=(
+    NOJ_VERSION DOMAIN APP_URL CORS_ALLOWED_ORIGINS TRUSTED_PROXIES
+    POSTGRES_PASSWORD REDIS_PASSWORD MINIO_ROOT_USER MINIO_ROOT_PASSWORD
+    S3_ACCESS_KEY S3_SECRET_KEY S3_BUCKET S3_ENDPOINT STORAGE_PROVIDER
+    JWT_SECRET TFA_ENCRYPTION_KEY NOJ_LLM_SERVICE_TOKEN NOJ_LLM_STORE_KEY
+    EMAIL_PROVIDER
+  )
+  local missing=0
+  for key in "${required_keys[@]}"; do
+    value="$(env_value "$key")"
+    if is_placeholder "$value"; then
+      printf "  - %s 未配置或仍是占位值\n" "$key" >&2
+      missing=1
+    fi
+  done
+  judge_enabled || true
+  if judge_enabled; then
+    for key in JUDGE_DOCKER_SOCKET JUDGE_DOCKER_SOCKET_GID; do
+      value="$(env_value "$key")"
+      if is_placeholder "$value"; then
+        printf "  - %s 未配置或仍是占位值\n" "$key" >&2
+        missing=1
+      fi
+    done
+  fi
+  ((missing == 0)) || fail "生产配置未完成，请先修复上面的配置项"
+
+  is_site_address "$(env_value DOMAIN)" || {
+    printf "  - 网站地址必须是域名或服务器 IP\n" >&2
+    missing=1
+  }
+
+  case "$(env_value EMAIL_PROVIDER)" in
+    aliyun)
+      for key in ALIBABA_ACCESS_KEY_ID ALIBABA_ACCESS_KEY_SECRET ALIBABA_FROM_EMAIL; do
+        value="$(env_value "$key")"
+        is_placeholder "$value" && { printf "  - %s 未配置或仍是占位值\n" "$key" >&2; missing=1; }
+      done
+      ;;
+    tencent)
+      for key in TENCENT_SECRET_ID TENCENT_SECRET_KEY TENCENT_FROM_EMAIL TENCENT_REGION; do
+        value="$(env_value "$key")"
+        is_placeholder "$value" && { printf "  - %s 未配置或仍是占位值\n" "$key" >&2; missing=1; }
+      done
+      ;;
+    disabled)
+      ;;
+    *)
+      printf "  - EMAIL_PROVIDER 必须是 aliyun、tencent 或 disabled\n" >&2
+      missing=1
+      ;;
+  esac
+
+  [[ "$(env_value STORAGE_PROVIDER)" == "s3" ]] || {
+    printf "  - STORAGE_PROVIDER 必须设置为 s3\n" >&2
+    missing=1
+  }
+  [[ "$(env_value JWT_SECRET)" != *test* ]] || {
+    printf "  - JWT_SECRET 不得使用测试密钥\n" >&2
+    missing=1
+  }
+  if judge_enabled && ! [[ "$(env_value JUDGE_DOCKER_SOCKET_GID)" =~ ^[0-9]+$ ]]; then
+    printf "  - JUDGE_DOCKER_SOCKET_GID 必须是数字\n" >&2
+    missing=1
+  fi
+  local app_url="$(env_value APP_URL)"
+  if [[ "$app_url" == http://* && "$(env_value NOJ_ALLOW_INSECURE_HTTP)" != true ]]; then
+    printf "  - 网站完整网址使用 HTTP 时，必须明确选择临时 HTTP 模式\n" >&2
+    missing=1
+  fi
+  if [[ "$app_url" != http://* && "$app_url" != https://* ]]; then
+    printf "  - 网站完整网址必须以 http:// 或 https:// 开头\n" >&2
+    missing=1
+  fi
+  local version="$(env_value NOJ_VERSION)"
+  [[ "$version" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+    printf "  - NOJ_VERSION 必须是不可变 Release 标签（如 v0.1.0 或 0.1.1-rc.1）\n" >&2
+    missing=1
+  }
+  ((missing == 0)) || fail "生产配置校验失败"
+}
+
+check_judge_socket() {
+  local socket_path="$(env_value JUDGE_DOCKER_SOCKET)"
+  case "$socket_path" in
+    /var/run/docker.sock|/run/docker.sock)
+      fail "禁止将应用宿主机 Docker socket 挂载给 judge：$socket_path"
+      ;;
+  esac
+  [[ -e "$socket_path" ]] ||
+    fail "Judge 隔离 Docker socket 不存在：$socket_path"
+  ok "Judge 使用独立 Docker socket"
+}
+
+check_port_value() {
+  local port="$(env_value NGINX_PORT)"
+  port="${port:-8080}"
+  [[ "$port" =~ ^[0-9]+$ ]] && ((port >= 1 && port <= 65535)) ||
+    fail "NGINX_PORT 必须是 1-65535 的端口号"
+  if command -v lsof >/dev/null 2>&1 &&
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    warn "NGINX_PORT=$port 已被其他进程监听；启动时可能发生端口冲突"
+  fi
+}
+
+detect_panel() {
+  PANEL_NAME="none"
+  case "$PANEL_MODE" in
+    baota) PANEL_NAME="baota" ;;
+    none) return 0 ;;
+    auto)
+      if [[ -d "$PANEL_ROOT" || -x "$PANEL_COMMAND" ]]; then
+        PANEL_NAME="baota"
+      fi
+      ;;
+  esac
+}
+
+show_panel_guidance() {
+  [[ "$PANEL_NAME" == baota ]] || return 0
+  section "宝塔兼容模式"
+  cat <<'EOF'
+已检测到宝塔面板。脚本会直接使用宝塔管理的标准 Docker/Compose，不调用宝塔 API。
+
+前后端 Compose 自带 Nginx。请在宝塔的网站/反向代理中把域名转发到
+127.0.0.1:NGINX_PORT，默认端口为 8080；如果修改了 .env.prod 中的 NGINX_PORT，
+请使用修改后的端口。请先确认该端口没有被宝塔已有网站或其他服务占用。
+
+脚本不会修改已有站点、证书、反向代理、容器或面板配置。如果安装 Judge，仍必须使用
+只服务于 Judge 的 rootless Docker socket，不能填写 /run/docker.sock 或 /var/run/docker.sock。
+EOF
+  ok "宝塔兼容提示已启用"
+}
+
+check_dependencies() {
+  section "检查部署环境"
+  detect_panel
+  show_panel_guidance
+  command -v "$DOCKER_BIN" >/dev/null 2>&1 ||
+    fail "找不到 Docker CLI：$DOCKER_BIN"
+  "$DOCKER_BIN" info >/dev/null 2>&1 || fail "Docker daemon 未运行或当前用户无权限"
+  "$DOCKER_BIN" compose version >/dev/null 2>&1 ||
+    fail "Docker Compose v2 不可用"
+  if [[ "$(env_value NOJ_ENFORCE_IMAGE_SIGNATURES)" != "false" ]]; then
+    "$DOCKER_BIN" buildx version >/dev/null 2>&1 ||
+      fail "镜像签名校验需要 Docker Buildx"
+  fi
+  [[ -f "$COMPOSE_FILE" ]] || fail "找不到生产 Compose 文件：$COMPOSE_FILE"
+  ok "Docker daemon 与 Compose 可用"
+}
+
+verify_image_signatures() {
+  [[ "$(env_value NOJ_ENFORCE_IMAGE_SIGNATURES)" != "false" ]] || {
+    warn "NOJ_ENFORCE_IMAGE_SIGNATURES=false，已关闭镜像签名校验"
+    return 0
+  }
+
+  command -v cosign >/dev/null 2>&1 ||
+    fail "已开启镜像签名校验，但找不到 Cosign；请先安装 Cosign，或将 NOJ_ENFORCE_IMAGE_SIGNATURES 设置为 false"
+
+  local version registry identity image digest
+  version="$(env_value NOJ_VERSION)"
+  registry="$(env_value NOJ_IMAGE_REGISTRY)"
+  registry="${registry:-ghcr.io/neuro-oj}"
+  identity="$(env_value NOJ_COSIGN_CERT_IDENTITY_REGEX)"
+  identity="${identity:-^https://github.com/Neuro-OJ/neuro-oj/.github/workflows/release.yml@.*$}"
+  section "校验生产镜像签名"
+
+  local images=(noj-server noj-ui noj-llm-gateway)
+  if judge_enabled; then
+    images+=(noj-judge noj-evaluator-python noj-solution-python)
+  fi
+  for image in "${images[@]}"; do
+    local image_name="$image"
+    image="$registry/$image_name:$version"
+    digest="$("$DOCKER_BIN" buildx imagetools inspect "$image" 2>/dev/null |
+      awk '/^Digest:/ {print $2; exit}')"
+    [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+      fail "无法解析生产镜像 digest：$image"
+    cosign verify \
+      --certificate-identity-regexp "$identity" \
+      --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+      "$image@$digest" >/dev/null ||
+      fail "生产镜像 Cosign 签名校验失败：$image@$digest"
+    VERIFIED_IMAGE_DIGESTS+=("$image_name $digest")
+    ok "$image@$digest"
+  done
+}
+
+record_deployment_metadata() {
+  ((DRY_RUN)) && return 0
+  ((${#VERIFIED_IMAGE_DIGESTS[@]} > 0)) || return 0
+
+  mkdir -p "$BACKUP_DIR"
+  local tmp manifest
+  manifest="$BACKUP_DIR/current-deployment.txt"
+  tmp="$(mktemp "$BACKUP_DIR/.current-deployment.XXXXXX")"
+  {
+    printf 'version=%s\n' "$(env_value NOJ_VERSION)"
+    printf 'recorded_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '%s\n' "${VERIFIED_IMAGE_DIGESTS[@]}" | sort
+  } >"$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$manifest"
+  ok "已记录当前部署版本与镜像 digest：$manifest"
+}
+
+check_configuration() {
+  [[ -f "$ENV_FILE" ]] || fail "找不到生产配置：${ENV_FILE}，请先执行 install"
+  check_file_permissions
+  check_required_values
+  if judge_enabled; then
+    check_judge_socket
+  else
+    ok "已跳过 Judge Docker socket 检查"
+  fi
+  check_port_value
+
+  if ((DRY_RUN)); then
+    ok "[dry-run] 跳过会输出 Compose 解析结果的命令"
+  else
+    run_compose config --quiet ||
+      fail "Docker Compose 配置无效，请检查环境变量和生产 Compose 文件"
+  fi
+  case "$COMMAND" in
+    install|start|upgrade|verify) verify_image_signatures ;;
+  esac
+  ok "生产配置检查通过"
+}
+
+passphrase_file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
+}
+
+ensure_backup_passphrase() {
+  local configured_file target_file parent temp mode
+  ((DRY_RUN)) && return 0
+  configured_file="$(env_value NOJ_BACKUP_PASSPHRASE_FILE)"
+  target_file="${BACKUP_PASSPHRASE_FILE:-${configured_file:-$DEFAULT_BACKUP_PASSPHRASE_FILE}}"
+  BACKUP_PASSPHRASE_FILE="$target_file"
+
+  if [[ -e "$target_file" ]]; then
+    [[ -f "$target_file" ]] || fail "GPG 备份口令路径不是普通文件：$target_file"
+    mode="$(passphrase_file_mode "$target_file")"
+    [[ "$mode" == 600 || "$mode" == 400 ]] ||
+      fail "GPG 备份口令文件权限必须为 600 或 400：$target_file"
+    return 0
+  fi
+
+  command -v openssl >/dev/null 2>&1 ||
+    fail "无法自动创建 GPG 备份口令文件，请安装 openssl 或使用 --passphrase-file 指定已有文件"
+  parent="$(dirname -- "$target_file")"
+  mkdir -p -m 700 -- "$parent" ||
+    fail "无法创建 GPG 备份口令目录：$parent；请使用 --passphrase-file 指定可写路径"
+  temp="$(mktemp "$target_file.tmp.XXXXXX")" ||
+    fail "无法创建 GPG 备份口令文件：$target_file"
+  chmod 600 "$temp"
+  if ! openssl rand -hex 32 >"$temp" || ! mv -- "$temp" "$target_file"; then
+    rm -f -- "$temp"
+    fail "无法创建 GPG 备份口令文件：$target_file"
+  fi
+  chmod 600 "$target_file"
+  if [[ -z "$configured_file" && -z "${NOJ_BACKUP_PASSPHRASE_FILE:-}" ]]; then
+    set_env_value NOJ_BACKUP_PASSPHRASE_FILE "$target_file"
+  fi
+  ok "已准备 GPG 备份口令文件：$target_file"
+  warn "请将该口令文件安全复制到仓库外的异地位置，否则无法恢复加密快照"
+}
+
+run_compose() {
+  local -a compose_args=(--env-file "$ENV_FILE" -f "$COMPOSE_FILE")
+  if ((INCLUDE_ALL_PROFILES)) || judge_enabled; then
+    compose_args+=(--profile judge)
+  fi
+  if ((DRY_RUN)); then
+    printf "[dry-run] docker compose --env-file %s -f %s" "$ENV_FILE" "$COMPOSE_FILE"
+    if judge_enabled; then
+      printf " --profile judge"
+    fi
+    printf " %s" "$@"
+    printf "\n"
+    return 0
+  fi
+  "$DOCKER_BIN" compose "${compose_args[@]}" "$@"
+}
+
+wait_for_stack() {
+  section "等待服务健康"
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将等待 Compose healthcheck 完成"
+    return 0
+  fi
+  run_compose up -d --wait --wait-timeout 180 --remove-orphans ||
+    fail "服务启动或健康检查失败，请执行 status 和 logs 排查"
+  run_compose up -d --force-recreate --no-deps nginx ||
+    fail "反向代理刷新失败，请执行 status 和 logs 排查"
+  ok "生产服务已通过 Compose 健康检查"
+}
+
+prepare_and_check() {
+  check_dependencies
+  check_configuration
+}
+
+install() {
+  check_dependencies
+  initialize_env
+  ensure_backup_passphrase
+  check_configuration
+  section "拉取生产镜像"
+  run_compose pull
+  wait_for_stack
+  record_deployment_metadata
+  ok "生产部署完成"
+  cat <<'EOF'
+
+下一步：打开网站并注册第一个用户。新站点的第一个注册用户会自动获得管理员权限；
+请立即完成注册，避免其他人抢先注册。已有站点的用户权限不会因升级改变。
+EOF
+  if judge_enabled; then
+    ok "评测服务 Judge 已安装并启动"
+  else
+    cat <<'EOF'
+
+当前跳过了评测服务 Judge，网站暂时不能进行代码评测。
+以后准备好独立的 Judge Docker 服务后，将 .env.prod 中的 JUDGE_ENABLED 改为 true，
+补充 JUDGE_DOCKER_SOCKET 和 JUDGE_DOCKER_SOCKET_GID，再执行：
+  bash scripts/deploy/deploy.sh start
+EOF
+  fi
+}
+
+start() {
+  prepare_and_check
+  wait_for_stack
+  record_deployment_metadata
+  ok "生产服务已启动"
+}
+
+upgrade() {
+  prepare_and_check
+  ensure_backup_passphrase
+  run_backup "upgrade"
+  section "拉取目标版本镜像"
+  run_compose pull
+  wait_for_stack
+  record_deployment_metadata
+  ok "生产服务已升级"
+}
+
+stop() {
+  prepare_and_check
+  section "停止生产服务"
+  run_compose stop
+  ok "服务已停止，数据卷已保留"
+}
+
+confirm_uninstall() {
+  ((DRY_RUN)) && return 0
+  if ((UNINSTALL_CONFIRMED)); then
+    return 0
+  fi
+  has_interactive_tty ||
+    fail "卸载需要交互确认；自动化环境请显式使用 --yes"
+  if ((UNINSTALL_ALL)); then
+    cat >&2 <<'EOF'
+警告：即将完全删除 NOJ：
+  - 删除当前 Compose 栈的容器、网络、本地镜像和全部数据卷
+  - 删除当前安装目录中的配置、备份和部署文件
+  - 删除指向当前安装目录的 PATH 命令软链接
+  - 不修改宿主机 Nginx/Caddy/宝塔站点、证书或其他容器
+此操作不可恢复，请先确认备份已经下载到其他位置。
+EOF
+    read_prompt '请输入 DELETE ALL 确认完全删除（其他输入取消）：'
+    [[ "$PROMPT_VALUE" == 'DELETE ALL' ]] ||
+      fail "未确认完全删除，未修改任何服务或文件"
+  else
+    cat >&2 <<'EOF'
+即将卸载 NOJ 生产服务：
+  - 删除当前 Compose 栈的容器、网络和本地镜像
+  - 保留 PostgreSQL、Redis、MinIO、题目包和 Judge 缓存数据卷
+  - 保留 .env.prod、备份和部署目录
+  - 不修改宿主机 Nginx/Caddy/宝塔站点、证书或其他容器
+EOF
+    read_prompt '请输入 UNINSTALL 确认卸载（其他输入取消）：'
+    [[ "$PROMPT_VALUE" == UNINSTALL ]] ||
+      fail "未确认卸载，未修改任何服务或文件"
+  fi
+}
+
+check_uninstall_dependencies() {
+  section "检查卸载环境"
+  command -v "$DOCKER_BIN" >/dev/null 2>&1 ||
+    fail "找不到 Docker CLI：$DOCKER_BIN"
+  "$DOCKER_BIN" info >/dev/null 2>&1 || fail "Docker daemon 未运行或当前用户无权限"
+  "$DOCKER_BIN" compose version >/dev/null 2>&1 ||
+    fail "Docker Compose v2 不可用"
+  [[ -f "$ENV_FILE" ]] || fail "找不到生产配置：$ENV_FILE；无法安全定位生产 Compose 栈"
+  [[ -f "$COMPOSE_FILE" ]] || fail "找不到生产 Compose 文件：$COMPOSE_FILE"
+  ok "Docker daemon、Compose 和卸载配置可用"
+}
+
+uninstall() {
+  confirm_uninstall
+  check_uninstall_dependencies
+  section "卸载生产服务"
+  INCLUDE_ALL_PROFILES=1
+  if ((UNINSTALL_ALL)); then
+    run_compose down --remove-orphans --rmi all --volumes
+    ok "生产容器、网络、本地镜像和数据卷已清理"
+  else
+    run_compose down --remove-orphans --rmi local
+    ok "生产容器、网络和 Compose 管理的本地镜像已清理"
+    ok "数据卷、生产配置、备份和部署目录已保留"
+  fi
+}
+
+status() {
+  prepare_and_check
+  run_compose ps
+}
+
+logs() {
+  prepare_and_check
+  local args=(logs --tail=200)
+  if ((FOLLOW)); then args+=(--follow); fi
+  if ((${#POSITIONAL[@]} > 0)); then args+=("${POSITIONAL[@]}"); fi
+  run_compose "${args[@]}"
+}
+
+run_backup() {
+  local reason="${1:-manual}"
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将在${reason}流程中创建并校验完整生产备份"
+    return 0
+  fi
+  local args=(create --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" --backup-dir "$BACKUP_DIR")
+  [[ -n "$BACKUP_PASSPHRASE_FILE" ]] && args+=(--passphrase-file "$BACKUP_PASSPHRASE_FILE")
+  NOJ_BACKUP_DOCKER_BIN="$DOCKER_BIN" bash "$SCRIPT_DIR/backup.sh" "${args[@]}"
+}
+
+backup() {
+  prepare_and_check
+  ensure_backup_passphrase
+  run_backup "手动备份"
+}
+
+verify() {
+  prepare_and_check
+  ok "生产镜像验证完成"
+}
+
+main() {
+  parse_args "$@"
+  case "$COMMAND" in
+    install) install ;;
+    start) start ;;
+    upgrade) upgrade ;;
+    stop) stop ;;
+    uninstall) uninstall ;;
+    status) status ;;
+    logs) logs ;;
+    backup) backup ;;
+    verify) verify ;;
+    *) fail "未知命令：$COMMAND" ;;
+  esac
+}
+
+if [[ "${NOJ_DEPLOY_SOURCE_ONLY:-0}" != "1" ]]; then
+  main "$@"
+fi

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -1,0 +1,700 @@
+#!/usr/bin/env bash
+#
+# Neuro OJ 内部 bootstrap 与旧版本兼容入口。
+#
+# 新用户请使用 setup.sh；此文件保留用于旧版本兼容和 setup.sh 的内部引导，不依赖当前
+# 工作目录或本地 Git 仓库。
+#
+# Bootstrap 只负责获取源码；生产 Compose、配置校验和服务生命周期仍由
+# 下载后的 scripts/deploy/deploy.sh 负责。
+
+set -Eeuo pipefail
+
+readonly DEFAULT_REPOSITORY="https://github.com/Neuro-OJ/neuro-oj"
+
+REPOSITORY="${NOJ_BOOTSTRAP_REPOSITORY:-$DEFAULT_REPOSITORY}"
+REF="${NOJ_BOOTSTRAP_REF:-}"
+TARGET_DIR="${NOJ_BOOTSTRAP_DIR:-/opt/neuro-oj}"
+CHECK_PORT="${NOJ_BOOTSTRAP_PORT:-8080}"
+EXISTING_INSTALL=0
+PANEL_MODE="${NOJ_BOOTSTRAP_PANEL:-auto}"
+PANEL_MODE_SET=0
+PANEL_NAME="none"
+PANEL_ROOT="${NOJ_BOOTSTRAP_PANEL_ROOT:-/www/server/panel}"
+PANEL_COMMAND="${NOJ_BOOTSTRAP_PANEL_COMMAND:-/usr/bin/bt}"
+COMMAND=""
+DOWNLOAD_ONLY=0
+FILES_ONLY=0
+DRY_RUN=0
+NON_INTERACTIVE=0
+TEMP_ROOT=""
+ARCHIVE_URL=""
+ARCHIVE_ROOT=""
+DEPLOY_ARGS=()
+ARCHIVE_PATH=""
+
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; RESET='\033[0m'
+else
+  GREEN=''; YELLOW=''; RED=''; RESET=''
+fi
+
+ok() { printf "%b✓%b %s\n" "$GREEN" "$RESET" "$*"; }
+warn() { printf "%b!%b %s\n" "$YELLOW" "$RESET" "$*" >&2; }
+section() { printf '\n== %s ==\n' "$*"; }
+fail() {
+  printf "%b✗%b %s\n" "$RED" "$RESET" "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Neuro OJ Linux 独立下载部署工具
+
+新用户请使用仓库根目录的 setup.sh；本脚本作为 setup.sh 的内部 bootstrap，并保留旧版本兼容。
+
+用法：
+  install.sh [check|install-env|install] [选项] [-- <deploy.sh 参数>]
+
+示例：
+  curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh \
+    -o noj-setup.sh
+  bash noj-setup.sh --dir /opt/neuro-oj
+  bash scripts/deploy/install.sh check       # 旧版本兼容检查
+  sudo bash scripts/deploy/install.sh install-env
+
+命令：
+  check                  检测 Linux、基础工具、Docker/Compose、资源和端口
+  install-env            安装基础工具并重新检测环境（不会安装 Docker）
+  install                下载源码并执行生产部署（默认命令）
+
+选项：
+  --repo URL             GitHub 仓库地址（默认 Neuro-OJ/neuro-oj）
+  --ref REF              固定分支或 Release tag（稳定版本通常使用 v 前缀；默认自动选择最新 Release）
+  --dir DIRECTORY        安装目录（默认 /opt/neuro-oj）
+  --port PORT            检测宿主机端口（默认 8080）
+  --panel MODE           面板模式：auto（默认）、baota 或 none
+  --download-only        只下载源码，不执行生产部署
+  --files-only            只更新安装目录中的部署文件和 noj 命令（内部兼容选项）
+  --dry-run              只显示下载计划，不下载、不写文件、不启动服务
+  --non-interactive      首次配置不询问，配置不完整时直接失败
+  -h, --help             显示帮助
+
+环境变量：
+  NOJ_BOOTSTRAP_REPOSITORY  默认仓库地址
+  NOJ_BOOTSTRAP_REF         默认 ref
+  NOJ_BOOTSTRAP_DIR         默认安装目录
+  NOJ_BOOTSTRAP_PANEL       面板模式（默认 auto）
+
+部署参数：
+  通过 -- 后传递给下载后的 deploy.sh install，例如 -- --non-interactive
+
+未指定 --ref 时脚本会自动使用仓库最新可用 Release；生产环境也可以显式指定 --ref 固定版本。
+目标目录非空时脚本会继续执行：只更新 NOJ 的部署文件和 noj 命令，保留现有配置、备份、数据卷及其他文件。
+如果目标目录已经是本工具安装的 Neuro OJ，会直接继续部署；其他非空目录也不会被清空。
+生产环境建议使用不可变 Release tag，并让 --ref 与 .env.prod 中的 NOJ_VERSION 一致。
+执行 install 时会在获取 Release、下载源码和写入目标目录前，先展示最低要求与当前主机环境；该步骤不会自动安装 Docker。
+install-env 只安装 curl、tar、openssl 和 CA 证书等基础工具；Docker 请按发行版官方文档安装。
+EOF
+}
+
+cleanup() {
+  if [[ -n "$TEMP_ROOT" && -d "$TEMP_ROOT" ]]; then
+    rm -rf -- "$TEMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+parse_args() {
+  while (($# > 0)); do
+    case "$1" in
+      check|install-env|install)
+        [[ -z "$COMMAND" ]] || fail "只能指定一个命令"
+        COMMAND="$1"
+        ;;
+      --repo|--repository)
+        (($# >= 2)) || fail "$1 需要一个仓库地址"
+        REPOSITORY="$2"
+        shift
+        ;;
+      --repo=*|--repository=*) REPOSITORY="${1#*=}" ;;
+      --ref)
+        (($# >= 2)) || fail "--ref 需要一个版本 ref"
+        REF="$2"
+        shift
+        ;;
+      --ref=*) REF="${1#*=}" ;;
+      --dir|--target-dir)
+        (($# >= 2)) || fail "$1 需要一个安装目录"
+        TARGET_DIR="$2"
+        shift
+        ;;
+      --dir=*|--target-dir=*) TARGET_DIR="${1#*=}" ;;
+      --port)
+        (($# >= 2)) || fail "--port 需要一个端口号"
+        CHECK_PORT="$2"
+        shift
+        ;;
+      --port=*) CHECK_PORT="${1#*=}" ;;
+      --panel)
+        (($# >= 2)) || fail "--panel 需要 auto、baota 或 none"
+        PANEL_MODE="$2"
+        PANEL_MODE_SET=1
+        shift
+        ;;
+      --panel=*) PANEL_MODE="${1#*=}"; PANEL_MODE_SET=1 ;;
+      --download-only) DOWNLOAD_ONLY=1 ;;
+      --files-only) FILES_ONLY=1 ;;
+      --dry-run) DRY_RUN=1 ;;
+      --non-interactive) NON_INTERACTIVE=1 ;;
+      -h|--help) usage; exit 0 ;;
+      --)
+        shift
+        DEPLOY_ARGS+=("$@")
+        break
+        ;;
+      *) fail "未知参数：$1；部署参数请放在 -- 之后" ;;
+    esac
+    shift
+  done
+  COMMAND="${COMMAND:-install}"
+  case "$PANEL_MODE" in
+    auto|baota|none) ;;
+    *) fail "--panel 只能是 auto、baota 或 none：$PANEL_MODE" ;;
+  esac
+}
+
+validate_inputs() {
+  [[ "$REPOSITORY" == https://* ]] ||
+    fail "仓库地址必须使用 HTTPS"
+  [[ "$REPOSITORY" != *[[:space:]]* && "$REPOSITORY" != *'@'* &&
+    "$REPOSITORY" != *'?'* && "$REPOSITORY" != *'#'* ]] ||
+    fail "仓库地址包含不支持的字符"
+  REPOSITORY="${REPOSITORY%/}"
+  REPOSITORY="${REPOSITORY%.git}"
+
+  [[ -n "$TARGET_DIR" && "$TARGET_DIR" != "/" && "$TARGET_DIR" != "." &&
+    "$TARGET_DIR" != ".." ]] ||
+    fail "安装目录不安全或为空"
+  [[ "$TARGET_DIR" != *$'\n'* && "$TARGET_DIR" != *$'\r'* ]] ||
+    fail "安装目录不能包含换行符"
+
+}
+
+validate_ref() {
+  [[ "$REF" =~ ^[A-Za-z0-9._/-]+$ && "$REF" != /* && "$REF" != */ &&
+    "$REF" != *'..'* && "$REF" != *//* && -n "$REF" ]] ||
+    fail "没有找到有效的 Release。请使用 --ref 指定版本，例如 --ref 0.8.0-rc.1"
+  ARCHIVE_URL="$REPOSITORY/archive/$REF.tar.gz"
+}
+
+resolve_latest_ref() {
+  local repository_slug metadata_url metadata tag
+  [[ -n "$REF" ]] && { validate_ref; return 0; }
+
+  [[ "$REPOSITORY" =~ ^https://github\.com/([^/]+/[^/]+)$ ]] ||
+    fail "无法自动获取最新版本；请对自定义仓库使用 --ref 指定 Release tag"
+  repository_slug="${BASH_REMATCH[1]}"
+  metadata_url="https://api.github.com/repos/$repository_slug/releases?per_page=1"
+  printf '正在获取最新 Release：%s\n' "$metadata_url" >&2
+  if command -v curl >/dev/null 2>&1; then
+    metadata="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+      --retry 3 --connect-timeout 15 --header 'Accept: application/vnd.github+json' \
+      --header 'User-Agent: neuro-oj-installer' "$metadata_url")" ||
+      fail "无法获取最新 Release，请检查网络，或使用 --ref 显式指定版本"
+  else
+    metadata="$(wget --https-only --tries=3 --timeout=20 --quiet --header='Accept: application/vnd.github+json' \
+      --header='User-Agent: neuro-oj-installer' -O - "$metadata_url")" ||
+      fail "无法获取最新 Release，请检查网络，或使用 --ref 显式指定版本"
+  fi
+  tag="$(awk '
+    match($0, /"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"/) {
+      value = substr($0, RSTART, RLENGTH)
+      sub(/^.*:[[:space:]]*"/, "", value)
+      sub(/"$/, "", value)
+      print value
+      exit
+    }
+  ' <<<"$metadata")"
+  [[ -n "$tag" ]] || fail "仓库没有可用 Release，请使用 --ref 显式指定版本"
+  REF="$tag"
+  validate_ref
+  ok "将使用最新 Release：$REF"
+}
+
+check_dependencies() {
+  command -v tar >/dev/null 2>&1 || fail "找不到 tar，请先安装 tar"
+  if command -v curl >/dev/null 2>&1; then
+    return 0
+  fi
+  command -v wget >/dev/null 2>&1 || fail "需要 curl 或 wget，请先安装其中一个"
+}
+
+docker_install_hint() {
+  cat >&2 <<'EOF'
+Docker Engine 或 Docker Compose v2 不可用。
+请按照发行版官方文档安装 Docker Engine 和 Compose plugin：
+  https://docs.docker.com/engine/install/
+安装后重新执行：bash scripts/deploy/install.sh check
+EOF
+}
+
+detect_panel() {
+  PANEL_NAME="none"
+  case "$PANEL_MODE" in
+    baota) PANEL_NAME="baota" ;;
+    none) return 0 ;;
+    auto)
+      if [[ -d "$PANEL_ROOT" || -x "$PANEL_COMMAND" ]]; then
+        PANEL_NAME="baota"
+      fi
+      ;;
+  esac
+}
+
+show_panel_guidance() {
+  [[ "$PANEL_NAME" == baota ]] || return 0
+  section "宝塔兼容模式"
+  cat <<'EOF'
+已检测到宝塔面板。脚本会直接使用宝塔管理的标准 Docker/Compose，不调用宝塔 API。
+
+前后端 Compose 自带 Nginx。部署完成后，请在宝塔的网站/反向代理中把域名转发到
+127.0.0.1:8080（如修改 NGINX_PORT，请使用修改后的端口）。请先确认该端口没有被
+宝塔已有网站或其他服务占用。脚本不会修改已有站点、证书、反向代理、容器或面板配置。
+
+Judge 仍必须使用只服务于 Judge 的 rootless Docker socket，不能填写
+/run/docker.sock 或 /var/run/docker.sock。
+EOF
+  ok "宝塔兼容提示已启用"
+}
+
+check_port() {
+  local occupied=0
+  [[ "$CHECK_PORT" =~ ^[0-9]+$ ]] && ((CHECK_PORT >= 1 && CHECK_PORT <= 65535)) || {
+    printf '  - 端口号无效：%s\n' "$CHECK_PORT" >&2
+    return 1
+  }
+  if ((FILES_ONLY)); then
+    ok "部署文件同步模式跳过宿主机端口占用检查"
+    return 0
+  fi
+  if command -v ss >/dev/null 2>&1; then
+    if ss -ltnH 2>/dev/null | awk -v port=":$CHECK_PORT" '$4 ~ (port "$") { found=1 } END { exit !found }'; then
+      occupied=1
+    fi
+  elif command -v lsof >/dev/null 2>&1; then
+    if lsof -nP -iTCP:"$CHECK_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+      occupied=1
+    fi
+  else
+    warn "未找到 ss/lsof，无法确认端口 $CHECK_PORT 是否被占用"
+    return 0
+  fi
+  if ((occupied)); then
+    printf '  - 端口 %s 已被监听，启动 Nginx 可能失败\n' "$CHECK_PORT" >&2
+    return 1
+  fi
+  ok "端口 $CHECK_PORT 可用"
+}
+
+show_environment_requirements() {
+  section "安装前环境预览"
+  cat <<'EOF'
+最低运行要求：
+  - Linux x86_64
+  - CPU：至少 2 vCPU
+  - 内存：至少 264 MiB
+  - Swap：至少 2 GiB
+  - 目标目录所在磁盘：至少 5 GiB 可用空间
+  - Docker 数据目录所在磁盘：至少 5 GiB 可用空间
+  - Docker Engine、Docker Compose v2、Bash、tar、OpenSSL，以及 curl 或 wget
+  - 可访问 ghcr.io/neuro-oj/；启用 Judge 时还需要独立的 rootless Docker socket
+
+下面将列出当前主机已检测到的环境；资源项是摘要，最终部署仍会执行配置、镜像和健康检查。
+EOF
+}
+
+check_host() {
+  local failed=0 system arch os_name mem_mb swap_mb cpu_count
+  local disk_path disk_kb docker_root_dir docker_disk_kb
+  show_environment_requirements
+  section "检查 Linux 部署环境"
+  detect_panel
+  show_panel_guidance
+
+  system="$(uname -s 2>/dev/null || true)"
+  if [[ "$system" != Linux ]]; then
+    printf '  - 当前系统：%s；生产部署脚本仅支持 Linux\n' "${system:-unknown}" >&2
+    failed=1
+  else
+    ok "操作系统：Linux"
+  fi
+
+  arch="$(uname -m 2>/dev/null || true)"
+  case "$arch" in
+    x86_64) ok "CPU 架构：$arch" ;;
+    aarch64|arm64)
+      printf '  - 当前 CPU 架构：%s；当前生产镜像仅发布 linux/amd64，请使用 x86_64 主机\n' "$arch" >&2
+      failed=1
+      ;;
+    *)
+      printf '  - 不支持的 CPU 架构：%s（当前生产镜像仅支持 x86_64）\n' "${arch:-unknown}" >&2
+      failed=1
+      ;;
+  esac
+  os_name="unknown"
+  [[ -r /etc/os-release ]] && os_name="$(awk -F= '$1 == "PRETTY_NAME" { gsub(/^"|"$/, "", $2); print $2; exit }' /etc/os-release)"
+  printf '系统版本：%s\n' "$os_name"
+
+  for command_name in bash tar openssl; do
+    if command -v "$command_name" >/dev/null 2>&1; then
+      ok "基础工具：$command_name"
+    else
+      printf '  - 缺少基础工具：%s\n' "$command_name" >&2
+      failed=1
+    fi
+  done
+  if command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1; then
+    ok "下载工具：curl 或 wget"
+  else
+    printf '  - 缺少下载工具：curl 或 wget\n' >&2
+    failed=1
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    ok "Docker CLI：$(docker --version 2>/dev/null || printf '可执行')"
+    if docker info >/dev/null 2>&1; then
+      ok "Docker daemon：可用"
+    else
+      printf '  - Docker daemon 未运行或当前用户无权限\n' >&2
+      failed=1
+    fi
+    if docker compose version >/dev/null 2>&1; then
+      ok "Docker Compose：v2 可用"
+    else
+      printf '  - Docker Compose v2 plugin 不可用\n' >&2
+      failed=1
+    fi
+  else
+    printf '  - 未安装 Docker CLI\n' >&2
+    docker_install_hint
+    failed=1
+  fi
+
+  cpu_count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || true)"
+  if [[ "$cpu_count" =~ ^[0-9]+$ ]]; then
+    printf '已有环境 CPU：%s vCPU\n' "$cpu_count"
+  else
+    warn "无法读取 CPU 数量"
+  fi
+
+  if [[ -r /proc/meminfo ]]; then
+    mem_mb="$(awk '/^MemTotal:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo)"
+    swap_mb="$(awk '/^SwapTotal:/ { printf "%d", $2 / 1024; exit }' /proc/meminfo)"
+    printf '已有环境内存：物理内存约 %s MiB\n' "$mem_mb"
+    if [[ "$swap_mb" =~ ^[0-9]+$ ]]; then
+      printf '已有环境 Swap：约 %s MiB\n' "$swap_mb"
+    else
+      warn "无法读取 Swap 大小"
+    fi
+  else
+    warn "无法读取 /proc/meminfo，跳过内存和 Swap 摘要"
+  fi
+  disk_path="$(dirname -- "$TARGET_DIR")"
+  [[ -d "$disk_path" ]] || disk_path="/"
+  disk_kb="$(df -Pk "$disk_path" 2>/dev/null | awk 'NR == 2 { print $4 }')"
+  if [[ "$disk_kb" =~ ^[0-9]+$ ]]; then
+    printf '已有环境目标磁盘：可用空间约 %s MiB（%s）\n' "$((disk_kb / 1024))" "$disk_path"
+  else
+    warn "无法读取目标目录所在磁盘空间"
+  fi
+  if command -v docker >/dev/null 2>&1; then
+    docker_root_dir="$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)"
+    if [[ -n "$docker_root_dir" && -d "$docker_root_dir" ]]; then
+      docker_disk_kb="$(df -Pk "$docker_root_dir" 2>/dev/null | awk 'NR == 2 { print $4 }')"
+      if [[ "$docker_disk_kb" =~ ^[0-9]+$ ]]; then
+        printf '已有环境 Docker 存储：可用空间约 %s MiB（%s）\n' \
+          "$((docker_disk_kb / 1024))" "$docker_root_dir"
+      else
+        warn "无法读取 Docker 数据目录所在磁盘空间"
+      fi
+    else
+      warn "无法读取 Docker 数据目录，跳过 Docker 存储摘要"
+    fi
+  fi
+  check_port || failed=1
+
+  if ((failed)); then
+    printf '%s\n' '环境检测失败，请先修复阻断项后重试。' >&2
+    return 1
+  fi
+  ok "环境检测通过"
+}
+
+install_env() {
+  local package_manager package_command
+  [[ "$(uname -s 2>/dev/null || true)" == Linux ]] ||
+    fail "install-env 仅支持 Linux"
+
+  if command -v apt-get >/dev/null 2>&1; then
+    package_manager=apt-get
+    package_command="$package_manager update && $package_manager install -y ca-certificates curl tar openssl"
+  elif command -v dnf >/dev/null 2>&1; then
+    package_manager=dnf
+    package_command="$package_manager install -y ca-certificates curl tar openssl"
+  elif command -v yum >/dev/null 2>&1; then
+    package_manager=yum
+    package_command="$package_manager install -y ca-certificates curl tar openssl"
+  elif command -v apk >/dev/null 2>&1; then
+    package_manager=apk
+    package_command="$package_manager add --no-cache ca-certificates curl tar openssl"
+  elif command -v pacman >/dev/null 2>&1; then
+    package_manager=pacman
+    package_command="$package_manager -Sy --needed --noconfirm ca-certificates curl tar openssl"
+  else
+    fail "无法识别包管理器；请手动安装 ca-certificates、curl、tar 和 openssl"
+  fi
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将使用 $package_manager 安装基础工具：ca-certificates curl tar openssl"
+    ok "[dry-run] 命令：$package_command"
+    return 0
+  fi
+  [[ "${EUID:-$(id -u)}" -eq 0 ]] ||
+    fail "install-env 需要 root 权限，请使用 sudo bash scripts/deploy/install.sh install-env"
+  case "$package_manager" in
+    apt-get) apt-get update; apt-get install -y ca-certificates curl tar openssl ;;
+    dnf|yum) "$package_manager" install -y ca-certificates curl tar openssl ;;
+    apk) apk add --no-cache ca-certificates curl tar openssl ;;
+    pacman) pacman -Sy --needed --noconfirm ca-certificates curl tar openssl ;;
+  esac
+  ok "基础工具安装完成（包管理器：$package_manager）"
+  check_host
+}
+
+check_target() {
+  [[ ! -L "$TARGET_DIR" ]] || fail "安装目录不能是符号链接：$TARGET_DIR"
+  if [[ -e "$TARGET_DIR" ]]; then
+    [[ -d "$TARGET_DIR" ]] || fail "安装路径已存在但不是目录：$TARGET_DIR"
+    if [[ -f "$TARGET_DIR/scripts/deploy/deploy.sh" &&
+      -f "$TARGET_DIR/docker-compose.prod.yml" ]]; then
+      EXISTING_INSTALL=1
+      ok "检测到已有 Neuro OJ 安装，将保留现有配置并继续部署：$TARGET_DIR"
+      return 0
+    fi
+    EXISTING_INSTALL=1
+    warn "检测到安装目录非空，将仅更新 NOJ 部署文件和 noj 命令，不清空已有内容：$TARGET_DIR"
+  fi
+}
+
+download_archive() {
+  ARCHIVE_PATH="$TEMP_ROOT/source.tar.gz"
+  printf '下载源码归档：%s\n' "$ARCHIVE_URL" >&2
+  if command -v curl >/dev/null 2>&1; then
+    curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+      --retry 3 --connect-timeout 15 --output "$ARCHIVE_PATH" "$ARCHIVE_URL" ||
+      if [[ "$REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        fail "源码下载失败，请检查仓库、网络或代理配置；正式版本标签通常带 v 前缀，请尝试 --ref v$REF"
+      else
+        fail "源码下载失败，请检查仓库、ref、网络或代理配置"
+      fi
+  else
+    wget --https-only --tries=3 --timeout=20 --quiet --output-document="$ARCHIVE_PATH" "$ARCHIVE_URL" ||
+      if [[ "$REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        fail "源码下载失败，请检查仓库、网络或代理配置；正式版本标签通常带 v 前缀，请尝试 --ref v$REF"
+      else
+        fail "源码下载失败，请检查仓库、ref、网络或代理配置"
+      fi
+  fi
+  [[ -s "$ARCHIVE_PATH" ]] || fail "下载的源码归档为空"
+}
+
+validate_archive() {
+  local archive="$1" entry root_count listing_file verbose_file
+  local -a roots=()
+
+  listing_file="$TEMP_ROOT/archive.list"
+  verbose_file="$TEMP_ROOT/archive.verbose"
+  tar -tzf "$archive" >"$listing_file" 2>/dev/null ||
+    fail "源码归档格式无效"
+  while IFS= read -r entry; do
+    [[ "$entry" != /* ]] || fail "源码归档包含绝对路径，拒绝解压"
+    case "/$entry/" in
+      */../*) fail "源码归档包含目录穿越路径，拒绝解压" ;;
+    esac
+  done <"$listing_file"
+
+  while IFS= read -r entry; do
+    roots+=("$entry")
+  done < <(awk -F/ 'NF { print $1 }' "$listing_file" | sort -u)
+  root_count="${#roots[@]}"
+  [[ "$root_count" -eq 1 && -n "${roots[0]}" ]] ||
+    fail "源码归档必须包含一个顶层项目目录"
+  ARCHIVE_ROOT="${roots[0]}"
+
+  # 允许仓库自身的安全相对符号链接（例如 CLAUDE.md -> AGENTS.md），
+  # 但拒绝绝对链接或包含 .. 的链接，避免解压时绕出临时目录。
+  local listing type
+  local link_target
+  tar -tvzf "$archive" >"$verbose_file" 2>/dev/null ||
+    fail "无法检查源码归档条目"
+  while IFS= read -r listing; do
+    type="${listing:0:1}"
+    [[ "$type" != "h" ]] || fail "源码归档包含硬链接，拒绝解压"
+    if [[ "$type" == "l" ]]; then
+      link_target="${listing##* -> }"
+      [[ "$link_target" != "$listing" && "$link_target" != /* &&
+        "$link_target" != *'..'* ]] ||
+        fail "源码归档包含不安全的符号链接，拒绝解压"
+    fi
+  done <"$verbose_file"
+}
+
+install_source() {
+  local archive extract_dir source_dir
+  if ((DRY_RUN)); then
+    if ((EXISTING_INSTALL)); then
+      ok "[dry-run] 将更新已有 Neuro OJ 的部署文件并保留配置、备份和数据"
+    else
+      ok "[dry-run] 将下载到临时目录并安装到：$TARGET_DIR"
+    fi
+    ok "[dry-run] 源码 ref：$REF"
+    return 0
+  fi
+
+  TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-bootstrap.XXXXXX")"
+  chmod 700 "$TEMP_ROOT"
+  download_archive
+  archive="$ARCHIVE_PATH"
+  validate_archive "$archive"
+  extract_dir="$TEMP_ROOT/extract"
+  mkdir -m 700 "$extract_dir"
+  tar -xzf "$archive" -C "$extract_dir" ||
+    fail "源码归档解压失败"
+
+  source_dir="$extract_dir/$ARCHIVE_ROOT"
+  [[ -f "$source_dir/scripts/deploy/deploy.sh" ]] ||
+    fail "下载的 ref 不包含 Neuro OJ 生产部署脚本"
+  [[ -f "$source_dir/docker-compose.prod.yml" ]] ||
+    fail "下载的 ref 不包含生产 Compose 文件"
+
+  if ((EXISTING_INSTALL)); then
+    cp -a "$source_dir/docker-compose.prod.yml" "$TARGET_DIR/"
+    [[ -f "$source_dir/.env.prod.example" ]] &&
+      cp -a "$source_dir/.env.prod.example" "$TARGET_DIR/"
+    mkdir -p "$TARGET_DIR/scripts/deploy"
+    cp -a "$source_dir/scripts/deploy/." "$TARGET_DIR/scripts/deploy/"
+    if [[ -f "$source_dir/noj" ]]; then
+      cp -a "$source_dir/noj" "$TARGET_DIR/noj"
+      chmod 755 "$TARGET_DIR/noj"
+    fi
+    if [[ -d "$source_dir/deploy" ]]; then
+      mkdir -p "$TARGET_DIR/deploy"
+      cp -a "$source_dir/deploy/." "$TARGET_DIR/deploy/"
+    fi
+    ok "已更新 Neuro OJ 部署文件；保留 .env.prod、备份和数据目录"
+    return 0
+  fi
+
+  mkdir -p -- "$(dirname -- "$TARGET_DIR")" ||
+    fail "无法创建安装目录的上级路径：$(dirname -- "$TARGET_DIR")；请使用有权限的用户，或通过 --dir 指定可写目录"
+  if [[ -d "$TARGET_DIR" ]]; then
+    mkdir -p "$TARGET_DIR/scripts/deploy"
+    cp -a "$source_dir/docker-compose.prod.yml" "$TARGET_DIR/"
+    [[ -f "$source_dir/.env.prod.example" ]] &&
+      cp -a "$source_dir/.env.prod.example" "$TARGET_DIR/"
+    cp -a "$source_dir/scripts/deploy/." "$TARGET_DIR/scripts/deploy/"
+    if [[ -f "$source_dir/noj" ]]; then
+      cp -a "$source_dir/noj" "$TARGET_DIR/noj"
+      chmod 755 "$TARGET_DIR/noj"
+    fi
+    if [[ -d "$source_dir/deploy" ]]; then
+      mkdir -p "$TARGET_DIR/deploy"
+      cp -a "$source_dir/deploy/." "$TARGET_DIR/deploy/"
+    fi
+    ok "已将部署文件安装到已有目录：$TARGET_DIR；原有内容已保留"
+    return 0
+  fi
+  mv -- "$source_dir" "$TARGET_DIR"
+  ok "源码已安装到：$TARGET_DIR"
+}
+
+run_deploy() {
+  local status deploy_entry
+  ((NON_INTERACTIVE)) && DEPLOY_ARGS+=(--non-interactive)
+  ((PANEL_MODE_SET)) && DEPLOY_ARGS+=(--panel "$PANEL_MODE")
+  ((DOWNLOAD_ONLY || FILES_ONLY)) && {
+    ((FILES_ONLY)) && ok "部署文件和 noj 命令已更新，未重启生产服务"
+    ((DOWNLOAD_ONLY)) && ok "仅下载模式完成，未启动生产服务"
+    return 0
+  }
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将调用：$TARGET_DIR/scripts/deploy/deploy.sh install"
+    return 0
+  fi
+
+  deploy_entry="$TARGET_DIR/scripts/deploy/deploy.sh"
+  if [[ -f "$TARGET_DIR/noj" ]]; then
+    deploy_entry="$TARGET_DIR/noj"
+  fi
+  set +e
+  if ((${#DEPLOY_ARGS[@]} > 0)); then
+    NOJ_BIN_DIR="${NOJ_BOOTSTRAP_BIN_DIR:-/usr/local/bin}" \
+    NOJ_DEPLOY_DEFAULT_VERSION="$REF" \
+      bash "$deploy_entry" install "${DEPLOY_ARGS[@]}"
+  else
+    NOJ_BIN_DIR="${NOJ_BOOTSTRAP_BIN_DIR:-/usr/local/bin}" \
+    NOJ_DEPLOY_DEFAULT_VERSION="$REF" \
+      bash "$deploy_entry" install
+  fi
+  status=$?
+  set -e
+  if ((status != 0)); then
+    warn "生产部署失败；可进入 $TARGET_DIR 执行 status 或 logs 排查"
+    return "$status"
+  fi
+  ok "生产部署完成"
+}
+
+register_noj_command() {
+  ((DOWNLOAD_ONLY || FILES_ONLY || DRY_RUN)) && return 0
+  [[ -f "$TARGET_DIR/noj" ]] || {
+    warn "当前源码未包含 noj 命令，跳过 PATH 注册"
+    return 0
+  }
+  chmod 755 "$TARGET_DIR/noj"
+  NOJ_INTERNAL_REGISTER=1 \
+  NOJ_BIN_DIR="${NOJ_BOOTSTRAP_BIN_DIR:-/usr/local/bin}" \
+    bash "$TARGET_DIR/noj" register-command ||
+    warn "无法自动注册 noj 到 PATH；部署已完成，请手动将 $TARGET_DIR/noj 加入 PATH"
+}
+
+main() {
+  parse_args "$@"
+  case "$COMMAND" in
+    check)
+      check_host
+      ;;
+    install-env)
+      install_env
+      ;;
+    install)
+      validate_inputs
+      check_host
+      check_dependencies
+      resolve_latest_ref
+      check_target
+      printf '仓库：%s\nref：%s\n目标目录：%s\n' "$REPOSITORY" "$REF" "$TARGET_DIR"
+      printf '下载地址：%s\n' "$ARCHIVE_URL"
+      install_source
+      run_deploy
+      register_noj_command
+      ;;
+    *)
+      fail "未知命令：$COMMAND"
+      ;;
+  esac
+}
+
+if [[ "${NOJ_BOOTSTRAP_SOURCE_ONLY:-0}" != "1" ]]; then
+  main "$@"
+fi

--- a/scripts/deploy/judge-install.sh
+++ b/scripts/deploy/judge-install.sh
@@ -1,0 +1,949 @@
+#!/usr/bin/env bash
+#
+# Neuro OJ 独立 Judge Worker 部署入口。
+#
+# 远程一键入口：
+#   curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/judge-install.sh \
+#     | bash -s -- install --dir /srv/noj-judge
+#
+# 该脚本只管理 noj-judge，不安装或替换宿主机 Docker daemon，且禁止使用共享的
+# /var/run/docker.sock。rootless Docker daemon 应由运维人员按目标发行版预先准备。
+
+set -Eeuo pipefail
+
+DOCKER_BIN="${NOJ_JUDGE_DOCKER_BIN:-docker}"
+CURL_BIN="${NOJ_JUDGE_CURL_BIN:-curl}"
+PROJECT_NAME="noj-judge-standalone"
+DEFAULT_REPO="https://github.com/Neuro-OJ/neuro-oj"
+REPO_URL="${NOJ_JUDGE_REPO:-$DEFAULT_REPO}"
+REF="${NOJ_JUDGE_REF:-main}"
+TARGET_DIR="${NOJ_JUDGE_DIR:-/srv/noj-judge}"
+REDIS_CONTAINER_NAME="${NOJ_JUDGE_REDIS_CONTAINER:-noj-judge-redis}"
+REDIS_IMAGE="${NOJ_JUDGE_REDIS_IMAGE:-redis:7-alpine}"
+REDIS_DEFAULT_PORT="${NOJ_JUDGE_REDIS_PORT:-16379}"
+ENV_FILE=""
+COMPOSE_FILE=""
+REDIS_METADATA_FILE=""
+COMMAND=""
+NON_INTERACTIVE=0
+DOWNLOAD_ONLY=0
+DRY_RUN=0
+FOLLOW=0
+VERSION_OVERRIDE=""
+REDIS_RUNTIME_URL_VALUE=""
+REDIS_CHECK_URL_VALUE=""
+REDIS_SOURCE_VALUE=""
+PANEL_MODE="${NOJ_JUDGE_PANEL:-auto}"
+PANEL_NAME="none"
+PANEL_ROOT="${NOJ_JUDGE_PANEL_ROOT:-/www/server/panel}"
+PANEL_COMMAND="${NOJ_JUDGE_PANEL_COMMAND:-/usr/bin/bt}"
+TTY_PATH="${NOJ_JUDGE_TTY_PATH:-/dev/tty}"
+POSITIONAL=()
+
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; RESET='\033[0m'
+else
+  GREEN=''; YELLOW=''; RED=''; RESET=''
+fi
+
+ok() { printf "%b✓%b %s\n" "$GREEN" "$RESET" "$*"; }
+warn() { printf "%b!%b %s\n" "$YELLOW" "$RESET" "$*" >&2; }
+fail() {
+  printf "%b✗%b %s\n" "$RED" "$RESET" "$*" >&2
+  exit 1
+}
+section() { printf "\n== %s ==\n" "$*"; }
+
+has_interactive_tty() {
+  [[ -r "$TTY_PATH" && -w "$TTY_PATH" ]] || return 1
+  (exec 3<>"$TTY_PATH") 2>/dev/null
+}
+
+read_prompt() {
+  local prompt="$1" secret="${2:-0}" value
+  if has_interactive_tty; then
+    printf '%s' "$prompt" >"$TTY_PATH"
+    if [[ "$secret" == 1 ]]; then
+      IFS= read -r -s value <"$TTY_PATH" || fail "读取配置输入失败"
+      printf '\n' >"$TTY_PATH"
+    else
+      IFS= read -r value <"$TTY_PATH" || fail "读取配置输入失败"
+    fi
+  elif [[ "$secret" == 1 ]]; then
+    IFS= read -r -s -p "$prompt" value || fail "读取配置输入失败"
+    printf '\n' >&2
+  else
+    IFS= read -r -p "$prompt" value || fail "读取配置输入失败"
+  fi
+  PROMPT_VALUE="$value"
+}
+
+usage() {
+  cat <<'EOF'
+Neuro OJ 独立 Judge Worker 部署工具
+
+用法：
+  judge-install.sh install       首次配置并启动独立 Judge
+  judge-install.sh install-env   检查部署依赖并输出 rootless 准备指引
+  judge-install.sh check         检查配置、Redis、Docker socket 和镜像架构
+  judge-install.sh start         启动 Judge（保留现有容器）
+  judge-install.sh stop          停止 Judge（保留配置、缓存和 Redis 任务）
+  judge-install.sh status        查看 Judge 状态和脱敏配置摘要
+  judge-install.sh logs [--follow]
+                                查看 Judge 日志
+  judge-install.sh upgrade       拉取配置中的版本并升级
+  judge-install.sh download      只从仓库下载本部署脚本
+
+选项：
+  --dir DIR              Judge 运行目录（默认 /srv/noj-judge）
+  --env-file FILE        配置文件（默认 DIR/.env.judge）
+  --compose-file FILE    Compose 文件（默认 DIR/docker-compose.judge.yml）
+  --repo URL             GitHub 仓库地址（download 使用）
+  --ref REF              仓库分支、标签或提交（download 使用，默认 main）
+  --version VERSION      install/upgrade 使用的 Release 版本
+  --redis-container NAME 本机 Redis 容器名（默认 noj-judge-redis）
+  --redis-port PORT      本机 Redis 宿主机端口（默认 16379）
+  --panel MODE           面板模式：auto（默认）、baota 或 none
+  --non-interactive      不读取终端输入，必填项从环境变量或配置文件读取
+  --download-only        只下载部署脚本，不执行 Docker 操作
+  --dry-run              只显示动作，不修改服务
+  -h, --help             显示帮助
+
+首次 install 的非交互环境变量：
+  NOJ_VERSION REDIS_URL JUDGE_DOCKER_SOCKET JUDGE_DOCKER_SOCKET_GID
+  JUDGE_QUEUE RESULT_QUEUE WORK_DIR JUDGE_MAX_CONCURRENT_JUDGES
+  JUDGE_IMAGE_PREFIX JUDGE_IMAGE_REGISTRY JUDGE_UID JUDGE_GID
+
+安全约束：
+  - 必须使用专用 Unix rootless Docker socket；禁止 /var/run/docker.sock 和 /run/docker.sock
+  - 不自动安装、替换或配置 Docker daemon
+  - 配置文件权限必须为 600 或 400；密码不会在提示和状态摘要中回显
+
+Redis：
+  - 交互式安装默认连接已有 Redis，也可明确选择创建本机 Redis
+  - 非交互安装必须提供 REDIS_URL，不会自动创建 Redis
+  - 本机 Redis 使用命名容器、持久化卷和仅绑定回环地址的端口
+
+服务器面板：
+  - 自动检测到宝塔时，脚本会复用标准 Docker/Compose 命令并给出面板操作提示
+  - 脚本不会调用宝塔 API，也不会修改已有站点、反向代理、容器或面板配置
+  - 可使用 --panel none 关闭提示，或使用 --panel baota 强制启用宝塔提示
+EOF
+}
+
+parse_args() {
+  while (($# > 0)); do
+    case "$1" in
+      install|install-env|check|start|stop|status|logs|upgrade|download)
+        [[ -z "$COMMAND" ]] || fail "只能指定一个操作：$COMMAND"
+        COMMAND="$1"
+        ;;
+      --dir)
+        (($# >= 2)) || fail "--dir 需要一个目录路径"
+        TARGET_DIR="$2"; shift
+        ;;
+      --dir=*) TARGET_DIR="${1#*=}" ;;
+      --env-file)
+        (($# >= 2)) || fail "--env-file 需要一个文件路径"
+        ENV_FILE="$2"; shift
+        ;;
+      --env-file=*) ENV_FILE="${1#*=}" ;;
+      --compose-file)
+        (($# >= 2)) || fail "--compose-file 需要一个文件路径"
+        COMPOSE_FILE="$2"; shift
+        ;;
+      --compose-file=*) COMPOSE_FILE="${1#*=}" ;;
+      --repo)
+        (($# >= 2)) || fail "--repo 需要仓库地址"
+        REPO_URL="$2"; shift
+        ;;
+      --repo=*) REPO_URL="${1#*=}" ;;
+      --ref)
+        (($# >= 2)) || fail "--ref 需要分支、标签或提交"
+        REF="$2"; shift
+        ;;
+      --ref=*) REF="${1#*=}" ;;
+      --version)
+        (($# >= 2)) || fail "--version 需要 Release 版本"
+        VERSION_OVERRIDE="$2"; shift
+        ;;
+      --version=*) VERSION_OVERRIDE="${1#*=}" ;;
+      --redis-container)
+        (($# >= 2)) || fail "--redis-container 需要容器名"
+        REDIS_CONTAINER_NAME="$2"; shift
+        ;;
+      --redis-container=*) REDIS_CONTAINER_NAME="${1#*=}" ;;
+      --redis-port)
+        (($# >= 2)) || fail "--redis-port 需要端口号"
+        REDIS_DEFAULT_PORT="$2"; shift
+        ;;
+      --redis-port=*) REDIS_DEFAULT_PORT="${1#*=}" ;;
+      --panel)
+        (($# >= 2)) || fail "--panel 需要 auto、baota 或 none"
+        PANEL_MODE="$2"; shift
+        ;;
+      --panel=*) PANEL_MODE="${1#*=}" ;;
+      --non-interactive) NON_INTERACTIVE=1 ;;
+      --download-only) DOWNLOAD_ONLY=1 ;;
+      --dry-run) DRY_RUN=1 ;;
+      --follow|-f) FOLLOW=1 ;;
+      -h|--help) usage; exit 0 ;;
+      --) shift; POSITIONAL+=("$@"); break ;;
+      *) POSITIONAL+=("$1") ;;
+    esac
+    shift
+  done
+  [[ -n "$COMMAND" ]] || { usage; exit 2; }
+  case "$PANEL_MODE" in
+    auto|baota|none) ;;
+    *) fail "--panel 只能是 auto、baota 或 none：$PANEL_MODE" ;;
+  esac
+  [[ -n "$ENV_FILE" ]] || ENV_FILE="$TARGET_DIR/.env.judge"
+  [[ -n "$COMPOSE_FILE" ]] || COMPOSE_FILE="$TARGET_DIR/docker-compose.judge.yml"
+}
+
+env_value() {
+  local key="$1" value=""
+  if [[ -f "$ENV_FILE" ]]; then
+    value="$(awk -v key="$key" '
+      index($0, key "=") == 1 { print substr($0, length(key) + 2); exit }
+    ' "$ENV_FILE")"
+    case "$value" in
+      \"*\") value="${value:1:${#value}-2}" ;;
+      \'*\') value="${value:1:${#value}-2}" ;;
+    esac
+  fi
+  if [[ -z "$value" ]]; then
+    value="$(printenv "$key" 2>/dev/null || true)"
+  fi
+  printf '%s\n' "$value"
+}
+
+set_env_value() {
+  local key="$1" value="$2" tmp
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE"
+  [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || fail "$key 不能包含换行"
+  tmp="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+  if ! awk -v key="$key" -v value="$value" '
+    BEGIN { found = 0 }
+    index($0, key "=") == 1 { print key "=" value; found = 1; next }
+    { print }
+    END { if (!found) print key "=" value }
+  ' "$ENV_FILE" >"$tmp"; then
+    rm -f "$tmp"
+    fail "更新配置失败"
+  fi
+  chmod 600 "$tmp"
+  mv "$tmp" "$ENV_FILE"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "缺少依赖：$1"
+}
+
+detect_panel() {
+  PANEL_NAME="none"
+  case "$PANEL_MODE" in
+    baota)
+      PANEL_NAME="baota"
+      ;;
+    none)
+      return 0
+      ;;
+    auto)
+      if [[ -d "$PANEL_ROOT" || -x "$PANEL_COMMAND" ]]; then
+        PANEL_NAME="baota"
+      fi
+      ;;
+  esac
+}
+
+show_panel_guidance() {
+  [[ "$PANEL_NAME" == baota ]] || return 0
+  section "宝塔兼容模式"
+  cat <<'EOF'
+已检测到宝塔面板。脚本会直接使用宝塔管理的标准 Docker/Compose，不调用宝塔 API。
+
+请在宝塔的 Docker 页面确认 Docker 已安装并运行；部署完成后可以在那里查看本机 Redis
+和 Judge 容器。脚本不会修改已有站点、反向代理、容器或面板配置，Judge 也不需要公开端口。
+
+安全提醒：Judge 仍必须使用只服务于 Judge 的 rootless Docker socket，不能填写
+/run/docker.sock 或 /var/run/docker.sock。宝塔面板本身不能替代这个隔离 socket。
+EOF
+  ok "宝塔兼容提示已启用"
+}
+
+is_version() {
+  [[ "$1" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]
+}
+
+is_placeholder() {
+  local value="$1"
+  [[ -z "$value" ]] && return 0
+  case "$value" in
+    *change-me*|*changeme*|*example*|*placeholder*|*replace-me*|*your-*|latest|main|xxx*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+stat_mode() {
+  local path="$1"
+  stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path" 2>/dev/null
+}
+
+stat_gid() {
+  local path="$1"
+  stat -c '%g' "$path" 2>/dev/null || stat -f '%g' "$path" 2>/dev/null
+}
+
+ensure_target_dir() {
+  if [[ -e "$TARGET_DIR" && ! -d "$TARGET_DIR" ]]; then
+    fail "目标路径不是目录：$TARGET_DIR"
+  fi
+  if [[ ! -d "$TARGET_DIR" ]]; then
+    ((DRY_RUN)) || mkdir -p "$TARGET_DIR"
+  fi
+}
+
+validate_existing_target() {
+  [[ -d "$TARGET_DIR" ]] || return 0
+  if [[ ! -f "$ENV_FILE" && ! -f "$COMPOSE_FILE" ]]; then
+    if find "$TARGET_DIR" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+      fail "目标目录非空但没有本工具配置；请指定新目录，或先明确清理后再安装：$TARGET_DIR"
+    fi
+  fi
+}
+
+prompt_value() {
+  local key="$1" label="$2" default_value="${3:-}" secret="${4:-0}" hint="${5:-}" value
+  value="$(env_value "$key")"
+  [[ -n "$value" ]] && { printf '%s\n' "$value"; return 0; }
+  ((NON_INTERACTIVE)) && fail "非交互安装缺少必填配置：$key"
+  [[ -n "$hint" ]] && printf '  说明：%s\n' "$hint" >&2
+  read_prompt "  $label${default_value:+ [$default_value]}：" "$secret"
+  value="$PROMPT_VALUE"
+  value="${value:-$default_value}"
+  [[ -n "$value" ]] || fail "$key 不能为空"
+  [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || fail "$key 不能包含换行"
+  printf '%s\n' "$value"
+}
+
+metadata_value() {
+  local file="$1" key="$2"
+  [[ -f "$file" ]] || return 1
+  awk -v key="$key" 'index($0, key "=") == 1 { print substr($0, length(key) + 2); exit }' "$file"
+}
+
+generate_redis_password() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 24
+  else
+    od -An -N24 -tx1 /dev/urandom | tr -d ' ' | tr -d '\n'
+  fi
+}
+
+validate_redis_port() {
+  local port="$1"
+  [[ "$port" =~ ^[0-9]+$ ]] || fail "本机 Redis 端口必须是数字：$port"
+  ((port >= 1024 && port <= 65535)) ||
+    fail "本机 Redis 端口必须在 1024-65535 范围内：$port"
+}
+
+port_is_in_use() {
+  local port="$1" pattern
+  pattern=":$port$"
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltnH 2>/dev/null | awk -v pattern="$pattern" '$4 ~ pattern { found = 1 } END { exit !found }'
+    return $?
+  fi
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+  return 1
+}
+
+write_redis_connection_files() {
+  local core_url="$1" runtime_url="$2" check_url="$3" port="$4" guide_file
+  REDIS_METADATA_FILE="$TARGET_DIR/.redis-connection.env"
+  guide_file="$TARGET_DIR/redis-connection.txt"
+  umask 077
+  cat >"$REDIS_METADATA_FILE" <<EOF
+REDIS_CORE_URL=$core_url
+REDIS_RUNTIME_URL=$runtime_url
+REDIS_CHECK_URL=$check_url
+EOF
+  chmod 600 "$REDIS_METADATA_FILE"
+  cat >"$guide_file" <<EOF
+# Redis 连接信息（含密码，请勿提交到代码仓库或公开分享）
+# noj-core 使用：
+REDIS_URL=$core_url
+
+# Judge 容器使用：
+REDIS_URL=$runtime_url
+EOF
+  chmod 600 "$guide_file"
+  ok "Redis 连接信息已保存：${guide_file}（权限 600）"
+  printf '  请让 noj-core 和 Judge 使用同一个 Redis；不要把它们配置到不同实例。\n' >&2
+  printf '  noj-core 地址：127.0.0.1:%s；Judge 容器地址：host.docker.internal:%s\n' "$port" "$port" >&2
+}
+
+create_local_redis() {
+  local container_name port password config_file core_url runtime_url check_url
+  container_name="$(prompt_value REDIS_LOCAL_CONTAINER "本机 Redis 容器名" "$REDIS_CONTAINER_NAME" 0 \
+    "脚本只会管理带有 Neuro OJ 标签的同名容器。")"
+  [[ "$container_name" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]] ||
+    fail "本机 Redis 容器名格式无效：$container_name"
+  port="$(prompt_value REDIS_LOCAL_PORT "本机 Redis 端口" "$REDIS_DEFAULT_PORT" 0 \
+    "仅绑定到 127.0.0.1，默认 16379；如果冲突可换一个端口。")"
+  validate_redis_port "$port"
+  REDIS_CONTAINER_NAME="$container_name"
+  REDIS_DEFAULT_PORT="$port"
+
+  if "$DOCKER_BIN" container inspect "$container_name" >/dev/null 2>&1; then
+    local label existing_runtime existing_check existing_core
+    label="$( "$DOCKER_BIN" container inspect --format '{{ index .Config.Labels "com.neuro-oj.component" }}' \
+      "$container_name" 2>/dev/null || true )"
+    [[ "$label" == "judge-standalone-redis" ]] ||
+      fail "Redis 容器名已被其他容器占用：${container_name}；不会删除或修改它，请换名或连接已有 Redis"
+    existing_runtime="$(metadata_value "$REDIS_METADATA_FILE" REDIS_RUNTIME_URL || true)"
+    existing_check="$(metadata_value "$REDIS_METADATA_FILE" REDIS_CHECK_URL || true)"
+    existing_core="$(metadata_value "$REDIS_METADATA_FILE" REDIS_CORE_URL || true)"
+    [[ -n "$existing_runtime" && -n "$existing_check" && -n "$existing_core" ]] ||
+      fail "检测到本工具创建的 Redis，但缺少连接信息：${REDIS_METADATA_FILE}；请手动恢复后再继续"
+    REDIS_RUNTIME_URL_VALUE="$existing_runtime"
+    REDIS_CHECK_URL_VALUE="$existing_check"
+    REDIS_SOURCE_VALUE="local"
+    ok "复用本工具已创建的 Redis：$container_name"
+    write_redis_connection_files "$existing_core" "$existing_runtime" "$existing_check" "$port"
+    return 0
+  fi
+
+  if port_is_in_use "$port"; then
+    fail "本机 Redis 端口已被占用：127.0.0.1:${port}；请换一个端口，或选择连接已有 Redis"
+  fi
+
+  password="$(generate_redis_password)"
+  [[ -n "$password" ]] || fail "无法生成本机 Redis 密码"
+  config_file="$TARGET_DIR/redis.conf"
+  umask 077
+  cat >"$config_file" <<EOF
+appendonly yes
+requirepass $password
+EOF
+  chmod 600 "$config_file"
+
+  if ! "$DOCKER_BIN" run -d --name "$container_name" \
+    --label com.neuro-oj.component=judge-standalone-redis \
+    --label com.neuro-oj.managed-by=judge-install \
+    --restart unless-stopped \
+    --publish "127.0.0.1:$port:6379" \
+    --volume "$container_name-data:/data" \
+    --volume "$config_file:/usr/local/etc/redis/redis.conf:ro" \
+    "$REDIS_IMAGE" redis-server /usr/local/etc/redis/redis.conf; then
+    fail "本机 Redis 创建失败；端口可能被占用或 Docker 权限不足。原有服务未被修改"
+  fi
+
+  core_url="redis://:$password@127.0.0.1:$port/0"
+  runtime_url="redis://:$password@host.docker.internal:$port/0"
+  check_url="$core_url"
+  REDIS_RUNTIME_URL_VALUE="$runtime_url"
+  REDIS_CHECK_URL_VALUE="$check_url"
+  REDIS_SOURCE_VALUE="local"
+  write_redis_connection_files "$core_url" "$runtime_url" "$check_url" "$port"
+  ok "本机 Redis 已创建：${container_name}（数据卷：${container_name}-data）"
+}
+
+configure_redis() {
+  local existing_url choice
+  existing_url="$(env_value REDIS_URL)"
+  if [[ -n "$existing_url" ]]; then
+    REDIS_RUNTIME_URL_VALUE="$existing_url"
+    REDIS_CHECK_URL_VALUE="$(env_value REDIS_CHECK_URL)"
+    [[ -n "$REDIS_CHECK_URL_VALUE" ]] || REDIS_CHECK_URL_VALUE="$existing_url"
+    REDIS_SOURCE_VALUE="existing"
+    return 0
+  fi
+  ((NON_INTERACTIVE)) && fail "非交互安装缺少必填配置：REDIS_URL；不会自动创建 Redis"
+
+  section "配置 Redis"
+  cat <<'EOF'
+Redis 是 noj-core 和 Judge 之间传递评测任务的中转站。
+Judge 必须连接 noj-core 正在使用的同一个 Redis、数据库和队列。
+
+  1. 连接已有 Redis（推荐，适合生产环境）
+  2. 创建本机 Redis（仅适合明确知道 core 也要使用它的场景）
+  3. 稍后配置（本次不会启动 Judge）
+
+EOF
+  read_prompt '请选择 Redis 来源 [1]：'
+  choice="$PROMPT_VALUE"
+  choice="${choice:-1}"
+  case "$choice" in
+    1)
+      REDIS_RUNTIME_URL_VALUE="$(prompt_value REDIS_URL "Redis 完整连接地址" "" 1 \
+        "无密码：redis://127.0.0.1:6379/0；有密码：redis://:密码@地址:6379/0。")"
+      REDIS_CHECK_URL_VALUE="$REDIS_RUNTIME_URL_VALUE"
+      REDIS_SOURCE_VALUE="existing"
+      ;;
+    2)
+      create_local_redis
+      ;;
+    3)
+      fail "已选择稍后配置；请配置与 noj-core 相同的 REDIS_URL 后重新执行 install"
+      ;;
+    *)
+      fail "无效的 Redis 选项：${choice}；请输入 1、2 或 3"
+      ;;
+  esac
+}
+
+initialize_env() {
+  section "配置独立 Judge"
+  cat <<'EOF'
+首次部署需要填写 Judge Worker 的连接信息。请按说明输入；带有默认值的项目直接回车即可。
+
+  NOJ_VERSION：要部署的已发布镜像版本，例如 0.8.0-rc.1；不能填写 main 或 latest。
+  REDIS_URL：noj-core 正在使用的 Redis 地址，Judge 必须连接同一个 Redis 和队列。
+    无密码示例：redis://127.0.0.1:6379/0
+    有密码示例：redis://:密码@127.0.0.1:6379/0
+    这一项输入时整行不会显示在屏幕上。
+  专用 Docker socket：必须是只供 Judge 使用的 rootless Docker socket，不能填写
+    /run/docker.sock 或 /var/run/docker.sock。没有专用 socket 时，请先执行 install-env。
+
+EOF
+  ensure_target_dir
+  validate_existing_target
+  if [[ -f "$ENV_FILE" ]]; then
+    chmod 600 "$ENV_FILE"
+    ok "保留已有配置：$ENV_FILE"
+    [[ -n "$VERSION_OVERRIDE" ]] && set_env_value NOJ_VERSION "$VERSION_OVERRIDE"
+    return 0
+  fi
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将创建配置：$ENV_FILE"
+    return 0
+  fi
+
+  umask 077
+  local version redis_url redis_check_url redis_source socket socket_gid queue result work_dir concurrency prefix registry uid gid
+  version="$VERSION_OVERRIDE"
+  [[ -n "$version" ]] || version="$(prompt_value NOJ_VERSION "Worker 版本（例如 0.8.0-rc.1）" "" 0 "填已发布的镜像版本，不要填写 main 或 latest。")"
+  REDIS_METADATA_FILE="$TARGET_DIR/.redis-connection.env"
+  configure_redis
+  redis_url="$REDIS_RUNTIME_URL_VALUE"
+  redis_check_url="$REDIS_CHECK_URL_VALUE"
+  redis_source="$REDIS_SOURCE_VALUE"
+  queue="$(prompt_value JUDGE_QUEUE "任务队列名称" "noj:judge:queue" 0 "必须与 noj-core 的任务队列名称一致，通常直接回车。")"
+  result="$(prompt_value RESULT_QUEUE "结果队列名称" "noj:judge:results" 0 "必须与 noj-core 的结果队列名称一致，通常直接回车。")"
+  work_dir="$(prompt_value WORK_DIR "Worker 容器工作目录" "/tmp/noj-judge" 0 "容器内部目录，通常直接回车。")"
+  concurrency="$(prompt_value JUDGE_MAX_CONCURRENT_JUDGES "最大并发评测数" "2" 0 "同时运行的评测数量；机器资源较少时可填写 1。")"
+  prefix="$(prompt_value JUDGE_IMAGE_PREFIX "评测镜像前缀" "noj-" 0 "题目运行时镜像的前缀，通常直接回车。")"
+  registry="$(prompt_value JUDGE_IMAGE_REGISTRY "Worker 镜像仓库" "ghcr.io/neuro-oj" 0 "Worker 镜像所在仓库，不要填写末尾的 /noj-judge。")"
+  socket="$(prompt_value JUDGE_DOCKER_SOCKET "专用 Docker socket 路径" "/run/noj-judge/docker.sock" 0 "必须是 Judge 专用 rootless socket，不能使用宿主机共享 socket。")"
+  socket_gid="$(prompt_value JUDGE_DOCKER_SOCKET_GID "Docker socket 所属组 GID" "10001" 0 "可用 stat -c '%g' /run/noj-judge/docker.sock 查询；必须与 socket 实际 GID 一致。")"
+  uid="$(prompt_value JUDGE_UID "Worker 用户 UID" "10001" 0 "容器内非 root 用户，通常直接回车。")"
+  gid="$(prompt_value JUDGE_GID "Worker 用户 GID" "10001" 0 "容器内非 root 用户组，通常直接回车。")"
+
+  cat >"$ENV_FILE" <<EOF
+NOJ_VERSION=$version
+REDIS_URL=$redis_url
+REDIS_CHECK_URL=$redis_check_url
+REDIS_SOURCE=$redis_source
+JUDGE_QUEUE=$queue
+RESULT_QUEUE=$result
+WORK_DIR=$work_dir
+JUDGE_MAX_CONCURRENT_JUDGES=$concurrency
+JUDGE_IMAGE_PREFIX=$prefix
+JUDGE_IMAGE_REGISTRY=$registry
+JUDGE_DOCKER_SOCKET=$socket
+JUDGE_DOCKER_SOCKET_GID=$socket_gid
+JUDGE_DOCKER_HOST=unix:///run/noj-judge/docker.sock
+JUDGE_REQUIRE_ISOLATED_DOCKER=true
+JUDGE_UID=$uid
+JUDGE_GID=$gid
+JUDGE_CPU_LIMIT_MILLICORES=1000
+JUDGE_MAX_EVALUATOR_TIME_MS=300000
+JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS=60000
+JUDGE_COMMAND_WHITELIST=python3,deno,node,bash,sh
+JUDGE_ALLOW_EVALUATOR_NETWORK=false
+JUDGE_EVALUATOR_NETWORK=bridge
+JUDGE_ALLOW_HTTP_S3=false
+SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT=60
+SUPPORT_CACHE_DIR=/tmp/noj-judge/support-cache
+SUPPORT_CACHE_MAX_ITEMS=500
+SUPPORT_CACHE_MAX_MB=2048
+EOF
+  chmod 600 "$ENV_FILE"
+  ok "已创建配置：$ENV_FILE"
+}
+
+write_compose() {
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将生成 Compose 配置：$COMPOSE_FILE"
+    return 0
+  fi
+  umask 077
+  cat >"$COMPOSE_FILE" <<'EOF'
+services:
+  judge:
+    image: "${JUDGE_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-judge:${NOJ_VERSION:?NOJ_VERSION is required}"
+    environment:
+      REDIS_URL: "${REDIS_URL:?REDIS_URL is required}"
+      JUDGE_QUEUE: "${JUDGE_QUEUE:-noj:judge:queue}"
+      RESULT_QUEUE: "${RESULT_QUEUE:-noj:judge:results}"
+      WORK_DIR: "${WORK_DIR:-/tmp/noj-judge}"
+      JUDGE_MAX_CONCURRENT_JUDGES: "${JUDGE_MAX_CONCURRENT_JUDGES:-2}"
+      JUDGE_CPU_LIMIT_MILLICORES: "${JUDGE_CPU_LIMIT_MILLICORES:-1000}"
+      JUDGE_MAX_EVALUATOR_TIME_MS: "${JUDGE_MAX_EVALUATOR_TIME_MS:-300000}"
+      JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS: "${JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS:-60000}"
+      JUDGE_IMAGE_PREFIX: "${JUDGE_IMAGE_PREFIX:-noj-}"
+      JUDGE_COMMAND_WHITELIST: "${JUDGE_COMMAND_WHITELIST:-python3,deno,node,bash,sh}"
+      JUDGE_ALLOW_EVALUATOR_NETWORK: "${JUDGE_ALLOW_EVALUATOR_NETWORK:-false}"
+      JUDGE_EVALUATOR_NETWORK: "${JUDGE_EVALUATOR_NETWORK:-bridge}"
+      JUDGE_ALLOW_HTTP_S3: "${JUDGE_ALLOW_HTTP_S3:-false}"
+      JUDGE_DOCKER_HOST: "${JUDGE_DOCKER_HOST:-unix:///run/noj-judge/docker.sock}"
+      JUDGE_REQUIRE_ISOLATED_DOCKER: "true"
+      SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT: "${SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT:-60}"
+      SUPPORT_CACHE_DIR: "${SUPPORT_CACHE_DIR:-/tmp/noj-judge/support-cache}"
+      SUPPORT_CACHE_MAX_ITEMS: "${SUPPORT_CACHE_MAX_ITEMS:-500}"
+      SUPPORT_CACHE_MAX_MB: "${SUPPORT_CACHE_MAX_MB:-2048}"
+    volumes:
+      - "${JUDGE_DOCKER_SOCKET:?JUDGE_DOCKER_SOCKET is required}:/run/noj-judge/docker.sock:ro"
+      - judge-cache:/tmp/noj-judge
+    user: "${JUDGE_UID:-10001}:${JUDGE_GID:-10001}"
+    group_add:
+      - "${JUDGE_DOCKER_SOCKET_GID:?JUDGE_DOCKER_SOCKET_GID is required}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+volumes:
+  judge-cache:
+    name: noj-judge-standalone-cache
+EOF
+  chmod 600 "$COMPOSE_FILE"
+  ok "已生成 Compose 配置：$COMPOSE_FILE"
+}
+
+check_base_environment() {
+  section "检查主机环境"
+  [[ "$(uname -s)" == "Linux" ]] || fail "独立 Judge 部署目前只支持 Linux"
+  detect_panel
+  show_panel_guidance
+  local machine arch
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64|amd64) arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+    *) fail "不支持的 CPU 架构：${machine}（当前支持 x86_64/amd64 与 ARM64）" ;;
+  esac
+  require_command "$DOCKER_BIN"
+  "$DOCKER_BIN" info >/dev/null 2>&1 || fail "Docker daemon 未运行或当前用户无权限"
+  "$DOCKER_BIN" compose version >/dev/null 2>&1 || fail "Docker Compose v2 不可用"
+  ok "Linux/${arch}、Docker daemon 和 Compose 可用"
+  if [[ -d "$TARGET_DIR" ]]; then
+    local available_kb memory_kb
+    available_kb="$(df -Pk "$TARGET_DIR" | awk 'NR==2 {print $4}')"
+    [[ "$available_kb" =~ ^[0-9]+$ ]] || fail "无法读取目标目录磁盘空间：$TARGET_DIR"
+    ((available_kb >= 5242880)) || warn "目标目录可用空间少于 5 GiB，评测镜像和缓存可能不足"
+    if [[ -r /proc/meminfo ]]; then
+      memory_kb="$(awk '/MemAvailable:/ {print $2; exit}' /proc/meminfo)"
+      [[ "$memory_kb" =~ ^[0-9]+$ ]] && ((memory_kb >= 524288)) ||
+        warn "可用内存少于 512 MiB，建议降低 Judge 并发"
+    fi
+  fi
+}
+
+check_config_values() {
+  local key value missing=0
+  local required=(NOJ_VERSION REDIS_URL JUDGE_QUEUE RESULT_QUEUE WORK_DIR
+    JUDGE_MAX_CONCURRENT_JUDGES JUDGE_IMAGE_PREFIX JUDGE_IMAGE_REGISTRY
+    JUDGE_DOCKER_SOCKET JUDGE_DOCKER_SOCKET_GID JUDGE_UID JUDGE_GID)
+  for key in "${required[@]}"; do
+    value="$(env_value "$key")"
+    if is_placeholder "$value"; then
+      printf "  - %s 未配置或仍是占位值\n" "$key" >&2
+      missing=1
+    fi
+  done
+  ((missing == 0)) || fail "Judge 配置未完成，请修复上面的配置项"
+  is_version "$(env_value NOJ_VERSION)" || fail "NOJ_VERSION 必须是不可变 Release 标签，如 v0.1.0"
+  [[ "$(env_value JUDGE_MAX_CONCURRENT_JUDGES)" =~ ^[1-9][0-9]*$ ]] ||
+    fail "JUDGE_MAX_CONCURRENT_JUDGES 必须是正整数"
+  [[ "$(env_value JUDGE_DOCKER_SOCKET_GID)" =~ ^[0-9]+$ ]] ||
+    fail "JUDGE_DOCKER_SOCKET_GID 必须是数字"
+  [[ "$(env_value JUDGE_UID)" =~ ^[0-9]+$ && "$(env_value JUDGE_GID)" =~ ^[0-9]+$ ]] ||
+    fail "JUDGE_UID 和 JUDGE_GID 必须是数字"
+  [[ "$(env_value JUDGE_DOCKER_HOST)" == unix:///* ]] ||
+    fail "JUDGE_DOCKER_HOST 必须使用 unix:// endpoint"
+  [[ "$(env_value JUDGE_DOCKER_HOST)" == unix:///run/noj-judge/docker.sock ]] ||
+    fail "JUDGE_DOCKER_HOST 必须为容器内专用 endpoint：unix:///run/noj-judge/docker.sock"
+  [[ "$(env_value JUDGE_REQUIRE_ISOLATED_DOCKER)" == true ]] ||
+    fail "JUDGE_REQUIRE_ISOLATED_DOCKER 必须为 true"
+}
+
+check_socket() {
+  local socket_path socket_gid socket_mode configured_gid
+  socket_path="$(env_value JUDGE_DOCKER_SOCKET)"
+  case "$socket_path" in
+    /var/run/docker.sock|/run/docker.sock)
+      fail "禁止使用应用宿主机 Docker socket：${socket_path}；请准备专用 rootless socket"
+      ;;
+  esac
+  [[ "$socket_path" == /* ]] || fail "JUDGE_DOCKER_SOCKET 必须是绝对路径"
+  [[ "$socket_path" != *:* ]] || fail "JUDGE_DOCKER_SOCKET 必须是本机 Unix socket 路径"
+  [[ -S "$socket_path" ]] || fail "专用 Docker socket 不存在或不是 Unix socket：${socket_path}"
+  [[ -r "$socket_path" && -w "$socket_path" ]] ||
+    fail "当前用户无法读写专用 Docker socket：${socket_path}"
+  socket_gid="$(stat_gid "$socket_path")"
+  configured_gid="$(env_value JUDGE_DOCKER_SOCKET_GID)"
+  [[ "$socket_gid" == "$configured_gid" ]] ||
+    fail "Docker socket GID=${socket_gid} 与配置 JUDGE_DOCKER_SOCKET_GID=${configured_gid} 不一致"
+  socket_mode="$(stat_mode "$socket_path")"
+  DOCKER_HOST="unix://${socket_path}" "$DOCKER_BIN" info >/dev/null 2>&1 ||
+    fail "专用 rootless Docker daemon 不可连接：${socket_path}"
+  ok "专用 rootless Docker socket 可用（GID=${socket_gid}，权限=${socket_mode}）"
+}
+
+redis_host() {
+  local url="$(env_value REDIS_CHECK_URL)"
+  [[ -n "$url" ]] || url="$(env_value REDIS_URL)"
+  url="${url#*://}"
+  url="${url#*@}"
+  url="${url%%/*}"
+  url="${url%%:*}"
+  printf '%s\n' "${url:-未知主机}"
+}
+
+check_redis() {
+  local url="$(env_value REDIS_URL)"
+  local check_url="$(env_value REDIS_CHECK_URL)"
+  local check_env=""
+  [[ "$url" =~ ^rediss?:// ]] || fail "REDIS_URL 必须使用 redis:// 或 rediss://"
+  [[ -n "$check_url" ]] || check_url="$url"
+  [[ "$check_url" =~ ^rediss?:// ]] || fail "REDIS_CHECK_URL 必须使用 redis:// 或 rediss://"
+  section "检查 Redis"
+  if command -v redis-cli >/dev/null 2>&1; then
+    redis-cli -u "$check_url" ping >/dev/null 2>&1 ||
+      fail "Redis 连接失败：$(redis_host)（密码不会显示）"
+  else
+    check_env="$(mktemp "${TMPDIR:-/tmp}/noj-judge-redis-check.XXXXXX")"
+    umask 077
+    printf 'REDIS_URL=%s\n' "$check_url" >"$check_env"
+    chmod 600 "$check_env"
+    if ! "$DOCKER_BIN" run --rm --network host --env-file "$check_env" redis:7-alpine sh -c 'redis-cli -u "$REDIS_URL" ping' >/dev/null 2>&1; then
+      rm -f "$check_env"
+      fail "Redis 连接失败：$(redis_host)；系统未安装 redis-cli，已尝试使用临时 Redis 客户端"
+    fi
+    rm -f "$check_env"
+  fi
+  ok "Redis 可连接：$(redis_host)"
+}
+
+image_name() {
+  printf '%s/noj-judge:%s\n' "$(env_value JUDGE_IMAGE_REGISTRY)" "$(env_value NOJ_VERSION)"
+}
+
+local_image_arch() {
+  "$DOCKER_BIN" image inspect "$(image_name)" --format '{{.Architecture}}' 2>/dev/null || true
+}
+
+check_image_architecture() {
+  local machine expected image details inspect_file local_image_arch_value
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64|amd64) expected=amd64 ;;
+    aarch64|arm64) expected=arm64 ;;
+    *) return 1 ;;
+  esac
+  image="$(image_name)"
+  local_image_arch_value="$(local_image_arch)"
+  if [[ -n "$local_image_arch_value" ]]; then
+    [[ "$local_image_arch_value" == "$expected" ]] ||
+      fail "本地 Worker 镜像架构为 ${local_image_arch_value}，当前主机需要 ${expected}：${image}"
+    ok "Worker 镜像已存在且架构匹配：${expected}"
+    return 0
+  fi
+  inspect_file="$(mktemp "${TMPDIR:-/tmp}/noj-judge-image-inspect.XXXXXX")"
+  if "$DOCKER_BIN" buildx imagetools inspect "$image" >"$inspect_file" 2>/dev/null; then
+    details="$(<"$inspect_file")"
+    rm -f "$inspect_file"
+    grep -Eiq "linux/${expected}|Architecture:[[:space:]]+${expected}" <<<"$details" ||
+      fail "Worker 镜像没有当前主机架构 linux/${expected}：${image}"
+    ok "Worker 镜像 manifest 包含 linux/${expected}"
+  else
+    rm -f "$inspect_file"
+    warn "无法预先读取 Worker manifest，将由 docker pull 报告网络、认证或架构错误：${image}"
+  fi
+}
+
+check_configuration() {
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE，请先执行 install"
+  [[ -f "$COMPOSE_FILE" ]] || fail "找不到 Compose 配置：$COMPOSE_FILE，请先执行 install"
+  local mode
+  mode="$(stat_mode "$ENV_FILE")"
+  [[ "$mode" == 600 || "$mode" == 400 ]] ||
+    fail "配置文件权限必须为 600 或 400：$ENV_FILE"
+  check_config_values
+  check_socket
+  if ((DRY_RUN)); then
+    ok "[dry-run] 跳过 Redis、镜像和 Compose 实际连接检查"
+  else
+    check_redis
+    check_image_architecture
+    "$DOCKER_BIN" compose --project-name "$PROJECT_NAME" --env-file "$ENV_FILE" \
+      -f "$COMPOSE_FILE" config --quiet || fail "独立 Judge Compose 配置无效"
+  fi
+  ok "Judge 配置检查通过"
+}
+
+run_compose() {
+  if ((DRY_RUN)); then
+    printf '[dry-run] docker compose --project-name %s --env-file %s -f %s' \
+      "$PROJECT_NAME" "$ENV_FILE" "$COMPOSE_FILE"
+    printf ' %s\n' "$*"
+    return 0
+  fi
+  "$DOCKER_BIN" compose --project-name "$PROJECT_NAME" --env-file "$ENV_FILE" \
+    -f "$COMPOSE_FILE" "$@"
+}
+
+download_script() {
+  require_command "$CURL_BIN"
+  [[ "$REPO_URL" =~ ^https://github\.com/[^/]+/[^/]+/?$ ]] ||
+    fail "--repo 目前只支持 https://github.com/组织/仓库"
+  local slug url tmp download_dir
+  slug="${REPO_URL#https://github.com/}"
+  slug="${slug%/}"
+  slug="${slug%.git}"
+  url="https://raw.githubusercontent.com/$slug/$REF/scripts/deploy/judge-install.sh"
+  download_dir="$TARGET_DIR"
+  if ((DRY_RUN)); then
+    ok "[dry-run] 将下载部署脚本：$url -> $download_dir/judge-install.sh"
+    return 0
+  fi
+  [[ -d "$download_dir" ]] || { ((DRY_RUN)) || mkdir -p "$download_dir"; }
+  tmp="$(mktemp "${download_dir}/.judge-install.XXXXXX")"
+  if ! "$CURL_BIN" -fsSL --retry 3 "$url" -o "$tmp"; then
+    rm -f "$tmp"
+    fail "下载部署脚本失败，请检查仓库、ref 和网络：$url"
+  fi
+  bash -n "$tmp" || { rm -f "$tmp"; fail "下载内容不是有效 Bash 脚本：$url"; }
+  chmod 700 "$tmp"
+  mv "$tmp" "$download_dir/judge-install.sh"
+  ok "已下载部署脚本：$download_dir/judge-install.sh"
+}
+
+install_env() {
+  section "检查 Judge 部署依赖"
+  [[ "$(uname -s)" == Linux ]] || fail "独立 Judge 部署目前只支持 Linux"
+  detect_panel
+  show_panel_guidance
+  require_command "$CURL_BIN"
+  require_command "$DOCKER_BIN"
+  "$DOCKER_BIN" info >/dev/null 2>&1 || fail "Docker daemon 未运行或当前用户无权限"
+  "$DOCKER_BIN" compose version >/dev/null 2>&1 || fail "Docker Compose v2 不可用"
+  ok "Docker daemon 与 Compose 可用"
+  cat <<'EOF'
+
+请确认已准备以下隔离条件：
+  1. 只服务于 Judge 的 rootless Docker daemon；
+  2. 独立 Unix socket（例如 /run/noj-judge/docker.sock）；
+  3. Worker 用户的 UID/GID 及 socket group 权限；
+  4. 与 noj-core 使用同一 Redis、任务队列和结果队列。
+
+本工具不会自动安装或替换 Docker daemon，也不会把 /var/run/docker.sock 提供给 Judge。
+EOF
+}
+
+install_worker() {
+  initialize_env
+  write_compose
+  check_base_environment
+  check_configuration
+  section "启动独立 Judge"
+  run_compose pull
+  run_compose up -d --remove-orphans
+  ok "独立 Judge 已启动（Compose project: ${PROJECT_NAME}）"
+}
+
+start_worker() {
+  check_base_environment
+  check_configuration
+  run_compose up -d --remove-orphans
+  ok "独立 Judge 已启动"
+}
+
+upgrade_worker() {
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE，请先执行 install"
+  [[ -n "$VERSION_OVERRIDE" ]] && set_env_value NOJ_VERSION "$VERSION_OVERRIDE"
+  write_compose
+  check_base_environment
+  check_configuration
+  section "升级独立 Judge"
+  run_compose pull
+  run_compose up -d --remove-orphans
+  ok "独立 Judge 已升级；配置、缓存和 Redis 任务已保留"
+}
+
+status_worker() {
+  check_base_environment
+  check_configuration
+  printf '版本：%s\n' "$(env_value NOJ_VERSION)"
+  printf 'Redis 主机：%s\n' "$(redis_host)"
+  printf '任务队列：%s\n' "$(env_value JUDGE_QUEUE)"
+  printf '结果队列：%s\n' "$(env_value RESULT_QUEUE)"
+  printf 'Docker socket：%s\n' "$(env_value JUDGE_DOCKER_SOCKET)"
+  run_compose ps
+}
+
+logs_worker() {
+  check_base_environment
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE，请先执行 install"
+  local args=(logs --tail=200)
+  ((FOLLOW)) && args+=(--follow)
+  run_compose "${args[@]}"
+}
+
+stop_worker() {
+  [[ -f "$ENV_FILE" ]] || fail "找不到配置文件：$ENV_FILE，请先执行 install"
+  run_compose stop
+  ok "独立 Judge 已停止；配置、缓存和 Redis 任务已保留"
+}
+
+main() {
+  parse_args "$@"
+  if ((DOWNLOAD_ONLY)) || [[ "$COMMAND" == download ]]; then
+    download_script
+    exit 0
+  fi
+  case "$COMMAND" in
+    install-env) install_env ;;
+    install)
+      check_base_environment
+      initialize_env
+      write_compose
+      check_configuration
+      run_compose pull
+      run_compose up -d --remove-orphans
+      ok "独立 Judge 已启动（Compose project: ${PROJECT_NAME}）"
+      ;;
+    check) check_base_environment; check_configuration ;;
+    start) start_worker ;;
+    stop) stop_worker ;;
+    status) status_worker ;;
+    logs) logs_worker ;;
+    upgrade) upgrade_worker ;;
+    download) download_script ;;
+  esac
+}
+
+main "$@"

--- a/scripts/deploy/test-backup.sh
+++ b/scripts/deploy/test-backup.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# backup.sh 的无 Docker 生产备份、校验和恢复安全边界测试。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_SCRIPT="$SCRIPT_DIR/backup.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-backup-test.XXXXXX")"
+FAKE_DOCKER="$TEST_ROOT/fake-docker"
+FAKE_LOG="$TEST_ROOT/docker.log"
+ENV_FILE="$TEST_ROOT/.env.prod"
+COMPOSE_FILE="$TEST_ROOT/docker-compose.prod.yml"
+PASSPHRASE_FILE="$TEST_ROOT/passphrase"
+BACKUP_DIR="$TEST_ROOT/backups"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+
+cat >"$FAKE_DOCKER" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$*" >>"${NOJ_BACKUP_TEST_LOG:?}"
+if [[ "${1:-}" == "info" ]]; then
+  exit 0
+fi
+if [[ "${NOJ_BACKUP_TEST_FAIL:-}" == "redis" && " $* " == *" redis "* ]]; then
+  exit 31
+fi
+if [[ "${1:-}" == "compose" && " $* " == *" pg_dumpall "* ]]; then
+  printf 'CREATE ROLE noj;\n'
+elif [[ "${1:-}" == "compose" && " $* " == *" pg_dump "* ]]; then
+  printf 'fake postgres dump\n'
+elif [[ "${1:-}" == "compose" && "$*" == *"pg_restore --list"* ]]; then
+  printf ';
+; Archive created at 2026-08-26
+1; TABLE public users noj
+'
+elif [[ "${1:-}" == "compose" && "$*" == *"to_regclass"* ]]; then
+  printf 'drizzle.__drizzle_migrations\n'
+elif [[ "${1:-}" == "compose" && " $* " == *" psql "* ]]; then
+  printf 'migration-hash:2026-08-26\n'
+elif [[ "${1:-}" == "compose" && "$*" == *"--rdb -"* ]]; then
+  printf 'fake redis rdb\n'
+elif [[ "${1:-}" == "compose" && "$*" == *"INFO persistence"* ]]; then
+  printf 'aof_enabled:1\n'
+fi
+EOF
+chmod +x "$FAKE_DOCKER"
+
+cat >"$ENV_FILE" <<'EOF'
+POSTGRES_USER=noj
+POSTGRES_DB=noj
+POSTGRES_PASSWORD=strong-postgres-password
+REDIS_PASSWORD=strong-redis-password
+MINIO_ROOT_USER=minio-root
+MINIO_ROOT_PASSWORD=strong-minio-password
+S3_BUCKET=noj-support-packages
+EOF
+chmod 600 "$ENV_FILE"
+printf 'services:\n  fake:\n    image: alpine:3\n' >"$COMPOSE_FILE"
+printf 'test-passphrase\n' >"$PASSPHRASE_FILE"
+chmod 600 "$PASSPHRASE_FILE"
+
+run_backup() {
+  NOJ_BACKUP_DOCKER_BIN="$FAKE_DOCKER" \
+  NOJ_BACKUP_TEST_LOG="$FAKE_LOG" \
+    bash "$BACKUP_SCRIPT" "$@" \
+      --env-file "$ENV_FILE" \
+      --compose-file "$COMPOSE_FILE" \
+      --backup-dir "$BACKUP_DIR" \
+      --passphrase-file "$PASSPHRASE_FILE" \
+      --min-free-mb 0
+}
+
+run_backup create >/dev/null 2>"$TEST_ROOT/create.err" || {
+  cat "$TEST_ROOT/create.err" >&2
+  fail "完整备份创建失败"
+}
+snapshot="$(find "$BACKUP_DIR" -mindepth 1 -maxdepth 1 -type d -name 'snapshot-*' -print -quit)"
+[[ -n "$snapshot" ]] || fail "未生成快照目录"
+for required in postgres.dump postgres-globals.sql postgres.restore-list redis.rdb redis-persistence.txt minio env.prod.gpg manifest.json migration-status.txt sha256sums.txt SUCCESS; do
+  [[ -e "$snapshot/$required" ]] || fail "快照缺少文件：$required"
+done
+[[ "$(file_mode "$snapshot")" == "700" ]] ||
+  fail "快照目录权限不是 700"
+if grep -R -q 'strong-postgres-password\|strong-redis-password\|strong-minio-password' "$snapshot"; then
+  fail "快照明文泄露生产凭据"
+fi
+pass "完整快照与秘密保护"
+
+run_backup verify "$snapshot" >/dev/null || fail "快照校验失败"
+cp "$snapshot/manifest.json" "$TEST_ROOT/manifest.json"
+printf 'tampered\n' >>"$snapshot/manifest.json"
+set +e
+run_backup verify "$snapshot" >/dev/null 2>"$TEST_ROOT/tamper.err"
+tamper_status=$?
+set -e
+mv "$TEST_ROOT/manifest.json" "$snapshot/manifest.json"
+[[ "$tamper_status" != "0" ]] || fail "快照篡改未被校验发现"
+report="$TEST_ROOT/restore-drill.txt"
+run_backup drill "$snapshot" --report "$report" >/dev/null || fail "恢复演练校验失败"
+grep -q '^result=verified$' "$report" || fail "恢复演练报告缺少成功结果"
+pass "SHA-256、GPG 和恢复演练校验"
+
+run_backup restore "$snapshot" --confirm --project-name isolated-backup >/dev/null ||
+  fail "隔离 Compose 恢复编排失败"
+pass "显式确认后的恢复编排"
+
+old_snapshot="$BACKUP_DIR/snapshot-20200101-000000"
+mkdir -p "$old_snapshot"
+touch -t 202001010000 "$old_snapshot"
+run_backup create --retention-days 30 >/dev/null || fail "保留策略测试备份失败"
+[[ ! -e "$old_snapshot" ]] || fail "过期快照未被清理"
+pass "快照保留策略"
+
+before_count="$(find "$BACKUP_DIR" -mindepth 1 -maxdepth 1 -type d -name 'snapshot-*' | wc -l | tr -d ' ')"
+set +e
+NOJ_BACKUP_TEST_FAIL=redis run_backup create >/dev/null 2>"$TEST_ROOT/component-failure.err"
+failed_status=$?
+set -e
+[[ "$failed_status" != "0" ]] || fail "组件失败未返回非零状态"
+after_count="$(find "$BACKUP_DIR" -mindepth 1 -maxdepth 1 -type d -name 'snapshot-*' | wc -l | tr -d ' ')"
+[[ "$before_count" == "$after_count" ]] || fail "组件失败产生了不完整快照"
+pass "组件失败状态与原子性"
+
+set +e
+run_backup restore "$snapshot" >/dev/null 2>"$TEST_ROOT/restore-confirm.err"
+confirm_status=$?
+set -e
+[[ "$confirm_status" != "0" ]] || fail "未确认的恢复应该失败"
+grep -q -- '--confirm' "$TEST_ROOT/restore-confirm.err" || fail "恢复确认提示缺失"
+pass "恢复破坏性操作确认"
+
+printf '全部备份脚本测试通过\n'

--- a/scripts/deploy/test-deploy.sh
+++ b/scripts/deploy/test-deploy.sh
@@ -1,0 +1,594 @@
+#!/usr/bin/env bash
+# deploy.sh 的无 Docker 生产资源测试。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/deploy.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-deploy-test.XXXXXX")"
+FAKE_DOCKER="$TEST_ROOT/fake-docker"
+FAKE_LOG="$TEST_ROOT/docker.log"
+ENV_FILE="$TEST_ROOT/.env.prod"
+COMPOSE_FILE="$TEST_ROOT/docker-compose.prod.yml"
+PASSPHRASE_FILE="$TEST_ROOT/passphrase"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+
+cat >"$FAKE_DOCKER" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$*" >>"${NOJ_DEPLOY_TEST_LOG:?}"
+if [[ "${NOJ_DEPLOY_TEST_FAIL:-}" == "up" && " $* " == *" up "* ]]; then
+  exit 23
+fi
+if [[ "${NOJ_BACKUP_TEST_FAIL:-}" == "redis" && " $* " == *" redis "* ]]; then
+  exit 31
+fi
+if [[ "${1:-}" == "info" ]]; then
+  exit 0
+elif [[ "${1:-}" == "buildx" && "${2:-}" == "version" ]]; then
+  exit 0
+elif [[ "${1:-}" == "buildx" && "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+  printf 'Digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'
+elif [[ "${1:-}" == "compose" && " $* " == *" pg_dumpall "* ]]; then
+  printf 'CREATE ROLE noj;\n'
+elif [[ "${1:-}" == "compose" && " $* " == *" pg_dump "* ]]; then
+  printf 'fake postgres dump\n'
+elif [[ "${1:-}" == "compose" && "$*" == *"pg_restore --list"* ]]; then
+  printf '1; TABLE public users noj\n'
+elif [[ "${1:-}" == "compose" && "$*" == *"to_regclass"* ]]; then
+  printf 'drizzle.__drizzle_migrations\n'
+elif [[ "${1:-}" == "compose" && " $* " == *" psql "* ]]; then
+  printf 'migration-hash:2026-08-26\n'
+elif [[ "${1:-}" == "compose" && "$*" == *"--rdb -"* ]]; then
+  printf 'fake redis rdb\n'
+elif [[ "${1:-}" == "compose" && "$*" == *"INFO persistence"* ]]; then
+  printf 'aof_enabled:1\n'
+fi
+EOF
+chmod +x "$FAKE_DOCKER"
+
+cat >"$ENV_FILE" <<'EOF'
+NOJ_VERSION=v0.1.0
+NOJ_ENFORCE_IMAGE_SIGNATURES=false
+APP_URL=https://noj.test
+DOMAIN=noj.test
+CORS_ALLOWED_ORIGINS=https://noj.test
+NOJ_ALLOW_INSECURE_HTTP=false
+TRUSTED_PROXIES=172.28.0.0/16
+POSTGRES_PASSWORD=strong-postgres-password
+POSTGRES_USER=noj
+POSTGRES_DB=noj
+REDIS_PASSWORD=strong-redis-password
+MINIO_ROOT_USER=minio-root
+MINIO_ROOT_PASSWORD=strong-minio-password
+S3_ACCESS_KEY=noj-storage
+S3_SECRET_KEY=strong-storage-password
+S3_BUCKET=noj-support-packages
+S3_ENDPOINT=http://minio:9000
+STORAGE_PROVIDER=s3
+JWT_SECRET=strong-random-jwt-secret-value-1234567890
+TFA_ENCRYPTION_KEY=strong-random-tfa-secret-value-1234567890
+NOJ_LLM_SERVICE_TOKEN=strong-llm-service-token
+NOJ_LLM_STORE_KEY=strong-llm-store-key
+ADMIN_EMAIL=admin@noj.test
+ADMIN_PASS=strong-admin-password
+EMAIL_PROVIDER=aliyun
+ALIBABA_ACCESS_KEY_ID=aliyun-id
+ALIBABA_ACCESS_KEY_SECRET=aliyun-secret
+ALIBABA_FROM_EMAIL=admin@noj.test
+JUDGE_DOCKER_SOCKET=__TEST_ROOT__/isolated-docker.sock
+JUDGE_DOCKER_SOCKET_GID=10001
+NGINX_PORT=18080
+EOF
+sed -i.bak "s#__TEST_ROOT__#$TEST_ROOT#g" "$ENV_FILE"
+touch "$TEST_ROOT/isolated-docker.sock"
+chmod 600 "$ENV_FILE"
+printf 'services:\n  fake:\n    image: alpine:3\n' >"$COMPOSE_FILE"
+printf 'test-passphrase\n' >"$PASSPHRASE_FILE"
+chmod 600 "$PASSPHRASE_FILE"
+
+run_deploy_with() {
+  local env_file="$1"
+  shift
+  NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" \
+  NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  NOJ_BACKUP_TEST_LOG="$FAKE_LOG" \
+  NOJ_BACKUP_PASSPHRASE_FILE="$PASSPHRASE_FILE" \
+  NOJ_BACKUP_TEST_FAIL="${NOJ_BACKUP_TEST_FAIL:-}" \
+  PATH="$TEST_ROOT:$PATH" \
+    bash "$DEPLOY_SCRIPT" "$@" --env-file "$env_file" --compose-file "$COMPOSE_FILE"
+}
+
+run_deploy() {
+  run_deploy_with "$ENV_FILE" "$@"
+}
+
+[[ "$(bash "$DEPLOY_SCRIPT" --help)" == *"生产部署工具"* ]] || fail "帮助输出缺少工具标题"
+pass "帮助输出"
+
+NOJ_DEPLOY_SOURCE_ONLY=1 bash -c '
+  source "$1"
+  has_interactive_tty() { return 0; }
+  read_prompt() { PROMPT_VALUE=UNINSTALL; }
+  confirm_uninstall
+' bash "$DEPLOY_SCRIPT" >/dev/null 2>"$TEST_ROOT/uninstall-confirm.err" ||
+  fail "输入 UNINSTALL 后应允许卸载"
+if NOJ_DEPLOY_SOURCE_ONLY=1 bash -c '
+  source "$1"
+  has_interactive_tty() { return 0; }
+  read_prompt() { PROMPT_VALUE=no; }
+  confirm_uninstall
+' bash "$DEPLOY_SCRIPT" >/dev/null 2>"$TEST_ROOT/uninstall-cancel.err"; then
+  fail "未输入 UNINSTALL 时不应允许卸载"
+fi
+grep -q '未确认卸载' "$TEST_ROOT/uninstall-cancel.err" || fail "卸载取消提示缺失"
+pass "uninstall 交互确认词"
+
+NOJ_DEPLOY_SOURCE_ONLY=1 bash -c '
+  source "$1"
+  UNINSTALL_ALL=1
+  has_interactive_tty() { return 0; }
+  read_prompt() { PROMPT_VALUE="DELETE ALL"; }
+  confirm_uninstall
+' bash "$DEPLOY_SCRIPT" >/dev/null 2>"$TEST_ROOT/uninstall-all-confirm.err" ||
+  fail "输入 DELETE ALL 后应允许完全删除"
+if NOJ_DEPLOY_SOURCE_ONLY=1 bash -c '
+  source "$1"
+  UNINSTALL_ALL=1
+  has_interactive_tty() { return 0; }
+  read_prompt() { PROMPT_VALUE=UNINSTALL; }
+  confirm_uninstall
+' bash "$DEPLOY_SCRIPT" >/dev/null 2>"$TEST_ROOT/uninstall-all-cancel.err"; then
+  fail "完全删除不应接受普通 UNINSTALL 确认词"
+fi
+grep -q '未确认完全删除' "$TEST_ROOT/uninstall-all-cancel.err" || fail "完全删除取消提示缺失"
+pass "uninstall --all 交互确认词"
+
+default_ip="$(NOJ_DEPLOY_DEFAULT_IP=192.0.2.10 NOJ_DEPLOY_SOURCE_ONLY=1 bash -c 'source "$1"; detect_default_ipv4' bash "$DEPLOY_SCRIPT")"
+[[ "$default_ip" == 192.0.2.10 ]] || fail "服务器 IP 默认值检测失败"
+pass "服务器 IP 默认值检测"
+
+grep -q '可直接回车使用检测到的 IP' "$DEPLOY_SCRIPT" || fail "网站地址的服务器 IP 引导提示缺失"
+grep -q '正式环境仍需 HTTPS' "$DEPLOY_SCRIPT" || fail "IP 场景 HTTPS 提示缺失"
+pass "服务器 IP 默认值和 HTTPS 提示"
+
+bad_domain_env="$TEST_ROOT/bad-domain.env"
+cp "$ENV_FILE" "$bad_domain_env"
+sed -i.bak 's/^DOMAIN=.*/DOMAIN=exit/' "$bad_domain_env"
+stored_bad_domain="$(NOJ_DEPLOY_SOURCE_ONLY=1 bash -c 'source "$1"; ENV_FILE="$2"; current_config_value DOMAIN' bash "$DEPLOY_SCRIPT" "$bad_domain_env")"
+[[ -z "$stored_bad_domain" ]] || fail "旧的退出文字仍被当成网站地址默认值"
+if run_deploy_with "$bad_domain_env" start >"$TEST_ROOT/bad-domain.out" 2>&1; then
+  fail "无效网站地址不应通过配置校验"
+fi
+grep -q '网站地址必须是域名或服务器 IP' "$TEST_ROOT/bad-domain.out" ||
+  fail "无效网站地址未给出易懂错误提示"
+pass "清理旧的退出文字配置"
+
+reuse_yes="$(NOJ_DEPLOY_SOURCE_ONLY=1 NOJ_DEPLOY_TEST_CONFIRM=y bash -c 'source "$1"; read_prompt() { PROMPT_VALUE="$NOJ_DEPLOY_TEST_CONFIRM"; }; confirm_reuse_config' bash "$DEPLOY_SCRIPT")"
+[[ "$reuse_yes" == *"将使用先前配置"* ]] || fail "确认使用先前配置未生效"
+reuse_no="$(NOJ_DEPLOY_SOURCE_ONLY=1 NOJ_DEPLOY_TEST_CONFIRM=n bash -c 'source "$1"; read_prompt() { PROMPT_VALUE="$NOJ_DEPLOY_TEST_CONFIRM"; }; confirm_reuse_config' bash "$DEPLOY_SCRIPT" 2>&1 || true)"
+[[ "$reuse_no" == *"重新填写"* ]] || fail "拒绝使用先前配置未进入覆盖流程"
+pass "先前配置复用确认"
+
+grep -q '是否写入配置？（Y=写入并继续部署，N=取消）' "$DEPLOY_SCRIPT" || fail "最终写入确认提示缺失"
+grep -q '回车继续使用，输入 skip 暂不配置' "$DEPLOY_SCRIPT" || fail "已有邮件配置的复用提示缺失"
+grep -q '直接回车暂不配置' "$DEPLOY_SCRIPT" || fail "无邮件配置的跳过提示缺失"
+empty_email_label="$(NOJ_DEPLOY_SOURCE_ONLY=1 bash -c 'source "$1"; email_provider_prompt_label ""' bash "$DEPLOY_SCRIPT")"
+[[ "$empty_email_label" == *"直接回车暂不配置"* ]] || fail "无邮件配置时回车含义不清楚"
+aliyun_email_label="$(NOJ_DEPLOY_SOURCE_ONLY=1 bash -c 'source "$1"; email_provider_prompt_label aliyun' bash "$DEPLOY_SCRIPT")"
+[[ "$aliyun_email_label" == *"回车继续使用"* ]] || fail "阿里云配置复用提示缺失"
+pass "邮件服务回车与跳过提示"
+
+staging_env="$TEST_ROOT/staging.env"
+cp "$ENV_FILE" "$staging_env"
+staging_before="$(sha256sum "$staging_env" 2>/dev/null || shasum "$staging_env")"
+NOJ_DEPLOY_SOURCE_ONLY=1 NOJ_DEPLOY_TEST_SOCKET="$TEST_ROOT/isolated-docker.sock" bash -c '
+  source "$1"
+  ENV_FILE="$2"
+  begin_config_staging
+  set_env_value STAGING_TEST_KEY staged-value
+  [[ "$(env_value STAGING_TEST_KEY)" == staged-value ]]
+  [[ "$(grep -c "^STAGING_TEST_KEY=" "$2" || true)" == 0 ]]
+  cancel_config_staging
+  [[ ! -e "$CONFIG_STAGE_FILE" ]]
+  [[ "$(env_value STAGING_TEST_KEY)" == "" ]]
+' bash "$DEPLOY_SCRIPT" "$staging_env" || fail "配置暂存或取消流程失败"
+staging_after_cancel="$(sha256sum "$staging_env" 2>/dev/null || shasum "$staging_env")"
+[[ "$staging_before" == "$staging_after_cancel" ]] || fail "取消暂存后正式配置发生变化"
+NOJ_DEPLOY_SOURCE_ONLY=1 bash -c '
+  source "$1"
+  ENV_FILE="$2"
+  begin_config_staging
+  set_env_value STAGING_TEST_KEY committed-value
+  commit_config_staging
+  [[ "$(env_value STAGING_TEST_KEY)" == committed-value ]]
+' bash "$DEPLOY_SCRIPT" "$staging_env" || fail "配置确认写入流程失败"
+grep -q '^STAGING_TEST_KEY=committed-value$' "$staging_env" || fail "确认后未写入正式配置"
+pass "配置暂存、取消和最终写入"
+
+generated_passphrase="$TEST_ROOT/generated-passphrase"
+generated_env="$TEST_ROOT/generated-passphrase.env"
+cp "$ENV_FILE" "$generated_env"
+NOJ_DEPLOY_SOURCE_ONLY=1 bash -c '
+  source "$1"
+  ENV_FILE="$2"
+  DEFAULT_BACKUP_PASSPHRASE_FILE="$3"
+  BACKUP_PASSPHRASE_FILE=""
+  ensure_backup_passphrase
+  [[ -f "$3" ]]
+  [[ "$(passphrase_file_mode "$3")" == 600 ]]
+  grep -q "^NOJ_BACKUP_PASSPHRASE_FILE=$3$" "$2"
+' bash "$DEPLOY_SCRIPT" "$generated_env" "$generated_passphrase" ||
+  fail "首次部署未自动准备备份口令文件"
+pass "备份口令文件自动准备与路径持久化"
+
+configure_commit_env="$TEST_ROOT/configure-commit.env"
+cp "$ENV_FILE" "$configure_commit_env"
+NOJ_DEPLOY_SOURCE_ONLY=1 NOJ_DEPLOY_TEST_SOCKET="$TEST_ROOT/isolated-docker.sock" bash -c '
+  source "$1"
+  ENV_FILE="$2"
+  prompt_text() {
+    case "$1" in
+      安装版本*) PROMPT_VALUE=v0.8.0-rc.1 ;;
+      网站地址*) PROMPT_VALUE=noj.example.com ;;
+      管理员邮箱*) PROMPT_VALUE=admin@noj.example.com ;;
+      邮件服务*) PROMPT_VALUE=disabled ;;
+      评测服务连接位置*) PROMPT_VALUE="$NOJ_DEPLOY_TEST_SOCKET" ;;
+      评测服务连接编号*) PROMPT_VALUE=10001 ;;
+      *) return 1 ;;
+    esac
+  }
+  prompt_password() { PROMPT_VALUE=strong-admin-password; }
+  prompt_yes_no() {
+    [[ "$1" == *"是否写入配置"* ]] || return 0
+    return 0
+  }
+  configure_env_interactive 1
+' bash "$DEPLOY_SCRIPT" "$configure_commit_env" "$TEST_ROOT/isolated-docker.sock" \
+  >/dev/null 2>"$TEST_ROOT/configure-commit.err" || fail "配置向导确认写入失败"
+grep -q '^NOJ_VERSION=v0.8.0-rc.1$' "$configure_commit_env" || fail "配置向导确认后未写入版本"
+grep -q '^EMAIL_PROVIDER=disabled$' "$configure_commit_env" || fail "配置向导确认后未写入邮件选项"
+pass "配置向导最终确认写入"
+
+configure_cancel_env="$TEST_ROOT/configure-cancel.env"
+cp "$ENV_FILE" "$configure_cancel_env"
+configure_cancel_before="$(sha256sum "$configure_cancel_env" 2>/dev/null || shasum "$configure_cancel_env")"
+if NOJ_DEPLOY_SOURCE_ONLY=1 NOJ_DEPLOY_TEST_SOCKET="$TEST_ROOT/isolated-docker.sock" bash -c '
+  source "$1"
+  ENV_FILE="$2"
+  prompt_text() {
+    case "$1" in
+      安装版本*) PROMPT_VALUE=v0.8.0-rc.1 ;;
+      网站地址*) PROMPT_VALUE=noj.example.com ;;
+      管理员邮箱*) PROMPT_VALUE=admin@noj.example.com ;;
+      邮件服务*) PROMPT_VALUE=disabled ;;
+      评测服务连接位置*) PROMPT_VALUE="$NOJ_DEPLOY_TEST_SOCKET" ;;
+      评测服务连接编号*) PROMPT_VALUE=10001 ;;
+      *) return 1 ;;
+    esac
+  }
+  prompt_password() { PROMPT_VALUE=strong-admin-password; }
+  prompt_yes_no() {
+    [[ "$1" == *"是否写入配置"* ]] && return 1
+    return 0
+  }
+  configure_env_interactive 1
+' bash "$DEPLOY_SCRIPT" "$configure_cancel_env" "$TEST_ROOT/isolated-docker.sock" \
+  >/dev/null 2>"$TEST_ROOT/configure-cancel.err"; then
+  fail "拒绝写入后配置向导不应继续部署"
+fi
+configure_cancel_after="$(sha256sum "$configure_cancel_env" 2>/dev/null || shasum "$configure_cancel_env")"
+[[ "$configure_cancel_before" == "$configure_cancel_after" ]] || fail "拒绝写入后正式配置发生变化"
+pass "配置向导取消不落盘"
+
+grep -q '是否使用先前配置？' "$DEPLOY_SCRIPT" || fail "先前配置确认提示缺失"
+reset_prompt="$(NOJ_DEPLOY_SOURCE_ONLY=1 bash -c 'source "$1"; config_prompt_value DOMAIN 1' bash "$DEPLOY_SCRIPT")"
+[[ -z "$reset_prompt" ]] || fail "选择重新填写时仍保留旧配置默认值"
+grep -q '网站地址（域名或服务器 IP' "$DEPLOY_SCRIPT" || fail "网站地址提示不够友好"
+grep -q '是否使用 HTTPS（证书需在宝塔或反向代理中配置）' "$DEPLOY_SCRIPT" || fail "HTTPS 选择提示缺失"
+grep -q '暂不配置' "$DEPLOY_SCRIPT" || fail "邮件服务跳过提示缺失"
+grep -q '是否安装评测服务 Judge' "$DEPLOY_SCRIPT" || fail "Judge 安装选择提示缺失"
+grep -q 'configure_env_interactive 1' "$DEPLOY_SCRIPT" || fail "重新填写未清空旧值默认值"
+pass "重新填写和易懂配置提示"
+
+skip_judge_config_env="$TEST_ROOT/skip-judge-config.env"
+cp "$ENV_FILE" "$skip_judge_config_env"
+if NOJ_DEPLOY_SOURCE_ONLY=1 bash -c '
+  source "$1"
+  ENV_FILE="$2"
+  prompt_text() {
+    case "$1" in
+      安装版本*) PROMPT_VALUE=v0.8.0-rc.1 ;;
+      网站地址*) PROMPT_VALUE=noj.example.com ;;
+      邮件服务*) PROMPT_VALUE=disabled ;;
+      评测服务连接位置*|评测服务连接编号*)
+        printf "不应在跳过 Judge 后询问连接配置\n" >&2
+        return 1
+        ;;
+      *) return 1 ;;
+    esac
+  }
+  prompt_yes_no() {
+    [[ "$1" == *"是否安装评测服务 Judge"* ]] && return 1
+    return 0
+  }
+  configure_env_interactive 1
+' bash "$DEPLOY_SCRIPT" "$skip_judge_config_env" \
+  >"$TEST_ROOT/skip-judge-config.out" 2>"$TEST_ROOT/skip-judge-config.err"; then
+  :
+else
+  fail "跳过 Judge 的配置向导失败"
+fi
+grep -q '^JUDGE_ENABLED=false$' "$skip_judge_config_env" || fail "跳过 Judge 后未写入关闭配置"
+pass "配置向导可跳过 Judge 连接配置"
+
+http_env="$TEST_ROOT/http.env"
+cp "$ENV_FILE" "$http_env"
+sed -i.bak \
+  -e 's#^APP_URL=.*#APP_URL=http://noj.test#' \
+  -e 's#^CORS_ALLOWED_ORIGINS=.*#CORS_ALLOWED_ORIGINS=http://noj.test#' \
+  -e 's#^NOJ_ALLOW_INSECURE_HTTP=.*#NOJ_ALLOW_INSECURE_HTTP=true#' \
+  "$http_env"
+run_deploy_with "$http_env" start >/dev/null 2>"$TEST_ROOT/http.err" ||
+  fail "明确开启临时 HTTP 后 start 不应失败"
+sed -i.bak 's#^NOJ_ALLOW_INSECURE_HTTP=.*#NOJ_ALLOW_INSECURE_HTTP=false#' "$http_env"
+if run_deploy_with "$http_env" start >"$TEST_ROOT/http-disabled.out" 2>&1; then
+  fail "未明确开启临时 HTTP 时不应通过配置校验"
+fi
+grep -q '必须明确选择临时 HTTP 模式' "$TEST_ROOT/http-disabled.out" ||
+  fail "HTTP 安全门禁提示缺失"
+pass "HTTPS 默认安全门禁和临时 HTTP"
+
+panel_root="$TEST_ROOT/baota/www/server/panel"
+mkdir -p "$panel_root"
+NOJ_DEPLOY_PANEL_ROOT="$panel_root" run_deploy start \
+  >"$TEST_ROOT/panel-auto.out" 2>&1 || fail "deploy.sh 宝塔自动检测不应失败"
+grep -q '宝塔兼容模式' "$TEST_ROOT/panel-auto.out" || fail "deploy.sh 宝塔自动检测提示缺失"
+grep -q '127.0.0.1:NGINX_PORT' "$TEST_ROOT/panel-auto.out" || fail "deploy.sh 面板端口提示缺失"
+NOJ_DEPLOY_PANEL_ROOT="$panel_root" run_deploy start --panel none \
+  >"$TEST_ROOT/panel-none.out" 2>&1 || fail "deploy.sh --panel none 不应失败"
+if grep -q '宝塔兼容模式' "$TEST_ROOT/panel-none.out"; then
+  fail "deploy.sh --panel none 不应输出宝塔提示"
+fi
+NOJ_DEPLOY_PANEL_ROOT="$TEST_ROOT/missing-panel" run_deploy start --panel baota \
+  >"$TEST_ROOT/panel-force.out" 2>&1 || fail "deploy.sh --panel baota 不应失败"
+grep -q '宝塔兼容模式' "$TEST_ROOT/panel-force.out" || fail "deploy.sh --panel baota 提示缺失"
+pass "deploy.sh 面板自动、强制和关闭模式"
+
+new_env="$TEST_ROOT/new.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" install --env-file "$new_env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/install.out" 2>"$TEST_ROOT/install.err"; then
+  fail "首次初始化应该提示补齐配置并返回非零"
+fi
+[[ -f "$new_env" ]] || fail "首次初始化未创建配置文件"
+[[ "$(file_mode "$new_env")" == "600" ]] ||
+  fail "新建配置文件权限不是 600"
+non_interactive_env="$TEST_ROOT/non-interactive.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" install --non-interactive --env-file "$non_interactive_env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/non-interactive.out" 2>"$TEST_ROOT/non-interactive.err"; then
+  fail "--non-interactive 首次初始化应该返回非零"
+fi
+grep -q '没有可交互终端' "$TEST_ROOT/non-interactive.err" ||
+  fail "--non-interactive 未给出明确的配置提示"
+[[ "$(file_mode "$non_interactive_env")" == "600" ]] ||
+  fail "--non-interactive 配置文件权限不是 600"
+pass "非交互式首次配置提示"
+grep -q '^JWT_SECRET=' "$new_env" || fail "首次初始化未写入随机密钥"
+if grep -q '^JWT_SECRET=change-' "$new_env"; then fail "首次初始化仍保留 JWT 占位值"; fi
+pass "首次配置初始化与权限保护"
+
+disabled_env="$TEST_ROOT/disabled-email.env"
+cp "$ENV_FILE" "$disabled_env"
+sed -i.bak 's/^EMAIL_PROVIDER=.*/EMAIL_PROVIDER=disabled/' "$disabled_env"
+run_deploy_with "$disabled_env" start >/dev/null 2>"$TEST_ROOT/disabled-email.err" ||
+  fail "跳过邮件服务后合法配置的 start 不应失败"
+pass "跳过邮件服务配置"
+
+no_admin_env="$TEST_ROOT/no-admin.env"
+cp "$ENV_FILE" "$no_admin_env"
+sed -i.bak -e '/^ADMIN_EMAIL=/d' -e '/^ADMIN_PASS=/d' "$no_admin_env"
+run_deploy_with "$no_admin_env" start >/dev/null 2>"$TEST_ROOT/no-admin.err" ||
+  fail "没有管理员环境变量时合法配置不应失败"
+if grep -q '管理员邮箱' "$DEPLOY_SCRIPT"; then
+  fail "生产配置向导不应继续询问管理员邮箱"
+fi
+pass "无需预先配置管理员"
+
+cat >"$TEST_ROOT/cosign" <<'EOF'
+#!/usr/bin/env bash
+exit 91
+EOF
+chmod +x "$TEST_ROOT/cosign"
+run_deploy start >"$TEST_ROOT/signature-disabled.out" 2>"$TEST_ROOT/signature-disabled.err" ||
+  fail "默认关闭镜像签名校验时不应要求 Cosign"
+grep -q '已关闭镜像签名校验' "$TEST_ROOT/signature-disabled.err" ||
+  fail "关闭镜像签名校验时未给出提示"
+pass "默认关闭镜像签名校验"
+
+if run_deploy start >/dev/null 2>"$TEST_ROOT/start.err"; then
+  :
+else
+  fail "合法配置的 start 不应失败"
+fi
+grep -q 'compose.*up -d --wait' "$FAKE_LOG" || fail "start 未调用 Compose 健康等待"
+grep -q 'compose.*up -d --force-recreate --no-deps nginx' "$FAKE_LOG" ||
+  fail "启动或升级后未刷新 Nginx 上游容器"
+grep -q 'compose.*--profile judge.*up -d --wait' "$FAKE_LOG" || fail "启用 Judge 时未启用 Compose profile"
+if grep -q 'down -v' "$FAKE_LOG"; then fail "部署脚本不得删除数据卷"; fi
+pass "启动参数与数据卷安全边界"
+
+grep -q 'pg_restore --list < "\$temp/postgres.dump"' "$SCRIPT_DIR/backup.sh" ||
+  fail "PostgreSQL 备份未从标准输入校验 dump"
+if grep -q 'pg_restore --list - < "\$temp/postgres.dump"' "$SCRIPT_DIR/backup.sh"; then
+  fail "PostgreSQL 备份仍传递不兼容的 - 文件参数"
+fi
+pass "PostgreSQL 备份结构校验"
+
+skip_judge_env="$TEST_ROOT/skip-judge.env"
+cp "$ENV_FILE" "$skip_judge_env"
+printf 'JUDGE_ENABLED=false\n' >>"$skip_judge_env"
+skip_judge_log_lines="$(wc -l <"$FAKE_LOG")"
+run_deploy_with "$skip_judge_env" start >"$TEST_ROOT/skip-judge.out" 2>"$TEST_ROOT/skip-judge.err" ||
+  fail "跳过 Judge 后合法配置的 start 不应失败"
+grep -q '已跳过 Judge Docker socket 检查' "$TEST_ROOT/skip-judge.out" ||
+  fail "跳过 Judge 后未跳过 socket 检查"
+if tail -n +$((skip_judge_log_lines + 1)) "$FAKE_LOG" | grep -- '--profile judge' >/dev/null; then
+  fail "跳过 Judge 后不应启用 Compose judge profile"
+fi
+pass "跳过 Judge 时不检查、不启动 Judge"
+
+sed -i.bak 's/^JUDGE_ENABLED=false$/JUDGE_ENABLED=true/' "$skip_judge_env"
+run_deploy_with "$skip_judge_env" start >"$TEST_ROOT/re-enable-judge.out" 2>"$TEST_ROOT/re-enable-judge.err" ||
+  fail "重新启用 Judge 后合法配置的 start 不应失败"
+grep -q 'compose.*--profile judge.*up -d --wait' "$FAKE_LOG" ||
+  fail "重新启用 Judge 后未启用 Compose profile"
+pass "Judge 可通过配置重新启用"
+
+run_deploy stop >/dev/null 2>"$TEST_ROOT/stop.err" || fail "合法配置的 stop 不应失败"
+grep -q 'compose.*stop' "$FAKE_LOG" || fail "stop 未调用 Compose stop"
+run_deploy upgrade >/dev/null 2>"$TEST_ROOT/upgrade.err" || fail "合法配置的 upgrade 不应失败"
+grep -q 'compose.*pull' "$FAKE_LOG" || fail "upgrade 未拉取镜像"
+
+uninstall_log_lines="$(wc -l <"$FAKE_LOG")"
+run_deploy uninstall --yes >/dev/null 2>"$TEST_ROOT/uninstall.err" ||
+  fail "合法配置的 uninstall 不应失败"
+tail -n +$((uninstall_log_lines + 1)) "$FAKE_LOG" | grep -E -q 'compose.*--profile judge.*down.*--remove-orphans.*--rmi local' ||
+  fail "uninstall 未清理全部 Compose profile 的容器、网络和本地镜像"
+if tail -n +$((uninstall_log_lines + 1)) "$FAKE_LOG" | grep -E -q 'down.*(--volumes|-v)'; then
+  fail "uninstall 不得删除数据卷"
+fi
+pass "uninstall 清理范围与数据卷保护"
+
+uninstall_no_confirm_lines="$(wc -l <"$FAKE_LOG")"
+if NOJ_DEPLOY_TTY_PATH="$TEST_ROOT/no-tty" run_deploy uninstall >"$TEST_ROOT/uninstall-no-confirm.out" 2>&1; then
+  fail "非交互 uninstall 未确认时应返回非零退出码"
+fi
+[[ "$(wc -l <"$FAKE_LOG")" == "$uninstall_no_confirm_lines" ]] ||
+  fail "未确认 uninstall 时不应调用 Docker"
+grep -q '请显式使用 --yes' "$TEST_ROOT/uninstall-no-confirm.out" ||
+  fail "未确认 uninstall 的提示不清晰"
+pass "uninstall 未确认保护"
+
+uninstall_all_log_lines="$(wc -l <"$FAKE_LOG")"
+run_deploy uninstall --all --yes >/dev/null 2>"$TEST_ROOT/uninstall-all.err" ||
+  fail "合法配置的 uninstall --all 不应失败"
+tail -n +$((uninstall_all_log_lines + 1)) "$FAKE_LOG" | grep -E -q 'compose.*--profile judge.*down.*--remove-orphans.*--rmi all.*--volumes' ||
+  fail "uninstall --all 未清理全部 Compose 数据"
+pass "uninstall --all 数据清理参数"
+
+upgrade_failure_log_lines="$(wc -l <"$FAKE_LOG")"
+set +e
+NOJ_BACKUP_TEST_FAIL=redis run_deploy upgrade >/dev/null 2>"$TEST_ROOT/upgrade-backup-failure.err"
+upgrade_backup_status=$?
+set -e
+[[ "$upgrade_backup_status" != "0" ]] || fail "升级前备份失败未阻断升级"
+if tail -n +$((upgrade_failure_log_lines + 1)) "$FAKE_LOG" | grep -E ' pull| up ' >/dev/null; then
+  fail "升级前备份失败后仍执行了镜像拉取或启动"
+fi
+pass "升级前备份门禁"
+run_deploy logs core >/dev/null 2>"$TEST_ROOT/logs.err" || fail "合法配置的 logs 不应失败"
+grep -q 'compose.*logs.*core' "$FAKE_LOG" || fail "logs 未传递服务名"
+log_lines_before="$(wc -l <"$FAKE_LOG")"
+run_deploy upgrade --dry-run >/dev/null 2>"$TEST_ROOT/dry-run.err" || fail "合法配置的 dry-run 不应失败"
+if tail -n +$((log_lines_before + 1)) "$FAKE_LOG" | grep -E ' pull| up ' >/dev/null; then
+  fail "dry-run 不应执行 Compose 变更操作"
+fi
+pass "生命周期命令"
+
+set +e
+NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" \
+NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+NOJ_DEPLOY_TEST_FAIL=up \
+  bash "$DEPLOY_SCRIPT" start --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/failed.out" 2>"$TEST_ROOT/failed.err"
+failed_status=$?
+set -e
+[[ "$failed_status" != "0" ]] || fail "Compose 失败未传递为部署失败"
+pass "Compose 失败状态传递"
+
+cp "$ENV_FILE" "$TEST_ROOT/unsafe.env"
+sed -i.bak 's#JUDGE_DOCKER_SOCKET=.*#JUDGE_DOCKER_SOCKET=/var/run/docker.sock#' "$TEST_ROOT/unsafe.env"
+chmod 600 "$TEST_ROOT/unsafe.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" start --env-file "$TEST_ROOT/unsafe.env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/unsafe.out" 2>"$TEST_ROOT/unsafe.err"; then
+  fail "应用宿主机 Docker socket 应该被拒绝"
+fi
+grep -q '应用宿主机 Docker socket' "$TEST_ROOT/unsafe.err" || fail "危险 socket 错误提示缺失"
+pass "Judge Docker socket 隔离检查"
+
+cp "$ENV_FILE" "$TEST_ROOT/missing-socket.env"
+sed -i.bak "s#JUDGE_DOCKER_SOCKET=.*#JUDGE_DOCKER_SOCKET=$TEST_ROOT/missing.sock#" "$TEST_ROOT/missing-socket.env"
+chmod 600 "$TEST_ROOT/missing-socket.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" start --env-file "$TEST_ROOT/missing-socket.env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/missing-socket.out" 2>"$TEST_ROOT/missing-socket.err"; then
+  fail "缺失的 Judge Docker socket 应该被拒绝"
+fi
+grep -q 'Docker socket 不存在' "$TEST_ROOT/missing-socket.err" || fail "缺失 socket 错误提示缺失"
+pass "Judge Docker socket 存在性检查"
+
+cp "$ENV_FILE" "$TEST_ROOT/invalid.env"
+sed -i.bak 's/NOJ_VERSION=v0.1.0/NOJ_VERSION=change-me-release-tag/' "$TEST_ROOT/invalid.env"
+chmod 600 "$TEST_ROOT/invalid.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" start --env-file "$TEST_ROOT/invalid.env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/invalid.out" 2>"$TEST_ROOT/invalid.err"; then
+  fail "占位配置应该失败"
+fi
+grep -q 'NOJ_VERSION' "$TEST_ROOT/invalid.err" || fail "占位配置错误未指出配置键"
+if grep -q 'strong-' "$TEST_ROOT/invalid.err" "$TEST_ROOT/invalid.out"; then
+  fail "配置检查输出泄露了 secret"
+fi
+pass "占位配置拒绝与 secret 不泄露"
+
+cp "$ENV_FILE" "$TEST_ROOT/mutable-version.env"
+sed -i.bak 's/NOJ_VERSION=v0.1.0/NOJ_VERSION=latest/' "$TEST_ROOT/mutable-version.env"
+chmod 600 "$TEST_ROOT/mutable-version.env"
+if NOJ_DEPLOY_DOCKER_BIN="$FAKE_DOCKER" NOJ_DEPLOY_TEST_LOG="$FAKE_LOG" \
+  bash "$DEPLOY_SCRIPT" start --env-file "$TEST_ROOT/mutable-version.env" --compose-file "$COMPOSE_FILE" \
+  >"$TEST_ROOT/mutable-version.out" 2>"$TEST_ROOT/mutable-version.err"; then
+  fail "latest 版本应该被拒绝"
+fi
+grep -q '不可变 Release 标签' "$TEST_ROOT/mutable-version.err" ||
+  fail "latest 版本错误提示缺失"
+pass "可变 Release 标签拒绝"
+
+cat >"$TEST_ROOT/cosign" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TEST_ROOT/cosign"
+cp "$ENV_FILE" "$TEST_ROOT/signed.env"
+sed -i.bak 's/NOJ_ENFORCE_IMAGE_SIGNATURES=false/NOJ_ENFORCE_IMAGE_SIGNATURES=true/' "$TEST_ROOT/signed.env"
+chmod 600 "$TEST_ROOT/signed.env"
+run_deploy_with "$TEST_ROOT/signed.env" start --backup-dir "$TEST_ROOT/signed-backups" \
+  >/dev/null 2>"$TEST_ROOT/signed.err" || fail "合法签名配置的 start 不应失败"
+manifest="$TEST_ROOT/signed-backups/current-deployment.txt"
+[[ -f "$manifest" ]] || fail "成功部署未记录当前版本与镜像 digest"
+grep -q '^version=v0.1.0$' "$manifest" || fail "部署记录缺少版本"
+[[ "$(grep -c '^noj-' "$manifest")" -eq 6 ]] || fail "部署记录未包含六个镜像 digest"
+pass "签名校验与部署 digest 记录"
+
+if run_deploy backup --backup-dir "$TEST_ROOT/backups" >/dev/null 2>"$TEST_ROOT/backup.err"; then
+  :
+else
+  fail "合法配置的 backup 不应失败"
+fi
+snapshot="$(find "$TEST_ROOT/backups" -mindepth 1 -maxdepth 1 -type d -name 'snapshot-*' -print -quit)"
+[[ -n "$snapshot" ]] || fail "未生成完整生产快照"
+[[ -f "$snapshot/postgres.dump" && -f "$snapshot/redis.rdb" && -f "$snapshot/env.prod.gpg" ]] ||
+  fail "完整快照缺少核心数据"
+[[ "$(file_mode "$snapshot")" == "700" ]] ||
+  fail "快照目录权限不是 700"
+pass "完整生产备份与文件权限"
+
+printf '全部部署脚本测试通过\n'

--- a/scripts/deploy/test-install.sh
+++ b/scripts/deploy/test-install.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# install.sh 的离线 bootstrap smoke test。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SCRIPT="$SCRIPT_DIR/install.sh"
+SOURCE_NOJ="$SCRIPT_DIR/../../noj"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-bootstrap-test.XXXXXX")"
+FAKE_BIN="$TEST_ROOT/bin"
+ARCHIVE="$TEST_ROOT/source.tar.gz"
+DOWNLOAD_LOG="$TEST_ROOT/download.log"
+DEPLOY_LOG="$TEST_ROOT/deploy.log"
+
+cleanup() { rm -rf -- "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+
+mkdir -p "$FAKE_BIN" "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/scripts/deploy"
+printf 'target\n' >"$TEST_ROOT/source/noj-neuro-oj-v0.1.0/AGENTS.md"
+cp "$SOURCE_NOJ" "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/noj"
+chmod 755 "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/noj"
+ln -s AGENTS.md "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/CLAUDE.md"
+cat >"$TEST_ROOT/source/noj-neuro-oj-v0.1.0/scripts/deploy/deploy.sh" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$*" >"${NOJ_BOOTSTRAP_DEPLOY_LOG:?}"
+exit "${NOJ_BOOTSTRAP_DEPLOY_STATUS:-0}"
+EOF
+chmod +x "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/scripts/deploy/deploy.sh"
+printf 'services:\n  fake:\n    image: alpine:3\n' \
+  >"$TEST_ROOT/source/noj-neuro-oj-v0.1.0/docker-compose.prod.yml"
+tar -czf "$ARCHIVE" -C "$TEST_ROOT/source" noj-neuro-oj-v0.1.0
+
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+output=''
+url=''
+while (($# > 0)); do
+  case "$1" in
+    --output|-o) output="$2"; shift ;;
+    --header) shift ;;
+  esac
+  url="$1"
+  shift
+done
+if [[ "$url" == *'/releases?per_page=1' ]]; then
+  [[ "${NOJ_BOOTSTRAP_API_FAIL:-0}" != 1 ]] || exit 22
+  printf '{"tag_name":"%s"}\n' "${NOJ_BOOTSTRAP_LATEST_REF:-v0.1.0}"
+  exit 0
+fi
+if [[ -n "${NOJ_SETUP_PAYLOAD:-}" ]]; then
+  cp "$NOJ_SETUP_PAYLOAD" "${output:?}"
+  exit 0
+fi
+printf '%s\n' "${output:?}" >>"${NOJ_BOOTSTRAP_DOWNLOAD_LOG:?}"
+if [[ "${NOJ_BOOTSTRAP_DOWNLOAD_FAIL:-0}" == 1 ]]; then
+  exit 22
+fi
+cp "${NOJ_BOOTSTRAP_ARCHIVE:?}" "$output"
+EOF
+chmod +x "$FAKE_BIN/curl"
+
+cat >"$FAKE_BIN/tar" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "${NOJ_BOOTSTRAP_DANGEROUS_TAR:-0}" == 1 && "${1:-}" == -*t* ]]; then
+  printf 'noj-neuro-oj-v0.1.0/../escape\n'
+  exit 0
+fi
+exec /usr/bin/tar "$@"
+EOF
+chmod +x "$FAKE_BIN/tar"
+
+cat >"$FAKE_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -s) printf 'Linux\n' ;;
+  -m) printf '%s\n' "${NOJ_BOOTSTRAP_TEST_ARCH:-x86_64}" ;;
+  *) /usr/bin/uname "$@" ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/uname"
+
+cat >"$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "${NOJ_BOOTSTRAP_DOCKER_FAIL:-0}" == 1 && "${1:-}" == info ]]; then
+  exit 1
+fi
+case "${1:-}" in
+  --version) printf 'Docker version 28.0.0, build test\n' ;;
+  info) exit 0 ;;
+  compose) printf 'Docker Compose version v2.36.0\n' ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/docker"
+
+cat >"$FAKE_BIN/ss" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${NOJ_BOOTSTRAP_PORT_OCCUPIED:-0}" == 1 ]]; then
+  printf 'LISTEN 0 128 0.0.0.0:18080 0.0.0.0:*\n'
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN/ss"
+
+cat >"$FAKE_BIN/apt-get" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN/apt-get"
+
+export PATH="$FAKE_BIN:$PATH"
+export NOJ_BOOTSTRAP_ARCHIVE="$ARCHIVE"
+export NOJ_BOOTSTRAP_DOWNLOAD_LOG="$DOWNLOAD_LOG"
+export NOJ_BOOTSTRAP_DEPLOY_LOG="$DEPLOY_LOG"
+export NOJ_BOOTSTRAP_BIN_DIR="$TEST_ROOT/noj-bin"
+
+bash "$INSTALL_SCRIPT" --help >/dev/null
+pass "帮助输出"
+
+NOJ_SETUP_BOOTSTRAP_URL="https://example.test/install.sh" \
+NOJ_SETUP_PAYLOAD="$INSTALL_SCRIPT" \
+  bash "$SCRIPT_DIR/../../setup.sh" --help >"$TEST_ROOT/setup.out"
+grep -q '默认自动选择最新 Release' "$TEST_ROOT/setup.out" || fail "根目录一键入口未转交 bootstrap"
+pass "根目录一键入口"
+
+check_out="$TEST_ROOT/check.out"
+bash "$INSTALL_SCRIPT" check --port 18080 >"$check_out" 2>&1
+grep -q '环境检测通过' "$check_out" || fail "环境检测通过提示缺失"
+grep -q '安装前环境预览' "$check_out" || fail "安装前环境预览标题缺失"
+grep -q '最低运行要求' "$check_out" || fail "最低运行要求清单缺失"
+grep -q 'Docker Compose：v2 可用' "$check_out" || fail "Compose 检测结果缺失"
+grep -q '已有环境 CPU' "$check_out" || fail "CPU 环境摘要缺失"
+grep -E -q '已有环境 Swap|跳过内存和 Swap 摘要' "$check_out" || fail "Swap 环境摘要缺失"
+pass "环境检测与资源摘要"
+
+panel_root="$TEST_ROOT/baota/www/server/panel"
+mkdir -p "$panel_root"
+NOJ_BOOTSTRAP_PANEL_ROOT="$panel_root" bash "$INSTALL_SCRIPT" check --port 18081 \
+  >"$TEST_ROOT/panel-check.out"
+grep -q '宝塔兼容模式' "$TEST_ROOT/panel-check.out" || fail "bootstrap 宝塔自动检测提示缺失"
+grep -q '反向代理' "$TEST_ROOT/panel-check.out" || fail "bootstrap 面板反向代理提示缺失"
+pass "bootstrap 宝塔自动检测"
+
+NOJ_BOOTSTRAP_PANEL_ROOT="$panel_root" bash "$INSTALL_SCRIPT" check --panel none --port 18082 \
+  >"$TEST_ROOT/panel-none.out"
+if grep -q '宝塔兼容模式' "$TEST_ROOT/panel-none.out"; then
+  fail "bootstrap --panel none 不应输出宝塔提示"
+fi
+NOJ_BOOTSTRAP_PANEL_ROOT="$TEST_ROOT/missing-panel" bash "$INSTALL_SCRIPT" check --panel baota --port 18083 \
+  >"$TEST_ROOT/panel-force.out"
+grep -q '宝塔兼容模式' "$TEST_ROOT/panel-force.out" || fail "bootstrap --panel baota 提示缺失"
+pass "bootstrap 面板模式覆盖"
+
+set +e
+NOJ_BOOTSTRAP_TEST_ARCH=aarch64 bash "$INSTALL_SCRIPT" check \
+  >"$TEST_ROOT/arm64.out" 2>"$TEST_ROOT/arm64.err"
+arm64_status=$?
+set -e
+[[ "$arm64_status" != 0 ]] || fail "ARM64 架构未被当前版本阻断"
+grep -q '仅发布 linux/amd64' "$TEST_ROOT/arm64.err" || fail "ARM64 提示缺失"
+pass "ARM64 架构提示"
+
+set +e
+NOJ_BOOTSTRAP_DOCKER_FAIL=1 bash "$INSTALL_SCRIPT" check >"$TEST_ROOT/check-fail.out" 2>"$TEST_ROOT/check-fail.err"
+check_status=$?
+set -e
+[[ "$check_status" != 0 ]] || fail "Docker daemon 缺失未被检测"
+grep -q 'Docker daemon' "$TEST_ROOT/check-fail.err" || fail "Docker 缺失错误提示缺失"
+[[ ! -s "$DOWNLOAD_LOG" ]] || fail "check 命令不应下载源码"
+pass "环境缺失状态与无副作用"
+
+install_env_out="$TEST_ROOT/install-env.out"
+bash "$INSTALL_SCRIPT" install-env --dry-run >"$install_env_out"
+grep -q '安装基础工具' "$install_env_out" || fail "install-env 未显示基础工具安装计划"
+grep -q 'Docker 请按发行版官方文档安装' <(bash "$INSTALL_SCRIPT" --help) ||
+  fail "Docker 安装边界说明缺失"
+pass "基础依赖安装计划"
+
+dry_run_dir="$TEST_ROOT/dry-run"
+bash "$INSTALL_SCRIPT" --dry-run --repo https://example.com/repo --ref v0.1.0 --dir "$dry_run_dir" >"$TEST_ROOT/dry-run.out"
+[[ ! -e "$dry_run_dir" ]] || fail "dry-run 创建了目标目录"
+[[ ! -s "$DOWNLOAD_LOG" ]] || fail "dry-run 下载了源码"
+grep -q '安装前环境预览' "$TEST_ROOT/dry-run.out" || fail "install 未在下载前展示环境预览"
+grep -q '已有环境目标磁盘' "$TEST_ROOT/dry-run.out" || fail "install 未展示目标磁盘摘要"
+grep -q 'https://example.com/repo/archive/v0.1.0.tar.gz' "$TEST_ROOT/dry-run.out" ||
+  fail "dry-run 未显示下载地址"
+pass "dry-run 不产生副作用"
+
+set +e
+NOJ_BOOTSTRAP_API_FAIL=1 bash "$INSTALL_SCRIPT" --dir "$TEST_ROOT/api-fail" \
+  >/dev/null 2>"$TEST_ROOT/api-fail.err"
+api_status=$?
+set -e
+[[ "$api_status" != 0 ]] || fail "最新 Release 获取失败未返回非零"
+grep -q '使用 --ref' "$TEST_ROOT/api-fail.err" || fail "最新 Release 获取失败提示缺少显式版本建议"
+pass "最新 Release 获取失败"
+
+NOJ_BOOTSTRAP_API_FAIL=1 NOJ_BOOTSTRAP_BIN_DIR="$TEST_ROOT/explicit-bin" \
+  bash "$INSTALL_SCRIPT" --ref v0.1.0 --dir "$TEST_ROOT/explicit-ref" >/dev/null
+pass "显式版本跳过 Release 查询"
+
+download_only_dir="$TEST_ROOT/download-only"
+rm -f "$DEPLOY_LOG"
+bash "$INSTALL_SCRIPT" --download-only --repo https://example.com/repo --ref v0.1.0 \
+  --dir "$download_only_dir" >/dev/null
+[[ -f "$download_only_dir/scripts/deploy/deploy.sh" ]] || fail "下载模式缺少部署脚本"
+[[ -x "$download_only_dir/noj" ]] || fail "下载模式缺少可执行 noj 命令"
+[[ ! -e "$DEPLOY_LOG" ]] || fail "download-only 启动了部署"
+[[ -z "$(find "$TEST_ROOT" -maxdepth 1 -type d -name 'noj-bootstrap.*' -print -quit)" ]] ||
+  fail "下载完成后未清理临时目录"
+pass "源码下载与临时文件清理"
+
+files_only_dir="$TEST_ROOT/files-only"
+cp -a "$download_only_dir" "$files_only_dir"
+NOJ_BOOTSTRAP_PORT_OCCUPIED=1 \
+  bash "$INSTALL_SCRIPT" --files-only --repo https://example.com/repo --ref v0.1.0 \
+  --dir "$files_only_dir" --port 18080 >"$TEST_ROOT/files-only.out" 2>&1
+grep -q '部署文件同步模式跳过宿主机端口占用检查' "$TEST_ROOT/files-only.out" ||
+  fail "files-only 仍被自身端口占用阻断"
+pass "已有安装同步跳过端口占用检查"
+
+deploy_dir="$TEST_ROOT/deploy"
+bash "$INSTALL_SCRIPT" --repo https://example.com/repo --ref v0.1.0 --dir "$deploy_dir" -- \
+  --env-file /tmp/example.env --backup-dir /tmp/backups >/dev/null
+[[ "$(cat "$DEPLOY_LOG")" == 'install --env-file /tmp/example.env --backup-dir /tmp/backups' ]] ||
+  fail "部署参数未正确传递"
+[[ -L "$NOJ_BOOTSTRAP_BIN_DIR/noj" ]] || fail "安装后未注册 PATH 命令"
+cmp -s "$NOJ_BOOTSTRAP_BIN_DIR/noj" "$deploy_dir/noj" || fail "PATH 命令未指向安装目录"
+pass "部署入口与参数传递"
+
+resume_dir="$TEST_ROOT/resume"
+mkdir -p "$resume_dir/scripts/deploy"
+cp "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/scripts/deploy/deploy.sh" \
+  "$resume_dir/scripts/deploy/deploy.sh"
+chmod +x "$resume_dir/scripts/deploy/deploy.sh"
+printf 'services:\n  fake:\n    image: alpine:3\n' >"$resume_dir/docker-compose.prod.yml"
+printf 'NOJ_VERSION=v0.1.0\nADMIN_PASS=keep-this-secret\n' >"$resume_dir/.env.prod"
+mkdir -p "$resume_dir/backups"
+printf 'keep\n' >"$resume_dir/backups/marker.txt"
+printf 'old-noj\n' >"$resume_dir/noj"
+chmod 600 "$resume_dir/noj"
+bash "$INSTALL_SCRIPT" --panel baota --dir "$resume_dir" >/dev/null
+grep -q 'install --panel baota' "$DEPLOY_LOG" || fail "已有 NOJ 安装未继续执行 deploy.sh"
+grep -q '^ADMIN_PASS=keep-this-secret$' "$resume_dir/.env.prod" || fail "续装覆盖了生产配置"
+[[ "$(cat "$resume_dir/backups/marker.txt")" == keep ]] || fail "续装覆盖了备份目录"
+cmp -s "$resume_dir/noj" "$TEST_ROOT/source/noj-neuro-oj-v0.1.0/noj" || fail "续装未更新 noj 命令"
+[[ -x "$resume_dir/noj" ]] || fail "续装后 noj 命令不可执行"
+pass "已有 NOJ 安装保留配置并继续部署"
+
+panel_deploy_dir="$TEST_ROOT/panel-deploy"
+bash "$INSTALL_SCRIPT" --panel baota --dir "$panel_deploy_dir" >/dev/null
+grep -q 'install --panel baota' "$DEPLOY_LOG" || fail "bootstrap 未将面板模式传递给 deploy.sh"
+pass "bootstrap 面板参数传递"
+
+nonempty_dir="$TEST_ROOT/nonempty"
+mkdir -p "$nonempty_dir"
+printf 'keep\n' >"$nonempty_dir/keep.txt"
+bash "$INSTALL_SCRIPT" --dir "$nonempty_dir" >/dev/null 2>"$TEST_ROOT/nonempty.err" ||
+  fail "非空目录未继续安装"
+grep -q '非空' "$TEST_ROOT/nonempty.err" || fail "非空目录提示缺失"
+[[ "$(cat "$nonempty_dir/keep.txt")" == keep ]] || fail "非空目录内容被覆盖"
+[[ -f "$nonempty_dir/scripts/deploy/deploy.sh" ]] || fail "非空目录未安装部署脚本"
+pass "非空目录保留内容并继续安装"
+
+set +e
+NOJ_BOOTSTRAP_DOWNLOAD_FAIL=1 TMPDIR="$TEST_ROOT/tmp-download-fail" \
+  bash "$INSTALL_SCRIPT" --dir "$TEST_ROOT/download-fail" >/dev/null 2>"$TEST_ROOT/download-fail.err"
+download_status=$?
+set -e
+[[ "$download_status" != 0 ]] || fail "下载失败未返回非零"
+[[ ! -e "$TEST_ROOT/download-fail" ]] || fail "下载失败创建了目标目录"
+[[ -z "$(find "$TEST_ROOT/tmp-download-fail" -mindepth 1 -maxdepth 1 -type d -name 'noj-bootstrap.*' -print -quit 2>/dev/null)" ]] ||
+  fail "下载失败后未清理临时目录"
+pass "下载失败传播与清理"
+
+set +e
+NOJ_BOOTSTRAP_DOWNLOAD_FAIL=1 \
+  bash "$INSTALL_SCRIPT" --ref 0.1.0 --dir "$TEST_ROOT/bare-stable-ref" \
+  >/dev/null 2>"$TEST_ROOT/bare-stable-ref.err"
+bare_stable_status=$?
+set -e
+[[ "$bare_stable_status" != 0 ]] || fail "裸稳定版本标签下载失败未返回非零"
+grep -q -- '--ref v0.1.0' "$TEST_ROOT/bare-stable-ref.err" ||
+  fail "裸稳定版本标签缺少 v 前缀修复提示"
+pass "稳定版本标签提示"
+
+set +e
+NOJ_BOOTSTRAP_DANGEROUS_TAR=1 \
+  bash "$INSTALL_SCRIPT" --dir "$TEST_ROOT/dangerous" >/dev/null 2>"$TEST_ROOT/dangerous.err"
+dangerous_status=$?
+set -e
+[[ "$dangerous_status" != 0 ]] || fail "危险归档未被拒绝"
+grep -q '目录穿越' "$TEST_ROOT/dangerous.err" || fail "危险归档错误提示缺失"
+[[ ! -e "$TEST_ROOT/dangerous" ]] || fail "危险归档创建了目标目录"
+pass "危险归档拒绝"
+
+set +e
+NOJ_BOOTSTRAP_DEPLOY_STATUS=37 \
+  bash "$INSTALL_SCRIPT" --dir "$TEST_ROOT/deploy-fail" >/dev/null 2>"$TEST_ROOT/deploy-fail.err"
+deploy_status=$?
+set -e
+if [[ "$deploy_status" -ne 37 ]]; then
+  printf '部署失败测试 stderr：\n' >&2
+  sed -n '1,80p' "$TEST_ROOT/deploy-fail.err" >&2
+  [[ -f "$DEPLOY_LOG" ]] && printf '部署记录：%s\n' "$(cat "$DEPLOY_LOG")" >&2
+  fail "部署失败状态未原样传递：$deploy_status"
+fi
+grep -q 'status 或 logs' "$TEST_ROOT/deploy-fail.err" || fail "部署失败诊断提示缺失"
+pass "部署失败状态传递"
+
+printf '全部 bootstrap 脚本测试通过\n'

--- a/scripts/deploy/test-judge-install.sh
+++ b/scripts/deploy/test-judge-install.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# 独立 Judge 部署脚本的离线安全边界测试。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/judge-install.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-judge-install-test.XXXXXX")"
+FAKE_DOCKER="$TEST_ROOT/fake-docker"
+FAKE_CURL="$TEST_ROOT/fake-curl"
+FAKE_UNAME="$TEST_ROOT/uname"
+FAKE_REDIS_CLI="$TEST_ROOT/redis-cli"
+FAKE_SS="$TEST_ROOT/ss"
+DOCKER_LOG="$TEST_ROOT/docker.log"
+TARGET_DIR="$TEST_ROOT/target"
+ENV_FILE="$TARGET_DIR/.env.judge"
+SOCKET="$TEST_ROOT/isolated-docker.sock"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+
+cat >"$FAKE_DOCKER" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$*" >>"${NOJ_JUDGE_TEST_LOG:-/dev/null}"
+case "${1:-}" in
+  info) exit 0 ;;
+  compose)
+    [[ "${2:-}" == version ]] && exit 0
+    exit 0
+    ;;
+  image)
+    exit 1
+    ;;
+  container)
+    if [[ "${NOJ_JUDGE_TEST_CONTAINER_CONFLICT:-0}" == 1 ]]; then
+      if [[ "${2:-}" == inspect ]]; then
+        [[ "${NOJ_JUDGE_TEST_MANAGED_REDIS:-0}" == 1 ]] &&
+          printf 'judge-standalone-redis\n' || printf 'other\n'
+        exit 0
+      fi
+    fi
+    exit 1
+    ;;
+  buildx)
+    printf 'Name: fake\nPlatform: linux/amd64\n'
+    exit 0
+    ;;
+  run)
+    printf 'PONG\n'
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$FAKE_DOCKER"
+
+cat >"$FAKE_CURL" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+output=""
+while (($# > 0)); do
+  if [[ "$1" == -o ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]] || exit 2
+cp "${NOJ_JUDGE_SOURCE_SCRIPT:?}" "$output"
+EOF
+chmod +x "$FAKE_CURL"
+
+cat >"$FAKE_UNAME" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == -m ]]; then
+  printf '%s\n' "${NOJ_JUDGE_TEST_ARCH:-x86_64}"
+else
+  printf 'Linux\n'
+fi
+EOF
+chmod +x "$FAKE_UNAME"
+
+cat >"$FAKE_REDIS_CLI" <<'EOF'
+#!/usr/bin/env bash
+printf 'PONG\n'
+EOF
+chmod +x "$FAKE_REDIS_CLI"
+
+cat >"$FAKE_SS" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${NOJ_JUDGE_TEST_PORT_CONFLICT:-0}" == 1 ]]; then
+  printf 'LISTEN 0 128 127.0.0.1:16379 0.0.0.0:*\n'
+fi
+EOF
+chmod +x "$FAKE_SS"
+
+mkdir -p "$TARGET_DIR"
+python3 - "$SOCKET" <<'PY'
+import socket
+import sys
+
+sock = socket.socket(socket.AF_UNIX)
+sock.bind(sys.argv[1])
+sock.listen(1)
+PY
+chmod 660 "$SOCKET"
+SOCKET_GID="$(stat -c '%g' "$SOCKET" 2>/dev/null || stat -f '%g' "$SOCKET")"
+
+cat >"$ENV_FILE" <<EOF
+NOJ_VERSION=v0.1.0
+REDIS_URL=redis://:secret-password@redis.test.local:6379/0
+JUDGE_QUEUE=noj:judge:queue
+RESULT_QUEUE=noj:judge:results
+WORK_DIR=/tmp/noj-judge
+JUDGE_MAX_CONCURRENT_JUDGES=2
+JUDGE_IMAGE_PREFIX=noj-
+JUDGE_IMAGE_REGISTRY=ghcr.io/neuro-oj
+JUDGE_DOCKER_SOCKET=$SOCKET
+JUDGE_DOCKER_SOCKET_GID=$SOCKET_GID
+JUDGE_DOCKER_HOST=unix:///run/noj-judge/docker.sock
+JUDGE_REQUIRE_ISOLATED_DOCKER=true
+JUDGE_UID=10001
+JUDGE_GID=10001
+EOF
+chmod 600 "$ENV_FILE"
+
+run_judge() {
+  NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+  NOJ_JUDGE_CURL_BIN="$FAKE_CURL" \
+  NOJ_JUDGE_TEST_LOG="$DOCKER_LOG" \
+  NOJ_JUDGE_SOURCE_SCRIPT="$DEPLOY_SCRIPT" \
+  PATH="$TEST_ROOT:$PATH" \
+    bash "$DEPLOY_SCRIPT" "$@" --dir "$TARGET_DIR"
+}
+
+[[ "$(bash "$DEPLOY_SCRIPT" --help)" == *"独立 Judge Worker 部署工具"* ]] ||
+  fail "帮助输出缺少工具标题"
+pass "帮助输出"
+
+NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+NOJ_JUDGE_CURL_BIN="$FAKE_CURL" \
+NOJ_JUDGE_TEST_LOG="$DOCKER_LOG" \
+NOJ_JUDGE_TTY_PATH="$TEST_ROOT/missing-tty" \
+PATH="$TEST_ROOT:$PATH" \
+  bash -s -- install-env <"$DEPLOY_SCRIPT" >/dev/null ||
+  fail "从 curl 管道执行 install-env 不应失败"
+pass "curl 管道入口"
+
+PROMPT_DIR="$TEST_ROOT/prompt-target"
+PROMPT_SOCKET="$TEST_ROOT/prompt.sock"
+mkdir -p "$PROMPT_DIR"
+python3 - "$PROMPT_SOCKET" <<'PY'
+import socket
+import sys
+
+sock = socket.socket(socket.AF_UNIX)
+sock.bind(sys.argv[1])
+sock.listen(1)
+PY
+chmod 660 "$PROMPT_SOCKET"
+PROMPT_SOCKET_GID="$(stat -c '%g' "$PROMPT_SOCKET" 2>/dev/null || stat -f '%g' "$PROMPT_SOCKET")"
+PROMPT_OUTPUT="$TEST_ROOT/prompt.out"
+set +e
+NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+NOJ_JUDGE_CURL_BIN="$FAKE_CURL" \
+NOJ_JUDGE_TEST_LOG="$DOCKER_LOG" \
+NOJ_JUDGE_TTY_PATH="$TEST_ROOT/missing-tty" \
+PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install --dir "$PROMPT_DIR" >"$PROMPT_OUTPUT" 2>&1 <<EOF
+v0.1.0
+1
+redis://redis.test.local:6379/0
+
+
+
+
+
+
+$PROMPT_SOCKET
+$PROMPT_SOCKET_GID
+
+
+EOF
+PROMPT_STATUS=$?
+set -e
+if ((PROMPT_STATUS != 0)); then
+  cat "$PROMPT_OUTPUT" >&2
+  fail "交互式配置测试失败"
+fi
+grep -q 'Redis 地址.*同一个 Redis 和队列' "$PROMPT_OUTPUT" || fail "Redis 配置说明缺失"
+grep -q '无密码示例：redis://127.0.0.1:6379/0' "$PROMPT_OUTPUT" || fail "Redis 示例缺失"
+grep -q '专用 Docker socket.*rootless' "$PROMPT_OUTPUT" || fail "Docker socket 配置说明缺失"
+grep -q '^JUDGE_QUEUE=noj:judge:queue$' "$PROMPT_DIR/.env.judge" || fail "默认任务队列未生效"
+grep -q '^RESULT_QUEUE=noj:judge:results$' "$PROMPT_DIR/.env.judge" || fail "默认结果队列未生效"
+pass "交互式配置说明和默认值"
+
+if NOJ_JUDGE_DOCKER_BIN="$TEST_ROOT/missing-docker" \
+  PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install --dir "$TEST_ROOT/no-docker" \
+  >"$TEST_ROOT/preflight.out" 2>&1; then
+  fail "Docker 缺失时安装应该在配置提示前失败"
+fi
+grep -q '缺少依赖：' "$TEST_ROOT/preflight.out" || fail "预检缺少 Docker 的错误提示"
+if grep -q '首次部署需要填写' "$TEST_ROOT/preflight.out"; then
+  fail "环境预检失败前不应显示配置向导"
+fi
+pass "环境预检先于配置向导"
+
+PANEL_ROOT_DIR="$TEST_ROOT/baota/www/server/panel"
+mkdir -p "$PANEL_ROOT_DIR"
+PANEL_OUTPUT="$TEST_ROOT/panel.out"
+NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+NOJ_JUDGE_CURL_BIN="$FAKE_CURL" \
+NOJ_JUDGE_PANEL_ROOT="$PANEL_ROOT_DIR" \
+PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install-env >"$PANEL_OUTPUT" 2>&1 || fail "宝塔自动检测不应失败"
+grep -q '宝塔兼容模式' "$PANEL_OUTPUT" || fail "宝塔自动检测提示缺失"
+grep -q '不调用宝塔 API' "$PANEL_OUTPUT" || fail "宝塔 API 边界提示缺失"
+pass "宝塔自动检测和兼容提示"
+
+if NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+  NOJ_JUDGE_PANEL_ROOT="$PANEL_ROOT_DIR" \
+  PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install-env --panel none >"$TEST_ROOT/panel-none.out" 2>&1; then
+  :
+else
+  fail "--panel none 不应失败"
+fi
+if grep -q '宝塔兼容模式' "$TEST_ROOT/panel-none.out"; then
+  fail "--panel none 不应输出宝塔提示"
+fi
+NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+NOJ_JUDGE_PANEL_ROOT="$TEST_ROOT/missing-panel" \
+PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install-env --panel baota >"$TEST_ROOT/panel-force.out" 2>&1 ||
+  fail "--panel baota 强制模式不应失败"
+grep -q '宝塔兼容模式' "$TEST_ROOT/panel-force.out" || fail "--panel baota 强制提示缺失"
+pass "宝塔模式覆盖选项"
+
+LOCAL_DIR="$TEST_ROOT/local-redis"
+LOCAL_OUTPUT="$TEST_ROOT/local-redis.out"
+set +e
+NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+NOJ_JUDGE_CURL_BIN="$FAKE_CURL" \
+NOJ_JUDGE_TEST_LOG="$DOCKER_LOG" \
+REDIS_LOCAL_CONTAINER=noj-judge-redis-test \
+REDIS_LOCAL_PORT=16379 \
+JUDGE_QUEUE=noj:judge:queue \
+RESULT_QUEUE=noj:judge:results \
+WORK_DIR=/tmp/noj-judge \
+JUDGE_MAX_CONCURRENT_JUDGES=2 \
+JUDGE_IMAGE_PREFIX=noj- \
+JUDGE_IMAGE_REGISTRY=ghcr.io/neuro-oj \
+JUDGE_DOCKER_SOCKET="$SOCKET" \
+JUDGE_DOCKER_SOCKET_GID="$SOCKET_GID" \
+JUDGE_UID=10001 \
+JUDGE_GID=10001 \
+PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install --dir "$LOCAL_DIR" >"$LOCAL_OUTPUT" 2>&1 <<EOF
+v0.1.0
+2
+
+
+
+
+
+
+
+$SOCKET
+$SOCKET_GID
+
+
+EOF
+LOCAL_STATUS=$?
+set -e
+if ((LOCAL_STATUS != 0)); then
+  cat "$LOCAL_OUTPUT" >&2
+  fail "本机 Redis 创建测试失败"
+fi
+grep -q '^REDIS_URL=redis://:[^@]*@host.docker.internal:16379/0$' "$LOCAL_DIR/.env.judge" ||
+  fail "本机 Redis 的 Judge 地址未写入配置"
+grep -q '^REDIS_CHECK_URL=redis://:[^@]*@127.0.0.1:16379/0$' "$LOCAL_DIR/.env.judge" ||
+  fail "本机 Redis 的检查地址未写入配置"
+grep -q 'host.docker.internal:host-gateway' "$LOCAL_DIR/docker-compose.judge.yml" ||
+  fail "Compose 缺少 host-gateway"
+[[ "$(stat -c '%a' "$LOCAL_DIR/redis.conf" 2>/dev/null || stat -f '%Lp' "$LOCAL_DIR/redis.conf")" == 600 ]] ||
+  fail "Redis 配置文件权限不安全"
+[[ "$(stat -c '%a' "$LOCAL_DIR/redis-connection.txt" 2>/dev/null || stat -f '%Lp' "$LOCAL_DIR/redis-connection.txt")" == 600 ]] ||
+  fail "Redis 连接信息文件权限不安全"
+LOCAL_PASSWORD="$(sed -n 's#^REDIS_URL=redis://:\([^@]*\)@.*#\1#p' "$LOCAL_DIR/.env.judge")"
+[[ -n "$LOCAL_PASSWORD" ]] || fail "本机 Redis 未生成密码"
+if grep -q "$LOCAL_PASSWORD" "$LOCAL_OUTPUT" "$DOCKER_LOG"; then
+  fail "本机 Redis 密码出现在输出或 Docker 日志"
+fi
+pass "本机 Redis 创建、连接地址和密码保护"
+
+CONFLICT_DIR="$TEST_ROOT/redis-container-conflict"
+if NOJ_JUDGE_TEST_CONTAINER_CONFLICT=1 \
+  NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+  PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install --dir "$CONFLICT_DIR" >"$TEST_ROOT/container-conflict.out" 2>&1 <<EOF
+v0.1.0
+2
+
+
+EOF
+then
+  fail "非本工具 Redis 容器冲突应该失败"
+fi
+grep -q '不会删除或修改它' "$TEST_ROOT/container-conflict.out" || {
+  cat "$TEST_ROOT/container-conflict.out" >&2
+  fail "Redis 容器冲突提示缺失"
+}
+pass "Redis 容器冲突保护"
+
+PORT_CONFLICT_DIR="$TEST_ROOT/redis-port-conflict"
+if NOJ_JUDGE_TEST_PORT_CONFLICT=1 \
+  NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+  PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install --dir "$PORT_CONFLICT_DIR" >"$TEST_ROOT/port-conflict.out" 2>&1 <<EOF
+v0.1.0
+2
+
+
+EOF
+then
+  fail "Redis 端口冲突应该失败"
+fi
+grep -q '端口已被占用' "$TEST_ROOT/port-conflict.out" || fail "Redis 端口冲突提示缺失"
+pass "Redis 端口冲突保护"
+
+DEFER_DIR="$TEST_ROOT/defer-redis"
+if NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+  PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install --dir "$DEFER_DIR" >"$TEST_ROOT/defer.out" 2>&1 <<EOF
+v0.1.0
+3
+EOF
+then
+  fail "稍后配置 Redis 应该停止安装"
+fi
+grep -q '本次不会启动 Judge' "$TEST_ROOT/defer.out" || fail "稍后配置提示缺失"
+[[ ! -f "$DEFER_DIR/.env.judge" ]] || fail "稍后配置不应生成 Judge 配置"
+pass "稍后配置 Redis"
+
+DOWNLOAD_DIR="$TEST_ROOT/download"
+NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" \
+NOJ_JUDGE_CURL_BIN="$FAKE_CURL" \
+NOJ_JUDGE_TEST_LOG="$DOCKER_LOG" \
+NOJ_JUDGE_SOURCE_SCRIPT="$DEPLOY_SCRIPT" \
+PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" download --dir "$DOWNLOAD_DIR" --ref test-ref >/dev/null
+[[ -x "$DOWNLOAD_DIR/judge-install.sh" ]] || fail "download 未生成可执行脚本"
+bash -n "$DOWNLOAD_DIR/judge-install.sh" || fail "下载脚本不是有效 Bash"
+pass "仅下载脚本"
+
+run_judge install >/dev/null
+[[ -f "$TARGET_DIR/docker-compose.judge.yml" ]] || fail "install 未生成 Compose 文件"
+grep -q 'JUDGE_REQUIRE_ISOLATED_DOCKER: "true"' "$TARGET_DIR/docker-compose.judge.yml" ||
+  fail "Compose 未启用隔离 Docker"
+grep -q ':ro"' "$TARGET_DIR/docker-compose.judge.yml" || fail "Docker socket 未以只读方式挂载"
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  docker compose --project-name noj-judge-standalone-test --env-file "$ENV_FILE" \
+    -f "$TARGET_DIR/docker-compose.judge.yml" config --quiet ||
+    fail "实际 Docker Compose 无法渲染独立 Judge 配置"
+fi
+if grep -q 'secret-password' "$DOCKER_LOG"; then fail "Docker 命令日志泄露 Redis 密码"; fi
+pass "配置生成、Compose 安全项和 secret 脱敏"
+
+run_judge start >/dev/null || fail "重复 start 不应失败"
+run_judge status >/dev/null || fail "status 不应失败"
+run_judge logs >/dev/null || fail "logs 不应失败"
+run_judge stop >/dev/null || fail "stop 不应失败"
+grep -q 'compose.*stop' "$DOCKER_LOG" || fail "stop 未调用 Compose stop"
+pass "生命周期命令和重复启动"
+
+run_judge upgrade --version v0.2.0 >/dev/null || fail "upgrade 不应失败"
+grep -q '^NOJ_VERSION=v0.2.0$' "$ENV_FILE" || fail "upgrade 未更新版本"
+pass "升级保留配置"
+
+cp "$ENV_FILE" "$TEST_ROOT/unsafe.env"
+sed -i.bak 's#JUDGE_DOCKER_SOCKET=.*#JUDGE_DOCKER_SOCKET=/var/run/docker.sock#' "$TEST_ROOT/unsafe.env"
+chmod 600 "$TEST_ROOT/unsafe.env"
+if run_judge check --panel baota --env-file "$TEST_ROOT/unsafe.env" >/dev/null 2>"$TEST_ROOT/unsafe.err"; then
+  fail "共享 Docker socket 应该被拒绝"
+fi
+grep -q '禁止使用应用宿主机 Docker socket' "$TEST_ROOT/unsafe.err" ||
+  fail "共享 socket 错误提示缺失"
+pass "共享 Docker socket 拒绝"
+
+cp "$ENV_FILE" "$TEST_ROOT/missing.env"
+sed -i.bak "s#JUDGE_DOCKER_SOCKET=.*#JUDGE_DOCKER_SOCKET=$TEST_ROOT/missing.sock#" "$TEST_ROOT/missing.env"
+chmod 600 "$TEST_ROOT/missing.env"
+if run_judge check --env-file "$TEST_ROOT/missing.env" >/dev/null 2>"$TEST_ROOT/missing.err"; then
+  fail "缺失 Docker socket 应该被拒绝"
+fi
+grep -q '不是 Unix socket' "$TEST_ROOT/missing.err" || fail "缺失 socket 错误提示缺失"
+pass "专用 Docker socket 存在性检查"
+
+if NOJ_JUDGE_TEST_ARCH=aarch64 run_judge check >/dev/null 2>"$TEST_ROOT/arm64.err"; then
+  fail "ARM64 无匹配镜像 manifest 时应该被拒绝"
+fi
+grep -q 'linux/arm64' "$TEST_ROOT/arm64.err" || fail "ARM64 架构错误提示缺失"
+pass "ARM64 镜像架构门禁"
+
+if NOJ_JUDGE_DOCKER_BIN="$FAKE_DOCKER" NOJ_JUDGE_TEST_LOG="$DOCKER_LOG" PATH="$TEST_ROOT:$PATH" \
+  bash "$DEPLOY_SCRIPT" install --dir "$TEST_ROOT/non-interactive" --non-interactive \
+  >"$TEST_ROOT/non-interactive.out" 2>"$TEST_ROOT/non-interactive.err"; then
+  fail "非交互模式缺少配置时应该失败"
+fi
+grep -q 'NOJ_VERSION' "$TEST_ROOT/non-interactive.err" || fail "非交互缺失配置提示缺少"
+pass "非交互必填配置门禁"
+
+if grep -q 'secret-password' "$TARGET_DIR/docker-compose.judge.yml" "$DOCKER_LOG"; then
+  fail "部署产物或 Docker 日志泄露了 Redis 密码"
+fi
+pass "最终 secret 泄露检查"
+
+printf '全部独立 Judge 部署脚本测试通过\n'

--- a/scripts/deploy/test-noj.sh
+++ b/scripts/deploy/test-noj.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# noj 命令入口的无 Docker 路由测试。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_NOJ="$SCRIPT_DIR/../../noj"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-cli-test.XXXXXX")"
+NORMALIZED_TEST_ROOT="$(cd -P "$TEST_ROOT" && pwd)"
+LOG_FILE="$TEST_ROOT/route.log"
+COMMAND_BIN="$TEST_ROOT/commands"
+UPDATE_LOG="$TEST_ROOT/update.log"
+CUSTOM_ENV="$TEST_ROOT/custom.env"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+
+mkdir -p "$TEST_ROOT/scripts/deploy"
+cp "$SOURCE_NOJ" "$TEST_ROOT/noj"
+chmod 755 "$TEST_ROOT/noj"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -Eeuo pipefail' \
+  'printf "%s\n" "$*" >>"${NOJ_FAKE_LOG:?}"' \
+  'if [[ "${NOJ_FAKE_EXIT:-0}" != 0 ]]; then exit "$NOJ_FAKE_EXIT"; fi' \
+  >"$TEST_ROOT/scripts/deploy/deploy.sh"
+chmod 755 "$TEST_ROOT/scripts/deploy/deploy.sh"
+printf '%s\n' 'NOJ_VERSION=v-test' >"$TEST_ROOT/.env.prod"
+printf '%s\n' 'NOJ_VERSION=v-custom' >"$CUSTOM_ENV"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -Eeuo pipefail' \
+  'printf "bootstrap=%s\\n" "$0" >>"${NOJ_UPDATE_LOG:?}"' \
+  'printf "%s\n" "$*" >>"${NOJ_UPDATE_LOG:?}"' \
+  >"$TEST_ROOT/scripts/deploy/install.sh"
+chmod 755 "$TEST_ROOT/scripts/deploy/install.sh"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -Eeuo pipefail' \
+  'if [[ "${NOJ_UPDATE_TEST_API_FAIL:-0}" == 1 ]]; then exit 22; fi' \
+  'printf '\''{"tag_name":"%s","draft":false,"prerelease":false}\n'\'' "${NOJ_UPDATE_TEST_LATEST_TAG:-v0.2.0}"' \
+  >"$TEST_ROOT/curl"
+chmod 755 "$TEST_ROOT/curl"
+
+run_noj() {
+  NOJ_BIN_DIR="${NOJ_BIN_DIR:-$COMMAND_BIN}" \
+  NOJ_FAKE_LOG="$LOG_FILE" NOJ_UPDATE_LOG="$UPDATE_LOG" NOJ_FAKE_EXIT="${NOJ_FAKE_EXIT:-0}" \
+  NOJ_UPDATE_API_URL="${NOJ_UPDATE_API_URL:-https://api.test/releases/latest}" \
+  PATH="$TEST_ROOT:$PATH" \
+    "$TEST_ROOT/noj" "$@"
+}
+
+assert_last_route() {
+  local expected="$1" actual
+  actual="$(tail -n 1 "$LOG_FILE")"
+  [[ "$actual" == "$expected" ]] ||
+    fail "路由错误：期望 [$expected]，实际 [$actual]"
+}
+
+: >"$LOG_FILE"
+[[ "$(run_noj --help)" == *"Neuro OJ 生产运维命令"* ]] || fail "帮助输出缺少标题"
+[[ ! -s "$LOG_FILE" ]] || fail "帮助命令不应调用部署脚本"
+pass "帮助命令"
+
+for command in install start stop status logs backup verify; do
+  : >"$LOG_FILE"
+  run_noj "$command" --env-file /tmp/noj-test.env
+  assert_last_route "$command --env-file /tmp/noj-test.env"
+done
+[[ -L "$COMMAND_BIN/noj" ]] || fail "install 未注册 PATH 命令"
+cmp -s "$COMMAND_BIN/noj" "$TEST_ROOT/noj" || fail "PATH 命令未指向当前安装"
+pass "基础命令路由与参数透传"
+
+: >"$LOG_FILE"
+run_noj check --port 18080
+[[ ! -s "$LOG_FILE" ]] || fail "环境检查不应调用生产部署脚本"
+pass "环境检查入口"
+
+: >"$LOG_FILE"
+run_noj uninstall --yes
+assert_last_route "uninstall --yes"
+[[ ! -e "$COMMAND_BIN/noj" ]] || fail "uninstall 未移除当前安装的 PATH 命令"
+pass "uninstall 路由与当前 PATH 命令清理"
+
+: >"$LOG_FILE"
+run_noj install
+[[ -L "$COMMAND_BIN/noj" ]] || fail "重复注册破坏了 PATH 命令"
+pass "PATH 命令重复注册"
+
+: >"$LOG_FILE"
+run_noj uninstall --yes --dry-run >"$TEST_ROOT/uninstall-dry-run.out"
+assert_last_route "uninstall --yes --dry-run"
+[[ -L "$COMMAND_BIN/noj" ]] || fail "uninstall dry-run 不应移除 PATH 命令"
+pass "uninstall dry-run 无副作用"
+
+ln -s "$TEST_ROOT/noj" "$TEST_ROOT/linked-noj"
+: >"$LOG_FILE"
+NOJ_BIN_DIR="$TEST_ROOT/linked-commands" NOJ_FAKE_LOG="$LOG_FILE" NOJ_FAKE_EXIT=0 \
+  "$TEST_ROOT/linked-noj" status
+assert_last_route "status"
+pass "软链接调用定位安装目录"
+
+: >"$LOG_FILE"
+: >"$UPDATE_LOG"
+run_noj update --dry-run
+assert_last_route "upgrade --dry-run"
+grep -Fqx -- "--ref v-test --dir $NORMALIZED_TEST_ROOT --files-only --dry-run" "$UPDATE_LOG" ||
+  fail "update 未先同步配置版本的部署文件"
+bootstrap_path="$(sed -n 's/^bootstrap=//p' "$UPDATE_LOG" | tail -n 1)"
+[[ "$bootstrap_path" != "$TEST_ROOT/scripts/deploy/install.sh" && ! -e "$bootstrap_path" ]] ||
+  fail "update 仍直接执行或遗留安装目录中的 bootstrap"
+pass "update 同步部署文件并升级服务"
+
+: >"$LOG_FILE"
+run_noj update --env-file "$CUSTOM_ENV" --dry-run
+assert_last_route "upgrade --env-file $CUSTOM_ENV --dry-run"
+pass "update 路由到 upgrade"
+
+: >"$LOG_FILE"
+: >"$UPDATE_LOG"
+run_noj update --latest --dry-run >"$TEST_ROOT/latest-dry-run.out"
+grep -E -q '^upgrade --dry-run --env-file .+/.env.prod\.latest\.[A-Za-z0-9]+$' "$LOG_FILE" ||
+  fail "update --latest --dry-run 未使用版本配置暂存文件"
+grep -Fqx -- "--ref v0.2.0 --dir $NORMALIZED_TEST_ROOT --files-only --dry-run" "$UPDATE_LOG" ||
+  fail "update --latest --dry-run 未同步目标版本部署文件"
+grep -Fqx 'NOJ_VERSION=v-test' "$TEST_ROOT/.env.prod" ||
+  fail "update --latest --dry-run 不应修改生产版本配置"
+grep -q '最新稳定版本：v0.2.0' "$TEST_ROOT/latest-dry-run.out" ||
+  fail "update --latest 未展示目标版本"
+pass "update --latest dry-run"
+
+: >"$LOG_FILE"
+: >"$UPDATE_LOG"
+run_noj update --latest >"$TEST_ROOT/latest.out"
+grep -Fqx -- "--ref v0.2.0 --dir $NORMALIZED_TEST_ROOT --files-only" "$UPDATE_LOG" ||
+  fail "update --latest 未同步目标版本部署文件"
+grep -q '^NOJ_VERSION=v0.2.0$' "$TEST_ROOT/.env.prod" ||
+  fail "update --latest 成功后未提交目标版本配置"
+pass "update --latest 成功升级"
+
+before_noop_log="$(wc -l <"$LOG_FILE")"
+run_noj update --latest >"$TEST_ROOT/latest-noop.out"
+after_noop_log="$(wc -l <"$LOG_FILE")"
+[[ "$before_noop_log" == "$after_noop_log" ]] || fail "已经是最新版本时不应重启或升级"
+grep -q '无需升级' "$TEST_ROOT/latest-noop.out" || fail "已经是最新版本时未给出无操作提示"
+pass "update --latest 已是最新版本"
+
+before_rc_log="$(wc -l <"$LOG_FILE")"
+if NOJ_UPDATE_TEST_LATEST_TAG=v0.3.0-rc.1 \
+  run_noj update --latest >"$TEST_ROOT/latest-rc.out" 2>&1; then
+  fail "稳定版本自动升级不应选择 RC 标签"
+fi
+after_rc_log="$(wc -l <"$LOG_FILE")"
+[[ "$before_rc_log" == "$after_rc_log" ]] || fail "RC 标签被拒绝前不应进入升级流程"
+grep -E -q '不是稳定版本标签|无效或仍是预发布版本' "$TEST_ROOT/latest-rc.out" || fail "RC 标签拒绝提示不清晰"
+pass "update --latest 拒绝 RC 标签"
+
+cp "$TEST_ROOT/.env.prod" "$TEST_ROOT/api-failure.env"
+before_api_failure="$(sha256sum "$TEST_ROOT/api-failure.env" 2>/dev/null || shasum "$TEST_ROOT/api-failure.env")"
+if NOJ_UPDATE_TEST_API_FAIL=1 NOJ_UPDATE_API_URL=https://api.test/releases/latest \
+  run_noj update --latest --env-file "$TEST_ROOT/api-failure.env" >"$TEST_ROOT/latest-api-failure.out" 2>&1; then
+  fail "最新版本 API 失败时应返回非零退出码"
+fi
+after_api_failure="$(sha256sum "$TEST_ROOT/api-failure.env" 2>/dev/null || shasum "$TEST_ROOT/api-failure.env")"
+[[ "$before_api_failure" == "$after_api_failure" ]] || fail "最新版本 API 失败时修改了生产配置"
+pass "update --latest API 失败保护"
+
+cp "$TEST_ROOT/.env.prod" "$TEST_ROOT/upgrade-failure.env"
+before_upgrade_failure="$(sha256sum "$TEST_ROOT/upgrade-failure.env" 2>/dev/null || shasum "$TEST_ROOT/upgrade-failure.env")"
+if NOJ_UPDATE_TEST_LATEST_TAG=v0.3.0 NOJ_FAKE_EXIT=17 \
+  run_noj update --latest --env-file "$TEST_ROOT/upgrade-failure.env" >"$TEST_ROOT/latest-upgrade-failure.out" 2>&1; then
+  fail "升级失败时应返回非零退出码"
+fi
+after_upgrade_failure="$(sha256sum "$TEST_ROOT/upgrade-failure.env" 2>/dev/null || shasum "$TEST_ROOT/upgrade-failure.env")"
+[[ "$before_upgrade_failure" == "$after_upgrade_failure" ]] || fail "升级失败时修改了生产配置"
+pass "update --latest 升级失败保护"
+
+: >"$LOG_FILE"
+run_noj restart --env-file "$CUSTOM_ENV"
+[[ "$(sed -n '1p' "$LOG_FILE")" == "stop --env-file $CUSTOM_ENV" ]] || fail "restart 未先停止服务"
+[[ "$(sed -n '2p' "$LOG_FILE")" == "start --env-file $CUSTOM_ENV" ]] || fail "restart 未再启动服务"
+pass "restart 顺序"
+
+: >"$LOG_FILE"
+run_noj config check --env-file "$CUSTOM_ENV"
+assert_last_route "verify --env-file $CUSTOM_ENV"
+pass "config check 路由"
+
+: >"$LOG_FILE"
+if run_noj unknown >/dev/null 2>&1; then
+  fail "未知命令应返回非零退出码"
+fi
+[[ ! -s "$LOG_FILE" ]] || fail "未知命令不应调用部署脚本"
+pass "未知命令"
+
+: >"$LOG_FILE"
+if NOJ_FAKE_EXIT=17 run_noj status >/dev/null 2>&1; then
+  fail "底层部署脚本失败时 noj 应返回非零退出码"
+fi
+pass "底层退出码透传"
+
+mkdir -p "$TEST_ROOT/conflict-bin"
+printf 'existing command\n' >"$TEST_ROOT/conflict-bin/noj"
+NOJ_BIN_DIR="$TEST_ROOT/conflict-bin" run_noj install >"$TEST_ROOT/conflict.out" 2>&1 ||
+  fail "PATH 冲突不应导致已完成安装失败"
+grep -q '未覆盖已有命令' "$TEST_ROOT/conflict.out" || fail "PATH 冲突未给出保护提示"
+pass "已有同名命令保护"
+
+other_install="$TEST_ROOT/other-install"
+mkdir -p "$other_install"
+printf '#!/usr/bin/env bash\n' >"$other_install/noj"
+rm -f -- "$COMMAND_BIN/noj"
+ln -s "$other_install/noj" "$COMMAND_BIN/noj"
+: >"$LOG_FILE"
+run_noj uninstall --yes
+assert_last_route "uninstall --yes"
+[[ -L "$COMMAND_BIN/noj" ]] || fail "uninstall 错误删除了其他安装的 PATH 命令"
+pass "其他安装的 PATH 命令保护"
+
+rm -f -- "$COMMAND_BIN/noj"
+run_noj install >/dev/null
+before_uninstall_failure_link="$(readlink "$COMMAND_BIN/noj")"
+if NOJ_FAKE_EXIT=17 run_noj uninstall --yes >"$TEST_ROOT/uninstall-failure.out" 2>&1; then
+  fail "uninstall 底层失败时应返回非零退出码"
+fi
+[[ "$(readlink "$COMMAND_BIN/noj")" == "$before_uninstall_failure_link" ]] ||
+  fail "uninstall 失败时不应移除 PATH 命令"
+pass "uninstall 失败保护"
+
+printf 'not a directory\n' >"$TEST_ROOT/blocked-bin"
+HOME="$TEST_ROOT/fallback-home" \
+NOJ_BIN_DIR="$TEST_ROOT/blocked-bin/subdir" run_noj install >"$TEST_ROOT/fallback.out" 2>&1 ||
+  fail "全局目录不可写时不应导致已完成安装失败"
+[[ -L "$TEST_ROOT/fallback-home/.local/bin/noj" ]] || fail "全局目录不可用时未回退用户目录"
+grep -Fqx 'export PATH="$HOME/.local/bin:$PATH"' "$TEST_ROOT/fallback-home/.profile" ||
+  fail "用户目录回退时未补充登录 PATH"
+pass "用户级 PATH 回退"
+
+mv "$TEST_ROOT/scripts/deploy/deploy.sh" "$TEST_ROOT/scripts/deploy/deploy.sh.missing"
+if run_noj status >"$TEST_ROOT/missing.out" 2>&1; then
+  fail "缺少部署脚本时 noj 应返回非零退出码"
+fi
+grep -q '未找到生产部署脚本' "$TEST_ROOT/missing.out" || fail "缺少部署脚本时错误提示不清晰"
+pass "部署脚本缺失提示"
+
+mv "$TEST_ROOT/scripts/deploy/deploy.sh.missing" "$TEST_ROOT/scripts/deploy/deploy.sh"
+printf 'services:\n  fake:\n    image: alpine:3\n' >"$TEST_ROOT/docker-compose.prod.yml"
+mkdir "$TEST_ROOT/.git"
+if run_noj uninstall --all --yes >"$TEST_ROOT/uninstall-all-git.out" 2>&1; then
+  fail "uninstall --all 不应删除 Git 工作区"
+fi
+[[ -d "$TEST_ROOT" ]] || fail "Git 工作区保护失败后安装目录不应被删除"
+grep -q '检测到 Git 工作区' "$TEST_ROOT/uninstall-all-git.out" || fail "Git 工作区保护提示缺失"
+rmdir "$TEST_ROOT/.git"
+pass "uninstall --all Git 工作区保护"
+
+run_noj install >/dev/null
+all_output="$(run_noj uninstall --all --yes 2>&1)" || fail "uninstall --all 应成功删除完整安装目录"
+[[ "$all_output" == *"已删除 NOJ 安装目录"* ]] || fail "uninstall --all 未报告安装目录已删除"
+[[ ! -d "$TEST_ROOT" ]] || fail "uninstall --all 未删除当前安装目录"
+printf '✓ uninstall --all 删除安装目录\n'
+
+printf 'noj CLI 路由测试通过\n'

--- a/scripts/deploy/verify-compose-server.ts
+++ b/scripts/deploy/verify-compose-server.ts
@@ -1,4 +1,4 @@
-/** 校验 docker-compose.prod.yml 已从 noj-core/core 改名为 noj-server/server。 */
+/** 校验生产 Compose 的兼容命名：core 服务使用当前已发布的 noj-server 镜像。 */
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,31 +13,25 @@ export function verifyComposeServer(): string[] {
   const problems: string[] = [];
   const text = Deno.readTextFileSync(COMPOSE);
 
-  if (text.includes("noj-core")) {
-    problems.push("compose 仍出现 noj-core（应全部改名 noj-server）");
-  }
-  if (/^\s{2}core:\s*$/m.test(text)) {
-    problems.push("compose 仍存在服务 core（应为 server）");
-  }
-  if (!text.includes("x-server-env: &server-env")) {
+  if (!text.includes("x-core-env: &core-env")) {
     problems.push(
-      "compose 缺少锚点 x-server-env: &server-env（应替换 x-core-env）",
+      "compose 缺少兼容锚点 x-core-env: &core-env",
     );
   }
   if (!text.includes("/noj-server:${NOJ_VERSION")) {
     problems.push(
-      "compose server/migrate 镜像未使用 ghcr.io/neuro-oj/noj-server",
+      "compose core/migrate 镜像未使用当前已发布的 ghcr.io/neuro-oj/noj-server",
     );
   }
-  if (!/^\s{2}server:\s*$/m.test(text)) {
-    problems.push("compose 缺少服务 server");
+  if (!/^\s{2}core:\s*$/m.test(text)) {
+    problems.push("compose 缺少兼容服务 core");
   }
-  if (!text.includes("NUXT_API_BASE: http://server:8000")) {
-    problems.push("ui 的 NUXT_API_BASE 未指向 http://server:8000");
+  if (!text.includes("NUXT_API_BASE: http://core:8000")) {
+    problems.push("ui 的 NUXT_API_BASE 未指向 http://core:8000");
   }
-  // ui 的 depends_on 下必须有 server；该行缩进 6 空格，形如 `      server:`
-  if (!/^\s{6}server:\s*$/m.test(text)) {
-    problems.push("depends_on 中缺少 server 依赖项");
+  // ui 的 depends_on 下必须有 core；该行缩进 6 空格，形如 `      core:`
+  if (!/^\s{6}core:\s*$/m.test(text)) {
+    problems.push("depends_on 中缺少 core 依赖项");
   }
   return problems;
 }

--- a/scripts/deploy/verify-compose-server_test.ts
+++ b/scripts/deploy/verify-compose-server_test.ts
@@ -4,7 +4,7 @@ function assert(cond: unknown, msg: string): void {
   if (!cond) throw new Error(msg);
 }
 
-Deno.test("Compose 改名门禁：无 noj-core && 有 server", () => {
+Deno.test("Compose 兼容门禁：有 core 服务并使用 noj-server 镜像", () => {
   const problems = verifyComposeServer();
   assert(problems.length === 0, `应无问题，实际: ${problems.join("; ")}`);
 });

--- a/scripts/release/check-supply-chain.sh
+++ b/scripts/release/check-supply-chain.sh
@@ -105,6 +105,11 @@ check_compose() {
 check_release_workflow() {
   local file="$ROOT_DIR/.github/workflows/release.yml"
   require_file ".github/workflows/release.yml"
+  grep -Fq -- '- name: noj-server' "$file" \
+    || fail "Release workflow 未发布 noj-server 镜像"
+  if grep -Eq 'build-binaries|gh release upload|noj-cli-linux-(amd64|arm64)' "$file"; then
+    fail "Release workflow 不得构建或上传 noj-cli 二进制；CLI 应与生产镜像发布解耦"
+  fi
   grep -q 'provenance: mode=max' "$file" || fail "Release workflow 未启用 provenance"
   grep -q 'sbom: true' "$file" || fail "Release workflow 未启用 BuildKit SBOM"
   grep -q 'trivy' "$file" || fail "Release workflow 未配置漏洞扫描"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Neuro OJ 唯一公开的一键安装入口。
+#
+# 推荐用法：
+#   curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | bash
+#
+# setup.sh 只负责获取内部 bootstrap 并完成首次安装；安装完成后的服务启停、更新
+# 和管理统一使用安装目录中的 noj 命令。
+
+set -Eeuo pipefail
+
+readonly BOOTSTRAP_URL="${NOJ_SETUP_BOOTSTRAP_URL:-https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/scripts/deploy/install.sh}"
+tmp_file="$(mktemp "${TMPDIR:-/tmp}/noj-setup.XXXXXX")"
+cleanup() { rm -f -- "$tmp_file"; }
+trap cleanup EXIT
+
+if command -v curl >/dev/null 2>&1; then
+  curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+    --retry 3 --connect-timeout 15 --output "$tmp_file" "$BOOTSTRAP_URL" || {
+    printf '无法下载 NOJ 安装程序。请检查网络，或先下载 setup.sh 后人工检查再执行。\n' >&2
+    exit 1
+  }
+elif command -v wget >/dev/null 2>&1; then
+  wget --https-only --tries=3 --timeout=20 --quiet --output-document="$tmp_file" "$BOOTSTRAP_URL" || {
+    printf '无法下载 NOJ 安装程序。请检查网络，或先下载 setup.sh 后人工检查再执行。\n' >&2
+    exit 1
+  }
+else
+  printf '需要 curl 或 wget。请先安装其中一个，再重新执行一键安装命令。\n' >&2
+  exit 1
+fi
+
+[[ -s "$tmp_file" ]] || { printf '下载的 NOJ 安装程序为空。\n' >&2; exit 1; }
+exec bash "$tmp_file" "$@"


### PR DESCRIPTION
## 变更摘要

- 恢复 setup.sh 一键安装入口、noj 运维命令及 deploy 下的生产部署/备份/Judge 脚本。
- 修复非空安装目录阻断：仅更新 NOJ 部署文件和命令，保留配置、备份、数据卷及其他文件。
- 恢复 core 服务兼容命名，同时继续使用当前已发布的 noj-server 镜像。
- noj-cli 保留为独立源码工具，移除 GitHub Release 二进制构建和上传。
- 增加发布工作流防回归检查，并同步部署文档。

## 验证

- bash 脚本语法检查
- 部署、备份、Judge、noj 入口测试全部通过
- Compose 与供应链门禁通过
- CI 仓库级门禁通过
- noj-cli deno task check 通过

## 说明

本 PR 不修改 noj-cli 的源码功能，仅调整其与生产部署及 GitHub Release 的边界。