### PR TITLE
feat(core,judge,ui,problems): 题目级 LLM 调用/token 预算

### DIFF
--- a/.agents/notes/implemented/feature/2026-09-05-llm-problem-budget.md
+++ b/.agents/notes/implemented/feature/2026-09-05-llm-problem-budget.md
@@ -1,0 +1,45 @@
+# Agent Note: 题目级 LLM 调用/token 预算
+
+Status: implemented
+
+## Problem
+
+题目包此前无法声明单次评测的 LLM 调用次数与 billed token 上限；`eval_token`
+始终使用平台默认 `NOJ_LLM_MAX_CALLS` / `NOJ_LLM_MAX_TOKENS`。trial-snowy-manor
+在 evaluator 内自行维护本地 LLM 计数与效率分，既与 gateway 的强制额度重复，
+也让“题目可配置自己评测预算”的能力缺失。
+
+## Decision
+
+- `LlmConfig` 增加可选 `max_calls` / `max_tokens`，`isValidLlmConfig` 与
+  `validateBundleManifest` 做纯值域校验（正整数，缺省允许）。
+- 新增 `llm-limits.ts` 集中处理平台默认值：`getDefaultLlmLimits()` 读取环境
+  变量；`resolveLlmLimits()` 在签发 `eval_token` 时对题目值做 `Math.min`
+  防御；`assertLlmLimitsWithinDefault()` 在 CRUD / bundle 导入写库前拒绝超过
+  平台默认的声明。
+- 题目上限只经既有 `eval_token` 的 `max_calls` / `max_tokens` 流向
+  noj-llm-gateway；不新增 DB 列、不新增 `JudgeTaskLlm` 字段、不向 evaluator
+  注入题目预算环境变量。BYOK（`user_llm`）仍使用平台默认。
+- noj-judge evaluator SDK 将 HTTP 错误结构化：`LLMError` 携带
+  `status_code` / `error_code`，可识别 gateway 的 429 `out_of_usage`。
+- noj-ui 题目编辑器增加“调用上限 / Token 上限”两个可选输入，留空不发送键。
+- trial-snowy-manor 移除本地 LLM 计数与 LLM 效率分，主谋分从 200 调整为
+  250；配额耗尽由 SDK 识别 gateway `out_of_usage` 后置评测失败并判 0 分。
+
+## Alternatives considered
+
+- 新增 MQ / 数据库字段单独传递题目预算：实现直观，但增加跨服务契约与迁移
+  成本；既有 `eval_token` 已具备该语义，只需在签发侧填充。
+- 让 evaluator / solution 感知题目配额并在本地预检：与 gateway 强制重复，
+  且题目实际 billing 口径（billed token）只在 gateway 侧可靠。
+- 保留 LLM 效率分并继续本地计数：分数语义复杂化，且与“配额到顶直接 0 分”
+  的题目设计目标冲突。
+
+## Consequences
+
+- 出题人可在题目 `llm_config` 或 bundle manifest 中声明单次评测上限；平台默认
+  值同时是安全天花板，超限声明在写库前被拒绝。
+- 配额耗尽时 gateway 返回 OpenAI 兼容 429 `out_of_usage`，SDK 结构化后由题包
+  将评测判为 0 分；evaluator / solution 无需读取题目预算即可得到一致行为。
+- trial-snowy-manor 满分结构变为：反驳 5×100 + 主谋 250 + 证据 200 + 理由 50
+  = 1000，不再有 `efficiency_score`。

