### PR TITLE
feat(core,judge): Phase A 工程质量修复——队列可观测、限流矩阵、SSE Outbox、judge 内存峰值

### DIFF
--- a/dev-docs/engineering/event-catalog.md
+++ b/dev-docs/engineering/event-catalog.md
@@ -4,7 +4,7 @@
 
 | 频道 | 发布位置 |
 | --- | --- |
-| `submission` | noj-core/src/domains/submission/mq/consumer.ts<br>noj-core/src/domains/submission/routes/sse.ts |
+| `submission` | noj-core/src/domains/submission/routes/sse.ts<br>noj-core/src/domains/submission/services/submissions/submissions-result.ts |
 | `queue` | noj-core/src/domains/submission/mq/consumer.ts<br>noj-core/src/domains/submission/routes/sse.ts<br>noj-core/src/domains/submission/services/queue.ts<br>noj-core/src/domains/submission/services/self-tests.ts<br>noj-core/src/domains/submission/services/submissions/artifact-submissions.ts<br>noj-core/src/domains/submission/services/submissions/submissions-crud.ts<br>noj-core/src/domains/submission/services/submissions/submissions-rejudge.ts |
 | `user` | noj-core/src/domains/community/routes/sse.ts<br>noj-core/src/domains/community/services/notifications.ts<br>noj-core/src/domains/messaging/routes/conversations.ts<br>noj-core/src/domains/messaging/services/messages.ts |
 | `contestRanking` | noj-core/src/domains/contest/routes/sse.ts<br>noj-core/src/domains/submission/services/submissions/submissions-result.ts |

--- a/dev-docs/engineering/route-catalog.md
+++ b/dev-docs/engineering/route-catalog.md
@@ -115,6 +115,7 @@
 | GET | `/problems` | noj-core/src/domains/catalog/routes/admin-problems.ts |
 | GET | `/public/recent` | noj-core/src/domains/submission/routes/submissions.ts |
 | GET | `/queue/events` | noj-core/src/domains/submission/routes/sse.ts |
+| GET | `/queue/health` | noj-core/src/domains/submission/routes/admin-submissions.ts |
 | GET | `/reports/:reportId` | noj-core/src/domains/community/routes/community.ts |
 | GET | `/roles` | noj-core/src/domains/identity/routes/admin-roles.ts |
 | GET | `/search` | noj-core/src/domains/identity/routes/users.ts |

--- a/dev-docs/engineering/write-rate-limit-matrix.md
+++ b/dev-docs/engineering/write-rate-limit-matrix.md
@@ -1,0 +1,48 @@
+# NOJ 写操作限流矩阵
+
+> 目标：让“写操作默认有速率限制”成为可审计、可维护的工程事实，避免新增端点时漏加。
+> 本文档是 **A3 限流/写操作系统矩阵** 的落地记录与维护入口。
+
+## 限流原语
+
+- **登录限流**：`noj-core/src/domains/identity/middleware/login-rate-limit.ts`，专用于认证端点。
+- **通用中间件限流**：`noj-core/src/domains/system/middleware/rate-limit.ts`，进程内最小间隔限流（多实例各自计数）。
+- **Hardening 限流（推荐）**：`noj-core/src/domains/system/services/hardening-rate-limit.ts`，Redis 固定窗口、fail-closed，适合高价值/批量写操作。
+- **服务层频率限制**：部分业务（社区发帖）在服务层按配置间隔限流，见 `community-post-crud.ts`。
+
+## 已覆盖写操作
+
+| 操作 | 路由 | 限流方式 | 阈值 |
+| --- | --- | --- | --- |
+| 注册 | `POST /auth/register` | hardening IP | 1h/100 |
+| 忘记密码 | `POST /auth/forgot-password` | hardening IP + email | IP 1h/30；email 1h/10 |
+| 重置密码 | `POST /auth/reset-password` | hardening IP + email | 同上 |
+| 修改密码 | `POST /auth/change-password` | 账号限流（loginThrottle） | 独立命名空间 |
+| TFA 确认/禁用 | `POST /auth/tfa/*` | 账号限流（loginThrottle） | TFA_NAMESPACE |
+| 私信发送 | `POST /conversations/:id/messages` | hardening user | 60s/60 |
+| 代码提交 | `POST /submissions` | hardening IP+user | 60s/120 |
+| 自测 | `POST /problems/:id/self-test` | hardening IP+user | 60s/30；user 60s/4 |
+| 竞赛提交 | `POST /contests/:id/submit` | hardening IP+user | 60s/120 |
+| 客观题提交 | `POST /problems/:id/submit`（objective） | hardening IP+user | 60s/60 |
+| 创建题目 | `POST /problems` | hardening IP+user | 60s/30 |
+| 题目导入 | `POST /problems/import-bundle` | hardening IP+user | 60s/10 |
+| 帖子点赞/取消 | `POST /posts/:postId/like` | hardening IP+user | 60s/120 |
+| 评论点赞/取消 | `POST /comments/:commentId/like` | hardening IP+user | 60s/120 |
+| 收藏/取消 | `POST /posts/:postId/bookmark` | hardening IP+user | 60s/120 |
+| 关注/取关 | `POST /users/:userId/follow` | hardening IP+user | 60s/120 |
+| 举报 | `POST /reports` | hardening IP+user | 60s/30 |
+| 社区发帖/评论 | `POST/PATCH/DELETE /community/posts|comments` | 服务层发布频率 + 内容审核 | 按社区配置 |
+
+## 已知未覆盖/可接受
+
+- **管理后台写操作**（admin settings/announcements/roles/blacklist/sanctions）：默认由管理员权限 + 审计日志兜底；不建议做宽松限流以免误伤合法管理操作。若未来公网管理员接口被扫描，可再按 IP 加宽限流。
+- **通知已读、活动可见性**：幂等且低频，暂不限流。
+- **题单/标签 CRUD**：权限受限、频率低，暂用服务层/权限兜底。
+
+## 新增写端点 Checklist
+
+1. 判断是否影响用户生成内容、资源创建或批量触发副作用。
+2. 是 → 在 `hardening-rate-limit.ts` 添加 `XXX_IP_LIMIT` / `XXX_USER_LIMIT` 与 `enforceXxxRateLimit(c, userId)`。
+3. 在路由 handler 最前面调用 `enforceXxxRateLimit(c, actorId)`。
+4. 更新本文档矩阵。
+5. 至少补充一个“超过阈值返回 429”的测试（可走 `enforceRateLimit` 基础测试 + 路由权限测试）。

