### PR TITLE
feat(core,ui): 配置分层语义治理——scope 两分法统一注册表

### DIFF
--- a/.agents/notes/implemented/architecture/2026-09-02-config-layering-semantics.md
+++ b/.agents/notes/implemented/architecture/2026-09-02-config-layering-semantics.md
@@ -1,0 +1,67 @@
+# Agent Note: 配置分层语义治理——scope 两分法统一注册表
+
+Status: implemented
+日期: 2026-09-02
+
+## Problem
+
+noj-core 存在三套并存、职责不清的配置来源：DB-backed 设置（66 项，admin 可改，
+读取链 DB→env→default）、env-only 白名单（13 项，后台只读展示）、纯 infra/ops env
+（约 30 项直接 `Deno.env.get`，后台完全不可见）。核心痛点：
+
+- 66 个 DB-backed 项混着两种生命周期（可热改 vs 启动期定型），注册表只对个别项标
+  `needsRestart`，运营者无法预知改了什么要重启；
+- env fallback 的"遮蔽"语义无人讲清：DB 有值就完全忽略 env，运维改了 `.env` 重启
+  后仍不生效，除非先去后台点"重置"；
+- 前端硬编码键白名单/分类，后端元数据多份手写副本（.env.example、check-env、
+  CLAUDE.md、docs），注册表注释与实际数量漂移。
+
+## Decision
+
+建立**生命周期两分法（scope）**语义，每个配置项有唯一归属：
+
+- **runtime（DB-owned）**：运行时可热改，读取链 `DB → env(仅兜底) → default`，
+  后台可改可重置；
+- **bootstrap（env-owned）**：启动期定型，读取链 `env → default`（不读 DB），
+  后台只读。
+
+落地方式：
+
+1. `settings-registry.ts` 合并 `SETTING_DEFINITIONS` + `ENV_ONLY_DEFINITIONS` 为
+   单一 `CONFIG_DEFINITIONS` 注册表，每项声明 `scope` + `envKey`（bootstrap）/
+   `envFallback`（runtime）；原 13 项 env-only 与 ~40 项 infra env（TFA/OAuth/LLM/
+   日志/评测等，开发测试键 `visible:false`）全部登记入册；
+2. storage(7) + email(9) + audit_log_retention_days(1) = 17 项按功能组整组划归
+   bootstrap（provider 单例/邮件 sendFn 缓存/保留任务均启动期定型）；
+3. `getSetting` 按 scope 分支：bootstrap 跳过 DB Map 直接读 env 快照；
+   `initSystemSettings` 不缓存 bootstrap 键；`updateSetting` 拒绝写 bootstrap 键；
+4. **存量不迁移**：bootstrap 项忽略 DB 残留旧值，启动日志提示 + 后台
+   `db_orphaned` 徽标 + DELETE 一键清理（`cleanupBootstrapRow`）；
+5. `listSettings` 返回全部可见项（bootstrap 未配置也返回，显示"未配置"），带
+   scope/visible/db_orphaned 元数据；`validateRegistry` 校验 scope 完整性与 env 键
+   唯一性；
+6. `settings.vue` 按 scope 两段渲染，删除硬编码 `ENV_ONLY_KEYS` 白名单与分类表；
+7. `check-env` 新增 `inspectConsistency`：可见 bootstrap 键必须出现在 .env.example
+   （注释示例也算声明），孤儿键警告（编排级白名单豁免）；
+8. 补齐 `.env.example` 缺失键（DATABASE_POOL_*、BCRYPT_SALT_ROUNDS、
+   CORS_ALLOWED_ORIGINS、NOJ_ENV、搜索限流 4 键等）。
+
+## Alternatives considered
+
+- **保留现状 + 强化语义表达**：不改数据归属，仅把规则讲透。缺点：storage/email
+  等启动定型项仍可被后台误写，DB 残留造成"改了不生效"的坑仍在。
+- **按单键生命周期收归（只收启动定型单键，凭据留 DB）**：会造成"provider 归 env、
+  密钥归 DB"的功能组割裂，故按功能组整组收归。
+- **存量自动清理迁移**：有静默丢配置风险，改为忽略 + 提示 + 一键清理。
+- **自动生成 .env.example**：丢失手写精细注释，仅做一致性校验。
+
+## Consequences
+
+- 配置语义清晰：后台两段 = 运行时配置（即时生效）/ 环境配置（改 env 重启）；
+- 前端不再硬编码后端元数据，注册表是唯一真源，check-env 阻止模板漂移；
+- 17 项划归后，若某环境只在 DB 配过 S3/邮件，切换后需在 env 补齐否则回退默认——
+  通过启动日志 + 后台徽标缓解；
+- `email_provider` 的 sendFn 缓存与 `storage_provider` 单例是"首次访问定型"而非
+  严格启动定型，文档已注明首次使用后需重启；
+- 风险：bootstrap 项读取依赖 `snapshotEnv()` 先于使用方初始化（main.ts 顺序已保证）；
+  测试环境（PGlite）快照为空时 bootstrap 项回退默认，语义正确。

--- a/dev-docs/engineering/config-layering.md
+++ b/dev-docs/engineering/config-layering.md
@@ -1,28 +1,64 @@
 # NOJ 配置分层
 
-NOJ 使用“环境模板 + 本地覆盖 + 校验”的配置分层，不引入额外配置框架。
+NOJ 使用"环境模板 + 本地覆盖 + 校验 + 生命周期归属"的配置体系。每个配置项由
+**统一注册表**（noj-core `src/shared/config/settings-registry.ts` 的
+`CONFIG_DEFINITIONS`）声明 归属（scope）与 env 键名，消灭多份手写副本。
 
-## 分层
+## 生命周期两分法（scope）
 
-| 层 | 文件 | 用途 |
-|---|---|---|
-| 模块模板 | `noj-core/.env.example` / `noj-llm-gateway/.env.example` | 模块级环境变量说明 |
-| E2E 模板 | `env.e2e.template` | 跨模块 E2E 固定测试配置 |
-| 生产模板 | `.env.prod.example` | 生产部署变量模板（不含真实密钥） |
-| 本地覆盖 | `noj-core/.env` 等 | 开发者本地实际值，gitignored |
+| scope                      | 存储                            | 读取链                      | 变更方式               | 后台                 |
+| -------------------------- | ------------------------------- | --------------------------- | ---------------------- | -------------------- |
+| **runtime**（DB-owned）    | DB `system_settings`            | `DB → env(仅兜底) → 默认值` | 管理后台写入，即时生效 | 可改、可重置         |
+| **bootstrap**（env-owned） | env（.env / compose / secrets） | `env → 默认值`（不读 DB）   | 改 env + 重启 noj-core | 只读展示（含未配置） |
+
+- runtime
+  项示例：限流、社区开关、审核阈值、`allow_register`、`maintenance_mode`；
+- bootstrap 项示例：`DATABASE_URL`/`JWT_SECRET`/`PORT` 等基础设施，以及
+  storage/email/审计保留等"启动期定型"项（改后需重启，故归 env 单一事实源）；
+- bootstrap 项在 DB 中的残留旧值**被忽略**（启动日志提示 +
+  后台徽标），可一键清理。
+
+## 配置来源分层
+
+| 层         | 文件                                                     | 用途                                                   |
+| ---------- | -------------------------------------------------------- | ------------------------------------------------------ |
+| 统一注册表 | `noj-core/src/shared/config/settings-registry.ts`                  | **单一事实源**：scope/type/默认值/secret/env 键名/分类 |
+| 模块模板   | `noj-core/.env.example` / `noj-llm-gateway/.env.example` | 模块级环境变量说明（与注册表一致，由 check-env 校验）  |
+| E2E 模板   | `env.e2e.template`                                       | 跨模块 E2E 固定测试配置                                |
+| 本地覆盖   | `noj-core/.env` 等                                       | 开发者本地实际值，gitignored                           |
+| 运行时配置 | DB `system_settings`（管理后台写入）                     | runtime 项的当前值                                     |
 
 ## 规则
 
-1. 新环境变量必须同步加入对应模块 `.env.example`（或 `.env.prod.example`）。
-2. 模板中禁止硬编码真实凭据；占位符应使用 `change-this-*` 等可被 `check-env.ts` 识别的形式。
-3. 生产部署必须显式注入 `JWT_SECRET`、`DATABASE_URL`、`TRUSTED_PROXIES` 等关键变量。
-4. `check-env.ts` 负责校验占位符与必填项，CI 不跑 strict 模式（CI 使用 Secrets）。
+1. **新配置项/新环境变量必须登记入注册表**（`CONFIG_DEFINITIONS`，声明 scope +
+   envKey/envFallback + type + 分类），并同步 `.env.example`；
+2. 生命周期划分：**运行时可热改 → runtime（DB）**；**启动期定型/基础设施 →
+   bootstrap（env）**，禁止把启动期定型项做成 DB 可写；
+3. bootstrap 项 env 键在注册表中唯一（`validateRegistry()` 启动校验，两个设置项
+   不得共用一个 env 变量）；
+4. 模板中禁止硬编码真实凭据；占位符应使用 `change-this-*` 等可被 `check-env.ts`
+   识别的形式；
+5. 生产部署必须显式注入 `JWT_SECRET`、`DATABASE_URL`、`TRUSTED_PROXIES`
+   等关键变量。
+
+### runtime env/DB 共存提示
+
+- 当某个 runtime 项**同时存在 DB 写入值与 env 兜底**时，当前实际生效的是 DB 值，
+  env 被遮蔽，容易造成“改了 .env 不生效”的歧义。
+- noj-core 启动时会输出 warning，列出 `key (envKey)`，建议移除 `.env`
+  中对应变量； 管理后台设置页进入时也会弹窗提示，并在 runtime 表格行上显示“env
+  兜底存在”徽标。
+- 该提示**不改变读取/写入行为**，仅用于提醒避免双源共存。
 
 ## 校验
 
 ```bash
 cd noj-core
-deno task check:env          # 基础校验
+deno task check:env          # 基础校验（占位符 + 注册表↔.env.example 键覆盖一致性）
 deno task check:env:strict   # 严格校验（本地开发用）
 deno task check:prod         # 校验生产模板
 ```
+
+`check-env` 的一致性检查：每个可见 bootstrap 键必须出现在 `.env.example`
+（注释示例也算）；`.env.example` 中注册表未登记的键按孤儿警告（部署编排级键
+白名单豁免）。

--- a/noj-core/.env.example
+++ b/noj-core/.env.example
@@ -11,6 +11,11 @@
 #      都会被 `deno task check:env` 脚本主动拦截，防止误用于生产。
 # ============================================================
 DATABASE_URL=postgres://noj:noj@localhost:5432/noj
+# 连接池参数（可选，默认见 db/connection.ts）
+# DATABASE_POOL_MAX=20
+# DATABASE_CONNECT_TIMEOUT=10
+# DATABASE_IDLE_TIMEOUT=30
+# DATABASE_MAX_LIFETIME=3600
 JWT_SECRET=change-this-to-a-strong-random-secret
 # TFA TOTP secret 加密密钥（必填，≥32 字符，与 JWT_SECRET 隔离）
 TFA_ENCRYPTION_KEY=change-this-to-a-strong-tfa-encryption-key
@@ -38,6 +43,14 @@ PORT=8000
 # RESULT_CONSUMER_CONCURRENCY=4
 # 密码重置邮件链接的可信应用地址；生产环境必须配置固定的 HTTPS 地址
 APP_URL=http://localhost:3000
+# noj-llm-gateway 内部服务地址（LLM 评测调用）
+# NOJ_LLM_GATEWAY_URL=http://localhost:8010
+# 允许 HTTP 明文回调（仅开发调试；生产必须保持 false/未设置）
+# NOJ_ALLOW_INSECURE_HTTP=false
+# 运行环境：空=development / production=生产（影响日志级别、CORS 等默认行为）
+# NOJ_ENV=development
+# 生产 CORS 白名单（逗号分隔 Origin；生产环境**必须**配置）
+# CORS_ALLOWED_ORIGINS=https://oj.example.com
 
 # ── 日志 ────────────────────────────────────────────────────
 # 日志级别：debug / info / warn / error。
@@ -52,6 +65,8 @@ APP_URL=http://localhost:3000
 ADMIN_EMAIL=change-me-admin@example.com
 # 管理员密码（需要与 ADMIN_EMAIL 配合使用；未设置但 ADMIN_EMAIL 对应已注册用户时仅提权）
 ADMIN_PASS=change-me-password-123
+# bcrypt 哈希轮数（修改影响已有密码一致性校验；测试建议低值加速）
+# BCRYPT_SALT_ROUNDS=12
 
 # ── 第三方登录（可选）─────────────────────────────────────
 # GitHub OAuth：两项同时填写后登录页显示 GitHub 按钮
@@ -80,6 +95,11 @@ RATE_LIMIT_LOGIN_BACKOFF_SEC=15
 # 失败锁定：连续 10 次失败后账号锁 1 小时
 RATE_LIMIT_LOGIN_LOCK_THRESHOLD=10
 RATE_LIMIT_LOGIN_LOCK_SECONDS=3600
+# 搜索限流：窗口内匿名/登录最大搜索次数
+# RATE_LIMIT_SEARCH_ENABLED=true
+# RATE_LIMIT_SEARCH_WINDOW=30
+# RATE_LIMIT_SEARCH_MAX_ANON=60
+# RATE_LIMIT_SEARCH_MAX_AUTHED=120
 # 可信代理白名单（逗号分隔 IP/CIDR）。配置后从 XFF 链中提取客户端 IP；
 # 留空则开发模式直接信任 XFF 首项。生产环境**必须**配置。
 TRUSTED_PROXIES=
@@ -105,6 +125,8 @@ TENCENT_REGION=ap-guangzhou
 # ── 对象存储 ──────────────────────────────────────────
 # 存储 Provider：local（开发测试用）或 s3（生产环境）
 STORAGE_PROVIDER=local
+# 本地存储目录（STORAGE_PROVIDER=local 时使用；默认 data/support-packages）
+# SUPPORT_PACKAGE_DIR=./data/support-packages
 # S3 兼容对象存储配置（STORAGE_PROVIDER=s3 时必填）
 S3_ENDPOINT=http://localhost:9000
 S3_REGION=us-east-1
@@ -114,6 +136,8 @@ S3_BUCKET=noj-support-packages
 S3_FORCE_PATH_STYLE=true
 # artifact 提交 NOJ 硬上限（MB），默认 2048（2GB）
 # NOJ_ARTIFACT_MAX_SIZE_MB=2048