--- a/dev-docs/superpowers/plans/2026-09-05-llm-problem-budget.md
+++ b/dev-docs/superpowers/plans/2026-09-05-llm-problem-budget.md
@@ -1,0 +1,1131 @@
+# 题目级 LLM 调用/token 预算实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让题目可声明 `llm.max_calls` / `llm.max_tokens`，经现有 `eval_token` 由 noj-llm-gateway 强制；同时移除 trial-snowy-manor 本地 LLM 预算与效率分。
+
+**Architecture:** `LlmConfig` 增加可选上限字段并做两层校验（纯值域校验 + 服务层平台默认天花板）；上限只通过 `eval_token` 流向 gateway，不新增 MQ 字段、不向 evaluator 注入预算环境变量；gateway 超限返回 `429 out_of_usage`，SDK 结构化该错误供题包判 0 分；trial 移除本地计数与 LLM 效率分并调整主谋分。
+
+**Tech Stack:** Deno 2 + Hono + TypeScript（noj-core/noj-ui）、Python 3（noj-judge SDK / noj-problems）、Vue 3 + Nuxt 4（noj-ui）。
+
+**Spec:** `dev-docs/superpowers/specs/2026-09-05-llm-problem-budget-design.md`
+
+## 全局约束
+
+- 不新增数据库列 / SQL 迁移；`problems.llm_config` 仍为 JSONB。
+- 不改变 noj-llm-gateway 代码；gateway 已从 `eval_token` 读 `max_calls/max_tokens`。
+- 不新增 `JudgeTaskLlm` 字段；不向 evaluator 注入题目预算环境变量。
+- 纯校验 `isValidLlmConfig` / `validateBundleManifest` 不得读取 `Deno.env`。
+- 平台默认 `NOJ_LLM_MAX_CALLS`（默认 100）/ `NOJ_LLM_MAX_TOKENS`（默认 50000）同时是安全天花板；题目声明值只能 ≤ 平台默认。
+- 服务层写库前必须执行天花板校验，包括 bundle `createViaCrud` 与 `updateExisting`（后者要在删除旧支持包前校验）。
+- 提交规范：`feat(core)` / `feat(judge)` / `feat(ui)` / `feat(problems)` 中文描述，GPG 签名；主仓库与 `noj-problems` 均使用 jj。
+- Python SDK 测试命令：`cd noj-judge/sdk/evaluator && PYTHONPATH=.:../common python3 -m unittest noj_evaluator_sdk.tests.test_llm -v`
+- trial 测试命令：`cd noj-problems/trial-snowy-manor && PYTHONPATH=. python3 -m unittest discover -s tests -v`
+- 主仓库 noj-core 测试命令：`cd noj-core && deno task test <测试文件>`；noj-ui 验证命令：`cd noj-ui && deno task check`。
+
+---
+
+### Task 1: noj-core `LlmConfig` 可选上限 + 纯值域校验
+
+**Files:**
+- Modify: `noj-core/src/domains/catalog/types/problems.ts`
+- Test: `noj-core/src/domains/gateway/tests/services/llm-problem.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface LlmConfig { provider_id: string; model: string; max_calls?: number; max_tokens?: number }`
+  - `function isValidLlmConfig(value: unknown): value is LlmConfig`（`max_calls`/`max_tokens` 若存在必须是正整数）
+
+- [ ] **Step 1: 写失败测试**
+
+在 `noj-core/src/domains/gateway/tests/services/llm-problem.test.ts` 中追加：
+
+```ts
+Deno.test("llm-config: isValidLlmConfig 接受可选 max 字段", () => {
+  assert(isValidLlmConfig({
+    provider_id: "p1",
+    model: "qwen-plus",
+    max_calls: 10,
+    max_tokens: 1000,
+  }));
+  assert(isValidLlmConfig({ provider_id: "p1", model: "qwen-plus" }));
+});
+
+Deno.test("llm-config: isValidLlmConfig 拒绝 0/负数/非整数/字符串/null max", () => {
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_calls: 0 }));
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_calls: -1 }));
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_calls: 1.5 }));
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_tokens: "100" }));
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_tokens: null }));
+});
+
+Deno.test("llm-bundle: P 型携带合法 max 字段通过", () => {
+  const manifest = validateBundleManifest({
+    format_version: 1,
+    title: "LLM 题",
+    type: "P",
+    runtime_config: {
+      evaluator: {
+        image: "noj-evaluator-python",
+        time_limit_ms: 60000,
+        memory_limit_mb: 512,
+        network: { enabled: true },
+      },
+      solution: {
+        image: "noj-solution-python",
+        call_timeout_ms: 5000,
+        memory_limit_mb: 512,
+      },
+    },
+    llm: { provider_id: "p1", model: "qwen-plus", max_calls: 10, max_tokens: 1000 },
+  });
+  assertEquals(manifest.llm?.max_calls, 10);
+  assertEquals(manifest.llm?.max_tokens, 1000);
+});
+
+Deno.test("llm-bundle: 非法 max 字段被拒", () => {
+  assertThrows(() =>
+    validateBundleManifest({
+      format_version: 1,
+      title: "LLM 题",
+      type: "P",
+      runtime_config: {
+        evaluator: {
+          image: "noj-evaluator-python",
+          time_limit_ms: 60000,
+          memory_limit_mb: 512,
+          network: { enabled: true },
+        },
+        solution: {
+          image: "noj-solution-python",
+          call_timeout_ms: 5000,
+          memory_limit_mb: 512,
+        },
+      },
+      llm: { provider_id: "p1", model: "m", max_calls: 0 },
+    })
+  );
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd /home/xyber-nova/Github/neuro-oj/noj-core && deno task test src/domains/gateway/tests/services/llm-problem.test.ts`
+Expected: FAIL——当前 `isValidLlmConfig` 对多余字段的 0/负值仍返回 true，或 `validateBundleManifest` 未保留 max 字段。
+
+- [ ] **Step 3: 实现类型与纯校验**
+
+修改 `noj-core/src/domains/catalog/types/problems.ts`：
+
+```ts
+export interface LlmConfig {
+  provider_id: string;
+  model: string;
+  /** 单次评测 LLM 调用上限；缺省 = 平台默认 */
+  max_calls?: number;
+  /** 单次评测 LLM billed token 上限；缺省 = 平台默认 */
+  max_tokens?: number;
+}
+
+export function isValidLlmConfig(value: unknown): value is LlmConfig {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  const isValidPositiveInt = (v: unknown): boolean =>
+    v === undefined ||
+    (typeof v === "number" && Number.isInteger(v) && v > 0);
+  return typeof obj.provider_id === "string" && obj.provider_id.length > 0 &&
+    typeof obj.model === "string" && obj.model.length > 0 &&
+    isValidPositiveInt(obj.max_calls) && isValidPositiveInt(obj.max_tokens);
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd /home/xyber-nova/Github/neuro-oj/noj-core && deno task test src/domains/gateway/tests/services/llm-problem.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+jj describe -m "feat(core): LlmConfig 支持题目级 max_calls/max_tokens 纯校验" && jj new
+```
+
+---
+
+### Task 2: noj-core 集中 limits helper + eval_token 签发使用题目上限
+
+**Files:**
+- Create: `noj-core/src/domains/gateway/services/llm-limits.ts`
+- Modify: `noj-core/src/domains/gateway/index.ts`
+- Modify: `noj-core/src/domains/gateway/services/llm-token.ts`
+- Test: `noj-core/src/domains/gateway/tests/services/llm-problem.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `function getDefaultLlmLimits(): { max_calls: number; max_tokens: number }`
+  - `function resolveLlmLimits(llm: Pick<LlmConfig, "max_calls" | "max_tokens">): { max_calls: number; max_tokens: number }`
+  - `function assertLlmLimitsWithinDefault(llm: Pick<LlmConfig, "max_calls" | "max_tokens">): void`（超过平台默认抛 `BadRequestError`）
+  - `buildJudgeTaskLlmForProvider` 增加可选参数 `limits?: { max_calls: number; max_tokens: number }`（放在参数列表末尾，现有调用点不破坏）
+- Consumes: Task 1 的 `LlmConfig` 类型。
+
+- [ ] **Step 1: 写失败测试**
+
+在 `noj-core/src/domains/gateway/tests/services/llm-problem.test.ts` 顶部 import 增加：
+
+```ts
+import { BadRequestError } from "../../../../shared/base/errors.ts";
+import {
+  assertLlmLimitsWithinDefault,
+  getDefaultLlmLimits,
+  resolveLlmLimits,
+} from "../../services/llm-limits.ts";
+```
+
+并追加：
+
+```ts
+Deno.test("llm-limits: getDefaultLlmLimits 读取环境变量", () => {
+  const oldCalls = Deno.env.get("NOJ_LLM_MAX_CALLS");
+  const oldTokens = Deno.env.get("NOJ_LLM_MAX_TOKENS");
+  Deno.env.set("NOJ_LLM_MAX_CALLS", "123");
+  Deno.env.set("NOJ_LLM_MAX_TOKENS", "456");
+  try {
+    assertEquals(getDefaultLlmLimits(), { max_calls: 123, max_tokens: 456 });
+  } finally {
+    if (oldCalls === undefined) Deno.env.delete("NOJ_LLM_MAX_CALLS");
+    else Deno.env.set("NOJ_LLM_MAX_CALLS", oldCalls);
+    if (oldTokens === undefined) Deno.env.delete("NOJ_LLM_MAX_TOKENS");
+    else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
+  }
+});
+
+Deno.test("llm-limits: resolveLlmLimits 缺省用默认、题目值截断到默认", () => {
+  const oldCalls = Deno.env.get("NOJ_LLM_MAX_CALLS");
+  const oldTokens = Deno.env.get("NOJ_LLM_MAX_TOKENS");
+  Deno.env.set("NOJ_LLM_MAX_CALLS", "100");
+  Deno.env.set("NOJ_LLM_MAX_TOKENS", "50000");
+  try {
+    assertEquals(resolveLlmLimits({}), { max_calls: 100, max_tokens: 50000 });
+    assertEquals(
+      resolveLlmLimits({ max_calls: 30, max_tokens: 20000 }),
+      { max_calls: 30, max_tokens: 20000 },
+    );
+    assertEquals(
+      resolveLlmLimits({ max_calls: 999, max_tokens: 999999 }),
+      { max_calls: 100, max_tokens: 50000 },
+    );
+  } finally {
+    if (oldCalls === undefined) Deno.env.delete("NOJ_LLM_MAX_CALLS");
+    else Deno.env.set("NOJ_LLM_MAX_CALLS", oldCalls);
+    if (oldTokens === undefined) Deno.env.delete("NOJ_LLM_MAX_TOKENS");
+    else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
+  }
+});
+
+Deno.test("llm-limits: assertLlmLimitsWithinDefault 超默认抛 BadRequestError", () => {
+  const oldCalls = Deno.env.get("NOJ_LLM_MAX_CALLS");
+  const oldTokens = Deno.env.get("NOJ_LLM_MAX_TOKENS");
+  Deno.env.set("NOJ_LLM_MAX_CALLS", "100");
+  Deno.env.set("NOJ_LLM_MAX_TOKENS", "50000");
+  try {
+    assertLlmLimitsWithinDefault({ max_calls: 30, max_tokens: 20000 });
+    assertThrows(
+      () => assertLlmLimitsWithinDefault({ max_calls: 101 }),
+      BadRequestError,
+      "max_calls",
+    );
+    assertThrows(
+      () => assertLlmLimitsWithinDefault({ max_tokens: 50001 }),
+      BadRequestError,
+      "max_tokens",
+    );
+  } finally {
+    if (oldCalls === undefined) Deno.env.delete("NOJ_LLM_MAX_CALLS");
+    else Deno.env.set("NOJ_LLM_MAX_CALLS", oldCalls);
+    if (oldTokens === undefined) Deno.env.delete("NOJ_LLM_MAX_TOKENS");
+    else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
+  }
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd /home/xyber-nova/Github/neuro-oj/noj-core && deno task test src/domains/gateway/tests/services/llm-problem.test.ts`
+Expected: FAIL——`llm-limits.ts` 不存在。
+
+- [ ] **Step 3: 创建 `llm-limits.ts`**
+
+Create `noj-core/src/domains/gateway/services/llm-limits.ts`：
+
+```ts
+/**
+ * 题目级 LLM 预算的默认值与解析/校验。
+ *
+ * 平台默认值同时是安全天花板：
+ * - CRUD / bundle 导入在写库前调用 assertLlmLimitsWithinDefault 拒绝超限声明；
+ * - eval_token 签发调用 resolveLlmLimits 做 Math.min 防御。
+ */
+import { BadRequestError } from "../../../shared/base/errors.ts";
+import type { LlmConfig } from "../../catalog/index.ts";
+
+/** 读取平台默认单次评测 LLM 预算。 */
+export function getDefaultLlmLimits(): { max_calls: number; max_tokens: number } {
+  return {
+    max_calls: Number(Deno.env.get("NOJ_LLM_MAX_CALLS") ?? "100"),
+    max_tokens: Number(Deno.env.get("NOJ_LLM_MAX_TOKENS") ?? "50000"),
+  };
+}
+
+/** 解析题目声明值；缺省用平台默认，声明值超过默认时截断到默认（防御）。 */
+export function resolveLlmLimits(
+  llm: Pick<LlmConfig, "max_calls" | "max_tokens">,
+): { max_calls: number; max_tokens: number } {
+  const defaults = getDefaultLlmLimits();
+  return {
+    max_calls: Math.min(llm.max_calls ?? defaults.max_calls, defaults.max_calls),
+    max_tokens: Math.min(llm.max_tokens ?? defaults.max_tokens, defaults.max_tokens),
+  };
+}
+
+/** 服务层写库前校验：题目声明值不得超过平台默认。 */
+export function assertLlmLimitsWithinDefault(
+  llm: Pick<LlmConfig, "max_calls" | "max_tokens">,
+): void {
+  const defaults = getDefaultLlmLimits();
+  if (llm.max_calls !== undefined && llm.max_calls > defaults.max_calls) {
+    throw new BadRequestError("llm.max_calls 超过平台默认上限");
+  }
+  if (llm.max_tokens !== undefined && llm.max_tokens > defaults.max_tokens) {
+    throw new BadRequestError("llm.max_tokens 超过平台默认上限");
+  }
+}
+```
+
+- [ ] **Step 4: 导出并在 token 签发中复用**
+
+修改 `noj-core/src/domains/gateway/index.ts`：
+
+```ts
+export * from "./services/llm.ts";
+export * from "./services/llm-limits.ts";
+export * from "./services/llm-token.ts";
+```
+
+修改 `noj-core/src/domains/gateway/services/llm-token.ts`：
+
+```ts
+import { getDefaultLlmLimits, resolveLlmLimits } from "./llm-limits.ts";
+```
+
+将 `buildJudgeTaskLlm` 改为：
+
+```ts
+export function buildJudgeTaskLlm(
+  llmConfig: LlmConfig,
+  submissionId: string,
+  problemId: string,
+  userId: string,
+  runtimeConfig: RuntimeConfig,
+): Promise<JudgeTaskLlm> {
+  return buildJudgeTaskLlmForProvider(
+    llmConfig.provider_id,
+    llmConfig.model,
+    submissionId,
+    problemId,
+    userId,
+    runtimeConfig,
+    resolveLlmLimits(llmConfig),
+  );
+}
+```
+
+将 `buildJudgeTaskLlmForProvider` 签名与 `max_calls`/`max_tokens` 改为：
+
+```ts
+export async function buildJudgeTaskLlmForProvider(
+  providerId: string,
+  model: string,
+  submissionId: string,
+  problemId: string,
+  userId: string,
+  runtimeConfig: RuntimeConfig,
+  limits?: { max_calls: number; max_tokens: number },
+): Promise<JudgeTaskLlm> {
+  const gatewayUrl = Deno.env.get("NOJ_LLM_GATEWAY_URL") ??
+    "http://localhost:8001";
+  const timeLimitMs = runtimeConfig.evaluator.time_limit_ms;
+  const ttlSeconds = Math.max(60, Math.ceil((timeLimitMs * 4) / 1000));
+  const now = Math.floor(Date.now() / 1000);
+  const resolved = limits ?? getDefaultLlmLimits();
+  const token = await mintEvalToken({
+    jti: crypto.randomUUID(),
+    submission_id: submissionId,
+    problem_id: problemId,
+    user_id: userId,
+    provider_id: providerId,
+    allowed_models: [model],
+    iat: now,
+    exp: now + ttlSeconds,
+    max_calls: resolved.max_calls,
+    max_tokens: resolved.max_tokens,
+  });
+  return {
+    gateway_url: gatewayUrl,
+    eval_token: token,
+    provider_id: providerId,
+    allowed_models: [model],
+  };
+}
+```
+
+- [ ] **Step 5: 运行测试确认通过**
+
+Run: `cd /home/xyber-nova/Github/neuro-oj/noj-core && deno task test src/domains/gateway/tests/services/llm-problem.test.ts`
+Expected: PASS。
+
+- [ ] **Step 6: 提交**
+
+```bash
+jj describe -m "feat(core): 集中 LLM 预算 helper 并让 eval_token 使用题目上限" && jj new
+```
+
+---
+
+### Task 3: noj-core CRUD / bundle 导入写库前天花板校验
+
+**Files:**
+- Modify: `noj-core/src/domains/catalog/services/problems/problems-crud.ts`
+- Modify: `noj-core/src/domains/catalog/services/problems/problem-bundle.ts`
+- Create: `noj-core/src/domains/catalog/tests/services/problems-llm-limits.test.ts`
+- Modify: `noj-core/src/domains/catalog/tests/routes/problem-bundle.test.ts`
+
+**Interfaces:**
+- Consumes: `assertLlmLimitsWithinDefault` from Task 2。
+- Produces: 无新导出；行为变更——`createProblem` / `updateProblem` / `createViaCrud` / `updateExisting` 在写库/删旧包前拒绝超过平台默认的 `llm.max_*`。
+
+- [ ] **Step 1: 写失败测试（服务层）**
+
+Create `noj-core/src/domains/catalog/tests/services/problems-llm-limits.test.ts`：
+
+```ts
+/**
+ * 题目 LLM 上限服务层校验（需要 DB）。
+ */
+import { assertRejects } from "jsr:@std/assert@^1";
+import { createProblem, updateProblem } from "../../index.ts";
+import { getDb, resetDbForTest } from "../../../../shared/db/connection.ts";
+import { users } from "../../../../shared/db/schema.ts";
+import { BadRequestError } from "../../../../shared/base/errors.ts";
+import { getDefaultLlmLimits } from "../../../gateway/index.ts";
+
+// 与 problems.test.ts 一致：PGlite 内存库始终可用
+const dbAvailable = true;
+const skip = !dbAvailable;
+const ts = Date.now();
+
+const NETWORKED_RUNTIME_CONFIG = {
+  evaluator: {
+    image: "noj-evaluator-python",
+    command: "python3 /workspace/evaluate.py",
+    time_limit_ms: 5000,
+    memory_limit_mb: 512,
+    network: { enabled: true },
+  },
+  solution: {
+    image: "noj-solution-python",
+    call_timeout_ms: 2000,
+    memory_limit_mb: 512,
+  },
+};
+
+async function createAdminUser(): Promise<string> {
+  const db = getDb();
+  const id = `llm-admin-${ts}`;
+  const now = new Date().toISOString();
+  await db.insert(users).values({
+    id,
+    username: `llm-admin-${ts}`,
+    email: `llm-admin-${ts}@test.com`,
+    password_hash: "",
+    created_at: now,
+    updated_at: now,
+  });
+  return id;
+}
+
+/** stub gateway /internal/providers/:id，返回 enabled provider，避免测试依赖真实网络。 */
+function stubEnabledLlmProvider(): () => void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((_input: Request | URL | string) => {
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: {
+            id: "p-does-not-matter",
+            name: "stub",
+            base_url: "http://stub",
+            model: "m",
+            cost_per_1k_tokens: 0,
+            api_key_masked: "sk-****",
+            enabled: true,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+Deno.test({
+  name: "problems-llm-limits: createProblem 拒绝 max_calls 超过平台默认",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const restore = stubEnabledLlmProvider();
+    try {
+      const adminId = await createAdminUser();
+      const defaults = getDefaultLlmLimits();
+      await assertRejects(
+        () =>
+          createProblem(
+            {
+              title: `LLM 超限 ${Date.now()}`,
+              description: "d",
+              type: "P",
+              runtime_config: NETWORKED_RUNTIME_CONFIG,
+              llm: {
+                provider_id: "p-does-not-matter",
+                model: "m",
+                max_calls: defaults.max_calls + 1,
+              },
+            },
+            adminId,
+            "admin",
+          ),
+        BadRequestError,
+        "max_calls",
+      );
+    } finally {
+      restore();
+    }
+  },
+});
+
+Deno.test({
+  name: "problems-llm-limits: updateProblem 拒绝 max_tokens 超过平台默认",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const restore = stubEnabledLlmProvider();
+    try {
+      const adminId = await createAdminUser();
+      const created = await createProblem(
+        {
+          title: `LLM 更新超限 ${Date.now()}`,
+          description: "d",
+          type: "P",
+          runtime_config: NETWORKED_RUNTIME_CONFIG,
+        },
+        adminId,
+        "admin",
+      );
+      const defaults = getDefaultLlmLimits();
+      await assertRejects(
+        () =>
+          updateProblem(
+            created.id,
+            {
+              llm: {
+                provider_id: "p-does-not-matter",
+                model: "m",
+                max_tokens: defaults.max_tokens + 1,
+              },
+            },
+            adminId,
+            "admin",
+          ),
+        BadRequestError,
+        "max_tokens",
+      );
+    } finally {
+      restore();
+    }
+  },
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run:
+```bash
+cd /home/xyber-nova/Github/neuro-oj/noj-core && NOJ_LLM_SERVICE_TOKEN=test-service-token-0123456789abcdef deno task test src/domains/catalog/tests/services/problems-llm-limits.test.ts
+```
+Expected: FAIL——当前 CRUD 未拒绝超限值；在 stub gateway 下 `createProblem`/`updateProblem` 会成功，`assertRejects(BadRequestError)` 因 promise resolve 而失败。
+
+- [ ] **Step 3: 修改 `problems-crud.ts`**
+
+在 import 区把 `getLlmProviderById` 的导入扩展为：
+
+```ts
+import {
+  assertLlmLimitsWithinDefault,
+  getLlmProviderById,
+} from "../../../gateway/index.ts";
+```
+
+在 `createProblem` 的 LLM 准入校验中，`type !== "P"` 判断之后、provider 查询之前插入：
+
+```ts
+    assertLlmLimitsWithinDefault(input.llm);
+```
+
+在 `updateProblem` 的 LLM 变更校验中，`isObjective` 判断之后、provider 查询之前插入：
+
+```ts
+      assertLlmLimitsWithinDefault(input.llm);
+```
+
+- [ ] **Step 4: 修改 `problem-bundle.ts`**
+
+在 import 区增加：
+
+```ts
+import { assertLlmLimitsWithinDefault } from "../../../gateway/index.ts";
+```
+
+在 `updateExisting` 中，`enforceResourceLimits(manifest.runtime_config!)` 之后、删除旧支持包之前插入：
+
+```ts
+  if (manifest.llm) {
+    assertLlmLimitsWithinDefault(manifest.llm);
+  }
+```
+
+在 `createViaCrud` 中，`enforceResourceLimits(manifest.runtime_config!)` 之后、`const db = getDb();` 之前插入：
+
+```ts
+  if (manifest.llm) {
+    assertLlmLimitsWithinDefault(manifest.llm);
+  }
+```
+
+- [ ] **Step 5: 增加 bundle 导入路由测试**
+
+修改 `noj-core/src/domains/catalog/tests/routes/problem-bundle.test.ts`：在 import 区增加
+
+```ts
+import { getDefaultLlmLimits } from "../../../gateway/index.ts";
+```
+
+在文件末尾追加：
+
+```ts
+Deno.test({
+  name: "import-bundle: LLM max_calls 超过平台默认被拒（400）",
+  ignore: skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const token = await createUserToken("admin");
+    const defaults = getDefaultLlmLimits();
+    const formData = new FormData();
+    formData.append(
+      "file",
+      makeZipBlob({
+        type: "P",
+        runtime_config: {
+          evaluator: {
+            image: "noj-evaluator-python",
+            time_limit_ms: 60000,
+            memory_limit_mb: 512,
+            network: { enabled: true },
+          },
+          solution: {
+            image: "noj-solution-python",
+            call_timeout_ms: 5000,
+            memory_limit_mb: 512,
+          },
+        },
+        llm: {
+          provider_id: "p1",
+          model: "m",
+          max_calls: defaults.max_calls + 1,
+        },
+      }),
+      "llm-over.zip",
+    );
+    const res = await app.request("/api/v1/problems/import-bundle", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    });
+    assertEquals(res.status, 400);
+  },
+});
+```
+
+- [ ] **Step 6: 运行相关测试确认通过**
+
+Run:
+```bash
+# service 层：PGlite 内存库始终可跑；token 仅为与红测命令保持一致（实现后不访问 gateway）
+cd /home/xyber-nova/Github/neuro-oj/noj-core && NOJ_LLM_SERVICE_TOKEN=test-service-token-0123456789abcdef deno task test src/domains/catalog/tests/services/problems-llm-limits.test.ts
+# route 层：需要 JWT_SECRET/DATABASE_URL；无环境时该测试文件自身 skipEnv
+cd /home/xyber-nova/Github/neuro-oj/noj-core && deno task test:pg src/domains/catalog/tests/routes/problem-bundle.test.ts
+```
+Expected: service 层 PASS；route 层在有 env 时 PASS，无 env 时该文件按仓库约定 skip。
+
+- [ ] **Step 7: 提交**
+
+```bash
+jj describe -m "feat(core): CRUD 与 bundle 导入写库前拒绝超默认 LLM 上限" && jj new
+```
+
+---
+
+### Task 4: noj-judge evaluator SDK 结构化 429 out_of_usage
+
+**Files:**
+- Modify: `noj-judge/sdk/evaluator/noj_evaluator_sdk/llm.py`
+- Test: `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_llm.py`
+
+**Interfaces:**
+- Produces:
+  - `class LLMError(Exception)` 增加 `status_code: int | None` 与 `error_code: str | None`
+  - `llm.complete()` 对 HTTP 错误解析响应体 `error.code`，填入 `LLMError.error_code`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_llm.py` 中追加：
+
+```python
+    def test_out_of_usage_error_raises_structured(self):
+        server = _start_server()
+        old_status = _Handler.status
+        old_response = _Handler.response
+        _Handler.status = 429
+        _Handler.response = {"error": {"code": "out_of_usage"}}
+        try:
+            os.environ["NOJ_LLM_GATEWAY_URL"] = f"http://127.0.0.1:{server.server_port}"
+            os.environ["NOJ_LLM_TOKEN"] = "test-token"
+            os.environ["NOJ_LLM_ALLOWED_MODELS"] = "qwen-plus"
+            with self.assertRaises(llm.LLMError) as ctx:
+                llm.complete(model="qwen-plus", messages=[{"role": "user", "content": "hi"}])
+            self.assertEqual(ctx.exception.status_code, 429)
+            self.assertEqual(ctx.exception.error_code, "out_of_usage")
+        finally:
+            _Handler.status = old_status
+            _Handler.response = old_response
+            server.shutdown()
+            server.server_close()
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd /home/xyber-nova/Github/neuro-oj/noj-judge/sdk/evaluator && PYTHONPATH=.:../common python3 -m unittest noj_evaluator_sdk.tests.test_llm -v`
+Expected: FAIL——`LLMError` 没有 `status_code` / `error_code` 属性。
+
+- [ ] **Step 3: 实现结构化错误**
+
+修改 `noj-judge/sdk/evaluator/noj_evaluator_sdk/llm.py`：
+
+```python
+class LLMError(Exception):
+    """LLM 调用失败（配置缺失、token 失效、上游错误等）。"""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+```
+
+将 `HTTPError` 分支替换为：
+
+```python
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        error_code = None
+        try:
+            body = json.loads(detail)
+            error_code = body.get("error", {}).get("code")
+        except Exception:
+            error_code = None
+        raise LLMError(
+            f"LLM gateway 返回 {e.code}: {detail}",
+            status_code=e.code,
+            error_code=error_code,
+        ) from e
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd /home/xyber-nova/Github/neuro-oj/noj-judge/sdk/evaluator && PYTHONPATH=.:../common python3 -m unittest noj_evaluator_sdk.tests.test_llm -v`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+jj describe -m "feat(judge): evaluator SDK 解析 gateway out_of_usage 错误结构" && jj new
+```
+
+---
+
+### Task 5: noj-ui 题目编辑器增加可选上限输入
+
+**Files:**
+- Modify: `noj-ui/components/editor/CodingProblemEditor.vue`
+
+**Interfaces:**
+- Consumes: `LlmConfig.max_calls` / `max_tokens`（来自 API `llm_config`）。
+- Produces: 创建/更新请求 `llm` payload 中可选的 `max_calls` / `max_tokens`；留空不发送键。
+
+- [ ] **Step 1: 在 script 中增加状态与逻辑**
+
+在 `noj-ui/components/editor/CodingProblemEditor.vue` 的 LLM 状态区，`const llmModel = ref("")` 之后增加：
+
+```ts
+const llmMaxCalls = ref("")
+const llmMaxTokens = ref("")
+```
+
+编辑模式加载处，将 LLM 回填改为：
+
+```ts
+    const llmConfig = (p as {
+      llm_config?: {
+        provider_id: string
+        model: string
+        max_calls?: number | null
+        max_tokens?: number | null
+      } | null
+    }).llm_config
+    if (llmConfig) {
+      llmEnabled.value = true
+      llmProviderId.value = llmConfig.provider_id
+      llmModel.value = llmConfig.model
+      llmMaxCalls.value = llmConfig.max_calls != null ? String(llmConfig.max_calls) : ""
+      llmMaxTokens.value = llmConfig.max_tokens != null ? String(llmConfig.max_tokens) : ""
+    }
+```
+
+`validate()` 的 `llmEnabled` 分支增加校验：
+
+```ts
+  if (llmEnabled.value) {
+    if (!llmProviderId.value.trim()) errors.llm_provider = "请选择 LLM Provider"
+    if (!llmModel.value.trim()) errors.llm_model = "请输入模型名"
+    if (!evaluatorNetworkEnabled.value) errors.evaluator_network = "启用 LLM 必须开启 Evaluator 联网"
+    const maxCalls = llmMaxCalls.value === "" ? null : Number(llmMaxCalls.value)
+    const maxTokens = llmMaxTokens.value === "" ? null : Number(llmMaxTokens.value)
+    if (maxCalls !== null && (!Number.isInteger(maxCalls) || maxCalls <= 0)) {
+      errors.llm_max_calls = "调用上限必须是正整数"
+    }
+    if (maxTokens !== null && (!Number.isInteger(maxTokens) || maxTokens <= 0)) {
+      errors.llm_max_tokens = "token 上限必须是正整数"
+    }
+  }
+```
+
+`handleSubmit()` 中 `llmPayload` 构造改为：
+
+```ts
+    const llmMaxCallsNum = llmMaxCalls.value === "" ? null : Number(llmMaxCalls.value)
+    const llmMaxTokensNum = llmMaxTokens.value === "" ? null : Number(llmMaxTokens.value)
+    const llmPayload = llmEnabled.value
+      ? {
+          provider_id: llmProviderId.value.trim(),
+          model: llmModel.value.trim(),
+          ...(llmMaxCallsNum !== null ? { max_calls: llmMaxCallsNum } : {}),
+          ...(llmMaxTokensNum !== null ? { max_tokens: llmMaxTokensNum } : {}),
+        }
+      : null
+```
+
+- [ ] **Step 2: 在模板中增加输入**
+
+在 `CodingProblemEditor.vue` 的 LLM 区块中，`llmModel` 的 `fieldErrors.llm_model` 段落之后、琥珀色提示块之前插入：
+
+```html
+                <div class="grid grid-cols-2 gap-2">
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs font-semibold text-text">调用上限</label>
+                    <input
+                      v-model="llmMaxCalls"
+                      type="number"
+                      min="1"
+                      class="px-2.5 py-1.5 text-sm border border-border rounded-md bg-white"
+                      placeholder="留空使用平台默认"
+                    />
+                    <p v-if="fieldErrors.llm_max_calls" class="text-xs text-red-600">{{ fieldErrors.llm_max_calls }}</p>
+                  </div>
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs font-semibold text-text">Token 上限</label>
+                    <input
+                      v-model="llmMaxTokens"
+                      type="number"
+                      min="1"
+                      class="px-2.5 py-1.5 text-sm border border-border rounded-md bg-white"
+                      placeholder="留空使用平台默认"
+                    />
+                    <p v-if="fieldErrors.llm_max_tokens" class="text-xs text-red-600">{{ fieldErrors.llm_max_tokens }}</p>
+                  </div>
+                </div>
+```
+
+- [ ] **Step 3: 验证 noj-ui 检查**
+
+Run: `cd /home/xyber-nova/Github/neuro-oj/noj-ui && deno task check`
+Expected: PASS（fmt/lint/type-check）。
+
+- [ ] **Step 4: 提交**
+
+```bash
+jj describe -m "feat(ui): 题目编辑器支持声明 LLM 调用/token 上限" && jj new
+```
+
+---
+
+### Task 6: trial-snowy-manor 移除本地 LLM 预算与效率分（独立 noj-problems 仓库）
+
+**Repo boundary:** 以下文件属于独立仓库 `/home/xyber-nova/Github/neuro-oj/noj-problems`（主仓库 `.gitignore` 忽略 `noj-problems/`）。提交在 `noj-problems` 仓库内执行。
+
+**Files:**
+- Modify: `trial-snowy-manor/scenario_runner.py`
+- Modify: `trial-snowy-manor/sdk_evaluate.py`
+- Modify: `trial-snowy-manor/evaluate_offline.py`
+- Modify: `trial-snowy-manor/README.e2e.md`
+- Modify: `trial-snowy-manor/tests/test_scenario_runner.py`
+- Modify: `trial-snowy-manor/tests/test_offline_e2e.py`（如断言依赖旧满分结构则同步）
+
+**Interfaces:**
+- Produces:
+  - `TrialRunner.__init__(scenario, max_evidence_queries, max_wrong_rebuttals=3, seed="default")`（移除 `max_llm_calls` / `max_llm_tokens`）
+  - 移除 `TrialRunner.llm_called()`、`used_llm_calls`、`used_llm_tokens`
+  - `scoring()` 返回值不再含 `efficiency_score`；`MASTERMIND_SCORE = 250`；满分仍 1000
+  - `sdk_evaluate.cap_llm_complete` 捕获 `llm.LLMError` 中 `error_code == "out_of_usage"` 后置失败并抛 `RuntimeError`
+
+**机制说明（capability 异常传播）：** `cap_llm_complete` 是 evaluator capability handler。
+它在 handler 内抛出的 `RuntimeError` 不会冒泡到 `sdk_evaluate.main()` 的 try/except；
+SDK `SolutionRunner._handle_capability` 会把它编码为 error 帧回传给 solution 侧调用者。
+真正使评测判 0 分的路径是 `runner._is_failed = True` → 最终 `runner.scoring()` 返回
+`score: 0` → `sdk_evaluate.main()` 调用 `result.wrong_answer(score=0, ...)`。因此实现时
+不要依赖 `main()` 捕获 capability 异常；只需保证捕获 `out_of_usage` 后置失败并继续抛出
+`RuntimeError`（用于让 solution 收到错误并停止调用）。
+
+- [ ] **Step 1: 修改 `scenario_runner.py`**
+
+将常量区改为：
+
+```python
+# spec §7 分值（无 LLM 效率分）
+REBUTTAL_PER_ROUND = 100
+MASTERMIND_SCORE = 250
+EVIDENCE_SCORE = 200
+```
+
+将 `__init__` 改为：
+
+```python
+    def __init__(
+        self,
+        scenario: Scenario,
+        max_evidence_queries: int,
+        max_wrong_rebuttals: int = 3,
+        seed: str = "default",
+    ) -> None:
+        self._scenario = scenario
+        self._max_evidence_queries = max_evidence_queries
+        self._max_wrong_rebuttals = max_wrong_rebuttals
+        self._seed = seed
+        self.current_round_index = 0
+        self.used_evidence_queries = 0
+        self.used_wrong_rebuttals = 0
+        self.queried_evidence_ids: set[str] = set()
+        self._is_failed = False
+        self._is_finished = False
+        self._final: dict[str, Any] | None = None
+```
+
+删除整个 `llm_called` 方法：
+
+```python
+    def llm_called(self, billed_tokens: int = 0) -> None:
+        ...
+```
+
+将 `scoring()` 改为：
+
+```python
+    def scoring(self, reason_score: int = 0) -> dict[str, int]:
+        if self._is_failed:
+            return {
+                "max_score": 1000,
+                "score": 0,
+                "rebuttal_score": 0,
+                "mastermind_score": 0,
+                "evidence_score": 0,
+                "reason_score": 0,
+            }
+        if self._final is None:
+            # 未调用 final_verdict：只保留已正确反驳分
+            rebuttal = self.current_round_index * REBUTTAL_PER_ROUND
+            return {
+                "max_score": 1000,
+                "score": rebuttal,
+                "rebuttal_score": rebuttal,
+                "mastermind_score": 0,
+                "evidence_score": 0,
+                "reason_score": 0,
+            }
+
+        rebuttal = self.current_round_index * REBUTTAL_PER_ROUND
+        mastermind = MASTERMIND_SCORE if self._final["person_id"] == self._scenario.mastermind_id else 0
+        # 只有 final_verdict 中引用且确实 get_evidence 查询过的关键证据才计证据分
+        queried_key = set(self._scenario.key_evidence_ids) & self.queried_evidence_ids
+        matched = set(self._final["evidence_ids"]) & queried_key
+        evidence = round(EVIDENCE_SCORE * len(matched) / len(self._scenario.key_evidence_ids)) if self._scenario.key_evidence_ids else 0
+
+        score = rebuttal + mastermind + evidence + reason_score
+        return {
+            "max_score": 1000,
+            "score": score,
+            "rebuttal_score": rebuttal,
+            "mastermind_score": mastermind,
+            "evidence_score": evidence,
+            "reason_score": reason_score,
+        }
+```
+
+- [ ] **Step 2: 修改 `sdk_evaluate.py`**
+
+`_load_runner()` 改为：
+
+```python
+    return TrialRunner(
+        scenario,
+        max_evidence_queries=max_evidence,
+        max_wrong_rebuttals=int(os.environ.get("NOJ_TRIAL_MAX_WRONG", "3")),
+        seed=seed,
+    )
+```
+
+`cap_llm_complete` 改为：
+
+```python
+    def cap_llm_complete(
+        messages: list[dict[str, str]],
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        from noj_evaluator_sdk import llm
+        opts = dict(params or {})
+        try:
+            return llm.complete(messages=messages, **opts)
+        except llm.LLMError as exc:
+            if exc.status_code == 429 and exc.error_code == "out_of_usage":
+                runner._is_failed = True
+                raise RuntimeError("out_of_usage") from exc
+            raise
+```
+
+- [ ] **Step 3: 修改 `evaluate_offline.py`**
+
+`TrialRunner(...)` 调用改为：
+
+```python
+    runner = TrialRunner(
+        sc,
+        max_evidence_queries=max_evidence_queries,
+        max_wrong_rebuttals=max_wrong_rebuttals,
+        seed=seed,
+    )
+```
+
+`Api.llm` 改为：
+
+```python
+            def llm(self, messages, **params):
+                return {"choices": [{"message": {"content": "stub"}}]}
+```
+
+返回值移除 `"used_llm_calls": runner.used_llm_calls,`。
+
+- [ ] **Step 4: 修改 `README.e2e.md`**
+
+删除以下两行：
+
+```text
+- `NOJ_TRIAL_MAX_LLM=30`（Agent 本地 LLM 轮次上限）
+- `NOJ_TRIAL_MAX_TOKENS=20000`（Agent 本地 billed token 上限）
+```
+
+将说明块中的“并固定选择 `manor_001`。若需要这些环境变量真正生效……”改为：
+
+```text
+`NOJ_TRIAL_MAX_WRONG` / `NOJ_TRIAL_SOLVE_TIMEOUT_MS` / `NOJ_SUBMISSION_ID` / `NOJ_REJUDGE_SEQ` 目前 judge 不会自动注入 evaluator 容器；若未注入，`sdk_evaluate.py` 使用代码内默认值（3/240000/default），并固定选择 `manor_001`。题目级 LLM 预算由平台 `NOJ_LLM_MAX_CALLS` / `NOJ_LLM_MAX_TOKENS` 与题目声明的 `llm.max_calls` / `llm.max_tokens` 经 gateway 强制，不再由 trial 本地预检。
+```
+
+- [ ] **Step 5: 同步单测断言**
+
+在 `trial-snowy-manor/tests/test_scenario_runner.py` 的 `test_final_verdict_scoring` 中，将：
+
+```python
+        self.assertEqual(breakdown["mastermind_score"], 200)
+```
+
+改为：
+
+```python
+        self.assertEqual(breakdown["mastermind_score"], 250)
+```
+
+并在该测试末尾增加：
+
+```python
+        self.assertNotIn("efficiency_score", breakdown)
+        self.assertEqual(breakdown["score"], 600)
+```
+
+说明：该测试场景 1 轮反驳（100）+ 主谋（250）+ 2/2 关键证据（200）+ reason（50）= 600。
+
+若 `test_offline_e2e.py` 的 `test_reference_agent_scores_high_without_llm` 仍断言 `score >= 750`，无需改动（新满分 1000 下参考 Agent 仍满足）。
+
+- [ ] **Step 6: 运行 trial 测试**
+
+Run: `cd /home/xyber-nova/Github/neuro-oj/noj-problems/trial-snowy-manor && PYTHONPATH=. python3 -m unittest discover -s tests -v`
+Expected: PASS（19+ 用例，无 `used_llm_calls` / `efficiency_score` 依赖）。
+
+- [ ] **Step 7: 提交（在 noj-problems 仓库内）**
+
+```bash
+cd /home/xyber-nova/Github/neuro-oj/noj-problems
+jj describe -m "feat(problems): trial-snowy-manor 移除本地 LLM 预算与效率分" && jj new
+```
+
+---
+
+### 自审核对
+
+- Spec §5.1（数据模型）：Task 1 实现 `LlmConfig` 可选字段。
+- Spec §5.2（两层校验）：Task 1 纯校验；Task 3 服务层天花板校验。
+- Spec §5.3（集中 helper / token 签发）：Task 2。
+- Spec §5.4 / §5.5（gateway 不改 / SDK 错误增强）：Task 4；gateway 无改动。
+- Spec §5.6（UI）：Task 5。
+- Spec §5.7（trial 适配与评分）：Task 6。
+- Spec §5.8（测试计划）：各任务均含失败→实现→通过的测试步骤。
+- 兼容性：不新增 DB 列/迁移、不新增 MQ 字段、不注入 evaluator 预算环境变量。

--- a/dev-docs/superpowers/specs/2026-09-05-llm-problem-budget-design.md
+++ b/dev-docs/superpowers/specs/2026-09-05-llm-problem-budget-design.md
@@ -1,0 +1,263 @@
+# 题目级 LLM 调用/token 上限设计
+
+> Status: proposed
+> Date: 2026-09-05
+> Scope: noj-core / noj-llm-gateway / noj-judge SDK / noj-ui / noj-problems(trial-snowy-manor)
+
+## 1. 背景
+
+当前单次评测的 LLM `max_calls` / `max_tokens` 由 noj-core 从平台环境变量
+`NOJ_LLM_MAX_CALLS` / `NOJ_LLM_MAX_TOKENS` 统一读取，并签入 `eval_token`。
+所有 LLM 题共享同一预算，无法让不同题目声明各自需要的“有限 token 解题”预算。
+
+PR #421 已引入 billed-token 计费口径：上游返回 `usage.prompt_tokens_details.cached_tokens`
+时，缓存命中部分不计入限额；gateway 在超限时返回 OpenAI 兼容
+`429 { error: { code: "out_of_usage" } }`。这为“题目声明自己的上限并由 gateway 强制”
+提供了现成的执行通道。
+
+trial-snowy-manor 当前在 evaluator 侧维护一套本地 LLM 预算
+（`NOJ_TRIAL_MAX_LLM` / `NOJ_TRIAL_MAX_TOKENS`，默认 30 / 20000），在转发 gateway 前
+自行计数拦截，并在 `scoring()` 中计算 LLM 效率分。该机制与“题目级预算由 gateway 统一
+强制”的架构重叠，且会因题目声明值与本地默认值不一致而误停或漏停。
+
+## 2. 目标
+
+- 允许题目在 `problem.json` / 管理端 UI 中声明本次评测的 LLM 调用次数与 token 上限。
+- 题目声明值通过现有 `eval_token` 传给 noj-llm-gateway，作为该题整次评测的硬上限。
+- 未声明时继续使用平台默认 `NOJ_LLM_MAX_CALLS` / `NOJ_LLM_MAX_TOKENS`。
+- 移除 trial-snowy-manor 的本地 LLM 预算与 LLM 效率分，超限统一由 gateway 返回
+  `out_of_usage`，题包捕获后判 0 分。
+- 保持 evaluator/选手侧不感知额度（KISS，不注入额外运行时环境，不做剩余额度查询）。
+
+## 3. 非目标
+
+- 不约束用户自带 BYOK（`user_llm`）的调用；BYOK 仍走现状的平台/用户配额保护。
+- 不新增 `JudgeTaskLlm` 的显式 `max_calls` / `max_tokens` 字段。
+- 不向 evaluator 注入题目预算环境变量。
+- 不提供选手侧“剩余额度查询”capability。
+- 不改变 noj-llm-gateway 的限流/结算逻辑。
+- 不新增数据库列或 SQL 迁移。
+
+## 4. 现状与耦合点
+
+| 耦合点 | 位置 | 说明 |
+|---|---|---|
+| 题目 LLM 配置 | `noj-core/src/domains/catalog/types/problems.ts` `LlmConfig` | 仅 `provider_id` / `model` |
+| manifest 校验 | `noj-core/src/domains/catalog/types/problem-bundle.ts` `validateBundleManifest` | 复用 `isValidLlmConfig` |
+| CRUD 校验 | `noj-core/src/domains/catalog/services/problems/problems-crud.ts` | 创建/更新时校验 `input.llm` |
+| eval_token 签发 | `noj-core/src/domains/gateway/services/llm-token.ts` `buildJudgeTaskLlm` | 从环境变量读默认上限 |
+| 硬限执行 | `noj-llm-gateway/src/limits.ts` + `routes/llm.ts` | 从 `eval_token` 读 `max_calls/max_tokens`，已支持 billed-token 与 `out_of_usage` |
+| 题目 UI | `noj-ui/components/editor/CodingProblemEditor.vue` | LLM 区块仅 provider/model |
+| trial 本地预算 | `noj-problems/trial-snowy-manor/sdk_evaluate.py`、`evaluate_offline.py`、`scenario_runner.py` | 本地计数 + LLM 效率分 |
+
+## 5. 设计
+
+### 5.1 数据模型与格式
+
+扩展 `LlmConfig`：
+
+```ts
+interface LlmConfig {
+  provider_id: string;
+  model: string;
+  /** 单次评测 LLM 调用上限；缺省 = 平台默认 */
+  max_calls?: number;
+  /** 单次评测 LLM billed token 上限；缺省 = 平台默认 */
+  max_tokens?: number;
+}
+```
+
+- `problems.llm_config` 仍为 JSONB，无 SQL 迁移。
+- `problem.json` 示例：
+
+```json
+{
+  "llm": {
+    "provider_id": "REPLACE_WITH_PROVIDER_UUID",
+    "model": "REPLACE_WITH_MODEL",
+    "max_calls": 30,
+    "max_tokens": 20000
+  }
+}
+```
+
+- 语义：平台固定 LLM 的整次评测总预算，按 billed token 口径由 gateway 强制。
+- `null` / `0` / 负数 / 非整数均非法；缺省才表示“用平台默认”。
+
+### 5.2 校验规则
+
+校验分两层，避免纯函数/纯 manifest 校验读取环境变量：
+
+- 纯校验 `isValidLlmConfig` 只做类型与值域检查：
+  - `max_calls` 若存在，必须是正整数（`Number.isInteger && > 0`）。
+  - `max_tokens` 若存在，必须是正整数。
+- 服务层“天花板校验”（写库前执行，读取平台默认作为安全上限）：
+  - `createProblem` / `updateProblem`（problems-crud.ts）：若题目声明 `max_calls` > `NOJ_LLM_MAX_CALLS`，拒绝（400）；`max_tokens` 同理。
+  - bundle 导入路径 `createViaCrud` / `updateExisting`（problem-bundle.ts）：同样执行天花板校验，不能只依赖 `createProblem` / `updateProblem` 覆盖。
+  - 未声明则使用平台默认；声明值只能小于等于平台默认。
+- 在 eval_token 签发处仍执行 `Math.min` 防御，防止配置与代码间出现竞态/不一致。
+
+### 5.3 noj-core 改动
+
+新增集中 helper（建议放 `llm-token.ts` 或共享目录，供 CRUD、bundle 导入与 token 签发复用）：
+
+```ts
+export function getDefaultLlmLimits(): { max_calls: number; max_tokens: number } {
+  return {
+    max_calls: Number(Deno.env.get("NOJ_LLM_MAX_CALLS") ?? "100"),
+    max_tokens: Number(Deno.env.get("NOJ_LLM_MAX_TOKENS") ?? "50000"),
+  };
+}
+
+export function resolveLlmLimits(
+  llm: Pick<LlmConfig, "max_calls" | "max_tokens">,
+): { max_calls: number; max_tokens: number } {
+  const defaults = getDefaultLlmLimits();
+  return {
+    max_calls: Math.min(llm.max_calls ?? defaults.max_calls, defaults.max_calls),
+    max_tokens: Math.min(llm.max_tokens ?? defaults.max_tokens, defaults.max_tokens),
+  };
+}
+```
+
+- 服务层（CRUD 与 bundle 导入）在写库前调用 `getDefaultLlmLimits()` 做天花板校验，
+  拒绝声明值大于平台默认的请求。
+- `buildJudgeTaskLlm`（平台固定 LLM）改用 `resolveLlmLimits(llmConfig)`，
+  将结果写入现有 `eval_token` 的 `max_calls` / `max_tokens`：
+  - 题目声明了值 → 使用题目值（已 ≤ 平台默认）。
+  - 题目未声明 → 使用平台默认。
+- `buildJudgeTaskLlmForProvider`（BYOK / sweeper 恢复）保持现状不变，继续读平台默认。
+- 各 submission 调用点无需修改，因为它们已经传入完整的 `LlmConfig`。
+
+### 5.4 noj-llm-gateway / noj-judge
+
+- noj-llm-gateway 不需要代码改动：已从 `eval_token` 读取 `max_calls/max_tokens`，
+  由 Redis Lua 原子检查 + billed-token 结算强制，超限返回 `out_of_usage`。
+- noj-judge Rust worker 不需要代码改动：不新增 MQ 字段，不注入 evaluator 环境，
+  SDK 与题包之间仍沿用现有 stdout 协议。
+- noj-judge 的 evaluator Python SDK `llm.py` 需要增强错误信息（见 5.5），
+  使题包能识别 gateway 429 `out_of_usage`。
+
+### 5.5 noj-judge SDK 错误增强
+
+`noj_evaluator_sdk/llm.py` 的 `LLMError` 增加结构化字段：
+
+```python
+class LLMError(Exception):
+    def __init__(self, message: str, status_code: int | None = None,
+                 error_code: str | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+```
+
+在 `HTTPError` 分支解析响应体：
+
+```python
+detail = e.read().decode("utf-8", errors="replace")
+try:
+    body = json.loads(detail)
+    error_code = body.get("error", {}).get("code")
+except Exception:
+    error_code = None
+raise LLMError(
+    f"LLM gateway 返回 {e.code}: {detail}",
+    status_code=e.code,
+    error_code=error_code,
+)
+```
+
+保持向后兼容：现有 `str(exc)` 行为不变；测试仅新增 429 `out_of_usage` 断言。
+
+### 5.6 noj-ui / 管理端
+
+`CodingProblemEditor.vue`：
+
+- LLM 区块增加两个可留空数字输入：
+  - 单次评测调用上限（`llmMaxCalls`，正整数，可空）
+  - 单次评测 token 上限（`llmMaxTokens`，正整数，可空）
+- 编辑模式从 `llm_config.max_calls / max_tokens` 回填。
+- 提交时：
+  - 留空则不发送 `max_calls` / `max_tokens` 键（由服务端使用平台默认）。
+  - 填写则随 `llm` payload 一起发送。
+- 前端校验：若填写则必须是正整数；最终以服务端天花板校验为准。
+- 组件类型定义同步更新（LLM config 类型含可选 max 字段）。
+
+### 5.7 trial-snowy-manor 适配
+
+#### 5.7.1 移除本地 LLM 预算
+
+- `sdk_evaluate.py`：
+  - 不再读取 `NOJ_TRIAL_MAX_LLM` / `NOJ_TRIAL_MAX_TOKENS`。
+  - 不再用本地计数在调用前拦截。
+  - `cap_llm_complete` 改为直接调用 `llm.complete()`；
+    - 若 `LLMError.error_code == "out_of_usage"`（或 429 + code），置
+      `runner._is_failed = True` 并抛出 `RuntimeError("out_of_usage")`。
+    - 其他错误继续按原样抛出/处理。
+- `scenario_runner.py`：
+  - `TrialRunner` 移除 `max_llm_calls`、`max_llm_tokens` 构造参数。
+  - 移除 `used_llm_calls`、`used_llm_tokens`、`llm_called()`。
+  - `scoring()` 不再计算 LLM 效率分。
+- `evaluate_offline.py`：
+  - 不再传 `max_llm_calls=30`，`Api.llm()` 不再调用 `runner.llm_called()`。
+  - 返回值移除 `used_llm_calls` / `used_llm_tokens`。
+- `README.e2e.md` 删除 `NOJ_TRIAL_MAX_LLM` / `NOJ_TRIAL_MAX_TOKENS` 相关说明。
+
+#### 5.7.2 评分结构调整
+
+- 移除 `EFFICIENCY_SCORE = 50` 与全部效率分计算。
+- `MASTERMIND_SCORE` 从 200 调整为 250，使满分保持 1000：
+
+| 分项 | 分值 |
+|---|---|
+| 反驳（每轮 100 × 5 轮） | 500 |
+| 主谋 | 250 |
+| 关键证据 | 200 |
+| 理由评分 | 50 |
+| **满分** | **1000** |
+
+- `scoring()` 各分支的 `max_score` 保持 1000；失败分支仍返回 0。
+- 单测中依赖旧满分/效率分的断言同步更新。
+
+#### 5.7.3 超限转 0 分语义
+
+- 选手 Agent 在 `solve_agent` 内通过 `llm_complete` 消耗预算：
+  - 预算未耗尽：正常返回。
+  - 预算耗尽：gateway 返回 429 `out_of_usage`，`cap_llm_complete` 捕获后置失败并抛出；
+    `sdk_evaluate.main()` 的异常捕获路径会把整次评测记为 0 分（或 runner 已 failed）。
+- 评测后的 LLM-as-judge 理由评分若遇到 `out_of_usage`，现有异常捕获令
+  `reason_score = 0`，不会产生额外扣费。
+
+### 5.8 测试计划
+
+| 模块 | 测试 |
+|---|---|
+| noj-core types | `isValidLlmConfig` 接受合法 max 字段、拒绝 0/负/非整数 |
+| noj-core problem-bundle | manifest 携带合法/非法 max 字段、客观题拒绝、非 P 拒绝 |
+| noj-core CRUD | 创建/更新时 max > 平台默认被 400 拒绝 |
+| noj-core llm-token | `buildJudgeTaskLlm` 使用题目 max 写入 eval_token；缺省使用平台默认；BYOK 仍用默认 |
+| noj-judge SDK | `llm.complete` 对 429 `out_of_usage` 抛 `LLMError(status_code=429, error_code="out_of_usage")` |
+| noj-problems | trial 单测适配：TrialRunner 无 LLM 预算、评分满分 1000、失败分支 0 分 |
+| noj-ui | 类型检查/模板编译；后续可加组件测试 |
+
+## 6. 兼容性
+
+- 已存在的 `problem.json` / `llm_config` 不包含 max 字段，行为与现状完全一致。
+- 已有 `NOJ_LLM_MAX_CALLS` / `NOJ_LLM_MAX_TOKENS` 环境变量语义不变。
+- `eval_token` 格式不改变（payload 字段仍为 `max_calls/max_tokens`，只是值来源变化）。
+- gateway / judge MQ 协议不变。
+
+## 7. 风险与缓解
+
+- 题目声明值与平台默认不一致导致误判：通过 CRUD/import 写前拒绝 + 签发时
+  `Math.min` 双重保障。
+- trial 移除本地预检后，若选手死循环调用 LLM，会直接打到 gateway 超限返回 0 分，
+  不会再由本地提前停；这是“配额到了直接零分”的题面设计预期。
+- LLM-as-judge 评分与选手共用同一预算：若选手耗尽预算，reason 分可能为 0；
+  这是“整次评测总预算”语义的预期结果，文档会明确说明。
+
+## 8. 后续（不在本次范围）
+
+- 题目级上限的展示/管理报表（如 usage 页显示题目声明值与实际消耗）。
+- 是否让 BYOK 也支持用户级自定义上限。
+- 是否把题目上限暴露给 evaluator 做更精细的评分（当前明确不做）。

--- a/noj-core/src/domains/catalog/services/problems/problem-bundle.ts
+++ b/noj-core/src/domains/catalog/services/problems/problem-bundle.ts
@@ -51,6 +51,7 @@ import { judgeOptions } from "../../../objective/index.ts";
 import { getProblem } from "./problems-list.ts";
 import { getTagIdsByNames, listTags } from "../tags.ts";
 import { logAudit } from "../../../system/index.ts";
+import { assertLlmLimitsWithinDefault } from "../../../gateway/index.ts";
 import { MAX_SUPPORT_PACKAGE_SIZE } from "../support-package.ts";
 import { ROOT_USER_ID } from "./../../../../shared/base/constants.ts";
 
@@ -265,6 +266,9 @@ async function updateExisting(
     manifest.runtime_config!,
   );
   enforceResourceLimits(manifest.runtime_config!);
+  if (manifest.llm) {
+    assertLlmLimitsWithinDefault(manifest.llm);
+  }
 
   if (oldStorageUrl) {
     try {
@@ -523,6 +527,9 @@ async function createViaCrud(
     manifest.runtime_config!,
   );
   enforceResourceLimits(manifest.runtime_config!);
+  if (manifest.llm) {
+    assertLlmLimitsWithinDefault(manifest.llm);
+  }
 
   const db = getDb();
   const tagIds = await resolveTagIds(manifest.tags);

--- a/noj-core/src/domains/catalog/services/problems/problems-crud.ts
+++ b/noj-core/src/domains/catalog/services/problems/problems-crud.ts
@@ -28,7 +28,10 @@ import { getStorageProvider } from "./../../../system/index.ts";
 import { logger } from "./../../../../shared/base/logging.ts";
 import { validateJudgeImageWithKind } from "../../../system/index.ts";
 import { logAudit } from "../../../system/index.ts";
-import { getLlmProviderById } from "../../../gateway/index.ts";
+import {
+  assertLlmLimitsWithinDefault,
+  getLlmProviderById,
+} from "../../../gateway/index.ts";
 import {
   type CreateProblemInput,
   DIFFICULTIES,
@@ -171,6 +174,7 @@ export async function createProblem(
     if (type !== "P") {
       throw new ForbiddenError("仅 P 型/官方题可启用 LLM");
     }
+    assertLlmLimitsWithinDefault(input.llm);
     const provider = await getLlmProviderById(input.llm.provider_id).catch(
       () => null,
     );
@@ -425,6 +429,7 @@ export async function updateProblem(
       if (isObjective) {
         throw new BadRequestError("客观题套卷不支持 LLM 配置");
       }
+      assertLlmLimitsWithinDefault(input.llm);
       const provider = await getLlmProviderById(input.llm.provider_id).catch(
         () => null,
       );

--- a/noj-core/src/domains/catalog/tests/routes/problem-bundle.test.ts
+++ b/noj-core/src/domains/catalog/tests/routes/problem-bundle.test.ts
@@ -11,6 +11,7 @@ import { getDb, resetDbForTest } from "../../../../shared/db/connection.ts";
 import { problems, users } from "../../../../shared/db/schema.ts";
 import { eq, sql } from "drizzle-orm";
 import { createUserToken } from "../../../../../tests/helper.ts";
+import { getDefaultLlmLimits } from "../../../gateway/index.ts";
 
 const hasEnv = !!Deno.env.get("JWT_SECRET");
 const skipEnv = !hasEnv;
@@ -809,5 +810,50 @@ Deno.test({
       body: formData,
     });
     assertEquals(res.status, 403);
+  },
+});
+
+Deno.test({
+  name: "import-bundle: LLM max_calls 超过平台默认被拒（400）",
+  ignore: skipEnv,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const app = createApp();
+    const token = await createUserToken("admin");
+    const defaults = getDefaultLlmLimits();
+    const formData = new FormData();
+    formData.append(
+      "file",
+      makeZipBlob({
+        type: "P",
+        runtime_config: {
+          evaluator: {
+            image: "noj-evaluator-python",
+            time_limit_ms: 60000,
+            memory_limit_mb: 512,
+            network: { enabled: true },
+          },
+          solution: {
+            image: "noj-solution-python",
+            call_timeout_ms: 5000,
+            memory_limit_mb: 512,
+          },
+        },
+        llm: {
+          provider_id: "p1",
+          model: "m",
+          max_calls: defaults.max_calls + 1,
+        },
+      }),
+      "llm-over.zip",
+    );
+    const res = await app.request("/api/v1/problems/import-bundle", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    });
+    assertEquals(res.status, 400);
   },
 });

--- a/noj-core/src/domains/catalog/tests/services/problems-llm-limits.test.ts
+++ b/noj-core/src/domains/catalog/tests/services/problems-llm-limits.test.ts
@@ -1,0 +1,153 @@
+/**
+ * 题目 LLM 上限服务层校验（需要 DB）。
+ */
+import { assertRejects } from "jsr:@std/assert@^1";
+import { createProblem, updateProblem } from "../../index.ts";
+import { getDb, resetDbForTest } from "../../../../shared/db/connection.ts";
+import { users } from "../../../../shared/db/schema.ts";
+import { BadRequestError } from "../../../../shared/base/errors.ts";
+import { getDefaultLlmLimits } from "../../../gateway/index.ts";
+
+// 与 problems.test.ts 一致：PGlite 内存库始终可用
+const dbAvailable = true;
+const skip = !dbAvailable;
+const ts = Date.now();
+
+const NETWORKED_RUNTIME_CONFIG = {
+  evaluator: {
+    image: "noj-evaluator-python",
+    command: "python3 /workspace/evaluate.py",
+    time_limit_ms: 5000,
+    memory_limit_mb: 512,
+    network: { enabled: true },
+  },
+  solution: {
+    image: "noj-solution-python",
+    call_timeout_ms: 2000,
+    memory_limit_mb: 512,
+  },
+};
+
+async function createAdminUser(): Promise<string> {
+  const db = getDb();
+  const id = `llm-admin-${ts}`;
+  const now = new Date().toISOString();
+  await db.insert(users).values({
+    id,
+    username: `llm-admin-${ts}`,
+    email: `llm-admin-${ts}@test.com`,
+    password_hash: "",
+    created_at: now,
+    updated_at: now,
+  });
+  return id;
+}
+
+/** stub gateway /internal/providers/:id，返回 enabled provider，避免测试依赖真实网络。 */
+function stubEnabledLlmProvider(): () => void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((_input: Request | URL | string) => {
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: {
+            id: "p-does-not-matter",
+            name: "stub",
+            base_url: "http://stub",
+            model: "m",
+            cost_per_1k_tokens: 0,
+            api_key_masked: "sk-****",
+            enabled: true,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+Deno.test({
+  name: "problems-llm-limits: createProblem 拒绝 max_calls 超过平台默认",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const restore = stubEnabledLlmProvider();
+    try {
+      const adminId = await createAdminUser();
+      const defaults = getDefaultLlmLimits();
+      await assertRejects(
+        () =>
+          createProblem(
+            {
+              title: `LLM 超限 ${Date.now()}`,
+              description: "d",
+              type: "P",
+              runtime_config: NETWORKED_RUNTIME_CONFIG,
+              llm: {
+                provider_id: "p-does-not-matter",
+                model: "m",
+                max_calls: defaults.max_calls + 1,
+              },
+            },
+            adminId,
+            "admin",
+          ),
+        BadRequestError,
+        "max_calls",
+      );
+    } finally {
+      restore();
+    }
+  },
+});
+
+Deno.test({
+  name: "problems-llm-limits: updateProblem 拒绝 max_tokens 超过平台默认",
+  ignore: skip,
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await resetDbForTest();
+    const restore = stubEnabledLlmProvider();
+    try {
+      const adminId = await createAdminUser();
+      const created = await createProblem(
+        {
+          title: `LLM 更新超限 ${Date.now()}`,
+          description: "d",
+          type: "P",
+          runtime_config: NETWORKED_RUNTIME_CONFIG,
+        },
+        adminId,
+        "admin",
+      );
+      const defaults = getDefaultLlmLimits();
+      await assertRejects(
+        () =>
+          updateProblem(
+            created.id,
+            {
+              llm: {
+                provider_id: "p-does-not-matter",
+                model: "m",
+                max_tokens: defaults.max_tokens + 1,
+              },
+            },
+            adminId,
+            "admin",
+          ),
+        BadRequestError,
+        "max_tokens",
+      );
+    } finally {
+      restore();
+    }
+  },
+});

--- a/noj-core/src/domains/catalog/types/problems.ts
+++ b/noj-core/src/domains/catalog/types/problems.ts
@@ -60,6 +60,10 @@ export function isValidProblemType(value: string): value is ProblemType {
 export interface LlmConfig {
   provider_id: string;
   model: string;
+  /** 单次评测 LLM 调用上限；缺省 = 平台默认 */
+  max_calls?: number;
+  /** 单次评测 LLM billed token 上限；缺省 = 平台默认 */
+  max_tokens?: number;
 }
 
 /**
@@ -68,8 +72,12 @@ export interface LlmConfig {
 export function isValidLlmConfig(value: unknown): value is LlmConfig {
   if (typeof value !== "object" || value === null) return false;
   const obj = value as Record<string, unknown>;
+  const isValidPositiveInt = (v: unknown): boolean =>
+    v === undefined ||
+    (typeof v === "number" && Number.isInteger(v) && v > 0);
   return typeof obj.provider_id === "string" && obj.provider_id.length > 0 &&
-    typeof obj.model === "string" && obj.model.length > 0;
+    typeof obj.model === "string" && obj.model.length > 0 &&
+    isValidPositiveInt(obj.max_calls) && isValidPositiveInt(obj.max_tokens);
 }
 
 /**

--- a/noj-core/src/domains/gateway/index.ts
+++ b/noj-core/src/domains/gateway/index.ts
@@ -1,2 +1,3 @@
 export * from "./services/llm.ts";
+export * from "./services/llm-limits.ts";
 export * from "./services/llm-token.ts";

--- a/noj-core/src/domains/gateway/services/llm-limits.ts
+++ b/noj-core/src/domains/gateway/services/llm-limits.ts
@@ -1,0 +1,50 @@
+/**
+ * 题目级 LLM 预算的默认值与解析/校验。
+ *
+ * 平台默认值同时是安全天花板：
+ * - CRUD / bundle 导入在写库前调用 assertLlmLimitsWithinDefault 拒绝超限声明；
+ * - eval_token 签发调用 resolveLlmLimits 做 Math.min 防御。
+ */
+import { BadRequestError } from "../../../shared/base/errors.ts";
+import type { LlmConfig } from "../../catalog/index.ts";
+
+/** 读取平台默认单次评测 LLM 预算。 */
+export function getDefaultLlmLimits(): {
+  max_calls: number;
+  max_tokens: number;
+} {
+  return {
+    max_calls: Number(Deno.env.get("NOJ_LLM_MAX_CALLS") ?? "100"),
+    max_tokens: Number(Deno.env.get("NOJ_LLM_MAX_TOKENS") ?? "50000"),
+  };
+}
+
+/** 解析题目声明值；缺省用平台默认，声明值超过默认时截断到默认（防御）。 */
+export function resolveLlmLimits(
+  llm: Pick<LlmConfig, "max_calls" | "max_tokens">,
+): { max_calls: number; max_tokens: number } {
+  const defaults = getDefaultLlmLimits();
+  return {
+    max_calls: Math.min(
+      llm.max_calls ?? defaults.max_calls,
+      defaults.max_calls,
+    ),
+    max_tokens: Math.min(
+      llm.max_tokens ?? defaults.max_tokens,
+      defaults.max_tokens,
+    ),
+  };
+}
+
+/** 服务层写库前校验：题目声明值不得超过平台默认。 */
+export function assertLlmLimitsWithinDefault(
+  llm: Pick<LlmConfig, "max_calls" | "max_tokens">,
+): void {
+  const defaults = getDefaultLlmLimits();
+  if (llm.max_calls !== undefined && llm.max_calls > defaults.max_calls) {
+    throw new BadRequestError("llm.max_calls 超过平台默认上限");
+  }
+  if (llm.max_tokens !== undefined && llm.max_tokens > defaults.max_tokens) {
+    throw new BadRequestError("llm.max_tokens 超过平台默认上限");
+  }
+}

--- a/noj-core/src/domains/gateway/services/llm-limits.ts
+++ b/noj-core/src/domains/gateway/services/llm-limits.ts
@@ -8,15 +8,26 @@
 import { BadRequestError } from "../../../shared/base/errors.ts";
 import type { LlmConfig } from "../../catalog/index.ts";
 
-/** 读取平台默认单次评测 LLM 预算。 */
+/** 平台默认单次评测 LLM 预算（环境变量非法时回退的安全值）。 */
+const DEFAULT_MAX_CALLS = 100;
+const DEFAULT_MAX_TOKENS = 50_000;
+
+/** 读取平台默认单次评测 LLM 预算；环境变量非法/非正数时回退默认值。 */
 export function getDefaultLlmLimits(): {
   max_calls: number;
   max_tokens: number;
 } {
   return {
-    max_calls: Number(Deno.env.get("NOJ_LLM_MAX_CALLS") ?? "100"),
-    max_tokens: Number(Deno.env.get("NOJ_LLM_MAX_TOKENS") ?? "50000"),
+    max_calls: readPositiveIntEnv("NOJ_LLM_MAX_CALLS", DEFAULT_MAX_CALLS),
+    max_tokens: readPositiveIntEnv("NOJ_LLM_MAX_TOKENS", DEFAULT_MAX_TOKENS),
   };
+}
+
+function readPositiveIntEnv(key: string, fallback: number): number {
+  const raw = Deno.env.get(key);
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && Number.isInteger(n) && n > 0 ? n : fallback;
 }
 
 /** 解析题目声明值；缺省用平台默认，声明值超过默认时截断到默认（防御）。 */
@@ -25,22 +36,40 @@ export function resolveLlmLimits(
 ): { max_calls: number; max_tokens: number } {
   const defaults = getDefaultLlmLimits();
   return {
-    max_calls: Math.min(
-      llm.max_calls ?? defaults.max_calls,
-      defaults.max_calls,
+    max_calls: Math.max(
+      1,
+      Math.min(
+        llm.max_calls ?? defaults.max_calls,
+        defaults.max_calls,
+      ),
     ),
-    max_tokens: Math.min(
-      llm.max_tokens ?? defaults.max_tokens,
-      defaults.max_tokens,
+    max_tokens: Math.max(
+      1,
+      Math.min(
+        llm.max_tokens ?? defaults.max_tokens,
+        defaults.max_tokens,
+      ),
     ),
   };
 }
 
-/** 服务层写库前校验：题目声明值不得超过平台默认。 */
+/** 服务层写库前校验：题目声明值必须是正整数且不得超过平台默认。 */
 export function assertLlmLimitsWithinDefault(
   llm: Pick<LlmConfig, "max_calls" | "max_tokens">,
 ): void {
   const defaults = getDefaultLlmLimits();
+  if (
+    llm.max_calls !== undefined &&
+    (!Number.isInteger(llm.max_calls) || llm.max_calls <= 0)
+  ) {
+    throw new BadRequestError("llm.max_calls 必须是正整数");
+  }
+  if (
+    llm.max_tokens !== undefined &&
+    (!Number.isInteger(llm.max_tokens) || llm.max_tokens <= 0)
+  ) {
+    throw new BadRequestError("llm.max_tokens 必须是正整数");
+  }
   if (llm.max_calls !== undefined && llm.max_calls > defaults.max_calls) {
     throw new BadRequestError("llm.max_calls 超过平台默认上限");
   }

--- a/noj-core/src/domains/gateway/services/llm-token.ts
+++ b/noj-core/src/domains/gateway/services/llm-token.ts
@@ -5,6 +5,7 @@ import type { LlmConfig } from "./../../catalog/index.ts";
 import type { JudgeTaskLlm } from "../../submission/index.ts";
 import type { RuntimeConfig } from "../../catalog/index.ts";
 import { encodeBase64 } from "@std/encoding/base64";
+import { getDefaultLlmLimits, resolveLlmLimits } from "./llm-limits.ts";
 
 const IV_LENGTH = 12;
 
@@ -80,6 +81,7 @@ export function buildJudgeTaskLlm(
     problemId,
     userId,
     runtimeConfig,
+    resolveLlmLimits(llmConfig),
   );
 }
 
@@ -91,12 +93,14 @@ export async function buildJudgeTaskLlmForProvider(
   problemId: string,
   userId: string,
   runtimeConfig: RuntimeConfig,
+  limits?: { max_calls: number; max_tokens: number },
 ): Promise<JudgeTaskLlm> {
   const gatewayUrl = Deno.env.get("NOJ_LLM_GATEWAY_URL") ??
     "http://localhost:8001";
   const timeLimitMs = runtimeConfig.evaluator.time_limit_ms;
   const ttlSeconds = Math.max(60, Math.ceil((timeLimitMs * 4) / 1000));
   const now = Math.floor(Date.now() / 1000);
+  const resolved = limits ?? getDefaultLlmLimits();
   const token = await mintEvalToken({
     jti: crypto.randomUUID(),
     submission_id: submissionId,
@@ -106,8 +110,8 @@ export async function buildJudgeTaskLlmForProvider(
     allowed_models: [model],
     iat: now,
     exp: now + ttlSeconds,
-    max_calls: Number(Deno.env.get("NOJ_LLM_MAX_CALLS") ?? "100"),
-    max_tokens: Number(Deno.env.get("NOJ_LLM_MAX_TOKENS") ?? "50000"),
+    max_calls: resolved.max_calls,
+    max_tokens: resolved.max_tokens,
   });
   return {
     gateway_url: gatewayUrl,

--- a/noj-core/src/domains/gateway/tests/services/llm-problem.test.ts
+++ b/noj-core/src/domains/gateway/tests/services/llm-problem.test.ts
@@ -2,10 +2,16 @@
  * LLM 题目配置与 token 签发测试（纯函数，无需 DB）。
  */
 import { assert, assertEquals, assertThrows } from "jsr:@std/assert@^1";
+import { BadRequestError } from "../../../../shared/base/errors.ts";
 import { validateBundleManifest } from "../../../catalog/index.ts";
 import { isValidLlmConfig } from "../../../catalog/index.ts";
 import { buildJudgeTaskLlm } from "../../services/llm-token.ts";
 import type { RuntimeConfig } from "../../../catalog/index.ts";
+import {
+  assertLlmLimitsWithinDefault,
+  getDefaultLlmLimits,
+  resolveLlmLimits,
+} from "../../services/llm-limits.ts";
 
 Deno.test("llm-config: isValidLlmConfig", () => {
   assert(isValidLlmConfig({ provider_id: "p1", model: "qwen-plus" }));
@@ -137,8 +143,12 @@ Deno.test("llm-config: isValidLlmConfig 拒绝 0/负数/非整数/字符串/null
   assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_calls: 0 }));
   assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_calls: -1 }));
   assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_calls: 1.5 }));
-  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_tokens: "100" }));
-  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_tokens: null }));
+  assert(
+    !isValidLlmConfig({ provider_id: "p1", model: "m", max_tokens: "100" }),
+  );
+  assert(
+    !isValidLlmConfig({ provider_id: "p1", model: "m", max_tokens: null }),
+  );
 });
 
 Deno.test("llm-bundle: P 型携带合法 max 字段通过", () => {
@@ -159,7 +169,12 @@ Deno.test("llm-bundle: P 型携带合法 max 字段通过", () => {
         memory_limit_mb: 512,
       },
     },
-    llm: { provider_id: "p1", model: "qwen-plus", max_calls: 10, max_tokens: 1000 },
+    llm: {
+      provider_id: "p1",
+      model: "qwen-plus",
+      max_calls: 10,
+      max_tokens: 1000,
+    },
   });
   assertEquals(manifest.llm?.max_calls, 10);
   assertEquals(manifest.llm?.max_tokens, 1000);