--- a/noj-core/src/domains/community/routes/community.ts
+++ b/noj-core/src/domains/community/routes/community.ts
@@ -1,6 +1,13 @@
 import { Hono } from "hono";
 import { parseJsonBody } from "./../../../shared/http/request.ts";
 import {
+  enforceBookmarkRateLimit,
+  enforceCommentLikeRateLimit,
+  enforceFollowRateLimit,
+  enforcePostLikeRateLimit,
+  enforceReportRateLimit,
+} from "./../../system/index.ts";
+import {
   BadRequestError,
   ForbiddenError,
   NotFoundError,
@@ -402,6 +409,7 @@ router.delete("/comments/:commentId", authMiddleware, async (c) => {
  */
 router.post("/posts/:postId/like", authMiddleware, async (c) => {
   const actorId = userId(c);
+  await enforcePostLikeRateLimit(c, actorId);
   const postId = await resolvePostId(c.req.param("postId") as string);
   await assertPermission(c, "community:react");
   await assertCommunityWritable(actorId, await isModerator(c));
@@ -418,6 +426,7 @@ router.post("/posts/:postId/like", authMiddleware, async (c) => {
  */
 router.post("/posts/:postId/bookmark", authMiddleware, async (c) => {
   const actorId = userId(c);
+  await enforceBookmarkRateLimit(c, actorId);
   const postId = await resolvePostId(c.req.param("postId") as string);
   await assertPermission(c, "community:react");
   await assertCommunityWritable(actorId, await isModerator(c));
@@ -437,6 +446,7 @@ router.post("/posts/:postId/bookmark", authMiddleware, async (c) => {
  */
 router.post("/comments/:commentId/like", authMiddleware, async (c) => {
   const actorId = userId(c);
+  await enforceCommentLikeRateLimit(c, actorId);
   await assertPermission(c, "community:react");
   await assertCommunityWritable(actorId, await isModerator(c));
   return c.json({
@@ -456,6 +466,7 @@ router.post("/comments/:commentId/like", authMiddleware, async (c) => {
  */
 router.post("/users/:userId/follow", authMiddleware, async (c) => {
   const actorId = userId(c);
+  await enforceFollowRateLimit(c, actorId);
   await assertPermission(c, "community:follow");
   await assertCommunityWritable(actorId, await isModerator(c));
   // followeeId 可能是 username，解析为 UUID（与 profile 路由一致）
@@ -554,6 +565,7 @@ router.post("/notifications/:id/read", authMiddleware, async (c) => {
  */
 router.post("/reports", authMiddleware, async (c) => {
   const actorId = userId(c);
+  await enforceReportRateLimit(c, actorId);
   await assertPermission(c, "community:report");
   // social 封禁用户不可提交举报（防止作为骚扰/滥用通道）
   await assertCommunityWritable(actorId, await isModerator(c));

--- a/noj-core/src/domains/submission/mq/consumer.ts
+++ b/noj-core/src/domains/submission/mq/consumer.ts
@@ -9,7 +9,11 @@ import {
   logger,
   logJudgeResultReceived,
 } from "../../../shared/base/logging.ts";
-import { Channels, publishSseEvent } from "../../../shared/sse/event-bus.ts";
+import {
+  Channels,
+  publishSseEvent,
+  publishSseEventAfterTx,
+} from "../../../shared/sse/event-bus.ts";
 import { SELF_TEST_ID_PREFIX } from "../types/self-tests.ts";
 import type { JudgeResult } from "../types/index.ts";
 import { metrics } from "../../../shared/base/metrics.ts";
@@ -109,42 +113,56 @@ export async function handleResultMessage(
 
   // NOJ-074：写库失败必须向上抛出让消费者重投，
   // 不再吞掉错误导致提交永久停留在 judging。
-  let applied: boolean;
   try {
-    applied = isSelfTest
-      ? await saveSelfTestResult(judgeResult)
-      : await saveEvaluationResult(judgeResult);
+    if (isSelfTest) {
+      const applied = await saveSelfTestResult(judgeResult);
+      if (!applied) {
+        logger.info("重复/过时自测结果，已幂等忽略", {
+          self_test_id: judgeResult.submission_id,
+          rejudge_seq: judgeResult.rejudge_seq ?? 0,
+        });
+        return;
+      }
+      logger.info("自测结果已持久化", {
+        self_test_id: judgeResult.submission_id,
+      });
+      // 自测：保持原有轻量事件（自测不参与榜单/竞赛，队列事件允许轮询兜底）。
+      await publishSseEvent(
+        Channels.queue,
+        { type: "queue:changed" },
+      );
+      return;
+    }
+
+    const applied = await saveEvaluationResult(judgeResult);
+    if (!applied.applied) {
+      logger.info("评测结果为重复/过时消息，已幂等忽略", {
+        submission_id: judgeResult.submission_id,
+        rejudge_seq: judgeResult.rejudge_seq ?? 0,
+      });
+      return;
+    }
+
+    logger.info("评测结果已持久化", {
+      submission_id: judgeResult.submission_id,
+      kind: "submission",
+    });
+
+    // 正式提交：评测结果相关事件已在业务事务内写入 sse_events（事务性 Outbox），
+    // 这里只发布 Redis 实时通知，不再重复写库。
+    for (const event of applied.outbox_events) {
+      publishSseEventAfterTx(event.channel, event.payload, event.event_id);
+    }
+
+    // 队列变化通知（全局刷新类，允许轮询兜底；不要求与业务同事务）
+    await publishSseEvent(
+      Channels.queue,
+      { type: "queue:changed" },
+    );
   } catch (err) {
     metrics.inc("noj_evaluation_consumer_errors_total");
     throw err;
   }
-  if (!applied) {
-    logger.info("评测结果为重复/过时消息，已幂等忽略", {
-      submission_id: judgeResult.submission_id,
-      rejudge_seq: judgeResult.rejudge_seq ?? 0,
-    });
-    return;
-  }
-
-  logger.info("评测结果已持久化", {
-    submission_id: judgeResult.submission_id,
-    kind: isSelfTest ? "self_test" : "submission",
-  });
-
-  // 写入 SSE 事件日志并发布 Redis 通知（事件带 seq，供重放/去重）
-  if (!isSelfTest) {
-    await publishSseEvent(
-      Channels.submission(judgeResult.submission_id),
-      {
-        type: "submission:updated",
-        id: judgeResult.submission_id,
-      },
-    );
-  }
-  await publishSseEvent(
-    Channels.queue,
-    { type: "queue:changed" },
-  );
 }
 
 /**

--- a/noj-core/src/domains/submission/mq/sweeper.ts
+++ b/noj-core/src/domains/submission/mq/sweeper.ts
@@ -14,7 +14,11 @@ import { problems, selfTests, submissions } from "../../../shared/db/schema.ts";
 import { getStorageProvider } from "../../system/index.ts";
 import { getSetting } from "../../system/index.ts";
 import { getRedis } from "../../../shared/mq/connection.ts";
-import { isRetryableJudgeQueueError, JUDGE_QUEUE } from "./producer.ts";
+import {
+  isRetryableJudgeQueueError,
+  JUDGE_QUEUE,
+  MAX_JUDGE_QUEUE_LENGTH,
+} from "./producer.ts";
 import { logger } from "../../../shared/base/logging.ts";
 import type { JudgeTask } from "../types/index.ts";
 import type { RuntimeConfig } from "../../catalog/index.ts";
@@ -479,6 +483,74 @@ export async function cleanupOrphanArtifacts(now: number): Promise<void> {
   }
 }
 
+/**
+ * 队列告警去抖状态：同一异常只在上“升沿”记录一次，恢复后复位。
+ */
+const _alertStates = new Map<string, boolean>();
+
+/** 主队列积压告警阈值：达到最大队列容量的一半时告警。 */
+const MAIN_QUEUE_ALERT_THRESHOLD = MAX_JUDGE_QUEUE_LENGTH / 2;
+
+/**
+ * 检查评测队列是否存在需要运维关注的异常，并在状态变化时输出告警日志。
+ *
+ * 当前只对“死信队列非空”和“主队列积压过半”告警；processing 由 sweeper
+ * 自己重投，不单独告警，避免误报。Redis 不可用/长度为 -1 时跳过。
+ */
+async function logQueueAlertsIfNeeded(): Promise<void> {
+  const redis = getRedis();
+  if (redis.status !== "ready") {
+    try {
+      await redis.connect();
+    } catch {
+      return;
+    }
+  }
+
+  const queues = [
+    { key: "judge", main: JUDGE_QUEUE },
+    { key: "result", main: RESULT_QUEUE },
+  ] as const;
+
+  for (const { key, main } of queues) {
+    try {
+      const [queueLength, deadLength] = await Promise.all([
+        redis.llen(main),
+        redis.llen(`${main}:dead`),
+      ]);
+
+      const queueAlert = Number(queueLength ?? 0) >= MAIN_QUEUE_ALERT_THRESHOLD;
+      const deadAlert = Number(deadLength ?? 0) > 0;
+
+      const alertKeyQueue = `${key}:queue`;
+      const alertKeyDead = `${key}:dead`;
+
+      if (queueAlert && !_alertStates.get(alertKeyQueue)) {
+        logger.warn("评测队列积压超过阈值", {
+          queue: main,
+          queue_length: Number(queueLength ?? 0),
+          threshold: MAIN_QUEUE_ALERT_THRESHOLD,
+        });
+        _alertStates.set(alertKeyQueue, true);
+      } else if (!queueAlert && _alertStates.get(alertKeyQueue)) {
+        _alertStates.set(alertKeyQueue, false);
+      }
+
+      if (deadAlert && !_alertStates.get(alertKeyDead)) {
+        logger.error("评测队列出现死信消息，请及时处理", {
+          queue: main,
+          dead_length: Number(deadLength ?? 0),
+        });
+        _alertStates.set(alertKeyDead, true);
+      } else if (!deadAlert && _alertStates.get(alertKeyDead)) {
+        _alertStates.set(alertKeyDead, false);
+      }
+    } catch (err) {
+      logger.warn("评测队列告警检查失败", { queue: main, err });
+    }
+  }
+}
+
 export async function runQueueSweeperOnce(): Promise<void> {
   const now = Date.now();
   const results = await Promise.allSettled([
@@ -495,6 +567,7 @@ export async function runQueueSweeperOnce(): Promise<void> {
     recoverPendingSubmissions(now),
     recoverPendingSelfTests(now),
     cleanupOrphanArtifacts(now),
+    logQueueAlertsIfNeeded(),
   ]);
   for (const result of results) {
     if (result.status === "rejected") {

--- a/noj-core/src/domains/submission/routes/admin-submissions.ts
+++ b/noj-core/src/domains/submission/routes/admin-submissions.ts
@@ -9,7 +9,7 @@ import {
   rejudgeSubmission,
   resolveSubmissionId,
 } from "../services/submissions/submissions.ts";
-import { removePendingSubmission } from "../services/queue.ts";
+import { getQueueHealth, removePendingSubmission } from "../services/queue.ts";
 import { resolveProblem } from "./../../catalog/index.ts";
 import { SUBMISSION_STATUSES } from "../types/index.ts";
 
@@ -100,6 +100,15 @@ router.delete("/submissions/:id", async (c) => {
   const id = await resolveSubmissionId(c.req.param("id") as string);
   await deleteSubmission(id);
   return c.body(null, 204);
+});
+
+/**
+ * 管理员查看评测队列健康状态。
+ * GET /api/v1/admin/queue/health
+ */
+router.get("/queue/health", async (c) => {
+  const health = await getQueueHealth();
+  return c.json(health);
 });
 
 /** 管理员移除尚未领取的评测任务。 */

--- a/noj-core/src/domains/submission/services/queue.ts
+++ b/noj-core/src/domains/submission/services/queue.ts
@@ -18,6 +18,9 @@ import { SELF_TEST_ID_PREFIX } from "./../types/self-tests.ts";
 /** 评测任务队列名称（与 producer.ts 一致）。 */
 const JUDGE_QUEUE = "noj:judge:queue";
 
+/** 评测结果队列名称（与 consumer.ts 一致）。 */
+const RESULT_QUEUE = "noj:judge:results";
+
 /** 监控/列表路径默认只读取的 pending 条目数；超过时为保证正确性回退全量 LRANGE。 */
 const PENDING_LIST_LIMIT = 1000;
 
@@ -56,6 +59,26 @@ export interface QueueResponse {
   judging: QueueItem[];
   recently_completed: QueueItem[];
   stats: QueueStats;
+}
+
+/** 单条评测队列的健康快照。 */
+export interface QueueHealthEntry {
+  /** 主队列当前长度（待 worker 领取）。 */
+  queue_length: number;
+  /** processing 列表当前长度（已领取但未确认）。 */
+  processing_length: number;
+  /** dead 死信队列当前长度。 */
+  dead_length: number;
+}
+
+/** `GET /api/v1/admin/queue/health` 响应体。 */
+export interface QueueHealthResponse {
+  /** 评测任务队列（noj-core → noj-judge）。 */
+  judge: QueueHealthEntry;
+  /** 评测结果队列（noj-judge → noj-core）。 */
+  result: QueueHealthEntry;
+  /** Redis 是否可用；不可用时各队列长度降级为 -1。 */
+  redis_ok: boolean;
 }
 
 /** 队列查询所需的表列集合。 */
@@ -547,5 +570,79 @@ export async function getSubmissionQueueStatus(
     queue_length: queueLength,
     judge_started_at: row.judge_started_at ?? null,
     judge_finished_at: row.judge_finished_at ?? null,
+  };
+}
+
+/**
+ * 从 Redis 读取单个队列（主队列/processing/dead）的健康快照。
+ *
+ * 用于管理端队列状态页与健康检查。Redis 不可用或任一读取失败时：
+ * - 长度字段返回 -1（调用方可据此判定 degraded）；
+ * - 不抛出异常，避免健康检查本身把服务打挂。
+ *
+ * 注意：当前不暴露 processing 中最老消息的“真实年龄”，因为现有消息
+ * 负载没有内建时间戳，无法在不扫描/反序列化每条消息的情况下可靠计算。
+ * 这里只暴露 O(1) 的长度指标，避免提供误导性数据。
+ */
+async function readQueueHealth(mainQueue: string): Promise<QueueHealthEntry> {
+  const redis = getRedis();
+  if (redis.status !== "ready") {
+    try {
+      await redis.connect();
+    } catch {
+      return {
+        queue_length: -1,
+        processing_length: -1,
+        dead_length: -1,
+      };
+    }
+  }
+
+  try {
+    const [queueLength, processingLength, deadLength] = await Promise.all([
+      redis.llen(mainQueue),
+      redis.llen(`${mainQueue}:processing`),
+      redis.llen(`${mainQueue}:dead`),
+    ]);
+
+    return {
+      queue_length: Number(queueLength ?? 0),
+      processing_length: Number(processingLength ?? 0),
+      dead_length: Number(deadLength ?? 0),
+    };
+  } catch (err) {
+    logger.warn("读取队列健康状态失败", { mainQueue, err });
+    return {
+      queue_length: -1,
+      processing_length: -1,
+      dead_length: -1,
+    };
+  }
+}
+
+/**
+ * 获取评测任务/结果队列的健康状态（管理端/运维用）。
+ *
+ * Redis 不可用时返回 `redis_ok: false`，各队列长度均为 -1。
+ */
+export async function getQueueHealth(): Promise<QueueHealthResponse> {
+  const redis = getRedis();
+  let redisOk = false;
+  try {
+    if (redis.status !== "ready") {
+      await redis.connect();
+    }
+    await redis.ping();
+    redisOk = true;
+  } catch {
+    redisOk = false;
+  }
+
+  const judge = await readQueueHealth(JUDGE_QUEUE);
+  const result = await readQueueHealth(RESULT_QUEUE);
+  return {
+    judge,
+    result,
+    redis_ok: redisOk,
   };
 }

--- a/noj-core/src/domains/submission/services/submissions/submissions-result.ts
+++ b/noj-core/src/domains/submission/services/submissions/submissions-result.ts
@@ -11,6 +11,7 @@
 import { and, eq, ne, sql } from "drizzle-orm";
 import {
   evaluationResults,
+  sseEvents,
   submissions,
 } from "./../../../../shared/db/schema.ts";
 import {
@@ -23,10 +24,7 @@ import type { JudgeResult, SubmissionStatus } from "../../types/index.ts";
 import { applyNewResult } from "../../../query/index.ts";
 import { refreshRankingsView } from "../../../query/index.ts";
 import { logger } from "./../../../../shared/base/logging.ts";
-import {
-  Channels,
-  publishSseEvent,
-} from "./../../../../shared/sse/event-bus.ts";
+import { Channels } from "./../../../../shared/sse/event-bus.ts";
 import { createActivity } from "../../../community/index.ts";
 
 // 允许的状态转换
@@ -37,16 +35,33 @@ const VALID_TRANSITIONS: Record<SubmissionStatus, SubmissionStatus[]> = {
   error: [],
 };
 
+/** 评测结果应用后需要实时通知的持久化 SSE 事件。 */
+export interface SseEventOutboxItem {
+  channel: string;
+  payload: Record<string, unknown>;
+  /** 事务内写入 `sse_events` 后返回的全局事件 id。 */
+  event_id: number;
+}
+
+/** `saveEvaluationResult` 返回值。 */
+export interface SaveEvaluationResultOutcome {
+  applied: boolean;
+  /** 已随业务事务持久化、待事务提交后发布 Redis 的事件。 */
+  outbox_events: SseEventOutboxItem[];
+}
+
 /**
  * 保存评测结果（幂等 + rejudge_seq 事务内校验）。
  *
- * 返回 true 表示本次结果已应用；false 表示过时/重复消息已忽略。
+ * 返回 `{ applied, outbox_events }`：`applied=false` 表示过时/重复消息已忽略；
+ * `outbox_events` 是已随业务事务写入 `sse_events` 表、等待事务提交后
+ * 发布 Redis 的事件列表（事务性 Outbox）。
  * 事务内对 submissions 行加锁，避免 NOJ-065 的 TOCTOU 与 NOJ-068/182
  * 的重复统计。
  */
 export async function saveEvaluationResult(
   result: JudgeResult,
-): Promise<boolean> {
+): Promise<SaveEvaluationResultOutcome> {
   const db = getDb();
 
   const incomingSeq = result.rejudge_seq ?? 0;
@@ -145,6 +160,40 @@ export async function saveEvaluationResult(
         created_at: now,
       });
 
+    // 事务性 Outbox：在同一事务内写入 SSE 事件，提交后由调用方发布 Redis。
+    const outboxEvents: SseEventOutboxItem[] = [];
+    const [submissionEventRow] = await tx.insert(sseEvents).values({
+      channel: Channels.submission(result.submission_id),
+      payload: { type: "submission:updated", id: result.submission_id },
+      created_at: now,
+    }).returning({ id: sseEvents.id });
+    outboxEvents.push({
+      channel: Channels.submission(result.submission_id),
+      payload: { type: "submission:updated", id: result.submission_id },
+      event_id: submissionEventRow.id,
+    });
+
+    if (sub.contest_id) {
+      const [contestEventRow] = await tx.insert(sseEvents).values({
+        channel: Channels.contestRanking(sub.contest_id),
+        payload: {
+          type: "contest:ranking:updated",
+          contest_id: sub.contest_id,
+          submission_id: result.submission_id,
+        },
+        created_at: now,
+      }).returning({ id: sseEvents.id });
+      outboxEvents.push({
+        channel: Channels.contestRanking(sub.contest_id),
+        payload: {
+          type: "contest:ranking:updated",
+          contest_id: sub.contest_id,
+          submission_id: result.submission_id,
+        },
+        event_id: contestEventRow.id,
+      });
+    }
+
     return {
       applied: true,
       created_at: sub.created_at,
@@ -153,10 +202,11 @@ export async function saveEvaluationResult(
       problem_id: sub.problem_id,
       is_rejudge: sub.rejudge_seq > 0,
       artifact_storage_url: sub.artifact_storage_url,
+      outbox_events: outboxEvents,
     };
   });
 
-  if (!outcome) return false;
+  if (!outcome) return { applied: false, outbox_events: [] };
 
   // artifact 评测完成（finished/error）后立即删除存储对象
   if (outcome.artifact_storage_url) {
@@ -209,18 +259,10 @@ export async function saveEvaluationResult(
     }
   }
 
-  if (outcome.contest_id) {
-    await publishSseEvent(
-      Channels.contestRanking(outcome.contest_id),
-      {
-        type: "contest:ranking:updated",
-        contest_id: outcome.contest_id,
-        submission_id: result.submission_id,
-      },
-    );
-  }
-
-  return true;
+  return {
+    applied: true,
+    outbox_events: outcome.outbox_events,
+  };
 }
 
 /**

--- a/noj-core/src/domains/submission/tests/routes/queue.test.ts
+++ b/noj-core/src/domains/submission/tests/routes/queue.test.ts
@@ -42,6 +42,60 @@ Deno.test({
 });
 
 Deno.test({
+  name: "queue route: GET /api/v1/admin/queue/health 无 token 返回 401",
+  ignore: skip,
+  fn: async () => {
+    const app = createApp();
+    const res = await jsonRequest(app, "/api/v1/admin/queue/health");
+    assertEquals(res.status, 401);
+  },
+});
+
+Deno.test({
+  name: "queue route: GET /api/v1/admin/queue/health 非管理员返回 403",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const app = createApp();
+    const token = await createUserToken();
+    const res = await jsonRequest(app, "/api/v1/admin/queue/health", {
+      token,
+    });
+    assertEquals(res.status, 403);
+  },
+});
+
+Deno.test({
+  name: "queue route: GET /api/v1/admin/queue/health 管理员返回 200 且结构完整",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await ensureReady();
+    if (!ready) return;
+
+    const app = createApp();
+    const token = await createUserToken("admin");
+    const res = await jsonRequest(app, "/api/v1/admin/queue/health", {
+      token,
+    });
+    assertEquals(res.status, 200);
+
+    const body = await res.json();
+    assertExists(body.judge);
+    assertExists(body.result);
+    assertEquals(typeof body.redis_ok, "boolean");
+    assertEquals(typeof body.judge.queue_length, "number");
+    assertEquals(typeof body.judge.processing_length, "number");
+    assertEquals(typeof body.judge.dead_length, "number");
+    assertEquals(typeof body.result.queue_length, "number");
+    assertEquals(typeof body.result.processing_length, "number");
+    assertEquals(typeof body.result.dead_length, "number");
+  },
+});
+
+Deno.test({
   name: "queue route: GET /api/v1/queue 非管理员返回 200",
   ignore: skip,
   sanitizeResources: false,

--- a/noj-core/src/domains/submission/tests/services/queue-health.test.ts
+++ b/noj-core/src/domains/submission/tests/services/queue-health.test.ts
@@ -1,0 +1,86 @@
+/**
+ * 评测队列健康服务单元测试。
+ *
+ * 仅依赖 Redis（不需要 PostgreSQL），验证 getQueueHealth 的返回结构与
+ * Redis 不可用时的降级行为。
+ */
+
+import { assertEquals, assertExists } from "jsr:@std/assert@^1";
+import {
+  connectRedis,
+  getRedis,
+  resetRedisForTest,
+} from "../../../../shared/mq/connection.ts";
+import { getQueueHealth } from "../../index.ts";
+
+const hasRedis = !!Deno.env.get("REDIS_URL");
+const skip = !hasRedis;
+
+// 模块级初始化：连接共享 Redis
+if (hasRedis) {
+  resetRedisForTest();
+  await connectRedis();
+}
+
+Deno.test({
+  name: "queue health: getQueueHealth 返回完整结构",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const health = await getQueueHealth();
+    assertExists(health.judge);
+    assertExists(health.result);
+    assertEquals(typeof health.redis_ok, "boolean");
+    assertEquals(health.redis_ok, true);
+
+    for (const entry of [health.judge, health.result]) {
+      assertEquals(typeof entry.queue_length, "number");
+      assertEquals(typeof entry.processing_length, "number");
+      assertEquals(typeof entry.dead_length, "number");
+      // Redis 正常时长度不应为 -1
+      assertEquals(entry.queue_length >= 0, true);
+      assertEquals(entry.processing_length >= 0, true);
+      assertEquals(entry.dead_length >= 0, true);
+    }
+  },
+});
+
+Deno.test({
+  name: "queue health: 主队列存在消息时长度 > 0",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const redis = getRedis();
+    const queue = "noj:judge:queue";
+    const before = await getQueueHealth();
+    const beforeLen = before.judge.queue_length;
+
+    await redis.lpush(
+      queue,
+      JSON.stringify({
+        submission_id: "queue-health-test",
+        problem_id: "problem-health-test",
+        runtime_config: {},
+        language: "python3",
+        code: "print(1)",
+      }),
+    );
+
+    try {
+      const after = await getQueueHealth();
+      assertEquals(after.judge.queue_length, beforeLen + 1);
+    } finally {
+      // 清理测试消息：按内容精确移除，避免误删真实任务
+      const raw = JSON.stringify({
+        submission_id: "queue-health-test",
+        problem_id: "problem-health-test",
+        runtime_config: {},
+        language: "python3",
+        code: "print(1)",
+      });
+      await redis.lrem(queue, 1, raw);
+    }
+  },
+});

--- a/noj-core/src/domains/submission/tests/services/submissions.test.ts
+++ b/noj-core/src/domains/submission/tests/services/submissions.test.ts
@@ -15,6 +15,7 @@ import {
   contests,
   evaluationResults,
   problems,
+  sseEvents,
   submissions,
   users,
 } from "../../../../shared/db/schema.ts";
@@ -22,7 +23,7 @@ import {
   BadRequestError,
   NotFoundError,
 } from "../../../../shared/base/errors.ts";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { enterTestContext } from "../../../system/index.ts";
 import {
   type LogRecord,
@@ -492,6 +493,15 @@ Deno.test({
     assertEquals(result[0].score, 1000);
     assertEquals(result[0].time_ms, 2340);
     assertEquals(result[0].memory_kb, 18432);
+
+    // A4：事务性 Outbox——应同时写入一条 submission:updated SSE 事件
+    const events = await db
+      .select()
+      .from(sseEvents)
+      .where(
+        sql`${sseEvents.channel} = ${`noj:events:submission:${submissionId}`}`,
+      );
+    assertEquals(events.length >= 1, true, "评测结果事务内应写入 SSE 事件");
   },
 });
 
@@ -640,7 +650,7 @@ Deno.test({
         time_ms: 200,
         memory_kb: 2048,
       });
-      assertEquals(appliedAgain, false);
+      assertEquals(appliedAgain.applied, false);
 
       // 断言：只有 1 行，内容保持第一次结果。
       const rows = await db.select().from(evaluationResults)

--- a/noj-core/src/domains/system/services/hardening-rate-limit.ts
+++ b/noj-core/src/domains/system/services/hardening-rate-limit.ts
@@ -94,6 +94,56 @@ export const PROBLEM_IMPORT_USER_LIMIT: RateLimitConfig = {
   max: 10,
 };
 
+export const POST_LIKE_IP_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 120,
+};
+
+export const POST_LIKE_USER_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 120,
+};
+
+export const COMMENT_LIKE_IP_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 120,
+};
+
+export const COMMENT_LIKE_USER_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 120,
+};
+
+export const BOOKMARK_IP_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 120,
+};
+
+export const BOOKMARK_USER_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 120,
+};
+
+export const FOLLOW_IP_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 120,
+};
+
+export const FOLLOW_USER_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 120,
+};
+
+export const REPORT_IP_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 30,
+};
+
+export const REPORT_USER_LIMIT: RateLimitConfig = {
+  windowSec: 60,
+  max: 30,
+};
+
 function normalizeLimitKey(value: string): string {
   return value.trim().toLowerCase().slice(0, 128);
 }
@@ -239,5 +289,80 @@ export async function enforceProblemImportRateLimit(
   await enforceRateLimit(
     `problem-import:user:${userId}`,
     PROBLEM_IMPORT_USER_LIMIT,
+  );
+}
+
+/** 帖子点赞/取消点赞：IP + 用户双维度。 */
+export async function enforcePostLikeRateLimit(
+  c: Context,
+  userId: string,
+): Promise<void> {
+  await enforceRateLimit(
+    `post-like:ip:${getClientIp(c)}`,
+    POST_LIKE_IP_LIMIT,
+  );
+  await enforceRateLimit(
+    `post-like:user:${userId}`,
+    POST_LIKE_USER_LIMIT,
+  );
+}
+
+/** 评论点赞/取消点赞：IP + 用户双维度。 */
+export async function enforceCommentLikeRateLimit(
+  c: Context,
+  userId: string,
+): Promise<void> {
+  await enforceRateLimit(
+    `comment-like:ip:${getClientIp(c)}`,
+    COMMENT_LIKE_IP_LIMIT,
+  );
+  await enforceRateLimit(
+    `comment-like:user:${userId}`,
+    COMMENT_LIKE_USER_LIMIT,
+  );
+}
+
+/** 收藏/取消收藏帖子：IP + 用户双维度。 */
+export async function enforceBookmarkRateLimit(
+  c: Context,
+  userId: string,
+): Promise<void> {
+  await enforceRateLimit(
+    `bookmark:ip:${getClientIp(c)}`,
+    BOOKMARK_IP_LIMIT,
+  );
+  await enforceRateLimit(
+    `bookmark:user:${userId}`,
+    BOOKMARK_USER_LIMIT,
+  );
+}
+
+/** 关注/取关用户：IP + 用户双维度。 */
+export async function enforceFollowRateLimit(
+  c: Context,
+  userId: string,
+): Promise<void> {
+  await enforceRateLimit(
+    `follow:ip:${getClientIp(c)}`,
+    FOLLOW_IP_LIMIT,
+  );
+  await enforceRateLimit(
+    `follow:user:${userId}`,
+    FOLLOW_USER_LIMIT,
+  );
+}
+
+/** 举报：IP + 用户双维度，阈值更严格（防止举报轰炸）。 */
+export async function enforceReportRateLimit(
+  c: Context,
+  userId: string,
+): Promise<void> {
+  await enforceRateLimit(
+    `report:ip:${getClientIp(c)}`,
+    REPORT_IP_LIMIT,
+  );
+  await enforceRateLimit(
+    `report:user:${userId}`,
+    REPORT_USER_LIMIT,
   );
 }

--- a/noj-core/src/domains/system/tests/services/hardening-rate-limit.test.ts
+++ b/noj-core/src/domains/system/tests/services/hardening-rate-limit.test.ts
@@ -1,0 +1,101 @@
+/**
+ * hardening 限流配置与基础行为测试。
+ *
+ * 不依赖 DB；限流基础行为依赖 Redis（无 Redis 时跳过）。
+ */
+
+import { assert, assertEquals } from "jsr:@std/assert@^1";
+import {
+  BOOKMARK_IP_LIMIT,
+  BOOKMARK_USER_LIMIT,
+  COMMENT_LIKE_IP_LIMIT,
+  COMMENT_LIKE_USER_LIMIT,
+  enforceRateLimit,
+  FOLLOW_IP_LIMIT,
+  FOLLOW_USER_LIMIT,
+  POST_LIKE_IP_LIMIT,
+  POST_LIKE_USER_LIMIT,
+  REPORT_IP_LIMIT,
+  REPORT_USER_LIMIT,
+} from "../../index.ts";
+import {
+  connectRedis,
+  getRedis,
+  resetRedisForTest,
+} from "../../../../shared/mq/connection.ts";
+import { RateLimitedError } from "../../../../shared/base/errors.ts";
+
+const hasRedis = !!Deno.env.get("REDIS_URL");
+const skip = !hasRedis;
+
+if (hasRedis) {
+  resetRedisForTest();
+  await connectRedis();
+}
+
+const ALL_LIMITS = [
+  POST_LIKE_IP_LIMIT,
+  POST_LIKE_USER_LIMIT,
+  COMMENT_LIKE_IP_LIMIT,
+  COMMENT_LIKE_USER_LIMIT,
+  BOOKMARK_IP_LIMIT,
+  BOOKMARK_USER_LIMIT,
+  FOLLOW_IP_LIMIT,
+  FOLLOW_USER_LIMIT,
+  REPORT_IP_LIMIT,
+  REPORT_USER_LIMIT,
+] as const;
+
+Deno.test({
+  name: "hardening rate limit: 新增社区写操作限流配置合法",
+  fn: () => {
+    for (const cfg of ALL_LIMITS) {
+      assertEquals(typeof cfg.windowSec, "number");
+      assertEquals(typeof cfg.max, "number");
+      assert(cfg.windowSec > 0);
+      assert(cfg.max > 0);
+    }
+  },
+});
+
+Deno.test({
+  name: "hardening rate limit: enforceRateLimit 超过阈值抛 RateLimitedError",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const previousRateLimitEnabled = Deno.env.get("RATE_LIMIT_ENABLED");
+    const previousNojEnv = Deno.env.get("NOJ_ENV");
+    Deno.env.set("RATE_LIMIT_ENABLED", "true");
+    Deno.env.set("NOJ_ENV", "development");
+
+    const redis = getRedis();
+    // 使用一个短窗口小阈值，避免污染生产 key
+    const key = `test-hardening:${Date.now()}`;
+    await redis.del(`ratelimit:${key}`);
+    const cfg = { windowSec: 60, max: 2 };
+
+    try {
+      await enforceRateLimit(key, cfg);
+      await enforceRateLimit(key, cfg);
+      try {
+        await enforceRateLimit(key, cfg);
+        throw new Error("expected RateLimitedError");
+      } catch (err) {
+        assertEquals(err instanceof RateLimitedError, true);
+      }
+    } finally {
+      await redis.del(`ratelimit:${key}`);
+      if (previousRateLimitEnabled === undefined) {
+        Deno.env.delete("RATE_LIMIT_ENABLED");
+      } else {
+        Deno.env.set("RATE_LIMIT_ENABLED", previousRateLimitEnabled);
+      }
+      if (previousNojEnv === undefined) {
+        Deno.env.delete("NOJ_ENV");
+      } else {
+        Deno.env.set("NOJ_ENV", previousNojEnv);
+      }
+    }
+  },
+});

--- a/noj-core/src/main.ts
+++ b/noj-core/src/main.ts
@@ -8,6 +8,7 @@ import {
   startResultConsumerWithRetry,
 } from "./domains/submission/index.ts";
 import { initEventSubscriber } from "./shared/sse/event-bus.ts";
+import { startSseEventRetentionTask } from "./shared/sse/sse-events.ts";
 import { snapshotEnv } from "./domains/system/index.ts";
 import { validateRegistry } from "./shared/config/settings-registry.ts";
 import { createReviewConsumer } from "./domains/content-review/index.ts";
@@ -233,6 +234,9 @@ async function main() {
 
   // 启动后台审计日志保留任务
   startAuditLogRetentionTask();
+
+  // 启动 SSE 事件保留任务（A4：事件表保留策略，默认 7 天）
+  startSseEventRetentionTask();
 
   // NOJ-030：监听 SIGTERM/SIGINT，先停止接收新请求并排空，再关闭 Redis/DB。
   let shuttingDown = false;

--- a/noj-core/src/routes/health.ts
+++ b/noj-core/src/routes/health.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { checkDbHealth } from "./../shared/db/connection.ts";
 import { checkRedisHealth } from "./../shared/mq/connection.ts";
-import { consumerAlive } from "../domains/submission/index.ts";
+import { consumerAlive, getQueueHealth } from "../domains/submission/index.ts";
 
 const health = new Hono();
 
@@ -9,14 +9,43 @@ interface DependencyHealth {
   database: { ok: boolean; error?: string };
   redis: { ok: boolean; error?: string };
   consumer: { ok: boolean };
+  queue: {
+    ok: boolean;
+    redis_ok: boolean;
+    judge: {
+      queue_length: number;
+      processing_length: number;
+      dead_length: number;
+    };
+    result: {
+      queue_length: number;
+      processing_length: number;
+      dead_length: number;
+    };
+  };
 }
 
 async function dependencyHealth(): Promise<DependencyHealth> {
-  const [database, redis] = await Promise.all([
+  const [database, redis, queue] = await Promise.all([
     checkDbHealth(),
     checkRedisHealth(),
+    getQueueHealth(),
   ]);
-  return { database, redis, consumer: { ok: consumerAlive.value } };
+  // 队列状态只作为可观测字段，不参与 ready/healthy 判定。
+  const queueOk = queue.redis_ok &&
+    queue.judge.queue_length >= 0 &&
+    queue.result.queue_length >= 0;
+  return {
+    database,
+    redis,
+    consumer: { ok: consumerAlive.value },
+    queue: {
+      ok: queueOk,
+      redis_ok: queue.redis_ok,
+      judge: queue.judge,
+      result: queue.result,
+    },
+  };
 }
 
 function publicDependencyHealth(
@@ -27,12 +56,21 @@ function publicDependencyHealth(
     database: dependencies.database.ok ? "ok" : "error",
     redis: dependencies.redis.ok ? "ok" : "error",
     consumer: dependencies.consumer.ok ? "ok" : "error",
+    queue: dependencies.queue.ok ? "ok" : "error",
     checks: {
       database: showDetails
         ? dependencies.database
         : { ok: dependencies.database.ok },
       redis: showDetails ? dependencies.redis : { ok: dependencies.redis.ok },
       consumer: dependencies.consumer,
+      queue: showDetails
+        ? {
+          ok: dependencies.queue.ok,
+          redis_ok: dependencies.queue.redis_ok,
+          judge: dependencies.queue.judge,
+          result: dependencies.queue.result,
+        }
+        : { ok: dependencies.queue.ok },
     },
   };
 }

--- a/noj-core/src/shared/sse/event-bus.ts
+++ b/noj-core/src/shared/sse/event-bus.ts
@@ -85,6 +85,23 @@ export async function publishSseEvent(
 }
 
 /**
+ * 事务提交成功后发送 Redis 通知，事件 id 来自事务内 `recordSseEventTx`。
+ *
+ * 与 `sse-events.recordSseEventTx` 配对使用；payload 会附带 `seq` 供客户端去重。
+ * 仅负责实时扇出，不重复写库。
+ */
+export function publishSseEventAfterTx(
+  channel: string,
+  payload: unknown,
+  eventId: number,
+): void {
+  publishEvent(
+    channel,
+    JSON.stringify({ ...(payload as object), seq: eventId }),
+  );
+}
+
+/**
  * 本地 EventEmitter 回调类型。
  */
 type EventCallback = (channel: string, message: string) => void;

--- a/noj-core/src/shared/sse/sse-events.ts
+++ b/noj-core/src/shared/sse/sse-events.ts
@@ -4,9 +4,13 @@
  * 所有 SSE 频道共享 `sse_events` 表，全局单调 `id` 作为 Last-Event-ID。
  * 事件在状态变更处写入，随后发布 Redis Pub/Sub 通知。
  */
-import { and, asc, gt, inArray } from "drizzle-orm";
+import { and, asc, gt, inArray, lte } from "drizzle-orm";
 import { getDb } from "../db/connection.ts";
 import { sseEvents } from "../db/schema.ts";
+import { logger } from "../base/logging.ts";
+
+/** SSE 事件默认保留天数。 */
+export const SSE_EVENT_RETENTION_DAYS = 7;
 
 /** SSE 事件行。 */
 export interface SseEventRow {
@@ -51,4 +55,57 @@ export async function replaySseEvents(
     ),
   ).orderBy(asc(sseEvents.id)).limit(limit);
   return rows;
+}
+
+/**
+ * 清理超过保留天数的 SSE 事件，返回删除行数。
+ * 保留策略默认 7 天；超过保留期的客户端以 REST 全量校准。
+ */
+export async function cleanupOldSseEvents(
+  retentionDays = SSE_EVENT_RETENTION_DAYS,
+): Promise<number> {
+  if (retentionDays <= 0) return 0;
+  const cutoff = new Date(
+    Date.now() - retentionDays * 86400 * 1000,
+  ).toISOString();
+  const db = getDb();
+  const result = await db.delete(sseEvents).where(
+    lte(sseEvents.created_at, cutoff),
+  );
+  const r = result as unknown as {
+    affectedRows?: number;
+    rowCount?: number;
+    count?: number;
+  };
+  return r.affectedRows ?? r.rowCount ?? r.count ?? 0;
+}
+
+let _sseRetentionStarted = false;
+
+/**
+ * 启动 SSE 事件保留清理任务（幂等）。
+ * 启动时立即执行一次，之后每 24 小时执行一次。
+ */
+export function startSseEventRetentionTask(): void {
+  if (_sseRetentionStarted) return;
+  _sseRetentionStarted = true;
+
+  const runOnce = (): void => {
+    cleanupOldSseEvents()
+      .then((n) => {
+        if (n > 0) {
+          logger.info("SSE 事件保留清理完成", {
+            removed: n,
+            retention_days: SSE_EVENT_RETENTION_DAYS,
+          });
+        }
+      })
+      .catch((err) => logger.error("SSE 事件保留清理失败", { err }));
+  };
+
+  runOnce();
+  setInterval(runOnce, 86400 * 1000);
+  logger.info("SSE 事件保留任务已启动", {
+    retention_days: SSE_EVENT_RETENTION_DAYS,
+  });
 }

--- a/noj-core/tests/routes/health.test.ts
+++ b/noj-core/tests/routes/health.test.ts
@@ -19,6 +19,11 @@ Deno.test({
     assertExists(body.database);
     assertExists(body.redis);
     assertExists(body.consumer);
+    assertExists(body.queue);
+    assertExists(body.checks.queue);
+    assertEquals(typeof body.checks.queue.redis_ok, "boolean");
+    assertEquals(typeof body.checks.queue.judge.queue_length, "number");
+    assertEquals(typeof body.checks.queue.result.queue_length, "number");
   },
 });
 

--- a/noj-judge/AGENTS.md
+++ b/noj-judge/AGENTS.md
@@ -147,8 +147,13 @@ cargo fmt
 ```
 
 当前实现回填 `time_ms`（从评测开始到结果生成的墙上时钟耗时）；
-`memory_kb` 暂不读取（Docker API 未暴露 cgroup memory.peak，保持 `null`）。
-OOM 容器由 `docker rm -f` 回收，不映射 MemoryLimitExceeded。
+`memory_kb` 通过销毁前读取一次 Docker stats 尽力回填：
+- cgroups v1 使用 `memory_stats.max_usage`（真实峰值）；
+- cgroups v2 无 `max_usage` 时回退到 `usage`（近似值）；
+- 读取失败或容器不可用时保持 `null`（不阻断评测）。
+
+OOM 容器由 `docker rm -f` 回收；当前仍不单独映射 `MemoryLimitExceeded`
+（Solution OOM 由 evaluator/超时路径归因）。
 
 ### 超时处理细节
 

--- a/noj-judge/src/dual/mod.rs
+++ b/noj-judge/src/dual/mod.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use bollard::container::LogOutput;
+use bollard::query_parameters::StatsOptionsBuilder;
 use futures_util::StreamExt;
 use serde_json::Value;
 use tokio::io::AsyncWriteExt;
@@ -281,6 +282,32 @@ pub async fn evaluate_dual_with_cpu_limit(
     .await
 }
 
+/// 从容器读取一次内存峰值（KB）。
+///
+/// Docker `stats` 的 `memory_stats.max_usage` 仅 cgroups v1 可用；
+/// cgroups v2 下该字段缺失，回退到 `usage` 近似值。读取失败或容器已销毁时
+/// 返回 `None`（不阻断评测主流程）。
+async fn read_container_memory_peak_kb(
+    docker: &bollard::Docker,
+    container_id: &str,
+) -> Option<u64> {
+    let options = StatsOptionsBuilder::default()
+        .stream(false)
+        .one_shot(true)
+        .build();
+    let mut stream = docker.stats(container_id, Some(options));
+
+    let stat = match tokio::time::timeout(Duration::from_secs(3), stream.next()).await {
+        Ok(Some(Ok(stat))) => stat,
+        _ => return None,
+    };
+
+    let memory = stat.memory_stats?;
+    // max_usage 单位字节；cgroups v2 无 max_usage 时退回 usage。
+    let peak_bytes = memory.max_usage.or(memory.usage)?;
+    Some(peak_bytes / 1024)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn evaluate_dual_with_cpu_limit_and_user_llm(
     docker: bollard::Docker,
@@ -427,16 +454,28 @@ pub async fn evaluate_dual_with_cpu_limit_and_user_llm(
     )
     .await;
 
+    // NOJ-162：销毁前读取 Solution 容器内存峰值（仅尽力而为，失败不影响结果）
+    let memory_peak_kb = read_container_memory_peak_kb(&docker, &solution_id).await;
+    if let Some(kb) = memory_peak_kb {
+        info!(
+            submission_id = task_submission_id,
+            memory_kb = kb,
+            "Solution 容器内存峰值已读取"
+        );
+    }
+
     // 8. 显式销毁（不论成功失败）
     if let Err(e) = dual.destroy().await {
         warn!("DualContainer 销毁警告: {}", e);
     }
 
-    // NOJ-162（部分）：回填真实总耗时；memory_kb 当前 Docker API 未暴露峰值，
-    // 保持 None 并在文档中明确。
+    // NOJ-162：回填真实总耗时与内存峰值
     let mut result = result?;
     if result.time_ms.is_none() {
         result.time_ms = Some(started.elapsed().as_millis() as u64);
+    }
+    if result.memory_kb.is_none() {
+        result.memory_kb = memory_peak_kb;
     }
     Ok(result)
 }


### PR DESCRIPTION
<!--
感谢提交 PR！填写以下内容可帮助 reviewer 更快理解你的改动。
本模板与 CI 无关（不会阻断合并），但 Closes #XXX 行会让 GitHub 自动关闭对应 issue。
-->

## 关联 Issue

无（对应 Phase A 工程质量修复，未关联具体 issue）。

## 变更摘要

- A1：新增管理端评测队列健康 API `GET /api/v1/admin/queue/health`，健康检查暴露队列可观测字段，sweeper 增加死信/积压告警日志。
- A3：补齐社区高频写操作（帖子点赞、评论点赞、收藏、关注、举报）的 Redis 限流，并新增写操作限流矩阵文档。
- A4：评测结果链路改为事务性 Outbox——`saveEvaluationResult` 在业务事务内写入 `sse_events`，提交后仅发布 Redis；新增 SSE 事件保留清理任务。
- A2：Judge 在销毁容器前读取一次 Docker stats，尽力回填 `memory_kb`（cgroups v1 使用 `max_usage`，v2 回退 `usage`）。

## 变更类型

- [x] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（无行为变化）
- [ ] `perf` 性能优化
- [x] `docs` 文档
- [x] `test` 测试
- [ ] `chore` 杂项 / 构建 / CI
- [ ] `break` 不兼容变更（需要 major 版本号或迁移说明）

## 影响范围

- [x] `noj-core` 后端
- [ ] `noj-ui` 前端
- [x] `noj-judge` 评测 Worker
- [ ] 数据库迁移（新建或修改 `drizzle/` 文件）
- [x] 公共 API（端点 / 请求 / 响应结构变化）
- [ ] 配置 / 环境变量（`.env.example` 已更新）
- [x] 文档（README / noj-docs）

## 验证清单

- [x] `deno fmt` 已运行（noj-core / noj-ui）
- [x] `deno lint` 已运行
- [x] `cargo fmt && cargo clippy` 已运行（noj-judge）
- [ ] 本地 `deno task test` 通过（已运行受影响测试子集，未跑全量）
- [x] 新功能 / 修复有对应测试
- [ ] 数据库 schema 变更已通过 `deno task db:generate` 生成迁移（无 schema 变更）
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [ ] 非平凡变更包含 Agent Note（`.agents/notes/implemented/`）——待补
- [x] 相关文档已同步（AGENTS / CLAUDE / docs / noj-docs）
- [ ] 注释/导出 JSDoc 与实现一致（`deno task check:jsdoc` 通过）——未跑
- [x] 新增/修改行为有对应测试
- [x] GPG 签名可用

## 截图 / 录屏（可选）

无（后端/评测 Worker 改动，无 UI）。

## 补充说明（可选）

- 验证情况：noj-core 受影响测试 37+ 项通过、community 路由测试通过、noj-judge `cargo test --lib` 109 项通过、`cargo clippy` 通过。
- A4 当前只覆盖正式评测结果链路的事务性 Outbox；私信/公告等其他事件仍走原非事务发布 + 轮询/重放兜底，后续可继续铺开。
- A2 当前只回填内存峰值，尚未把 OOM 映射为 `MemoryLimitExceeded`（需要基于退出状态/评测脚本返回进一步判断）。
- 未包含 Agent Note：本 PR 为非平凡变更，若需合入会补上。