+# Judge 评测镜像仓库前缀（seed 默认镜像使用）
+# JUDGE_IMAGE_BASE=ghcr.io/neuro-oj
 
 # ── 系统设置（issue #99）─────────────────────────────────
 # 以下 5 项可在「管理后台 > 系统设置」运行时修改，env 值仅作启动期 fallback。

--- a/noj-core/CLAUDE.md
+++ b/noj-core/CLAUDE.md
@@ -139,7 +139,27 @@ noj-core/
 
 ## 环境变量
 
-从 `.env` 文件或 `Deno.env` 读取。**必须配置**：
+从 `.env` 文件或 `Deno.env` 读取。**配置分层语义（scope）**：
+
+- **runtime（DB-owned，运行时可热改）**：`管理后台 > 系统设置 > 运行时配置` 写入
+  DB 即时生效；env 值仅作启动期/开发环境兜底（DB 未写入时），读取链
+  `DB → env → 默认值`。下表标注"可热改"的项属此类。
+- **bootstrap（env-owned，启动期定型只读）**：由 env 唯一决定，读取链
+  `env → 默认值`（**不读 DB**，DB
+  残留旧值被忽略）。`管理后台 > 系统设置 >
+  环境配置` 只读展示全部 bootstrap
+  项（含未配置）；改 .env 后需重启 noj-core。 标注"后台只读"的项属此类。
+
+> 注册表单一事实源：`src/shared/config/settings-registry.ts` 的
+> `CONFIG_DEFINITIONS`（scope + envKey/envFallback）。新 env
+> 变量必须登记入注册表，并同步 `.env.example`； `deno task check:env`
+> 会校验注册表与 `.env.example` 键覆盖一致性。
+
+> **runtime 共存提示**：当 runtime 项同时存在 DB 值与 env 兜底时，当前 DB
+> 值优先， env 被遮蔽；启动日志会 warning，后台设置页进入时弹窗并显示“env
+> 兜底存在”徽标， 建议移除 `.env` 对应变量以避免歧义。
+
+**必须配置**（bootstrap，后台只读）：
 
 | 变量                              | 默认值                    | 说明                                                          |
 | --------------------------------- | ------------------------- | ------------------------------------------------------------- |

--- a/noj-core/scripts/check-env.ts
+++ b/noj-core/scripts/check-env.ts
@@ -27,8 +27,9 @@
  * 后续可在 PR #69 合并后把本脚本接入 seed.ts 早期校验。
  */
 