@@ -187,4 +202,67 @@ Deno.test("llm-bundle: 非法 max 字段被拒", () => {
       llm: { provider_id: "p1", model: "m", max_calls: 0 },
     })
   );
+});
+
+Deno.test("llm-limits: getDefaultLlmLimits 读取环境变量", () => {
+  const oldCalls = Deno.env.get("NOJ_LLM_MAX_CALLS");
+  const oldTokens = Deno.env.get("NOJ_LLM_MAX_TOKENS");
+  Deno.env.set("NOJ_LLM_MAX_CALLS", "123");
+  Deno.env.set("NOJ_LLM_MAX_TOKENS", "456");
+  try {
+    assertEquals(getDefaultLlmLimits(), { max_calls: 123, max_tokens: 456 });
+  } finally {
+    if (oldCalls === undefined) Deno.env.delete("NOJ_LLM_MAX_CALLS");
+    else Deno.env.set("NOJ_LLM_MAX_CALLS", oldCalls);
+    if (oldTokens === undefined) Deno.env.delete("NOJ_LLM_MAX_TOKENS");
+    else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
+  }
+});
+
+Deno.test("llm-limits: resolveLlmLimits 缺省用默认、题目值截断到默认", () => {
+  const oldCalls = Deno.env.get("NOJ_LLM_MAX_CALLS");
+  const oldTokens = Deno.env.get("NOJ_LLM_MAX_TOKENS");
+  Deno.env.set("NOJ_LLM_MAX_CALLS", "100");
+  Deno.env.set("NOJ_LLM_MAX_TOKENS", "50000");
+  try {
+    assertEquals(resolveLlmLimits({}), { max_calls: 100, max_tokens: 50000 });
+    assertEquals(
+      resolveLlmLimits({ max_calls: 30, max_tokens: 20000 }),
+      { max_calls: 30, max_tokens: 20000 },
+    );
+    assertEquals(
+      resolveLlmLimits({ max_calls: 999, max_tokens: 999999 }),
+      { max_calls: 100, max_tokens: 50000 },
+    );
+  } finally {
+    if (oldCalls === undefined) Deno.env.delete("NOJ_LLM_MAX_CALLS");
+    else Deno.env.set("NOJ_LLM_MAX_CALLS", oldCalls);
+    if (oldTokens === undefined) Deno.env.delete("NOJ_LLM_MAX_TOKENS");
+    else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
+  }
+});
+
+Deno.test("llm-limits: assertLlmLimitsWithinDefault 超默认抛 BadRequestError", () => {
+  const oldCalls = Deno.env.get("NOJ_LLM_MAX_CALLS");
+  const oldTokens = Deno.env.get("NOJ_LLM_MAX_TOKENS");
+  Deno.env.set("NOJ_LLM_MAX_CALLS", "100");
+  Deno.env.set("NOJ_LLM_MAX_TOKENS", "50000");
+  try {
+    assertLlmLimitsWithinDefault({ max_calls: 30, max_tokens: 20000 });
+    assertThrows(
+      () => assertLlmLimitsWithinDefault({ max_calls: 101 }),
+      BadRequestError,
+      "max_calls",
+    );
+    assertThrows(
+      () => assertLlmLimitsWithinDefault({ max_tokens: 50001 }),
+      BadRequestError,
+      "max_tokens",
+    );
+  } finally {
+    if (oldCalls === undefined) Deno.env.delete("NOJ_LLM_MAX_CALLS");
+    else Deno.env.set("NOJ_LLM_MAX_CALLS", oldCalls);
+    if (oldTokens === undefined) Deno.env.delete("NOJ_LLM_MAX_TOKENS");
+    else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
+  }
 });

--- a/noj-core/src/domains/gateway/tests/services/llm-problem.test.ts
+++ b/noj-core/src/domains/gateway/tests/services/llm-problem.test.ts
@@ -122,3 +122,69 @@ Deno.test("llm-token: buildJudgeTaskLlm 生成可校验字段", async () => {
     else Deno.env.set("NOJ_LLM_GATEWAY_URL", oldUrl);
   }
 });
+
+Deno.test("llm-config: isValidLlmConfig 接受可选 max 字段", () => {
+  assert(isValidLlmConfig({
+    provider_id: "p1",
+    model: "qwen-plus",
+    max_calls: 10,
+    max_tokens: 1000,
+  }));
+  assert(isValidLlmConfig({ provider_id: "p1", model: "qwen-plus" }));
+});
+
+Deno.test("llm-config: isValidLlmConfig 拒绝 0/负数/非整数/字符串/null max", () => {
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_calls: 0 }));
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_calls: -1 }));
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_calls: 1.5 }));
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_tokens: "100" }));
+  assert(!isValidLlmConfig({ provider_id: "p1", model: "m", max_tokens: null }));
+});
+
+Deno.test("llm-bundle: P 型携带合法 max 字段通过", () => {
+  const manifest = validateBundleManifest({
+    format_version: 1,
+    title: "LLM 题",
+    type: "P",
+    runtime_config: {
+      evaluator: {
+        image: "noj-evaluator-python",
+        time_limit_ms: 60000,
+        memory_limit_mb: 512,
+        network: { enabled: true },
+      },
+      solution: {
+        image: "noj-solution-python",
+        call_timeout_ms: 5000,
+        memory_limit_mb: 512,
+      },
+    },
+    llm: { provider_id: "p1", model: "qwen-plus", max_calls: 10, max_tokens: 1000 },
+  });
+  assertEquals(manifest.llm?.max_calls, 10);
+  assertEquals(manifest.llm?.max_tokens, 1000);
+});
+
+Deno.test("llm-bundle: 非法 max 字段被拒", () => {
+  assertThrows(() =>
+    validateBundleManifest({
+      format_version: 1,
+      title: "LLM 题",
+      type: "P",
+      runtime_config: {
+        evaluator: {
+          image: "noj-evaluator-python",
+          time_limit_ms: 60000,
+          memory_limit_mb: 512,
+          network: { enabled: true },
+        },
+        solution: {
+          image: "noj-solution-python",
+          call_timeout_ms: 5000,
+          memory_limit_mb: 512,
+        },
+      },
+      llm: { provider_id: "p1", model: "m", max_calls: 0 },
+    })
+  );
+});