-import { MIN_JWT_SECRET_LENGTH } from "./../src/shared/base/constants.ts";
-import { MIN_TFA_ENCRYPTION_KEY_LENGTH } from "./../src/shared/base/constants.ts";
+import { MIN_JWT_SECRET_LENGTH } from "../src/shared/base/constants.ts";
+import { MIN_TFA_ENCRYPTION_KEY_LENGTH } from "../src/shared/base/constants.ts";
+import { CONFIG_DEFINITIONS } from "../src/shared/config/settings-registry.ts";
 
 // 已知占位值黑名单（不区分大小写）。命中即视为未配置。
 const PLACEHOLDER_PATTERNS: readonly RegExp[] = [
@@ -86,6 +87,98 @@ interface Finding {
   key: string;
   display: string;
   reason: string;
+}
+
+/**
+ * 解析 .env.example 中"已声明"的键：活动键（KEY=value）与注释示例键
+ * （# KEY=value）都算已文档化。
+ */
+function parseExampleKeys(path: string): Set<string> {
+  const keys = new Set<string>();
+  let text: string;
+  try {
+    text = Deno.readTextFileSync(path);
+  } catch {
+    return keys;
+  }
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    // 去掉行首 #（注释示例也算声明），取 KEY= 部分
+    const noComment = line.startsWith("#") ? line.slice(1).trim() : line;
+    const eq = noComment.indexOf("=");
+    if (eq <= 0) continue;
+    const key = noComment.slice(0, eq).trim();
+    if (/^[A-Z][A-Z0-9_]*$/.test(key)) keys.add(key);
+  }
+  return keys;
+}
+
+/** 部署编排级键白名单：属于 compose/脚本而非 noj-core 直接读取，豁免孤儿检查 */
+const EXAMPLE_ORCHESTRATION_KEYS = new Set([
+  "NOJ_VERSION",
+  "POSTGRES_PASSWORD",
+  "POSTGRES_DB",
+  "POSTGRES_USER",
+  "REDIS_PASSWORD",
+  "MINIO_ROOT_USER",
+  "MINIO_ROOT_PASSWORD",
+  "NOJ_LLM_STORE_KEY",
+  "NOJ_LLM_PORT",
+  "NOJ_LLM_DATABASE_URL",
+  "NOJ_LLM_REDIS_URL",
+  "NOJ_LLM_LOG_LEVEL",
+  "NOJ_LLM_MAX_CALLS_PER_MINUTE",
+  "NOJ_LLM_MAX_TOKENS_PER_MINUTE",
+  "NUXT_API_BASE",
+  "NUXT_NOJ_ENV",
+  "NUXT_ALLOW_INSECURE_HTTP",
+  "NODE_ENV",
+]);
+
+/**
+ * 校验注册表（config-registry）与 .env.example 的键覆盖一致性。
+ * - 每个可见 bootstrap 项的 envKey 必须出现在 .env.example；
+ * - runtime envFallback 缺失仅警告（多为可选兜底）；
+ * - .env.example 中注册表未声明的键给出孤儿警告（编排级白名单豁免）。
+ */
+export function inspectConsistency(
+  registryKeys: readonly string[],
+  exampleKeys: Set<string>,
+): Finding[] {
+  const findings: Finding[] = [];
+
+  for (const def of CONFIG_DEFINITIONS) {
+    if (def.scope === "bootstrap" && def.visible !== false) {
+      if (!exampleKeys.has(def.envKey!)) {
+        findings.push({
+          key: def.envKey!,
+          display: "(缺失)",
+          reason: "注册表 bootstrap 项未在 .env.example 中声明",
+        });
+      }
+    }
+  }
+
+  for (const key of exampleKeys) {
+    const registered = registryKeys.includes(key);
+    if (!registered && !EXAMPLE_ORCHESTRATION_KEYS.has(key)) {
+      findings.push({
+        key,
+        display: "[孤儿]",
+        reason: ".env.example 中声明但注册表未登记（疑似废弃键）",
+      });
+    }
+  }
+
+  return findings;
+}
+
+/** 注册表声明的全部 env 键（bootstrap envKey + runtime envFallback） */
+function registryEnvKeys(): string[] {
+  return CONFIG_DEFINITIONS
+    .map((d) => (d.scope === "bootstrap" ? d.envKey : d.envFallback))
+    .filter((k): k is string => Boolean(k));
 }
 
 function inspect(env: Map<string, string>): Finding[] {
@@ -275,6 +368,18 @@ function main(): void {
     ...(production ? inspectProduction(env, envPath) : []),
   ];
 
+  // 注册表 ↔ .env.example 一致性（仅检查 .env 时附带校验模板覆盖）
+  if (envPath.endsWith(".env") && !envPath.endsWith(".env.example")) {
+    const examplePath = envPath + ".example";
+    const exampleKeys = parseExampleKeys(examplePath);
+    if (exampleKeys.size > 0) {
+      const consistency = inspectConsistency(registryEnvKeys(), exampleKeys);
+      for (const f of consistency) {
+        findings.push({ ...f, display: `${f.display}（.env.example）` });
+      }
+    }
+  }
+
   if (findings.length === 0) {
     console.log(
       `[check-env] ✅ ${envPath} 通过检查（${env.size} 个键，0 个占位值）`,
@@ -299,4 +404,6 @@ function main(): void {
   }
 }
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/noj-core/src/domains/system/routes/admin-settings.ts
+++ b/noj-core/src/domains/system/routes/admin-settings.ts
@@ -1,8 +1,10 @@
 import { Hono } from "hono";
-import type { AuthEnv } from "./../../identity/index.ts";
-import { parseJsonBody } from "./../../../shared/http/request.ts";
-import { BadRequestError } from "./../../../shared/base/errors.ts";
+import type { AuthEnv } from "../../identity/index.ts";
+import { parseJsonBody } from "../../../shared/http/request.ts";
+import { BadRequestError } from "../../../shared/base/errors.ts";
+import { isBootstrap } from "../../../shared/config/settings-registry.ts";
 import {
+  cleanupBootstrapRow,
   listSettings,
   resetSetting,
   updateSetting,
@@ -12,14 +14,15 @@ import {
  * 管理端系统设置路由（issue #99，挂载前缀 /api/v1/admin，见 admin/index.ts）。
  *
  * 提供：
- * - GET    /settings          列出所有设置项（DB-backed 5 项 + env-only N 项）
- * - PUT    /settings/:key     更新单个设置项（UPSERT）
- * - DELETE /settings/:key     重置单个设置项（回退到 env/default）
+ * - GET    /settings          列出全部配置项（runtime + bootstrap，含元数据）
+ * - PUT    /settings/:key     更新 runtime 项（UPSERT）；bootstrap 项返回 400
+ * - DELETE /settings/:key     runtime 项重置（回退 env/default）；
+ *                             bootstrap 项清理残留 DB 行（幂等）
  */
 const router = new Hono<AuthEnv>();
 
 /**
- * 列出所有系统设置项（DB-backed 5 项 + env-only N 项）。
+ * 列出全部配置项（runtime + bootstrap）。
  * GET /api/v1/admin/settings
  *
  * 注意：必须先注册静态路径 `/settings`，再注册参数化路径 `/settings/:key`，
@@ -31,7 +34,7 @@ router.get("/settings", async (c) => {
 });
 
 /**
- * 更新单个设置项（UPSERT）。
+ * 更新 runtime 项（UPSERT）。bootstrap 项由 service 层拒绝（400）。
  * PUT /api/v1/admin/settings/:key
  * body: { value: boolean | string }
  */
@@ -46,13 +49,20 @@ router.put("/settings/:key", async (c) => {
 });
 
 /**
- * 重置单个设置项（DELETE FROM system_settings，回退到 env/default）。
+ * 删除设置：
+ * - runtime 项：DELETE system_settings 行，回退到 env/default；
+ * - bootstrap 项：清理被忽略的残留 DB 行（值仍由 env 决定）。
  * DELETE /api/v1/admin/settings/:key
  * 幂等：DB 不存在也正常返回 204。
  */
 router.delete("/settings/:key", async (c) => {
   const key = c.req.param("key") as string;
-  await resetSetting(key, c.get("userId"));
+  const userId = c.get("userId");
+  if (isBootstrap(key)) {
+    await cleanupBootstrapRow(key, userId);
+  } else {
+    await resetSetting(key, userId);
+  }
   return c.body(null, 204);
 });
 

--- a/noj-core/src/domains/system/services/env-snapshot.ts
+++ b/noj-core/src/domains/system/services/env-snapshot.ts
@@ -1,125 +1,26 @@
 /**
- * 环境变量启动期快照（issue #99）。
+ * 环境变量启动期快照（issue #99 演进：配置分层语义治理）。
  *
  * 在 main.ts 启动顺序的"DB 迁移之后、MQ 消费者启动之前"调用 snapshotEnv()，
- * 一次性把白名单 env 键的当前值快照到 module-level envSnapshot 对象。
+ * 一次性把 bootstrap（env-owned）配置项的 env 键当前值快照到 module-level
+ * envSnapshot 对象。
  *
  * 后续所有"环境变量"读取走 snapshot，不直接调 Deno.env.get：
  * - 性能：O(1) 内存读 vs 系统调用
- * - 语义：env-only 设置项与 DB-backed 设置项同构（都是 Map 查找）
+ * - 语义：bootstrap 项与 runtime 项同构（都是 Map 查找）
  * - 测试：通过 _resetEnvSnapshotForTest 重置快照状态
  *
- * 与 settings-registry 的区别：
- * - settings-registry 定义 DB-backed 设置项（admin 可改）
- * - env-snapshot 定义 env-only 设置项（只读，admin 不可改）
+ * 快照键来源为统一注册表（settings-registry.ts）中所有 scope=bootstrap 的
+ * envKey（含原 env-only 白名单与划归的 storage/email/audit 启动期项）。
  */
 
-import type { SettingCategory } from "../../../shared/config/settings-registry.ts";
+import { CONFIG_DEFINITIONS } from "../../../shared/config/settings-registry.ts";
 
-/** env-only 设置项的元数据（只读展示用，admin 不可改） */
-export interface EnvOnlyDefinition {
-  key: string;
-  description: string;
-  is_secret: boolean;
-  category: SettingCategory;
+/** 快照白名单：所有 bootstrap 项的 envKey（原 ENV_ONLY_DEFINITIONS 已被注册表吸收） */
+export function getBootstrapEnvKeys(): string[] {
+  return CONFIG_DEFINITIONS.filter((d) => d.scope === "bootstrap")
+    .map((d) => d.envKey!);
 }
-
-/**
- * env-only 白名单（启动期快照键名）。
- * 仅保留基础设施配置项（DB 可用前就需要或启动期行为相关）。
- * 应用层配置项已在 settings-registry.ts 中定义为 DB-backed。
- *
- * 顺序敏感：管理后台按此顺序展示，分组用 category 字段。
- */
-export const ENV_ONLY_DEFINITIONS: readonly EnvOnlyDefinition[] = [
-  // ── 数据库 ───────────────────────────────────────────────
-  {
-    key: "DATABASE_URL",
-    description: "PostgreSQL 连接串",
-    is_secret: true,
-    category: "database",
-  },
-  {
-    key: "DATABASE_POOL_MAX",
-    description: "连接池大小",
-    is_secret: false,
-    category: "database",
-  },
-  {
-    key: "DATABASE_CONNECT_TIMEOUT",
-    description: "连接超时（秒）",
-    is_secret: false,
-    category: "database",
-  },
-  {
-    key: "DATABASE_IDLE_TIMEOUT",
-    description: "空闲连接超时（秒）",
-    is_secret: false,
-    category: "database",
-  },
-  {
-    key: "DATABASE_MAX_LIFETIME",
-    description: "连接最大生命周期（秒）",
-    is_secret: false,
-    category: "database",
-  },
-
-  // ── Redis ────────────────────────────────────────────────
-  {
-    key: "REDIS_URL",
-    description: "Redis 连接串",
-    is_secret: true,
-    category: "redis",
-  },
-
-  // ── 认证 ─────────────────────────────────────────────────
-  {
-    key: "JWT_SECRET",
-    description: "JWT 签名密钥（≥32 字符）",
-    is_secret: true,
-    category: "auth",
-  },
-  {
-    key: "ADMIN_EMAIL",
-    description: "Seed 管理员邮箱",
-    is_secret: false,
-    category: "auth",
-  },
-  {
-    key: "ADMIN_PASS",
-    description: "Seed 管理员密码",
-    is_secret: true,
-    category: "auth",
-  },
-  {
-    key: "BCRYPT_SALT_ROUNDS",
-    description: "bcrypt 哈希轮数（修改影响已有密码一致性）",
-    is_secret: false,
-    category: "auth",
-  },
-
-  // ── CORS ─────────────────────────────────────────────────
-  {
-    key: "CORS_ALLOWED_ORIGINS",
-    description: "生产 CORS 白名单（逗号分隔）",
-    is_secret: false,
-    category: "cors",
-  },
-
-  // ── 其他 ─────────────────────────────────────────────────
-  {
-    key: "PORT",
-    description: "HTTP 监听端口",
-    is_secret: false,
-    category: "other",
-  },
-  {
-    key: "NOJ_ENV",
-    description: "运行环境（空=development，production=生产）",
-    is_secret: false,
-    category: "other",
-  },
-] as const;
 
 /** module-level 快照：env 键 -> 当前值（undefined 表示未设置） */
 let envSnapshot: Record<string, string | undefined> = {};
@@ -129,7 +30,7 @@ let _snapshotted = false;
 
 /**
  * 执行启动期快照。
- * 遍历 ENV_ONLY_DEFINITIONS 把 Deno.env.get 结果写入 envSnapshot。
+ * 遍历 bootstrap 项的 envKey 把 Deno.env.get 结果写入 envSnapshot。
  *
  * 应在 main.ts 启动顺序的"DB 迁移之后"调用一次。
  */
@@ -139,8 +40,8 @@ export function snapshotEnv(): Record<string, string | undefined> {
   }
 
   const snap: Record<string, string | undefined> = {};
-  for (const def of ENV_ONLY_DEFINITIONS) {
-    snap[def.key] = Deno.env.get(def.key);
+  for (const envKey of getBootstrapEnvKeys()) {
+    snap[envKey] = Deno.env.get(envKey);
   }
   envSnapshot = snap;
   _snapshotted = true;

--- a/noj-core/src/domains/system/services/system-settings.ts
+++ b/noj-core/src/domains/system/services/system-settings.ts
@@ -16,21 +16,24 @@
  * 审计日志：已迁移至 logAudit()（issue #101）。
  */
 
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import {
   getDb,
   registerDbResetCallback,
-} from "./../../../shared/db/connection.ts";
-import { systemSettings } from "./../../../shared/db/schema.ts";
-import { ValidationError } from "./../../../shared/base/errors.ts";
+} from "../../../shared/db/connection.ts";
+import { systemSettings } from "../../../shared/db/schema.ts";
+import { ValidationError } from "../../../shared/base/errors.ts";
 import { logAudit } from "./audit-log.ts";
-import { ENV_ONLY_DEFINITIONS, getEnvSnapshotValue } from "./env-snapshot.ts";
+import { getEnvSnapshotValue } from "./env-snapshot.ts";
 import {
+  CONFIG_DEFINITIONS,
+  type ConfigScope,
   findDefinition,
-  SETTING_DEFINITIONS,
+  isBootstrap,
   type SettingCategory,
+  type SettingDefinition,
   type SettingType,
-} from "./../../../shared/config/settings-registry.ts";
+} from "../../../shared/config/settings-registry.ts";
 
 /** 单条设置项的解析后值（含来源溯源） */
 export interface SettingValue {
@@ -55,6 +58,8 @@ export interface SystemSettingListItem {
   /** 原始 JSON 编码字符串（调试用，前端不展示明文） */
   raw_value: string;
   source: "db" | "env" | "default";
+  /** 生命周期归属：runtime=DB 可热改；bootstrap=env 启动期定型只读 */
+  scope: ConfigScope;
   is_secret: boolean;
   description: string;
   updated_at: string | null;
@@ -66,6 +71,16 @@ export interface SystemSettingListItem {
   max?: number;
   /** 修改后需重启 noj-core 才能生效 */
   needsRestart?: boolean;
+  /** bootstrap 项在 DB 中是否存在残留旧值（被忽略，可一键清理） */
+  db_orphaned?: boolean;
+  /** runtime 项：对应的 env 兜底键名（envFallback） */
+  env_key?: string;
+  /** runtime 项：env 兜底当前是否非空存在 */
+  env_present?: boolean;
+  /** runtime 项：DB 是否已写入该键 */
+  db_present?: boolean;
+  /** runtime 项：DB 与 env 同时存在（当前 DB 值优先） */
+  conflict?: boolean;
 }
 
 /** module-level 缓存：key -> 解析后的值 */
@@ -219,6 +234,9 @@ export async function initSystemSettings(): Promise<void> {
 
   const newCache = new Map<string, SettingValue>();
   for (const row of rows) {
+    // bootstrap（env-owned）项忽略 DB 旧值：不缓存，读取走 env 快照
+    if (isBootstrap(row.key)) continue;
+
     let decoded: unknown;
     try {
       decoded = JSON.parse(row.value);
@@ -242,13 +260,24 @@ export async function initSystemSettings(): Promise<void> {
 // ─── 读路径 ─────────────────────────────────────────────────
 
 /**
- * 读单条：DB → env → registry.default 兜底链。
- * - DB 命中：source='db'，返回 DB 值
- * - DB miss + env 命中：source='env'，返回 env 值
- * - DB miss + env miss + default 存在：source='default'，返回 default
- * - 都不存在：返回 null
+ * 读单条：按 scope 分支。
+ * - runtime：DB → env 兜底 → registry.default 兜底链；
+ *   - DB 命中：source='db'，返回 DB 值
+ *   - DB miss + env 命中：source='env'，返回 env 值
+ *   - DB miss + env miss + default 存在：source='default'，返回 default
+ * - bootstrap：env 快照 → default（不读 DB，DB 残留旧值忽略）；
+ *   - env 命中：source='env'，返回 env 值（按 type 解析）
+ *   - env miss + default 存在：source='default'
+ *   - 都不存在：返回 null
  */
 export function getSetting(key: string): SettingValue | null {
+  const def = findDefinition(key);
+
+  // bootstrap（env-owned）：跳过 DB 缓存，直接读 env 快照
+  if (def?.scope === "bootstrap") {
+    return getSettingFromEnv(def);
+  }
+
   // 1. DB 缓存
   const cached = cache.get(key);
   if (cached) {
@@ -257,38 +286,8 @@ export function getSetting(key: string): SettingValue | null {
 
   // 2. env 兜底
   // envFallback 是注册表里声明的键名（与 key 可能不同）
-  const def = findDefinition(key);
   if (def) {
-    const envKey = def.envFallback;
-    // 优先走启动期快照（性能最优），快照中不存在时回退到实时 Deno.env.get
-    // （兼容测试/运维中环境变量在快照后设置或未进入 ENV_ONLY_DEFINITIONS 的场景）
-    const envValue = getEnvSnapshotValue(envKey) ?? Deno.env.get(envKey);
-    if (envValue !== undefined && envValue !== "") {
-      // 尝试按 type 解析
-      let decoded: unknown = envValue;
-      if (def.type === "boolean") {
-        decoded = envValue === "true" || envValue === "1";
-      } else if (def.type === "integer") {
-        const n = parseInt(envValue, 10);
-        decoded = Number.isFinite(n) ? n : envValue;
-      }
-      return {
-        value: decoded,
-        raw: JSON.stringify(decoded),
-        source: "env",
-        updatedAt: null,
-        updatedBy: null,
-      };
-    }
-
-    // 3. registry default
-    return {
-      value: def.default,
-      raw: JSON.stringify(def.default),
-      source: "default",
-      updatedAt: null,
-      updatedBy: null,
-    };
+    return getSettingFromEnv(def) ?? fallbackToDefault(def);
   }
 
   // 非注册表 key：env 直接读
@@ -306,48 +305,109 @@ export function getSetting(key: string): SettingValue | null {
   return null;
 }
 
+/** 从 env 快照读取（按注册表 type 解析），env 未设置时返回 null */
+function getSettingFromEnv(
+  def: SettingDefinition,
+): SettingValue | null {
+  const envKey = def.scope === "bootstrap" ? def.envKey! : def.envFallback!;
+  // 优先走启动期快照（性能最优），快照中不存在时回退到实时 Deno.env.get
+  // （兼容测试/运维中环境变量在快照后设置或未进入快照白名单的场景）
+  const envValue = getEnvSnapshotValue(envKey) ?? Deno.env.get(envKey);
+  if (envValue !== undefined && envValue !== "") {
+    // 尝试按 type 解析
+    let decoded: unknown = envValue;
+    if (def.type === "boolean") {
+      decoded = envValue === "true" || envValue === "1";
+    } else if (def.type === "integer") {
+      const n = parseInt(envValue, 10);
+      decoded = Number.isFinite(n) ? n : envValue;
+    }
+    return {
+      value: decoded,
+      raw: JSON.stringify(decoded),
+      source: "env",
+      updatedAt: null,
+      updatedBy: null,
+    };
+  }
+  return null;
+}
+
+/** 回退到注册表 default（无 default 时返回 null） */
+function fallbackToDefault(def: SettingDefinition): SettingValue | null {
+  if (def.default === undefined) return null;
+  return {
+    value: def.default,
+    raw: JSON.stringify(def.default),
+    source: "default",
+    updatedAt: null,
+    updatedBy: null,
+  };
+}
+
 /**
- * 列出所有设置项（DB-backed 5 项 + env-only N 项）。
+ * 列出所有可见配置项（runtime + bootstrap）。
  * 敏感字段在 effective_value 位置返回掩码后的字符串。
+ *
+ * - runtime：getSetting()（DB → env 兜底 → default），必返回；
+ * - bootstrap：env 快照（未设置时返回 null 值、source=default，后台显示"未配置"）。
  */
 export async function listSettings(): Promise<SystemSettingListItem[]> {
   const items: SystemSettingListItem[] = [];
 
-  // 1. DB-backed 设置项
-  for (const def of SETTING_DEFINITIONS) {
-    const val = getSetting(def.key);
-    if (!val) continue; // 不应发生（registry default 兜底）
+  // 预取 bootstrap 残留行（key 集合），用于标记 db_orphaned
+  const orphans = await listOrphanedBootstrapRows();
+  const orphanedKeys = new Set(orphans.map((r) => r.key));
 
-    // 后端脱敏：敏感字段在 API 响应中不暴露完整内容
-    const sanitized = def.is_secret ? maskSecret(val.value) : val.value;
-    const rawSanitized = def.is_secret ? JSON.stringify(sanitized) : val.raw;
+  for (const def of CONFIG_DEFINITIONS) {
+    if (def.visible === false) continue; // 开发/测试专用键不展示
 
-    items.push({
-      key: def.key,
-      type: def.type,
-      effective_value: sanitized,
-      raw_value: rawSanitized,
-      source: val.source,
-      is_secret: def.is_secret,
-      description: def.description,
-      updated_at: val.updatedAt,
-      updated_by: val.updatedBy,
-      category: def.category,
-      min: def.min,
-      max: def.max,
-      needsRestart: def.needsRestart,
-    });
-  }
+    if (def.scope === "runtime") {
+      const val = getSetting(def.key);
+      if (!val) continue; // 不应发生（registry default 兜底）
 
-  // 2. env-only 设置项
-  for (const def of ENV_ONLY_DEFINITIONS) {
-    const envVal = getEnvSnapshotValue(def.key);
-    if (envVal === undefined) continue; // 未设置不展示
+      // 后端脱敏：敏感字段在 API 响应中不暴露完整内容
+      const sanitized = def.is_secret ? maskSecret(val.value) : val.value;
+      const rawSanitized = def.is_secret ? JSON.stringify(sanitized) : val.raw;
+
+      const envPresent = def.envFallback
+        ? getSettingFromEnv(def) !== null
+        : false;
+      const dbPresent = val.source === "db";
+
+      items.push({
+        key: def.key,
+        type: def.type,
+        effective_value: sanitized,
+        raw_value: rawSanitized,
+        source: val.source,
+        is_secret: def.is_secret,
+        description: def.description,
+        updated_at: val.updatedAt,
+        updated_by: val.updatedBy,
+        category: def.category,
+        scope: def.scope,
+        min: def.min,
+        max: def.max,
+        needsRestart: def.needsRestart,
+        env_key: def.envFallback,
+        env_present: envPresent,
+        db_present: dbPresent,
+        conflict: dbPresent && envPresent,
+      });
+      continue;
+    }
+
+    // bootstrap：读 env 快照（envKey），未设置也返回（显示"未配置"）
+    const envVal = getEnvSnapshotValue(def.envKey!);
 
     // 后端脱敏：敏感值不在 API 响应中暴露完整内容
-    let sanitized: string;
+    let sanitized: unknown;
     let rawSanitized: string;
-    if (URL_CREDENTIAL_KEYS.has(def.key)) {
+    if (envVal === undefined) {
+      sanitized = null;
+      rawSanitized = "null";
+    } else if (URL_CREDENTIAL_KEYS.has(def.key)) {
       // URL 凭据：仅移除 user:password@，保留协议+主机+路径
       sanitized = stripUrlCredentials(envVal);
       rawSanitized = JSON.stringify(sanitized);
@@ -366,19 +426,49 @@ export async function listSettings(): Promise<SystemSettingListItem[]> {
 
     items.push({
       key: def.key,
-      type: "string",
+      type: def.type,
       effective_value: sanitized,
       raw_value: rawSanitized,
-      source: "env",
+      source: envVal === undefined ? "default" : "env",
       is_secret: def.is_secret,
       description: def.description,
       updated_at: null,
       updated_by: null,
       category: def.category,
+      scope: def.scope,
+      db_orphaned: orphanedKeys.has(def.key),
     });
   }
 
   return items;
+}
+
+// ─── runtime env/DB 共存检测 ────────────────────────────────
+
+/** 单条 runtime 共存冲突信息（不包含值，避免敏感信息泄露） */
+export interface RuntimeEnvConflict {
+  key: string;
+  envKey: string;
+}
+
+/**
+ * 检测 runtime 项 DB 与 env 兜底同时存在的情况。
+ *
+ * 语义：DB 有写入值且 envFallback 非空时，当前实际生效的是 DB 值，
+ * env 被完全遮蔽，容易造成“改了 .env 不生效”的歧义。
+ * 仅用于启动日志与后台提示，不改变任何读取/写入行为。
+ */
+export function listRuntimeEnvConflicts(): RuntimeEnvConflict[] {
+  const conflicts: RuntimeEnvConflict[] = [];
+  for (const def of CONFIG_DEFINITIONS) {
+    if (def.scope !== "runtime" || def.visible === false) continue;
+    if (!def.envFallback) continue;
+    if (!cache.has(def.key)) continue;
+    if (getSettingFromEnv(def) !== null) {
+      conflicts.push({ key: def.key, envKey: def.envFallback });
+    }
+  }
+  return conflicts;
 }
 
 // ─── 写路径 ─────────────────────────────────────────────────
@@ -400,6 +490,13 @@ export async function updateSetting(
   // deno-lint-ignore no-explicit-any
   tx?: any,
 ): Promise<SystemSettingListItem> {
+  // bootstrap（env-owned）项不可经后台写入：配置归 .env 管理，改后需重启
+  if (isBootstrap(key)) {
+    throw new ValidationError(
+      `${key} 由环境变量管理（bootstrap），请修改 .env 后重启 noj-core`,
+    );
+  }
+
   const validation = validateValueType(key, value);
   if (!validation.ok) {
     throw new ValidationError(validation.message);
@@ -449,6 +546,7 @@ export async function updateSetting(
       updated_at: now,
       updated_by: actorId,
       category: def.category,
+      scope: def.scope,
     };
   }
 
@@ -486,6 +584,7 @@ export async function updateSetting(
     updated_at: now,
     updated_by: actorId,
     category: def.category,
+    scope: def.scope,
   };
 }
 
@@ -571,4 +670,72 @@ export async function reloadSingleKey(key: string): Promise<void> {
 export function _resetSystemSettingsForTest(): void {
   cache = new Map();
   _initialized = false;
+}
+
+// ─── bootstrap 残留 DB 行处理 ───────────────────────────────
+
+/**
+ * 列出 bootstrap（env-owned）项在 DB 中的残留行。
+ * 这些行已不参与取值（读取走 env），仅用于启动日志提示与后台"清理残留"。
+ */
+export async function listOrphanedBootstrapRows(): Promise<
+  { key: string; updated_at: string | null; updated_by: string | null }[]
+> {
+  const db = getDb();
+  const bootstrapKeys = CONFIG_DEFINITIONS
+    .filter((d) => d.scope === "bootstrap")
+    .map((d) => d.key);
+  if (bootstrapKeys.length === 0) return [];
+
+  return await db
+    .select({
+      key: systemSettings.key,
+      updated_at: systemSettings.updated_at,
+      updated_by: systemSettings.updated_by,
+    })
+    .from(systemSettings)
+    .where(inArray(systemSettings.key, bootstrapKeys));
+}
+
+/**
+ * 清理单条 bootstrap 残留 DB 行（DELETE system_settings）。
+ * 幂等：DB 无该行也正常返回。审计记录 settings.reset。
+ */
+export async function cleanupBootstrapRow(
+  key: string,
+  _actorId: string,
+): Promise<void> {
+  const def = findDefinition(key);
+  if (!def || def.scope !== "bootstrap") {
+    throw new ValidationError(
+      `仅可清理 bootstrap（环境变量管理）配置项: ${key}`,
+    );
+  }
+
+  const db = getDb();
+  // 取 DB 残留旧值用于审计
+  const rows = await db
+    .select()
+    .from(systemSettings)
+    .where(eq(systemSettings.key, key))
+    .limit(1);
+  const oldRaw = rows.length > 0 ? rows[0].value : undefined;
+
+  await db.delete(systemSettings).where(eq(systemSettings.key, key));
+  cache.delete(key);
+
+  if (rows.length > 0) {
+    const fromValue = def.is_secret ? maskSecret(oldRaw) : oldRaw;
+    await logAudit(
+      "settings.update",
+      {
+        action: "settings.update",
+        operation: "DELETE",
+        key,
+        from: fromValue,
+        to: null,
+      },
+      { type: "system_setting", id: key },
+    );
+  }
 }

--- a/noj-core/src/domains/system/tests/routes/admin-settings.test.ts
+++ b/noj-core/src/domains/system/tests/routes/admin-settings.test.ts
@@ -9,9 +9,11 @@
  * - DELETE 重置设置
  */
 import { assertEquals } from "jsr:@std/assert@^1";
+import { eq } from "drizzle-orm";
 import { initRedisForTest } from "../../../../../tests/helper.ts";
 import { createApp } from "../../../../app.ts";
-import { resetDbForTest } from "../../../../shared/db/connection.ts";
+import { getDb, resetDbForTest } from "../../../../shared/db/connection.ts";
+import { systemSettings } from "../../../../shared/db/schema.ts";
 import {
   _resetSystemSettingsForTest,
   initSystemSettings,
@@ -89,6 +91,16 @@ Deno.test({
         ].includes(k)
       );
     assertEquals(dbKeys.length, 5);
+
+    // 每条含 scope 元数据；runtime 与 bootstrap 两类都存在
+    const allowRegister = body.data.find(
+      (d: { key: string }) => d.key === "allow_register",
+    );
+    assertEquals(allowRegister?.scope, "runtime");
+    const storageProvider = body.data.find(
+      (d: { key: string }) => d.key === "storage_provider",
+    );
+    assertEquals(storageProvider?.scope, "bootstrap");
   },
 });
 
@@ -170,19 +182,20 @@ Deno.test({
 });
 
 Deno.test({
-  name: "admin-settings route: PUT smtp_from email 格式错返回 400",
+  name: "admin-settings route: PUT bootstrap 键返回 400",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
     await freshSetup();
     const app = createApp();
     const token = await createUserToken("admin");
+    // email/storage 等划归 bootstrap 后不可经后台写
     const res = await jsonRequest(
       app,
-      "/api/v1/admin/settings/smtp_from",
+      "/api/v1/admin/settings/storage_provider",
       {
         method: "PUT",
-        body: { value: "not-an-email" },
+        body: { value: "s3" },
         token,
       },
     );
@@ -243,6 +256,37 @@ Deno.test({
       { method: "DELETE", token },
     );
     assertEquals(res.status, 204);
+  },
+});
+
+Deno.test({
+  name: "admin-settings route: DELETE bootstrap 键清理残留 DB 行 204",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const db = getDb();
+    await db.insert(systemSettings).values({
+      key: "email_provider",
+      value: JSON.stringify("mock"),
+      description: "测试残留",
+      is_secret: false,
+      updated_at: new Date().toISOString(),
+      updated_by: "0",
+    });
+    const app = createApp();
+    const token = await createUserToken("admin");
+    const res = await jsonRequest(
+      app,
+      "/api/v1/admin/settings/email_provider",
+      { method: "DELETE", token },
+    );
+    assertEquals(res.status, 204);
+    // DB 行已清理
+    const rows = await db.select().from(systemSettings).where(
+      eq(systemSettings.key, "email_provider"),
+    );
+    assertEquals(rows.length, 0);
   },
 });
 

--- a/noj-core/src/domains/system/tests/services/system-settings.test.ts
+++ b/noj-core/src/domains/system/tests/services/system-settings.test.ts
@@ -16,8 +16,11 @@ import { getDb, resetDbForTest } from "../../../../shared/db/connection.ts";
 import { systemSettings } from "../../../../shared/db/schema.ts";
 import {
   _resetSystemSettingsForTest,
+  cleanupBootstrapRow,
   getSetting,
   initSystemSettings,
+  listOrphanedBootstrapRows,
+  listRuntimeEnvConflicts,
   listSettings,
   maskSecret,
   resetSetting,
@@ -28,7 +31,10 @@ import {
   snapshotEnv,
 } from "../../services/env-snapshot.ts";
 import { ValidationError } from "../../../../shared/base/errors.ts";
-import { validateRegistry } from "../../../../shared/config/settings-registry.ts";
+import {
+  findDefinition,
+  validateRegistry,
+} from "../../../../shared/config/settings-registry.ts";
 
 const ts = Date.now();
 
@@ -105,41 +111,27 @@ Deno.test({
 });
 
 Deno.test({
-  name: "system-settings service: updateSetting smtp_from 格式错拒绝",
+  name: "system-settings service: updateSetting bootstrap 键拒绝写入",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
     await freshSetup();
+    // email/storage/audit 划归 bootstrap 后不可经后台写
     await assertRejects(
-      () => updateSetting("smtp_from", "not-an-email", "0"),
+      () => updateSetting("smtp_from", "noreply@noj.local", "0"),
       ValidationError,
-      "email 格式",
+      "环境变量管理",
     );
-  },
-});
-
-Deno.test({
-  name: "system-settings service: updateSetting smtp_from 空字符串允许",
-  sanitizeResources: false,
-  sanitizeOps: false,
-  fn: async () => {
-    await freshSetup();
-    await updateSetting("smtp_from", "", "0");
-    const got = getSetting("smtp_from");
-    assertEquals(got?.source, "db");
-    assertEquals(got?.value, "");
-  },
-});
-
-Deno.test({
-  name: "system-settings service: updateSetting smtp_from 合法 email 接受",
-  sanitizeResources: false,
-  sanitizeOps: false,
-  fn: async () => {
-    await freshSetup();
-    await updateSetting("smtp_from", "noreply@noj.local", "0");
-    const got = getSetting("smtp_from");
-    assertEquals(got?.value, "noreply@noj.local");
+    await assertRejects(
+      () => updateSetting("storage_provider", "s3", "0"),
+      ValidationError,
+      "环境变量管理",
+    );
+    await assertRejects(
+      () => updateSetting("audit_log_retention_days", 30, "0"),
+      ValidationError,
+      "环境变量管理",
+    );
   },
 });
 
@@ -210,11 +202,11 @@ Deno.test({
   sanitizeOps: false,
   fn: async () => {
     await freshSetup();
-    // audit_log_retention_days 定义 max:365
+    // content_review_risk_threshold 定义 max:100（runtime 项）
     await assertRejects(
-      () => updateSetting("audit_log_retention_days", 999, "0"),
+      () => updateSetting("content_review_risk_threshold", 999, "0"),
       ValidationError,
-      "不能大于 365",
+      "不能大于 100",
     );
   },
 });
@@ -240,6 +232,41 @@ Deno.test({
   fn: () => {
     // 当前注册表包含 22+ 个合法定义，不应抛错
     validateRegistry();
+  },
+});
+
+Deno.test({
+  name:
+    "system-settings service: 注册表 scope 声明完整（runtime/bootstrap 不重叠）",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    validateRegistry(); // 不应抛错
+    // 划归项 scope=bootstrap
+    for (
+      const k of [
+        "storage_provider",
+        "s3_endpoint",
+        "s3_secret_key",
+        "email_provider",
+        "alibaba_access_key_secret",
+        "audit_log_retention_days",
+      ]
+    ) {
+      assertEquals(findDefinition(k)?.scope, "bootstrap");
+    }
+    // 保留 runtime 项 scope=runtime
+    for (
+      const k of [
+        "allow_register",
+        "rate_limit_login_ip_max",
+        "maintenance_mode",
+        "homepage_banner",
+      ]
+    ) {
+      assertEquals(findDefinition(k)?.scope, "runtime");
+    }
   },
 });
 
@@ -405,6 +432,166 @@ Deno.test({
     assertEquals(JSON.parse(redis!.raw_value), "redis://127.0.0.1:6379/");
 
     Deno.env.delete("REDIS_URL");
+  },
+});
+
+// ─── runtime env/DB 共存冲突 ────────────────────────────────
+
+Deno.test({
+  name: "system-settings service: listRuntimeEnvConflicts 检测 DB+env 共存",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    Deno.env.set("ALLOW_REGISTER", "false");
+    await freshSetup();
+    await updateSetting("allow_register", false, "0");
+
+    const conflicts = listRuntimeEnvConflicts();
+    assertEquals(
+      conflicts.some((c) =>
+        c.key === "allow_register" && c.envKey === "ALLOW_REGISTER"
+      ),
+      true,
+    );
+
+    const items = await listSettings();
+    const item = items.find((i) => i.key === "allow_register");
+    assertEquals(item?.db_present, true);
+    assertEquals(item?.env_present, true);
+    assertEquals(item?.conflict, true);
+    assertEquals(item?.env_key, "ALLOW_REGISTER");
+
+    Deno.env.delete("ALLOW_REGISTER");
+  },
+});
+
+Deno.test({
+  name: "system-settings service: 仅 DB 无 env 不标记冲突",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    Deno.env.delete("ALLOW_REGISTER");
+    await freshSetup();
+    await updateSetting("allow_register", false, "0");
+
+    assertEquals(
+      listRuntimeEnvConflicts().some((c) => c.key === "allow_register"),
+      false,
+    );
+
+    const item = (await listSettings()).find((i) => i.key === "allow_register");
+    assertEquals(item?.db_present, true);
+    assertEquals(item?.env_present, false);
+    assertEquals(item?.conflict, false);
+  },
+});
+
+Deno.test({
+  name: "system-settings service: 仅 env 无 DB 不标记冲突",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    Deno.env.set("ALLOW_REGISTER", "false");
+    await freshSetup();
+
+    assertEquals(
+      listRuntimeEnvConflicts().some((c) => c.key === "allow_register"),
+      false,
+    );
+
+    const item = (await listSettings()).find((i) => i.key === "allow_register");
+    assertEquals(item?.source, "env");
+    assertEquals(item?.db_present, false);
+    assertEquals(item?.env_present, true);
+    assertEquals(item?.conflict, false);
+
+    Deno.env.delete("ALLOW_REGISTER");
+  },
+});
+
+// ─── bootstrap 残留行 ───────────────────────────────────────
+
+Deno.test({
+  name: "system-settings service: listOrphanedBootstrapRows 检测残留",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const db = getDb();
+    await db.insert(systemSettings).values({
+      key: "storage_provider",
+      value: JSON.stringify("local"),
+      description: "测试残留",
+      is_secret: false,
+      updated_at: new Date().toISOString(),
+      updated_by: "0",
+    });
+    const orphans = await listOrphanedBootstrapRows();
+    assertEquals(
+      orphans.some((r) => r.key === "storage_provider"),
+      true,
+    );
+    // runtime 键不应被列为孤儿
+    assertEquals(orphans.some((r) => r.key === "allow_register"), false);
+  },
+});
+
+Deno.test({
+  name: "system-settings service: listSettings bootstrap 残留标记 db_orphaned",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const db = getDb();
+    await db.insert(systemSettings).values({
+      key: "email_provider",
+      value: JSON.stringify("mock"),
+      description: "测试残留",
+      is_secret: false,
+      updated_at: new Date().toISOString(),
+      updated_by: "0",
+    });
+    const items = await listSettings();
+    const emailProvider = items.find((i) => i.key === "email_provider");
+    assertEquals(emailProvider?.db_orphaned, true);
+    const allowRegister = items.find((i) => i.key === "allow_register");
+    assertEquals(allowRegister?.db_orphaned, undefined);
+  },
+});
+
+Deno.test({
+  name: "system-settings service: cleanupBootstrapRow 清理残留行",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    const db = getDb();
+    await db.insert(systemSettings).values({
+      key: "s3_bucket",
+      value: JSON.stringify("old-bucket"),
+      description: "测试残留",
+      is_secret: false,
+      updated_at: new Date().toISOString(),
+      updated_by: "0",
+    });
+    await cleanupBootstrapRow("s3_bucket", "0");
+    const rows = await db.select().from(systemSettings).where(
+      eq(systemSettings.key, "s3_bucket"),
+    );
+    assertEquals(rows.length, 0);
+  },
+});
+
+Deno.test({
+  name: "system-settings service: cleanupBootstrapRow 拒绝 runtime 键",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await freshSetup();
+    await assertRejects(
+      () => cleanupBootstrapRow("allow_register", "0"),
+      ValidationError,
+    );
   },
 });
 

--- a/noj-core/src/main.ts
+++ b/noj-core/src/main.ts
@@ -14,7 +14,12 @@ import { createReviewConsumer } from "./domains/content-review/index.ts";
 import { ensureRootUser } from "./domains/identity/index.ts";
 import { ensureRbacSeeds } from "./domains/system/index.ts";
 import { getStorageProvider } from "./domains/system/index.ts";
-import { getSetting, initSystemSettings } from "./domains/system/index.ts";
+import {
+  getSetting,
+  initSystemSettings,
+  listOrphanedBootstrapRows,
+  listRuntimeEnvConflicts,
+} from "./domains/system/index.ts";
 import { startAuditLogRetentionTask } from "./domains/system/index.ts";
 import { logger } from "./shared/base/logging.ts";
 import {
@@ -144,6 +149,46 @@ async function main() {
   // 启动期 env 快照（issue #99）
   // 一次性读取 env-only 设置项到内存 Map，admin 面板只读展示。
   snapshotEnv();
+
+  // 提示 runtime（DB-owned）项同时存在 DB 值与 env 兜底：
+  // 当前 DB 值优先，env 被遮蔽；建议移除 .env 对应变量以避免歧义。
+  try {
+    const conflicts = listRuntimeEnvConflicts();
+    if (conflicts.length > 0) {
+      logger.warn(
+        `以下 ${conflicts.length} 项 runtime 配置同时存在 DB 值与 env 兜底，` +
+          "当前 DB 值优先；建议移除 .env 中对应变量以避免歧义：",
+        {
+          keys: conflicts.map((c) => `${c.key} (${c.envKey})`),
+        },
+      );
+    }
+  } catch (err) {
+    // 检测失败不阻断启动（仅提示）
+    logger.warn("runtime env/DB 共存冲突检测失败", { err });
+  }
+
+  // 提示 bootstrap（env-owned）项在 DB 中的残留旧值：
+  // 这些行已不参与取值（读取走 env），仅在管理后台可一键清理。
+  try {
+    const orphans = await listOrphanedBootstrapRows();
+    if (orphans.length > 0) {
+      logger.warn(
+        `以下 ${orphans.length} 项已由环境变量接管，DB 旧值不再生效，` +
+          "可到管理后台「环境配置」一键清理：",
+        {
+          keys: orphans.map((r) =>
+            `${r.key}（更新于 ${r.updated_at ?? "?"}，更新人 ${
+              r.updated_by ?? "?"
+            }）`
+          ),
+        },
+      );
+    }
+  } catch (err) {
+    // 残留检测失败不阻断启动（仅提示）
+    logger.warn("bootstrap 残留 DB 行检测失败", { err });
+  }
 
   // Issue #330：生产配置必须在 HTTP 监听前完成 fail-fast 校验。
   await fatalStep("生产配置校验", () => {

--- a/noj-core/src/shared/config/settings-registry.ts
+++ b/noj-core/src/shared/config/settings-registry.ts
@@ -1,24 +1,34 @@
 /**
- * 系统设置注册表（issue #99）。
+ * 统一配置注册表（issue #99 演进：配置分层语义治理）。
  *
- * 定义 54 个 DB-backed 设置项的元数据（含 boolean/string/text/integer 四种类型）。
- * 启动期 validateRegistry() 校验注册表合法性；
- * service 层 updateSetting/getSetting 依赖本表做严格 type 校验。
+ * 定义全部配置项的元数据，按 scope 分为两类生命周期：
+ * - runtime（DB-owned）：运行时可热改，读取链 DB > env 兜底 > default；
+ * - bootstrap（env-owned）：启动期定型，变更需重启，读取链 env > default（不读 DB）。
+ *
+ * 覆盖三类来源：
+ * - 原 DB-backed 设置项（admin 可改）；
+ * - 原 env-only 展示项（启动期快照、后台只读）；
+ * - 纯 infra/ops env（TFA/OAuth/LLM/日志等，后台只读，无配置盲区）。
+ *
+ * 启动期 validateRegistry() 校验注册表合法性（scope 声明完整、env 键唯一）。
  *
  * 分类（category）用于管理后台 UI 分组：
  * - auth: 认证 / 用户管理
  * - maintenance: 维护 / 公告
- * - email: 邮件发送
+ * - email: 邮件发送（bootstrap 启动期配置）
  * - rate_limit: 速率限制
  * - database: 数据库
  * - redis: Redis
  * - cors: 跨域
+ * - storage: 对象存储（bootstrap 启动期配置）
  * - judge: 评测资源限制
  * - review: 内容合规审核（issue #413）
  * - other: 其他
  */
 
 export type SettingType = "boolean" | "string" | "text" | "integer";
+
+export type ConfigScope = "runtime" | "bootstrap";
 
 export type SettingCategory =
   | "auth"
@@ -34,16 +44,20 @@ export type SettingCategory =
   | "review"
   | "other";
 
-/** 注册表条目（DB-backed 设置项的元数据） */
+/** 配置项元数据（统一注册表条目） */
 export interface SettingDefinition {
   key: string;
   type: SettingType;
-  /** 默认值（DB 与 env 均未配置时回退至此） */
-  default: boolean | string | number;
+  /** 默认值（DB 与 env 均未配置时回退至此；bootstrap env-only 项可无默认值） */
+  default?: boolean | string | number;
   description: string;
   is_secret: boolean;
-  /** env 兜底键名（仅展示用，实际读取走 env-snapshot） */
-  envFallback: string;
+  /** 生命周期归属：runtime=DB 可热改；bootstrap=env 启动期定型只读 */
+  scope: ConfigScope;
+  /** runtime 专属：env 兜底键名（仅首次启动/开发环境兜底用） */
+  envFallback?: string;
+  /** bootstrap 专属：env 事实源键名（唯一） */
+  envKey?: string;
   category: SettingCategory;
   /** integer 类型专用：最小值（含） */
   min?: number;
@@ -51,10 +65,12 @@ export interface SettingDefinition {
   max?: number;
   /** 修改后需重启 noj-core 才能生效（如启动时单例读取的配置） */
   needsRestart?: boolean;
+  /** 是否在管理后台展示（false=仅参与校验/登记，如开发测试专用键） */
+  visible?: boolean;
 }
 
-/** 54 个 DB-backed 设置项的元数据定义 */
-export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
+/** 统一配置注册表：全部配置项（runtime + bootstrap）的元数据定义 */
+export const CONFIG_DEFINITIONS: readonly SettingDefinition[] = [
   // ── auth ──────────────────────────────────────────────────
   {
     key: "allow_register",
@@ -64,6 +80,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "ALLOW_REGISTER",
     category: "auth",
+    scope: "runtime",
   },
   {
     key: "jwt_expires_in",
@@ -73,6 +90,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "JWT_EXPIRES_IN",
     category: "auth",
+    scope: "runtime",
   },
 
   // ── maintenance ───────────────────────────────────────────
@@ -84,6 +102,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "MAINTENANCE_MODE",
     category: "maintenance",
+    scope: "runtime",
   },
   {
     key: "homepage_banner",
@@ -93,6 +112,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "HOMEPAGE_BANNER",
     category: "maintenance",
+    scope: "runtime",
   },
 
   // ── email ─────────────────────────────────────────────────
@@ -102,8 +122,9 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "mock",
     description: "邮件服务（disabled / aliyun / tencent）",
     is_secret: false,
-    envFallback: "EMAIL_PROVIDER",
+    envKey: "EMAIL_PROVIDER",
     category: "email",
+    scope: "bootstrap",
   },
   {
     key: "smtp_from",
@@ -111,8 +132,9 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "",
     description: "系统发件人地址（邮件 Provider 通用）",
     is_secret: false,
-    envFallback: "SMTP_FROM",
+    envKey: "SMTP_FROM",
     category: "email",
+    scope: "bootstrap",
   },
   {
     key: "alibaba_access_key_id",
@@ -120,8 +142,9 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "",
     description: "阿里云 DirectMail AccessKey ID",
     is_secret: false,
-    envFallback: "ALIBABA_ACCESS_KEY_ID",
+    envKey: "ALIBABA_ACCESS_KEY_ID",
     category: "email",
+    scope: "bootstrap",
   },
   {
     key: "alibaba_access_key_secret",
@@ -130,8 +153,9 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     description:
       "阿里云 DirectMail AccessKey Secret（已脱敏：仅保留前 3 后 3 字符）",
     is_secret: true,
-    envFallback: "ALIBABA_ACCESS_KEY_SECRET",
+    envKey: "ALIBABA_ACCESS_KEY_SECRET",
     category: "email",
+    scope: "bootstrap",
   },
   {
     key: "alibaba_from_email",
@@ -139,8 +163,9 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "",
     description: "阿里云发信地址（需控制台验证域名）",
     is_secret: false,
-    envFallback: "ALIBABA_FROM_EMAIL",
+    envKey: "ALIBABA_FROM_EMAIL",
     category: "email",
+    scope: "bootstrap",
   },
   {
     key: "tencent_secret_id",
@@ -148,8 +173,9 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "",
     description: "腾讯云 SES SecretId",
     is_secret: false,
-    envFallback: "TENCENT_SECRET_ID",
+    envKey: "TENCENT_SECRET_ID",
     category: "email",
+    scope: "bootstrap",
   },
   {
     key: "tencent_secret_key",
@@ -157,8 +183,9 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "",
     description: "腾讯云 SES SecretKey（已脱敏：仅保留前 3 后 3 字符）",
     is_secret: true,
-    envFallback: "TENCENT_SECRET_KEY",
+    envKey: "TENCENT_SECRET_KEY",
     category: "email",
+    scope: "bootstrap",
   },
   {
     key: "tencent_from_email",
@@ -166,8 +193,9 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "",
     description: "腾讯云发信地址（需控制台验证域名）",
     is_secret: false,
-    envFallback: "TENCENT_FROM_EMAIL",
+    envKey: "TENCENT_FROM_EMAIL",
     category: "email",
+    scope: "bootstrap",
   },
   {
     key: "tencent_region",
@@ -175,8 +203,9 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "ap-guangzhou",
     description: "腾讯云地域",
     is_secret: false,
-    envFallback: "TENCENT_REGION",
+    envKey: "TENCENT_REGION",
     category: "email",
+    scope: "bootstrap",
   },
 
   // ── rate_limit ────────────────────────────────────────────
@@ -188,6 +217,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "RATE_LIMIT_LOGIN_ENABLED",
     category: "rate_limit",
+    scope: "runtime",
   },
   {
     key: "rate_limit_enabled",
@@ -197,6 +227,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "RATE_LIMIT_ENABLED",
     category: "rate_limit",
+    scope: "runtime",
   },
   {
     key: "rate_limit_login_ip_window",
@@ -208,6 +239,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 1,
     max: 3600,
+    scope: "runtime",
   },
   {
     key: "rate_limit_login_ip_max",
@@ -219,6 +251,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 1,
     max: 1000,
+    scope: "runtime",
   },
   {
     key: "rate_limit_login_acc_window",
@@ -230,6 +263,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 1,
     max: 3600,
+    scope: "runtime",
   },
   {
     key: "rate_limit_login_acc_max",
@@ -241,6 +275,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 1,
     max: 100,
+    scope: "runtime",
   },
   {
     key: "rate_limit_login_backoff_sec",
@@ -252,6 +287,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 0,
     max: 300,
+    scope: "runtime",
   },
   {
     key: "rate_limit_login_lock_threshold",
@@ -263,6 +299,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 1,
     max: 100,
+    scope: "runtime",
   },
   {
     key: "rate_limit_login_lock_seconds",
@@ -274,6 +311,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 60,
     max: 86400,
+    scope: "runtime",
   },
   {
     key: "rate_limit_search_enabled",
@@ -283,6 +321,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "RATE_LIMIT_SEARCH_ENABLED",
     category: "rate_limit",
+    scope: "runtime",
   },
   {
     key: "rate_limit_search_window",
@@ -294,6 +333,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 1,
     max: 3600,
+    scope: "runtime",
   },
   {
     key: "rate_limit_search_max_anon",
@@ -305,6 +345,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 1,
     max: 10000,
+    scope: "runtime",
   },
   {
     key: "rate_limit_search_max_authed",
@@ -316,6 +357,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "rate_limit",
     min: 1,
     max: 10000,
+    scope: "runtime",
   },
   {
     key: "trusted_proxies",
@@ -325,6 +367,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "TRUSTED_PROXIES",
     category: "rate_limit",
+    scope: "runtime",
   },
 
   // ── storage（修改需重启 noj-core：Provider 为启动时初始化的单例）───────
@@ -334,9 +377,10 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "local",
     description: "存储 Provider（local / s3）",
     is_secret: false,
-    envFallback: "STORAGE_PROVIDER",
+    envKey: "STORAGE_PROVIDER",
     category: "storage",
     needsRestart: true,
+    scope: "bootstrap",
   },
   {
     key: "s3_endpoint",
@@ -344,9 +388,10 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "",
     description: "S3 兼容对象存储端点",
     is_secret: false,
-    envFallback: "S3_ENDPOINT",
+    envKey: "S3_ENDPOINT",
     category: "storage",
     needsRestart: true,
+    scope: "bootstrap",
   },
   {
     key: "s3_region",
@@ -354,9 +399,10 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "us-east-1",
     description: "S3 区域",
     is_secret: false,
-    envFallback: "S3_REGION",
+    envKey: "S3_REGION",
     category: "storage",
     needsRestart: true,
+    scope: "bootstrap",
   },
   {
     key: "s3_access_key",
@@ -364,9 +410,10 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "",
     description: "S3 访问密钥",
     is_secret: false,
-    envFallback: "S3_ACCESS_KEY",
+    envKey: "S3_ACCESS_KEY",
     category: "storage",
     needsRestart: true,
+    scope: "bootstrap",
   },
   {
     key: "s3_secret_key",
@@ -374,9 +421,10 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "",
     description: "S3 秘密密钥（已脱敏：仅保留前 3 后 3 字符）",
     is_secret: true,
-    envFallback: "S3_SECRET_KEY",
+    envKey: "S3_SECRET_KEY",
     category: "storage",
     needsRestart: true,
+    scope: "bootstrap",
   },
   {
     key: "s3_bucket",
@@ -384,9 +432,10 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: "noj-support-packages",
     description: "S3 存储桶名",
     is_secret: false,
-    envFallback: "S3_BUCKET",
+    envKey: "S3_BUCKET",
     category: "storage",
     needsRestart: true,
+    scope: "bootstrap",
   },
   {
     key: "s3_force_path_style",
@@ -394,9 +443,10 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: false,
     description: "启用路径风格 URL（MinIO 等 S3 兼容存储需要设为 true）",
     is_secret: false,
-    envFallback: "S3_FORCE_PATH_STYLE",
+    envKey: "S3_FORCE_PATH_STYLE",
     category: "storage",
     needsRestart: true,
+    scope: "bootstrap",
   },
 
   // ── community ───────────────────────────────────────────
@@ -408,6 +458,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_guest_read_enabled",
@@ -417,6 +468,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_GUEST_READ_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_read_only",
@@ -426,6 +478,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_READ_ONLY",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_solutions_enabled",
@@ -435,6 +488,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_SOLUTIONS_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_discussions_enabled",
@@ -444,6 +498,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_DISCUSSIONS_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_moments_enabled",
@@ -453,6 +508,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_MOMENTS_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_activities_enabled",
@@ -462,6 +518,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_ACTIVITIES_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_comments_enabled",
@@ -471,6 +528,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_COMMENTS_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_reactions_enabled",
@@ -480,6 +538,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_REACTIONS_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_bookmarks_enabled",
@@ -489,6 +548,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_BOOKMARKS_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_follows_enabled",
@@ -498,6 +558,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_FOLLOWS_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "private_messaging_enabled",
@@ -507,6 +568,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "PRIVATE_MESSAGING_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_external_images_enabled",
@@ -516,6 +578,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_EXTERNAL_IMAGES_ENABLED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_solution_requires_accepted",
@@ -525,6 +588,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "COMMUNITY_SOLUTION_REQUIRES_ACCEPTED",
     category: "community",
+    scope: "runtime",
   },
   {
     key: "community_new_user_review_hours",
@@ -536,6 +600,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "community",
     min: 0,
     max: 8760,
+    scope: "runtime",
   },
   {
     key: "community_post_max_length",
@@ -547,6 +612,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "community",
     min: 100,
     max: 100000,
+    scope: "runtime",
   },
   {
     key: "community_moment_max_length",
@@ -558,6 +624,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "community",
     min: 20,
     max: 10000,
+    scope: "runtime",
   },
   {
     key: "community_comment_max_length",
@@ -569,6 +636,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "community",
     min: 20,
     max: 50000,
+    scope: "runtime",
   },
   {
     key: "community_post_interval_seconds",
@@ -580,6 +648,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "community",
     min: 0,
     max: 86400,
+    scope: "runtime",
   },
 
   // ── judge ───────────────────────────────────────────────
@@ -592,6 +661,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     envFallback: "JUDGE_MAX_EVALUATOR_TIME_LIMIT_MS",
     category: "judge",
     min: 0,
+    scope: "runtime",
   },
   {
     key: "judge_max_evaluator_memory_limit_mb",
@@ -602,6 +672,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     envFallback: "JUDGE_MAX_EVALUATOR_MEMORY_LIMIT_MB",
     category: "judge",
     min: 0,
+    scope: "runtime",
   },
   {
     key: "judge_max_solution_call_timeout_ms",
@@ -612,6 +683,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     envFallback: "JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS",
     category: "judge",
     min: 0,
+    scope: "runtime",
   },
   {
     key: "judge_max_solution_memory_limit_mb",
@@ -622,6 +694,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     envFallback: "JUDGE_MAX_SOLUTION_MEMORY_LIMIT_MB",
     category: "judge",
     min: 0,
+    scope: "runtime",
   },
 
   // ── review（内容合规审核，issue #413）───────────────────────
@@ -633,6 +706,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "CONTENT_REVIEW_ENABLED",
     category: "review",
+    scope: "runtime",
   },
   {
     key: "content_review_provider",
@@ -642,6 +716,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "CONTENT_REVIEW_PROVIDER",
     category: "review",
+    scope: "runtime",
   },
   {
     key: "content_review_provider_key",
@@ -652,6 +727,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: true,
     envFallback: "CONTENT_REVIEW_PROVIDER_KEY",
     category: "review",
+    scope: "runtime",
   },
   {
     key: "content_review_provider_secret",
@@ -661,6 +737,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: true,
     envFallback: "CONTENT_REVIEW_PROVIDER_SECRET",
     category: "review",
+    scope: "runtime",
   },
   {
     key: "content_review_risk_threshold",
@@ -672,6 +749,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "review",
     min: 0,
     max: 100,
+    scope: "runtime",
   },
   {
     key: "content_review_review_threshold",
@@ -683,6 +761,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "review",
     min: 0,
     max: 100,
+    scope: "runtime",
   },
   {
     key: "content_review_async_enabled",
@@ -692,6 +771,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     is_secret: false,
     envFallback: "CONTENT_REVIEW_ASYNC_ENABLED",
     category: "review",
+    scope: "runtime",
   },
   {
     key: "content_review_timeout_ms",
@@ -703,6 +783,7 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     category: "review",
     min: 100,
     max: 30000,
+    scope: "runtime",
   },
 
   // ── other ─────────────────────────────────────────────────
@@ -712,10 +793,449 @@ export const SETTING_DEFINITIONS: readonly SettingDefinition[] = [
     default: 90,
     description: "审计日志保留天数（0 = 禁用自动清理）",
     is_secret: false,
-    envFallback: "AUDIT_LOG_RETENTION_DAYS",
+    envKey: "AUDIT_LOG_RETENTION_DAYS",
     category: "other",
     min: 0,
     max: 365,
+    scope: "bootstrap",
+  },
+
+  // ══ bootstrap env-only 基础设施项（原 env-snapshot 白名单）══════
+  // scope: bootstrap，envKey 即 env 事实源；后台只读展示（已设置才展示）。
+  // ── database ───────────────────────────────────────────────
+  {
+    key: "DATABASE_URL",
+    type: "string",
+    description: "PostgreSQL 连接串",
+    is_secret: true,
+    scope: "bootstrap",
+    envKey: "DATABASE_URL",
+    category: "database",
+  },
+  {
+    key: "DATABASE_POOL_MAX",
+    type: "integer",
+    description: "连接池大小",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "DATABASE_POOL_MAX",
+    category: "database",
+  },
+  {
+    key: "DATABASE_CONNECT_TIMEOUT",
+    type: "integer",
+    description: "连接超时（秒）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "DATABASE_CONNECT_TIMEOUT",
+    category: "database",
+  },
+  {
+    key: "DATABASE_IDLE_TIMEOUT",
+    type: "integer",
+    description: "空闲连接超时（秒）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "DATABASE_IDLE_TIMEOUT",
+    category: "database",
+  },
+  {
+    key: "DATABASE_MAX_LIFETIME",
+    type: "integer",
+    description: "连接最大生命周期（秒）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "DATABASE_MAX_LIFETIME",
+    category: "database",
+  },
+  // ── Redis ──────────────────────────────────────────────────
+  {
+    key: "REDIS_URL",
+    type: "string",
+    description: "Redis 连接串",
+    is_secret: true,
+    scope: "bootstrap",
+    envKey: "REDIS_URL",
+    category: "redis",
+  },
+  // ── auth ───────────────────────────────────────────────────
+  {
+    key: "JWT_SECRET",
+    type: "string",
+    description: "JWT 签名密钥（≥32 字符）",
+    is_secret: true,
+    scope: "bootstrap",
+    envKey: "JWT_SECRET",
+    category: "auth",
+  },
+  {
+    key: "ADMIN_EMAIL",
+    type: "string",
+    description: "Seed 管理员邮箱",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "ADMIN_EMAIL",
+    category: "auth",
+  },
+  {
+    key: "ADMIN_PASS",
+    type: "string",
+    description: "Seed 管理员密码",
+    is_secret: true,
+    scope: "bootstrap",
+    envKey: "ADMIN_PASS",
+    category: "auth",
+  },
+  {
+    key: "BCRYPT_SALT_ROUNDS",
+    type: "integer",
+    description: "bcrypt 哈希轮数（修改影响已有密码一致性）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "BCRYPT_SALT_ROUNDS",
+    category: "auth",
+  },
+  // ── CORS ───────────────────────────────────────────────────
+  {
+    key: "CORS_ALLOWED_ORIGINS",
+    type: "string",
+    description: "生产 CORS 白名单（逗号分隔）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "CORS_ALLOWED_ORIGINS",
+    category: "cors",
+  },
+  // ── other（端口 / 环境）────────────────────────────────────
+  {
+    key: "PORT",
+    type: "integer",
+    description: "HTTP 监听端口",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "PORT",
+    category: "other",
+  },
+  {
+    key: "NOJ_ENV",
+    type: "string",
+    description: "运行环境（空=development，production=生产）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_ENV",
+    category: "other",
+  },
+
+  // ══ bootstrap 纯 infra/ops env（仅登记与展示，不改读取路径）══════
+  // ── 密钥类 ─────────────────────────────────────────────────
+  {
+    key: "TFA_ENCRYPTION_KEY",
+    type: "string",
+    description:
+      "TOTP secret 的 AES-256-GCM 加密密钥（≥32 字符，与 JWT_SECRET 隔离）",
+    is_secret: true,
+    scope: "bootstrap",
+    envKey: "TFA_ENCRYPTION_KEY",
+    category: "auth",
+  },
+  {
+    key: "NOJ_LLM_SERVICE_TOKEN",
+    type: "string",
+    description: "noj-llm-gateway 服务间鉴权 + AEAD eval_token 签发/校验密钥",
+    is_secret: true,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_SERVICE_TOKEN",
+    category: "other",
+  },
+  // ── 应用 URL / 网络 ────────────────────────────────────────
+  {
+    key: "APP_URL",
+    type: "string",
+    description:
+      "外部可信应用地址（密码重置邮件链接 / OAuth 回调，生产必须 HTTPS）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "APP_URL",
+    category: "auth",
+  },
+  {
+    key: "NOJ_ALLOW_INSECURE_HTTP",
+    type: "boolean",
+    description: "允许 HTTP 明文回调（仅开发；生产必须为 false）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_ALLOW_INSECURE_HTTP",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_GATEWAY_URL",
+    type: "string",
+    description: "noj-llm-gateway 内部服务地址",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_GATEWAY_URL",
+    category: "other",
+  },
+  // ── 日志 ───────────────────────────────────────────────────
+  {
+    key: "LOG_LEVEL",
+    type: "string",
+    description: "日志级别（debug/info/warn/error；未设置按 NOJ_ENV 回退）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "LOG_LEVEL",
+    category: "other",
+  },
+  {
+    key: "LOG_FORMAT",
+    type: "string",
+    description: "日志格式（json/pretty；未设置按 NOJ_ENV 回退）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "LOG_FORMAT",
+    category: "other",
+  },
+  // ── 评测 / 存储 / 运行参数 ─────────────────────────────────
+  {
+    key: "RESULT_CONSUMER_CONCURRENCY",
+    type: "integer",
+    description: "评测结果消费者并发数（1-16）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "RESULT_CONSUMER_CONCURRENCY",
+    category: "judge",
+  },
+  {
+    key: "SUPPORT_PACKAGE_DIR",
+    type: "string",
+    description: "本地存储目录（local Provider）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "SUPPORT_PACKAGE_DIR",
+    category: "storage",
+  },
+  {
+    key: "JUDGE_IMAGE_BASE",
+    type: "string",
+    description: "Judge 镜像仓库前缀",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "JUDGE_IMAGE_BASE",
+    category: "judge",
+  },
+  {
+    key: "NOJ_ARTIFACT_MAX_SIZE_MB",
+    type: "integer",
+    description: "artifact 提交硬上限（MB），默认 2048",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_ARTIFACT_MAX_SIZE_MB",
+    category: "judge",
+  },
+  // ── LLM 网关配额（core 侧读的 env 常量）────────────────────
+  {
+    key: "NOJ_LLM_MAX_CALLS",
+    type: "integer",
+    description: "单次评测 eval_token 调用上限（默认 100）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_MAX_CALLS",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_MAX_TOKENS",
+    type: "integer",
+    description: "单次评测 eval_token token 上限（默认 50000）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_MAX_TOKENS",
+    category: "other",
+  },
+  // ── 种子 / 引导行为 ────────────────────────────────────────
+  {
+    key: "NOJ_FORCE_PASSWORD_CHANGE",
+    type: "boolean",
+    description: "引导管理员是否强制首次改密（默认 true；开发自动 false）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_FORCE_PASSWORD_CHANGE",
+    category: "auth",
+  },
+  {
+    key: "NOJ_LLM_DEFAULT_GLOBAL_DAY_CALLS",
+    type: "integer",
+    description: "LLM 配额缺失 fallback：全局日调用上限",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_DEFAULT_GLOBAL_DAY_CALLS",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_DEFAULT_GLOBAL_DAY_TOKENS",
+    type: "integer",
+    description: "LLM 配额缺失 fallback：全局日 token 上限",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_DEFAULT_GLOBAL_DAY_TOKENS",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_DEFAULT_GLOBAL_DAY_COST",
+    type: "integer",
+    description: "LLM 配额缺失 fallback：全局日成本上限",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_DEFAULT_GLOBAL_DAY_COST",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_DEFAULT_USER_DAY_CALLS",
+    type: "integer",
+    description: "LLM 配额缺失 fallback：单用户日调用上限",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_DEFAULT_USER_DAY_CALLS",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_DEFAULT_USER_DAY_TOKENS",
+    type: "integer",
+    description: "LLM 配额缺失 fallback：单用户日 token 上限",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_DEFAULT_USER_DAY_TOKENS",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_DEFAULT_USER_DAY_COST",
+    type: "integer",
+    description: "LLM 配额缺失 fallback：单用户日成本上限",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_DEFAULT_USER_DAY_COST",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_DEFAULT_PROBLEM_DAY_CALLS",
+    type: "integer",
+    description: "LLM 配额缺失 fallback：单题日调用上限",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_DEFAULT_PROBLEM_DAY_CALLS",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_DEFAULT_PROBLEM_DAY_TOKENS",
+    type: "integer",
+    description: "LLM 配额缺失 fallback：单题日 token 上限",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_DEFAULT_PROBLEM_DAY_TOKENS",
+    category: "other",
+  },
+  {
+    key: "NOJ_LLM_DEFAULT_PROBLEM_DAY_COST",
+    type: "integer",
+    description: "LLM 配额缺失 fallback：单题日成本上限",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_LLM_DEFAULT_PROBLEM_DAY_COST",
+    category: "other",
+  },
+  // ── OAuth（第三方登录）─────────────────────────────────────
+  {
+    key: "OAUTH_GITHUB_CLIENT_ID",
+    type: "string",
+    description: "GitHub OAuth Client ID",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "OAUTH_GITHUB_CLIENT_ID",
+    category: "auth",
+  },
+  {
+    key: "OAUTH_GITHUB_CLIENT_SECRET",
+    type: "string",
+    description: "GitHub OAuth Client Secret",
+    is_secret: true,
+    scope: "bootstrap",
+    envKey: "OAUTH_GITHUB_CLIENT_SECRET",
+    category: "auth",
+  },
+  {
+    key: "OAUTH_OIDC_ISSUER_URL",
+    type: "string",
+    description: "OIDC Issuer URL",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "OAUTH_OIDC_ISSUER_URL",
+    category: "auth",
+  },
+  {
+    key: "OAUTH_OIDC_CLIENT_ID",
+    type: "string",
+    description: "OIDC Client ID",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "OAUTH_OIDC_CLIENT_ID",
+    category: "auth",
+  },
+  {
+    key: "OAUTH_OIDC_CLIENT_SECRET",
+    type: "string",
+    description: "OIDC Client Secret",
+    is_secret: true,
+    scope: "bootstrap",
+    envKey: "OAUTH_OIDC_CLIENT_SECRET",
+    category: "auth",
+  },
+  {
+    key: "OAUTH_OIDC_NAME",
+    type: "string",
+    description: "OIDC 展示名称（默认 OIDC）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "OAUTH_OIDC_NAME",
+    category: "auth",
+  },
+  // ── 开发/测试专用（visible:false，仅参与校验不展示）────────
+  {
+    key: "NOJ_RUN_E2E",
+    type: "boolean",
+    description: "E2E 模式开关（NOJ_RUN_E2E=1 时跳过引导管理员种子）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_RUN_E2E",
+    category: "other",
+    visible: false,
+  },
+  {
+    key: "TEST_SCHEMA",
+    type: "string",
+    description: "测试隔离 schema（search_path 分片）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "TEST_SCHEMA",
+    category: "other",
+    visible: false,
+  },
+  {
+    key: "NOJ_MIGRATIONS_DIR",
+    type: "string",
+    description: "迁移文件目录覆盖",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_MIGRATIONS_DIR",
+    category: "other",
+    visible: false,
+  },
+  {
+    key: "NOJ_BYPASS_JWT_REVOKE",
+    type: "boolean",
+    description: "跳过 JWT 吊销检查（仅开发调试）",
+    is_secret: false,
+    scope: "bootstrap",
+    envKey: "NOJ_BYPASS_JWT_REVOKE",
+    category: "other",
+    visible: false,
   },
 ] as const;
 
@@ -726,16 +1246,22 @@ const VALID_TYPES: readonly SettingType[] = [
   "integer",
 ] as const;
 
-/** 启动期注册表校验：key 唯一、type 合法 */
+/**
+ * 启动期注册表校验：
+ * - key 唯一、type 合法；
+ * - scope 声明完整：bootstrap 必须有 envKey，runtime 必须有 envFallback（或无兜底）；
+ * - env 键唯一：任一 env 键至多被一项声明（bootstrap envKey 或 runtime envFallback）。
+ */
 export function validateRegistry(): void {
-  const seen = new Set<string>();
-  for (const def of SETTING_DEFINITIONS) {
-    if (seen.has(def.key)) {
+  const seenKeys = new Set<string>();
+  const seenEnvKeys = new Set<string>();
+  for (const def of CONFIG_DEFINITIONS) {
+    if (seenKeys.has(def.key)) {
       throw new Error(
         `[settings-registry] 重复的 key: ${def.key}（每个设置项 key 必须唯一）`,
       );
     }
-    seen.add(def.key);
+    seenKeys.add(def.key);
 
     if (!VALID_TYPES.includes(def.type)) {
       throw new Error(
@@ -743,6 +1269,35 @@ export function validateRegistry(): void {
           VALID_TYPES.join(", ")
         }）`,
       );
+    }
+
+    if (def.scope !== "runtime" && def.scope !== "bootstrap") {
+      throw new Error(
+        `[settings-registry] 非法 scope: ${def.key} -> ${def.scope}（合法值: runtime/bootstrap）`,
+      );
+    }
+
+    // scope 完整性
+    if (def.scope === "bootstrap" && !def.envKey) {
+      throw new Error(
+        `[settings-registry] bootstrap 项必须声明 envKey: ${def.key}`,
+      );
+    }
+    if (def.scope === "runtime" && def.envKey) {
+      throw new Error(
+        `[settings-registry] runtime 项不应声明 envKey: ${def.key}（runtime 使用 envFallback）`,
+      );
+    }
+
+    // env 键唯一性
+    const envKey = def.envKey ?? def.envFallback;
+    if (envKey) {
+      if (seenEnvKeys.has(envKey)) {
+        throw new Error(
+          `[settings-registry] env 键重复声明: ${envKey}（两个设置项不能共用一个 env 变量）`,
+        );
+      }
+      seenEnvKeys.add(envKey);
     }
 
     // integer 类型需校验 min ≤ max
@@ -760,5 +1315,20 @@ export function validateRegistry(): void {
 
 /** 按 key 快速查找注册表条目（O(1) 命中，miss 返回 undefined） */
 export function findDefinition(key: string): SettingDefinition | undefined {
-  return SETTING_DEFINITIONS.find((d) => d.key === key);
+  return CONFIG_DEFINITIONS.find((d) => d.key === key);
+}
+
+/** 是否为 bootstrap（env-owned，启动期定型只读） */
+export function isBootstrap(key: string): boolean {
+  return findDefinition(key)?.scope === "bootstrap";
+}
+
+/** 是否为 runtime（DB-owned，运行时可热改） */
+export function isRuntime(key: string): boolean {
+  return findDefinition(key)?.scope === "runtime";
+}
+
+/** 是否在管理后台可见（visible !== false） */
+export function isVisible(key: string): boolean {
+  return findDefinition(key)?.visible !== false;
 }

--- a/noj-core/tests/scripts/check-env.test.ts
+++ b/noj-core/tests/scripts/check-env.test.ts
@@ -1,0 +1,69 @@
+/**
+ * check-env 一致性校验测试。
+ *
+ * 覆盖 inspectConsistency 的三个分支：
+ * - 可见 bootstrap 键缺失于 .env.example → 报告；
+ * - 孤儿键（注册表未登记）→ 报告；
+ * - 编排级键白名单 → 豁免。
+ */
+import { assertEquals } from "jsr:@std/assert@^1";
+import { inspectConsistency } from "../../scripts/check-env.ts";
+import {
+  CONFIG_DEFINITIONS,
+  validateRegistry,
+} from "../../src/shared/config/settings-registry.ts";
+
+function registryEnvKeys(): string[] {
+  return CONFIG_DEFINITIONS
+    .map((d) => (d.scope === "bootstrap" ? d.envKey : d.envFallback))
+    .filter((k): k is string => Boolean(k));
+}
+
+Deno.test({
+  name: "check-env: inspectConsistency 报告缺失的可见 bootstrap 键",
+  fn: () => {
+    const findings = inspectConsistency(
+      registryEnvKeys(),
+      new Set(["JWT_SECRET", "PORT"]),
+    );
+    // 当前注册表 bootstrap 可见键远多于 2 个，必然有缺失报告
+    assertEquals(findings.some((f) => f.key === "STORAGE_PROVIDER"), true);
+    assertEquals(findings.some((f) => f.key === "JWT_SECRET"), false);
+  },
+});
+
+Deno.test({
+  name: "check-env: inspectConsistency 报告孤儿键（注册表未登记）",
+  fn: () => {
+    const findings = inspectConsistency(
+      registryEnvKeys(),
+      new Set(["SOME_ORPHAN_KEY_XYZ"]),
+    );
+    assertEquals(
+      findings.some((f) => f.key === "SOME_ORPHAN_KEY_XYZ"),
+      true,
+    );
+  },
+});
+
+Deno.test({
+  name: "check-env: inspectConsistency 豁免编排级键",
+  fn: () => {
+    const findings = inspectConsistency(
+      registryEnvKeys(),
+      new Set(["POSTGRES_PASSWORD", "MINIO_ROOT_PASSWORD", "NOJ_VERSION"]),
+    );
+    assertEquals(
+      findings.some((f) => f.key === "POSTGRES_PASSWORD"),
+      false,
+    );
+    assertEquals(findings.some((f) => f.key === "NOJ_VERSION"), false);
+  },
+});
+
+Deno.test({
+  name: "check-env: 注册表自身合法（validateRegistry 通过）",
+  fn: () => {
+    validateRegistry();
+  },
+});

--- a/noj-ui/pages/admin/settings.vue
+++ b/noj-ui/pages/admin/settings.vue
@@ -16,18 +16,7 @@ useRequireLogin()
 
 type SettingType = "boolean" | "string" | "text" | "integer"
 type SettingSource = "db" | "env" | "default"
-type SettingCategory =
-  | "auth"
-  | "maintenance"
-  | "email"
-  | "rate_limit"
-  | "storage"
-  | "database"
-  | "redis"
-  | "cors"
-  | "judge"
-  | "review"
-  | "other"
+type SettingScope = "runtime" | "bootstrap"
 
 interface SystemSetting {
   key: string
@@ -35,17 +24,30 @@ interface SystemSetting {
   effective_value: unknown
   raw_value: string
   source: SettingSource
+  /** 生命周期归属：runtime=DB 可热改；bootstrap=env 启动期定型只读 */
+  scope: SettingScope
   is_secret: boolean
   description: string
   updated_at: string | null
   updated_by: string | null
-  category: SettingCategory
+  category: string
   min?: number
   max?: number
   needsRestart?: boolean
+  /** bootstrap 项在 DB 中是否有被忽略的残留旧值 */
+  db_orphaned?: boolean
+  /** runtime 项：对应的 env 兜底键名（envFallback） */
+  env_key?: string
+  /** runtime 项：env 兜底当前是否非空存在 */
+  env_present?: boolean
+  /** runtime 项：DB 是否已写入该键 */
+  db_present?: boolean
+  /** runtime 项：DB 与 env 同时存在（当前 DB 值优先） */
+  conflict?: boolean
 }
 
-const CATEGORY_LABEL: Record<SettingCategory, string> = {
+/** 分类展示文案（键集合来自 API 元数据，此处仅纯展示映射） */
+const CATEGORY_LABEL: Record<string, string> = {
   auth: "认证",
   maintenance: "维护与公告",
   email: "邮件",
@@ -54,12 +56,14 @@ const CATEGORY_LABEL: Record<SettingCategory, string> = {
   database: "数据库",
   redis: "Redis",
   cors: "CORS",
+  community: "社区",
   judge: "评测资源限制",
   review: "内容合规审核",
   other: "其他",
 }
 
 const { api } = useApi()
+const { dialog } = useDialog()
 
 // ─── 数据加载 ────────────────────────────────────────────
 
@@ -67,6 +71,8 @@ const settings = ref<SystemSetting[]>([])
 const tableLoading = ref(true)
 const tableError = ref("")
 let requestVersion = 0
+/** 是否已展示进入页面时的配置冲突弹窗（每次进入页面只弹一次） */
+let conflictDialogShown = false
 
 async function loadSettings() {
   if (!isLoggedIn.value) return
@@ -85,6 +91,21 @@ async function loadSettings() {
     for (const s of res.data) {
       drafts.value[s.key] = s.is_secret ? null : s.effective_value
     }
+    // 进入页面时提示 runtime 配置的 DB/env 共存冲突
+    if (!conflictDialogShown) {
+      conflictDialogShown = true
+      const conflicts = res.data.filter((s) => s.conflict)
+      if (conflicts.length > 0) {
+        // 先结束加载态，避免弹窗期间表格一直显示 loading
+        if (currentRequest === requestVersion) tableLoading.value = false
+        await dialog.alert(
+          `检测到 ${conflicts.length} 项运行时配置同时存在 DB 值与 env 兜底：\n\n` +
+            conflicts.map((s) => `- ${s.key}（${s.env_key ?? "?"}）`).join("\n") +
+            "\n\n当前 DB 值优先。如希望 DB 值持续生效，请从 .env 移除对应变量后重启 noj-core。",
+          { title: "检测到配置来源冲突" },
+        )
+      }
+    }
   } catch (err: unknown) {
     if (currentRequest !== requestVersion) return
     tableError.value = extractApiError(err).message
@@ -101,55 +122,42 @@ watch(isLoggedIn, (val) => {
 
 const drafts = ref<Record<string, unknown>>({})
 
-/** infrastructure env-only 键名白名单（与 noj-core settings-registry 的 env-only 定义同步） */
-const ENV_ONLY_KEYS = new Set([
-  "DATABASE_URL", "DATABASE_POOL_MAX", "DATABASE_CONNECT_TIMEOUT",
-  "DATABASE_IDLE_TIMEOUT", "DATABASE_MAX_LIFETIME",
-  "REDIS_URL",
-  "JWT_SECRET", "ADMIN_EMAIL", "ADMIN_PASS", "BCRYPT_SALT_ROUNDS",
-  "CORS_ALLOWED_ORIGINS",
-  "PORT", "NOJ_ENV",
-])
-
+/** runtime（DB-owned）项：运行时可改 */
 const dbSettings = computed(() =>
-  settings.value.filter((s) => !ENV_ONLY_KEYS.has(s.key))
+  settings.value.filter((s) => s.scope === "runtime")
 )
 
+/** bootstrap（env-owned）项：只读，改 env 重启生效 */
 const envOnlySettings = computed(() =>
-  settings.value.filter((s) => ENV_ONLY_KEYS.has(s.key))
+  settings.value.filter((s) => s.scope === "bootstrap")
 )
 
-// 按 category 分组（spec 要求），未声明分类的归到 other
+// 按 category 分组（用于 env-only 只读面板）
 const envOnlyGrouped = computed(() => {
-  const groups = new Map<SettingCategory, SystemSetting[]>()
+  const groups = new Map<string, SystemSetting[]>()
   for (const s of envOnlySettings.value) {
-    const cat = (s.category ?? "other") as SettingCategory
+    const cat = s.category || "other"
     if (!groups.has(cat)) groups.set(cat, [])
     groups.get(cat)!.push(s)
   }
-  // 固定分组顺序
-  const order: SettingCategory[] = [
+  // 固定分组顺序（仅排序不在展示列表中的分类，缺省归末尾）
+  const order = [
     "auth",
-    "maintenance",
     "email",
-    "rate_limit",
     "storage",
     "database",
     "redis",
     "cors",
+    "judge",
     "other",
   ]
-  return order
-    .filter((c) => groups.has(c))
-    .map((c) => ({ category: c, items: groups.get(c)! }))
+  const sorted = [...groups.entries()].sort((a, b) => {
+    const ia = order.indexOf(a[0])
+    const ib = order.indexOf(b[0])
+    return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib)
+  })
+  return sorted.map(([category, items]) => ({ category, items }))
 })
-
-/** UTable 列定义（env-only 只读面板） */
-const envOnlyColumns = [
-  { accessorKey: "key", header: "键名" },
-  { accessorKey: "effective_value", header: "当前值" },
-  { accessorKey: "description", header: "描述" },
-]
 
 /** 获取敏感字段的脱敏方式说明（显示在 tooltip 中） */
 function getSecretTooltip(key: string): string {
@@ -226,7 +234,6 @@ async function saveSetting(key: string) {
 // ─── 重置单个设置 ─────────────────────────────────────────
 
 const resettingKeys = ref(new Set<string>())
-const { dialog } = useDialog()
 
 async function confirmReset(s: SystemSetting) {
   // spec 要求 SweetAlert2 弹窗，文案：
@@ -262,12 +269,33 @@ async function confirmReset(s: SystemSetting) {
   }
 }
 
+// ─── 清理 bootstrap 残留 DB 行 ────────────────────────────
+
+async function cleanupBootstrapRow(s: SystemSetting) {
+  if (resettingKeys.value.has(s.key)) return
+  resettingKeys.value = new Set(resettingKeys.value).add(s.key)
+  try {
+    // 幂等：删除被忽略的 DB 残留行，值仍由 .env 决定
+    await api.delete(`/api/v1/admin/settings/${s.key}`, { silent: true })
+    // 刷新整表以更新 db_orphaned 标记
+    const res = await api.get<{ data: SystemSetting[] }>("/api/v1/admin/settings", { silent: true })
+    settings.value = res.data
+    toast.success(`已清理 ${s.key} 的残留 DB 值（当前值由 .env 决定）`)
+  } catch (err: unknown) {
+    toast.error(extractApiError(err).message)
+  } finally {
+    const next = new Set(resettingKeys.value)
+    next.delete(s.key)
+    resettingKeys.value = next
+  }
+}
+
 // ─── 编辑控件辅助 ─────────────────────────────────────────
 </script>
 
 <template>
   <div class="flex flex-col gap-4">
-    <PageHeader title="系统设置" description="运行时可改的配置项，修改即时生效；只读配置需重启服务" />
+    <PageHeader title="系统设置" description="运行时配置写入数据库即时生效；环境配置由 .env 管理，修改需重启服务" />
 
     <!-- 未保存更改标识 -->
     <div
@@ -283,10 +311,9 @@ async function confirmReset(s: SystemSetting) {
     <div class="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-md text-13px text-info-text">
       <UIcon name="i-lucide-info" class="size-4 shrink-0 mt-0.5" />
       <div>
-        <strong>运行时可改：</strong>第一组设置项写入数据库，下次请求立即生效，可随时重置。
-        <strong>只读配置：</strong>第二组（折叠面板）展示当前
-        <code class="px-1 py-0.5 bg-blue-100 rounded font-mono text-[12px]">.env</code>
-        中存在的环境变量，修改需更新 .env 并重启 noj-core 服务。
+        <strong>运行时配置：</strong>写入数据库，下次请求立即生效，可随时重置。
+        <strong>环境配置：</strong>由 .env 环境变量管理（启动期定型），后台只读，
+        修改需更新 .env 并重启 noj-core 服务。
       </div>
     </div>
 
@@ -426,6 +453,15 @@ async function confirmReset(s: SystemSetting) {
                 <span v-if="s.needsRestart" class="inline-flex items-center gap-0.5 text-11px font-semibold text-warning-text">
                   <UIcon name="i-lucide-refresh-cw" class="size-3" /> 需重启生效
                 </span>
+                <UTooltip
+                  v-if="s.conflict"
+                  text="该配置同时在 .env 中设置；当前 DB 值优先。如需 DB 生效，请移除 .env 对应变量后重启 noj-core。"
+                >
+                  <span class="inline-flex items-center gap-0.5 text-11px font-semibold text-warning-text">
+                    <UIcon name="i-lucide-alert-triangle" class="size-3" />
+                    env 兜底存在（当前 DB 值优先）
+                  </span>
+                </UTooltip>
               </div>
             </td>
 
@@ -481,46 +517,90 @@ async function confirmReset(s: SystemSetting) {
         <div class="flex items-start gap-2 px-5 py-3 bg-blue-50 border-b border-blue-100 text-13px text-info-text">
           <UIcon name="i-lucide-info" class="size-3.5 shrink-0 mt-0.5" />
           <div>
-            修改这些项需要更新 .env 并重启 noj-core 服务。当前展示的是已
+            这些配置项由 .env 环境变量管理（启动期定型），修改需更新 .env 并重启
+            noj-core 服务。当前展示的是
             <code class="px-1 py-0.5 bg-blue-100 rounded font-mono text-[12px]">snapshotEnv()</code>
-            启动时快照的值。
+            启动时快照的值；未设置的项显示「未配置」。若某项标注
+            <span class="font-semibold text-warning-text">忽略 DB 旧值</span>，
+            说明数据库中仍有切换前写入的旧值（已不生效），可一键清理。
           </div>
         </div>
 
         <div v-if="envOnlySettings.length === 0" class="p-6 text-center text-sm text-text-secondary">
-          当前 .env 中没有白名单内的环境变量
+          暂无环境配置项
         </div>
-        <UTable
-          v-else
-          :columns="envOnlyColumns"
-          :data="envOnlySettings"
-          :loading="false"
-        >
-          <template #key-cell="{ row }">
-            <code class="font-mono text-13px text-text">{{ row.original.key }}</code>
-          </template>
-          <template #effective_value-cell="{ row }">
-            <UTooltip v-if="row.original.is_secret" :text="getSecretTooltip(row.original.key)" class="cursor-help">
-              <span class="inline-flex items-center gap-1">
-                <UIcon name="i-lucide-lock" class="size-3 shrink-0 text-amber-700" />
-                <code
-                  class="font-mono text-13px px-2 py-0.5 rounded underline decoration-dotted underline-offset-2 bg-amber-50 text-amber-800"
+
+        <!-- 按分类分组的只读配置 -->
+        <div v-else class="divide-y divide-border">
+          <div
+            v-for="group in envOnlyGrouped"
+            :key="group.category"
+            class="px-5 py-4"
+          >
+            <h3 class="text-13px font-semibold text-text mb-2">
+              {{ CATEGORY_LABEL[group.category] ?? group.category }}
+              <span class="ml-1 text-xs font-normal text-text-secondary">{{ group.items.length }} 项</span>
+            </h3>
+            <table class="w-full text-sm">
+              <tbody>
+                <tr
+                  v-for="s in group.items"
+                  :key="s.key"
+                  class="border-t border-border first:border-t-0 hover:bg-primary-bg transition-colors"
                 >
-                  {{ String(row.original.effective_value) }}
-                </code>
-              </span>
-            </UTooltip>
-            <code
-              v-else
-              class="font-mono text-13px px-2 py-0.5 rounded bg-bg-page text-text"
-            >
-              {{ String(row.original.effective_value) }}
-            </code>
-          </template>
-          <template #description-cell="{ row }">
-            <span class="text-13px text-text-secondary">{{ row.original.description }}</span>
-          </template>
-        </UTable>
+                  <!-- 键名 + 类型 -->
+                  <td class="px-2 py-2.5 align-top w-[200px]">
+                    <div class="flex flex-col gap-0.5">
+                      <code class="font-mono text-13px font-semibold text-text">{{ s.key }}</code>
+                      <span class="text-11px text-text-secondary">{{ s.type }}</span>
+                    </div>
+                  </td>
+                  <!-- 当前值（只读） -->
+                  <td class="px-2 py-2.5 align-top w-[220px]">
+                    <UTooltip v-if="s.is_secret && s.effective_value !== null" :text="getSecretTooltip(s.key)" class="cursor-help">
+                      <span class="inline-flex items-center gap-1">
+                        <UIcon name="i-lucide-lock" class="size-3 shrink-0 text-amber-700" />
+                        <code class="font-mono text-13px px-2 py-0.5 rounded underline decoration-dotted underline-offset-2 bg-amber-50 text-amber-800">
+                          {{ String(s.effective_value) }}
+                        </code>
+                      </span>
+                    </UTooltip>
+                    <code
+                      v-else-if="s.effective_value !== null"
+                      class="font-mono text-13px px-2 py-0.5 rounded bg-bg-page text-text"
+                    >
+                      {{ String(s.effective_value) }}
+                    </code>
+                    <span v-else class="text-13px text-text-muted italic">未配置</span>
+                  </td>
+                  <!-- 描述 + 状态徽标 -->
+                  <td class="px-2 py-2.5 align-top text-13px text-text-secondary">
+                    <div class="flex flex-col gap-1">
+                      <span>{{ s.description }}</span>
+                      <div v-if="s.db_orphaned" class="flex items-center gap-2">
+                        <span class="inline-flex items-center gap-0.5 text-11px font-semibold text-warning-text">
+                          <UIcon name="i-lucide-alert-triangle" class="size-3" />
+                          忽略 DB 旧值
+                        </span>
+                        <UButton
+                          size="xs"
+                          color="warning"
+                          variant="outline"
+                          :loading="resettingKeys.has(s.key)"
+                          :disabled="resettingKeys.has(s.key)"
+                          icon="i-lucide-trash-2"
+                          @click="cleanupBootstrapRow(s)"
+                        >
+                          清理残留值
+                        </UButton>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
       </details>
     </section>
   </div>


### PR DESCRIPTION
## 关联 Issue

无（源自 brainstorming 设计：env × DB 配置统一协调）

## 变更摘要

- 建立**生命周期两分法（scope）**配置语义：runtime（DB-owned，可热改）与 bootstrap（env-owned，启动期定型只读），每个配置项唯一归属，消除"改 .env 不生效/后台乱写启动项"的歧义。
- 合并 `SETTING_DEFINITIONS` + `ENV_ONLY_DEFINITIONS` 为单一 `CONFIG_DEFINITIONS` 注册表（~110 项，含新登记 infra env），前端/文档/校验全部由注册表驱动。
- storage/email/audit 共 17 项按功能组划归 bootstrap；后台设置页两段语义重写；check-env 新增注册表↔.env.example 一致性校验。

## 变更类型

- [x] `feat` 新功能
- [x] `refactor` 重构（无行为变化）
- [x] `docs` 文档

## 影响范围

- [x] `noj-core` 后端
- [x] `noj-ui` 前端
- [x] 配置 / 环境变量（`.env.example` 已更新）
- [x] 文档（README / noj-docs）

## 验证清单

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [x] 本地 `deno task test` 通过（noj-core 全量 911 passed / 0 failed）
- [x] 新功能 / 修复有对应测试（service/route/check-env 单测）
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [x] 非平凡变更包含 Agent Note（`.agents/notes/implemented/architecture/2026-09-02-config-layering-semantics.md`）
- [x] 相关文档已同步（CLAUDE.md / config-layering.md / .env.example）

## 补充说明

- **语义**：runtime 读取链 `DB → env(仅兜底) → 默认值`，后台可改即时生效；bootstrap 读取链 `env → 默认值`（不读 DB，残留旧值忽略 + 后台徽标 + 一键清理）。
- **存量数据**：不自动迁移——bootstrap 项 DB 残留值被忽略，启动日志提示，后台可一键清理残留行。
- **行为变化**：`PUT /api/v1/admin/settings/:key` 对 bootstrap 键（storage/email/audit 共 17 项）现在返回 400；`GET` 返回全部可见项（含未配置 bootstrap，新增 scope/visible/db_orphaned 元数据）。
- **风险**：若某环境只在 DB 配过 S3/邮件，升级后需在 .env 补齐否则回退默认（启动日志 + 后台徽标已提示）。
- 相关 spec/plan：`dev-docs/superpowers/specs|plans/2026-09-02-config-layering-semantics*`