--- a/noj-core/src/domains/gateway/tests/services/llm-problem.test.ts
+++ b/noj-core/src/domains/gateway/tests/services/llm-problem.test.ts
@@ -266,3 +266,60 @@ Deno.test("llm-limits: assertLlmLimitsWithinDefault 超默认抛 BadRequestError
     else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
   }
 });
+
+Deno.test("llm-limits: 非法环境变量回退默认值", () => {
+  const oldCalls = Deno.env.get("NOJ_LLM_MAX_CALLS");
+  const oldTokens = Deno.env.get("NOJ_LLM_MAX_TOKENS");
+  Deno.env.set("NOJ_LLM_MAX_CALLS", "abc");
+  Deno.env.set("NOJ_LLM_MAX_TOKENS", "-1");
+  try {
+    assertEquals(getDefaultLlmLimits(), { max_calls: 100, max_tokens: 50000 });
+  } finally {
+    if (oldCalls === undefined) Deno.env.delete("NOJ_LLM_MAX_CALLS");
+    else Deno.env.set("NOJ_LLM_MAX_CALLS", oldCalls);
+    if (oldTokens === undefined) Deno.env.delete("NOJ_LLM_MAX_TOKENS");
+    else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
+  }
+});
+
+Deno.test("llm-limits: resolveLlmLimits 对非正声明值钳制到 1", () => {
+  const oldCalls = Deno.env.get("NOJ_LLM_MAX_CALLS");
+  const oldTokens = Deno.env.get("NOJ_LLM_MAX_TOKENS");
+  Deno.env.set("NOJ_LLM_MAX_CALLS", "100");
+  Deno.env.set("NOJ_LLM_MAX_TOKENS", "50000");
+  try {
+    assertEquals(
+      resolveLlmLimits({ max_calls: 0, max_tokens: -10 }),
+      { max_calls: 1, max_tokens: 1 },
+    );
+  } finally {
+    if (oldCalls === undefined) Deno.env.delete("NOJ_LLM_MAX_CALLS");
+    else Deno.env.set("NOJ_LLM_MAX_CALLS", oldCalls);
+    if (oldTokens === undefined) Deno.env.delete("NOJ_LLM_MAX_TOKENS");
+    else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
+  }
+});
+
+Deno.test("llm-limits: assertLlmLimitsWithinDefault 拒绝非正整数", () => {
+  const oldCalls = Deno.env.get("NOJ_LLM_MAX_CALLS");
+  const oldTokens = Deno.env.get("NOJ_LLM_MAX_TOKENS");
+  Deno.env.set("NOJ_LLM_MAX_CALLS", "100");
+  Deno.env.set("NOJ_LLM_MAX_TOKENS", "50000");
+  try {
+    assertThrows(
+      () => assertLlmLimitsWithinDefault({ max_calls: 0 }),
+      BadRequestError,
+      "max_calls",
+    );
+    assertThrows(
+      () => assertLlmLimitsWithinDefault({ max_tokens: -1 }),
+      BadRequestError,
+      "max_tokens",
+    );
+  } finally {
+    if (oldCalls === undefined) Deno.env.delete("NOJ_LLM_MAX_CALLS");
+    else Deno.env.set("NOJ_LLM_MAX_CALLS", oldCalls);
+    if (oldTokens === undefined) Deno.env.delete("NOJ_LLM_MAX_TOKENS");
+    else Deno.env.set("NOJ_LLM_MAX_TOKENS", oldTokens);
+  }
+});

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/llm.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/llm.py
@@ -24,6 +24,16 @@ from typing import Any, Optional
 class LLMError(Exception):
     """LLM 调用失败（配置缺失、token 失效、上游错误等）。"""
 
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+
 
 def _required_env(name: str) -> str:
     value = os.environ.get(name, "").strip()
@@ -77,7 +87,17 @@ def complete(
             payload = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
         detail = e.read().decode("utf-8", errors="replace")
-        raise LLMError(f"LLM gateway 返回 {e.code}: {detail}") from e
+        error_code = None
+        try:
+            body = json.loads(detail)
+            error_code = body.get("error", {}).get("code")
+        except Exception:
+            error_code = None
+        raise LLMError(
+            f"LLM gateway 返回 {e.code}: {detail}",
+            status_code=e.code,
+            error_code=error_code,
+        ) from e
     except urllib.error.URLError as e:
         raise LLMError(f"LLM gateway 连接失败: {e.reason}") from e
 

--- a/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_llm.py
+++ b/noj-judge/sdk/evaluator/noj_evaluator_sdk/tests/test_llm.py
@@ -92,3 +92,23 @@ class LlmTest(TestCase):
             _Handler.status = old_status
             server.shutdown()
             server.server_close()
+
+    def test_out_of_usage_error_raises_structured(self):
+        server = _start_server()
+        old_status = _Handler.status
+        old_response = _Handler.response
+        _Handler.status = 429
+        _Handler.response = {"error": {"code": "out_of_usage"}}
+        try:
+            os.environ["NOJ_LLM_GATEWAY_URL"] = f"http://127.0.0.1:{server.server_port}"
+            os.environ["NOJ_LLM_TOKEN"] = "test-token"
+            os.environ["NOJ_LLM_ALLOWED_MODELS"] = "qwen-plus"
+            with self.assertRaises(llm.LLMError) as ctx:
+                llm.complete(model="qwen-plus", messages=[{"role": "user", "content": "hi"}])
+            self.assertEqual(ctx.exception.status_code, 429)
+            self.assertEqual(ctx.exception.error_code, "out_of_usage")
+        finally:
+            _Handler.status = old_status
+            _Handler.response = old_response
+            server.shutdown()
+            server.server_close()

--- a/noj-ui/components/editor/CodingProblemEditor.vue
+++ b/noj-ui/components/editor/CodingProblemEditor.vue
@@ -103,6 +103,8 @@ const solutionMemoryLimitMb = ref(256)
 const llmEnabled = ref(false)
 const llmProviderId = ref("")
 const llmModel = ref("")
+const llmMaxCalls = ref("")
+const llmMaxTokens = ref("")
 const llmProviders = ref<{ id: string; name: string; base_url: string; model: string }[]>([])
 
 async function loadLlmProviders() {
@@ -239,11 +241,20 @@ async function loadProblem() {
       solutionMemoryLimitMb.value = rc.solution.memory_limit_mb
     }
     // 加载 LLM 配置
-    const llmConfig = (p as { llm_config?: { provider_id: string; model: string } | null }).llm_config
+    const llmConfig = (p as {
+      llm_config?: {
+        provider_id: string
+        model: string
+        max_calls?: number | null
+        max_tokens?: number | null
+      } | null
+    }).llm_config
     if (llmConfig) {
       llmEnabled.value = true
       llmProviderId.value = llmConfig.provider_id
       llmModel.value = llmConfig.model
+      llmMaxCalls.value = llmConfig.max_calls != null ? String(llmConfig.max_calls) : ""
+      llmMaxTokens.value = llmConfig.max_tokens != null ? String(llmConfig.max_tokens) : ""
     }
   } catch (err: unknown) {
     if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 404) {
@@ -286,6 +297,14 @@ function validate(): boolean {
     if (!llmProviderId.value.trim()) errors.llm_provider = "请选择 LLM Provider"
     if (!llmModel.value.trim()) errors.llm_model = "请输入模型名"
     if (!evaluatorNetworkEnabled.value) errors.evaluator_network = "启用 LLM 必须开启 Evaluator 联网"
+    const maxCalls = llmMaxCalls.value === "" ? null : Number(llmMaxCalls.value)
+    const maxTokens = llmMaxTokens.value === "" ? null : Number(llmMaxTokens.value)
+    if (maxCalls !== null && (!Number.isInteger(maxCalls) || maxCalls <= 0)) {
+      errors.llm_max_calls = "调用上限必须是正整数"
+    }
+    if (maxTokens !== null && (!Number.isInteger(maxTokens) || maxTokens <= 0)) {
+      errors.llm_max_tokens = "token 上限必须是正整数"
+    }
   }
   fieldErrors.value = errors
   return Object.keys(errors).length === 0
@@ -310,8 +329,15 @@ async function handleSubmit() {
         memory_limit_mb: solutionMemoryLimitMb.value,
       },
     }
+    const llmMaxCallsNum = llmMaxCalls.value === "" ? null : Number(llmMaxCalls.value)
+    const llmMaxTokensNum = llmMaxTokens.value === "" ? null : Number(llmMaxTokens.value)
     const llmPayload = llmEnabled.value
-      ? { provider_id: llmProviderId.value.trim(), model: llmModel.value.trim() }
+      ? {
+          provider_id: llmProviderId.value.trim(),
+          model: llmModel.value.trim(),
+          ...(llmMaxCallsNum !== null ? { max_calls: llmMaxCallsNum } : {}),
+          ...(llmMaxTokensNum !== null ? { max_tokens: llmMaxTokensNum } : {}),
+        }
       : null
     const submissionModePayload = submissionMode.value
     const artifactMaxSizePayload = artifactMaxSizeMb.value
@@ -543,6 +569,30 @@ async function handleSubmit() {
                   <label class="text-xs font-semibold text-text">模型 <span class="text-red-600">*</span></label>
                   <input v-model="llmModel" class="px-2.5 py-1.5 text-sm border border-border rounded-md outline-none focus:border-signal bg-white" placeholder="如：qwen-plus" />
                   <p v-if="fieldErrors.llm_model" class="text-xs text-red-600">{{ fieldErrors.llm_model }}</p>
+                </div>
+                <div class="grid grid-cols-2 gap-2">
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs font-semibold text-text">调用上限</label>
+                    <input
+                      v-model="llmMaxCalls"
+                      type="number"
+                      min="1"
+                      class="px-2.5 py-1.5 text-sm border border-border rounded-md bg-white"
+                      placeholder="留空使用平台默认"
+                    />
+                    <p v-if="fieldErrors.llm_max_calls" class="text-xs text-red-600">{{ fieldErrors.llm_max_calls }}</p>
+                  </div>
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs font-semibold text-text">Token 上限</label>
+                    <input
+                      v-model="llmMaxTokens"
+                      type="number"
+                      min="1"
+                      class="px-2.5 py-1.5 text-sm border border-border rounded-md bg-white"
+                      placeholder="留空使用平台默认"
+                    />
+                    <p v-if="fieldErrors.llm_max_tokens" class="text-xs text-red-600">{{ fieldErrors.llm_max_tokens }}</p>
+                  </div>
                 </div>
                 <div class="px-3 py-2.5 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-800">
                   <p class="font-semibold mb-1 flex items-center gap-1.5"><UIcon name="i-lucide-triangle-alert" class="size-3.5" />启用 LLM 调用必须开启 Evaluator 联网</p>


### PR DESCRIPTION
## 概述

让题目可声明单次评测的 LLM `max_calls` / `max_tokens` 上限，经现有 `eval_token`
由 noj-llm-gateway 强制；同时移除 trial-snowy-manor 本地 LLM 预算与效率分。

设计文档：`dev-docs/superpowers/specs/2026-09-05-llm-problem-budget-design.md`
实施计划：`dev-docs/superpowers/plans/2026-09-05-llm-problem-budget.md`

## 变更

- **core**: `LlmConfig` 支持可选 `max_calls`/`max_tokens` 纯值域校验
- **core**: 集中 LLM 预算 helper（`llm-limits.ts`），`eval_token` 签发使用题目上限
- **core**: CRUD 与 bundle 导入写库前拒绝超过平台默认上限的声明
- **judge**: evaluator SDK 结构化解析 gateway 429 `out_of_usage`
- **ui**: 题目编辑器支持声明 LLM 调用/token 上限（留空使用平台默认）
- **root**: Agent Note 记录实现决策

## 测试

- noj-core `deno task check` 通过；相关 gateway/catalog 14 测试通过
- noj-core route 层 `test:pg` 19 测试通过
- noj-judge SDK LLM 4 测试通过
- noj-ui `deno task check` 通过

> noj-problems 仓库的 trial-snowy-manor 配套变更已在独立仓库处理。