### PR TITLE
feat(root): 补齐备份隔离恢复演练、告警投递与发布就绪窗口 (#428/#429/#431)

### DIFF
--- a/.agents/notes/implemented/feature/2026-09-05-production-p1-restore-drill-alerting-release.md
+++ b/.agents/notes/implemented/feature/2026-09-05-production-p1-restore-drill-alerting-release.md
@@ -1,0 +1,55 @@
+# Agent Note: 生产上线 P1 收口——隔离恢复演练、告警投递与发布就绪窗口
+
+Status: implemented
+
+## Problem
+
+上线准备评估（issue #428 / #429 / #431）识别出三个 P1 缺口：
+
+1. `scripts/deploy/backup.sh drill` 只做文件级校验，报告仍把"隔离 Compose 恢复"列为
+   next_step，文件校验成功不能证明业务可恢复。
+2. 监控配置缺少 Alertmanager 投递配置、core 抓取失联检测、备份新鲜度检测，API 错误率
+   规则使用进程累计比例会稀释近期故障；Runbook 链接指向的锚点并不存在。
+3. release.yml 由 `release.published` 触发，CLI 又要求 Release 已含资产；发布可见但
+   构建/上传未完成时，安装器会选中不可安装的版本。
+
+## Decision
+
+- 新增 `scripts/deploy/restore-drill.sh` + `restore-drill-verify.ts`：把快照恢复到独立
+  Compose 项目（独立卷/子网/无宿主机端口），恢复后经真实 API 验收登录、题目读取、
+  附件（支持包）下载与一次真实双容器评测；报告记录快照时间、恢复耗时、数据核对、
+  业务结果与 RPO/RTO 达标情况；损坏快照、解密失败、恢复失败、业务失败均非零退出并
+  保留诊断报告；默认 `down -v` 回收演练资源。`backup.sh drill` 明确标注
+  `drill_type=file-verification-only` 并指向 restore-drill.sh。
+- `backup.sh create` / `restore-drill.sh` 输出 Prometheus textfile 指标
+  （`noj_backup_last_success_unix_time`、`noj_restore_drill_last_success_unix_time`），
+  供 node_exporter textfile collector 采集。
+- `deploy/monitoring/noj-alerts.yml` 新增 `NojCoreScrapeDown`、`NojCoreMetricsMissing`、
+  `NojJudgeHeartbeatMissing`、`NojApiErrorRateRecent*`（5 分钟滑动窗口）、
+  `NojBackup*`、`NojRestoreDrillStale`；`prometheus.yml` 增加 Alertmanager 告警段；
+  新增 `alertmanager.yml.example`（envsubst 渲染、凭据不入库）、
+  `deploy/monitoring/README.md`、`scripts/deploy/test-alert.sh`（投递演练 +
+  恢复通知）。Runbook（observability.md）改为带显式 `{#anchor}` 的小节，每个告警
+  注解都能定位到处理步骤。
+- release.yml 改为 `prereleased` 触发并拒绝非预发布事件；正式镜像 tag 重试时若指向
+  不同构建则拒绝覆盖；新增 `publish-release` 任务在镜像/CLI/校验资产就绪后将预发布
+  转正。`install.sh resolve_latest_ref` 只选择非 draft、非 prerelease 且资产包含
+  noj-cli 二进制与 .sha256 的 Release；无可选版本时给出明确提示。
+
+## Alternatives considered
+
+- 恢复演练内置到 backup.sh：会让单一脚本承担编排+验收+报告职责，且 verify.ts 需要
+  独立进程入口；拆分脚本 + core 容器内 Deno 验收更清晰。
+- 业务验收用 SQL 伪造断言：无法证明 API/judge 链路可用；真实评测改走
+  import-bundle + self-test 的官方路径，需 admin 演练用户，通过 SQL 注入到隔离库实现。
+- 安装器直接用 `/releases/latest`：该端点排除 prerelease，但无法校验资产就绪；
+  仍可能选中资产缺失的版本，故改为列表过滤。
+- 只调触发器不改安装器：无法防住"published 直接跳过门禁"的人工操作路径，保留双重过滤。
+
+## Consequences
+
+- 隔离恢复演练依赖宿主机 judge 沙箱 socket 与评测镜像；无 judge 环境可用 `--skip-judge`。
+- 备份/演练新鲜度告警依赖 node_exporter textfile collector；未启用时不触发，
+  `deploy/monitoring/README.md` 已记录该限制与启用方法。
+- 告警投递是否被真实接收仍需人工执行 `test-alert.sh` 并记录演练结果，脚本不能替代确认。
+- 发布流程多一步预发布操作；直接 published 不再触发构建（工作流内显式拒绝）。

--- a/.agents/notes/implemented/feature/2026-09-05-production-p1-restore-drill-alerting-release.md
+++ b/.agents/notes/implemented/feature/2026-09-05-production-p1-restore-drill-alerting-release.md
@@ -10,8 +10,8 @@ Status: implemented
    next_step，文件校验成功不能证明业务可恢复。
 2. 监控配置缺少 Alertmanager 投递配置、core 抓取失联检测、备份新鲜度检测，API 错误率
    规则使用进程累计比例会稀释近期故障；Runbook 链接指向的锚点并不存在。
-3. release.yml 由 `release.published` 触发，CLI 又要求 Release 已含资产；发布可见但
-   构建/上传未完成时，安装器会选中不可安装的版本。
+3. release.yml 仅由 `release.prereleased` 触发，GitHub 草稿预发布转为可见时不会触发；
+   CLI 又要求 Release 已含资产；发布可见但构建/上传未完成时，安装器会选中不可安装的版本。
 
 ## Decision
 
@@ -31,9 +31,10 @@ Status: implemented
   `deploy/monitoring/README.md`、`scripts/deploy/test-alert.sh`（投递演练 +
   恢复通知）。Runbook（observability.md）改为带显式 `{#anchor}` 的小节，每个告警
   注解都能定位到处理步骤。
-- release.yml 改为 `prereleased` 触发并拒绝非预发布事件；正式镜像 tag 重试时若指向
-  不同构建则拒绝覆盖；新增 `publish-release` 任务在镜像/CLI/校验资产就绪后将预发布
-  转正。`install.sh resolve_latest_ref` 只选择非 draft、非 prerelease 且资产包含
+- release.yml 监听 `published` / `prereleased`，但仅让预发布 Release（或手动触发）进入
+  构建门禁；正式镜像 tag 重试时若指向不同构建则拒绝覆盖，CLI 资产上传使用
+  `--clobber`；新增 `publish-release` 任务在镜像/CLI/校验资产就绪后将预发布转正。
+  `install.sh resolve_latest_ref` 只选择非 draft、非 prerelease 且资产包含
   noj-cli 二进制与 .sha256 的 Release；无可选版本时给出明确提示。
 
 ## Alternatives considered
@@ -52,4 +53,4 @@ Status: implemented
 - 备份/演练新鲜度告警依赖 node_exporter textfile collector；未启用时不触发，
   `deploy/monitoring/README.md` 已记录该限制与启用方法。
 - 告警投递是否被真实接收仍需人工执行 `test-alert.sh` 并记录演练结果，脚本不能替代确认。
-- 发布流程多一步预发布操作；直接 published 不再触发构建（工作流内显式拒绝）。
+- 发布流程多一步预发布操作；直接 published 会被工作流接收但跳过构建（工作流内显式拒绝）。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,22 @@
 # =============================================================================
-# Neuro OJ 生产镜像发布：候选构建 → 安全门禁 → 正式 Release tag → 发布验证
+# Neuro OJ 生产镜像发布：预发布候选 → 安全门禁 → 镜像/CLI 资产就绪 → 自动转正
 #
-# 触发条件：GitHub Release published 或 workflow_dispatch。
-# 普通 push / pull_request 不发布生产镜像。
+# 触发条件：GitHub Release prereleased（预发布）或 workflow_dispatch。
+# 普通 push / pull_request / 直接 published 不发布生产镜像。
+#
+# 就绪窗口控制（issue #431）：预发布 Release 先触发本工作流完成镜像构建、扫描、
+# 签名、验证与 noj-cli 资产上传，最后的 publish-release 任务把预发布转正为正式
+# Release。用户可见的正式版本因此总是具备同版本镜像与 CLI 资产；
+# 安装器（scripts/deploy/install.sh）同时只选择非 draft、非 prerelease 且
+# 已包含 CLI 资产的 Release，双重避免"版本可见但资产未就绪"。
 # 每次 Release 构建并推送 7 个镜像，平台为 linux/amd64（公测阶段只支持 amd64）。
-# 镜像验证通过后发布同版本 noj-cli 二进制，供一键安装器下载。
 # =============================================================================
 
 name: Release Images
 
 on:
   release:
-    types: [published]
+    types: [prereleased]
   workflow_dispatch:
 
 permissions:
@@ -103,6 +108,17 @@ jobs:
             file: noj-judge/docker/solution-ai/Dockerfile
 
     steps:
+      - name: 检查触发来源必须是预发布
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -Eeuo pipefail
+          if [[ "$EVENT_NAME" == "release" && "$PRERELEASE" != "true" ]]; then
+            echo "::error::生产镜像只允许从 prerelease 触发；请先创建预发布版本，资产就绪后由工作流自动转正。"
+            exit 1
+          fi
+
       - name: 检出代码
         uses: actions/checkout@v4
 
@@ -212,6 +228,16 @@ jobs:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -Eeuo pipefail
+          # 正式标签不可变：已存在且指向不同构建时拒绝覆盖，防止重试混用版本。
+          existing="$(docker buildx imagetools inspect "$TARGET" 2>/dev/null | awk '/^Digest:/ {print $2; exit}' || true)"
+          if [[ -n "$existing" ]]; then
+            [[ "$existing" == "$DIGEST" ]] || {
+              echo "::error::正式标签 $TARGET 已存在且指向不同构建（$existing != $DIGEST），禁止覆盖；请使用新版本号。"
+              exit 1
+            }
+            echo "正式标签已存在且 digest 一致（幂等重试），跳过重新打标"
+            exit 0
+          fi
           docker buildx imagetools create --tag "$TARGET" "$SOURCE@$DIGEST"
           actual="$(docker buildx imagetools inspect "$TARGET" | awk '/^Digest:/ {print $2; exit}')"
           [[ "$actual" == "$DIGEST" ]] || {
@@ -350,3 +376,22 @@ jobs:
             esac
             echo "已验证 $release@$digest"
           done
+
+  publish-release:
+    name: 资产就绪后转正 Release
+    needs: [verify-release, publish-cli]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: 将预发布转正为正式 Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.event.release.tag_name || github.ref_name }}
+        run: |
+          set -Eeuo pipefail
+          # 此时镜像标签、签名、SBOM/来源证明与 noj-cli 资产均已就绪，
+          # 转正后 /releases/latest 才会指向该版本，安装器即可选择它。
+          gh release edit "$VERSION" --draft=false --prerelease=false --latest
+          echo "Release $VERSION 已转正为最新正式版本"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Neuro OJ 生产镜像发布：预发布候选 → 安全门禁 → 镜像/CLI 资产就绪 → 自动转正
 #
-# 触发条件：GitHub Release prereleased（预发布）或 workflow_dispatch。
+# 触发条件：GitHub Release published/prereleased（仅预发布）或 workflow_dispatch。
 # 普通 push / pull_request / 直接 published 不发布生产镜像。
 #
 # 就绪窗口控制（issue #431）：预发布 Release 先触发本工作流完成镜像构建、扫描、
@@ -16,7 +16,7 @@ name: Release Images
 
 on:
   release:
-    types: [prereleased]
+    types: [published, prereleased]
   workflow_dispatch:
 
 permissions:
@@ -33,6 +33,7 @@ env:
 jobs:
   publish-cli:
     name: 发布生产运维 CLI
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true
     needs: verify-release
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -63,10 +64,12 @@ jobs:
         run: |
           gh release upload "$VERSION" \
             noj-cli/bin/noj-cli-linux-amd64 \
-            noj-cli/bin/noj-cli-linux-amd64.sha256
+            noj-cli/bin/noj-cli-linux-amd64.sha256 \
+            --clobber
 
   supply-chain-check:
     name: 检查供应链配置
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -78,6 +81,7 @@ jobs:
 
   build-and-gate:
     name: Build and gate ${{ matrix.name }}
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true
     needs: supply-chain-check
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -282,6 +286,7 @@ jobs:
 
   verify-release:
     name: 验证正式 Release 镜像
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true
     needs: build-and-gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -379,6 +384,7 @@ jobs:
 
   publish-release:
     name: 资产就绪后转正 Release
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true
     needs: [verify-release, publish-cli]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -1,0 +1,70 @@
+# 生产监控部署与告警投递
+
+本目录提供 Prometheus 抓取配置（`prometheus.yml`）、告警规则（`noj-alerts.yml`）、
+Alertmanager 配置模板（`alertmanager.yml.example`）与 Grafana 仪表盘（`grafana-dashboard.json`）。
+
+## 1. 组件与网络
+
+推荐在宿主机以独立容器运行 Prometheus / Alertmanager / node_exporter，
+并把 Prometheus 与 Alertmanager 加入生产内部网络 `noj-net`：
+
+```bash
+docker network inspect noj-prod_noj-net   # 确认生产网络名
+docker run -d --name noj-alertmanager \
+  --network noj-prod_noj-net \
+  -v /etc/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro \
+  prom/alertmanager:v0.27.0
+docker run -d --name noj-prometheus \
+  --network noj-prod_noj-net \
+  -v /etc/prometheus:/etc/prometheus:ro \
+  prom/prometheus:v2.54.1
+```
+
+凭据注入：**凭据不入库**。`alertmanager.yml.example` 中的 `${...}` 占位符用 `envsubst`
+渲染成 `/etc/alertmanager/alertmanager.yml`（权限 600，仅部署环境保留），见文件头注释。
+渲染后可用 `amtool check-config /etc/alertmanager/alertmanager.yml` 校验。
+
+## 2. node_exporter 与备份新鲜度指标
+
+`noj-alerts.yml` 中的备份/演练新鲜度告警依赖 textfile 指标：
+
+- `scripts/deploy/backup.sh create` 写出 `<备份目录>/metrics/noj_backup.prom`
+  （`noj_backup_last_success_unix_time`、`noj_backup_snapshot_bytes`）。
+- `scripts/deploy/restore-drill.sh` 写出 `<备份目录>/metrics/noj_restore_drill.prom`
+  （`noj_restore_drill_last_success_unix_time`）。
+
+宿主机 node_exporter 通过 textfile collector 采集这些文件，Prometheus 抓取后告警生效：
+
+```bash
+# textfile 目录必须包含备份指标目录（可用 bind mount 汇聚多个来源）
+docker run -d --name noj-node-exporter \
+  --network noj-prod_noj-net \
+  -v /opt/neuro-oj/backups/metrics:/var/lib/node_exporter/textfile:ro \
+  prom/node-exporter:v1.8.2 --collector.textfile.directory=/var/lib/node_exporter/textfile
+```
+
+然后取消 `prometheus.yml` 中 `job_name: node` 段的注释并重载 Prometheus。
+未启用 node_exporter 时，备份/演练新鲜度告警不会触发，请在容量规划中记录这一限制。
+
+## 3. 告警投递演练（上线前必须执行一次）
+
+规则文件只能产生告警，**不能证明有人收到**。每次部署或调整接收器后，执行一次投递演练：
+
+```bash
+bash scripts/deploy/test-alert.sh http://alertmanager:9093
+```
+
+脚本会向 Alertmanager 注入一条 `NojNotificationDrill` 测试告警（critical 与 warning 各一条），
+接收方应同时收到触发与恢复（resolved）通知。演练结果按下表记录（保留在本仓库外或运维手册）：
+
+| 日期 (UTC) | 演练人 | 告警条数 | 预期接收方 | 实际收到时间 | 恢复通知收到时间 | 结果 |
+|---|---|---|---|---|---|---|
+| 2026-09-05T10:00Z | （示例）张三 | 2 | ops@example.com | 10:01Z | 10:06Z | 通过 |
+
+## 4. 验证清单
+
+- [ ] Prometheus targets 页面中 `noj-core`（及可选 `node`）为 UP。
+- [ ] `amtool check-config` 通过，Alertmanager 日志无加载错误。
+- [ ] 执行过至少一次 `scripts/deploy/test-alert.sh` 且接收方确认收到触发与恢复通知，并已记录。
+- [ ] Runbook 链接（noj-alerts.yml 中的 `runbook` 注解）能定位到对应处理步骤。
+- [ ] 备份 cron 运行后 textfile 目录中出现 `noj_backup.prom`。

--- a/deploy/monitoring/alertmanager.yml.example
+++ b/deploy/monitoring/alertmanager.yml.example
@@ -38,6 +38,7 @@ receivers:
   - name: noj-default
     email_configs:
       - to: "${ALERTMANAGER_EMAIL_TO}"
+        send_resolved: true
     webhook_configs:
       - url: "${ALERTMANAGER_WEBHOOK_URL}"
         send_resolved: true
@@ -45,6 +46,7 @@ receivers:
   - name: noj-critical
     email_configs:
       - to: "${ALERTMANAGER_EMAIL_TO}"
+        send_resolved: true
     webhook_configs:
       - url: "${ALERTMANAGER_WEBHOOK_URL}"
         send_resolved: true

--- a/deploy/monitoring/alertmanager.yml.example
+++ b/deploy/monitoring/alertmanager.yml.example
@@ -1,0 +1,53 @@
+# Alertmanager 配置模板。
+#
+# 本文件是示例模板，含 ${...} 占位符，凭据不得直接写入或提交仓库。
+# 渲染方式（凭据只存在于部署环境）：
+#
+#   export ALERTMANAGER_SMTP_FROM="noj-alert@example.com"
+#   export ALERTMANAGER_SMTP_HOST="smtp.example.com:587"
+#   export ALERTMANAGER_SMTP_USER="noj-alert@example.com"
+#   export ALERTMANAGER_SMTP_PASS="..."            # 只在 shell 会话中存在
+#   export ALERTMANAGER_WEBHOOK_URL="https://hooks.example.com/xxx"
+#   envsubst < deploy/monitoring/alertmanager.yml.example > /etc/alertmanager/alertmanager.yml
+#   chmod 600 /etc/alertmanager/alertmanager.yml
+#
+# 生成的 alertmanager.yml 属于部署环境产物，不要提交回仓库。
+# 生效方式：挂载进 Alertmanager 容器或使用 `amtool check-config` 校验后重载。
+
+global:
+  # 邮件接收示例；不用邮件时可整段删除。
+  smtp_smarthost: "${ALERTMANAGER_SMTP_HOST}"
+  smtp_from: "${ALERTMANAGER_SMTP_FROM}"
+  smtp_auth_username: "${ALERTMANAGER_SMTP_USER}"
+  smtp_auth_password: "${ALERTMANAGER_SMTP_PASS}"
+
+route:
+  receiver: noj-default
+  group_by: [alertname, severity]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    # critical 告警走独立接收器，可配置更强打扰方式（电话/短信 webhook 等）。
+    - matchers:
+        - severity = "critical"
+      receiver: noj-critical
+      repeat_interval: 1h
+
+receivers:
+  - name: noj-default
+    email_configs:
+      - to: "${ALERTMANAGER_EMAIL_TO}"
+    webhook_configs:
+      - url: "${ALERTMANAGER_WEBHOOK_URL}"
+        send_resolved: true
+
+  - name: noj-critical
+    email_configs:
+      - to: "${ALERTMANAGER_EMAIL_TO}"
+    webhook_configs:
+      - url: "${ALERTMANAGER_WEBHOOK_URL}"
+        send_resolved: true
+
+# 演练与恢复通知：send_resolved: true 保证告警恢复时接收方同样收到通知。
+# 投递演练方法见 deploy/monitoring/README.md 与 Runbook「告警投递演练」一节。

--- a/deploy/monitoring/noj-alerts.yml
+++ b/deploy/monitoring/noj-alerts.yml
@@ -1,6 +1,38 @@
 groups:
   - name: noj-production
     rules:
+      # ---- 服务失联检测（不依赖 core 自身指标）----
+      - alert: NojCoreScrapeDown
+        expr: up{job="noj-core"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: Prometheus 无法抓取 noj-core
+          description: core 连续 2 分钟抓取失败，进程可能已退出或网络不通。该告警不依赖 core 自身返回的指标。
+          runbook: docs/operators/observability.md#core-失联
+
+      - alert: NojCoreMetricsMissing
+        expr: absent(up{job="noj-core"})
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: noj-core 指标序列缺失
+          description: 连续 5 分钟抓取不到任何 core 样本（target 被删除或 Prometheus 配置异常）。
+          runbook: docs/operators/observability.md#core-失联
+
+      - alert: NojJudgeHeartbeatMissing
+        expr: absent(noj_judge_workers)
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Judge 心跳指标缺失
+          description: 连续 10 分钟没有 noj_judge_workers 序列；通常伴随 core 失联，请与 NojCoreScrapeDown 一起判断。
+          runbook: docs/operators/observability.md#judge-worker-异常
+
+      # ---- 依赖与队列（core 上报指标）----
       - alert: NojDatabaseUnavailable
         expr: noj_database_up == 0
         for: 2m
@@ -81,14 +113,29 @@ groups:
           description: 最早 judging 任务已超过 10 分钟。
           runbook: docs/operators/observability.md#评测卡死
 
-      - alert: NojApiErrorRateHigh
-        expr: noj_api_error_rate_percent >= 5 and sum(noj_http_requests_total) >= 20
+      # ---- 近期错误率（滑动窗口，替代进程累计比例）----
+      - alert: NojApiErrorRateRecentWarning
+        expr: |
+          sum(rate(noj_http_request_errors_total[5m]))
+            / clamp_min(sum(rate(noj_http_requests_total[5m])), 0.001) >= 0.05
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: API 5xx 错误率升高
-          description: core 进程累计 API 5xx 比例达到 5%，请结合日志和请求延迟排查。
+          summary: API 近期 5xx 错误率升高
+          description: 按 5 分钟滑动窗口计算，API 5xx 比例达到 5%；比进程累计比例更能反映近期故障。
+          runbook: docs/operators/observability.md#api-错误率或延迟升高
+
+      - alert: NojApiErrorRateRecentCritical
+        expr: |
+          sum(rate(noj_http_request_errors_total[5m]))
+            / clamp_min(sum(rate(noj_http_requests_total[5m])), 0.001) >= 0.2
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: API 近期 5xx 错误率严重升高
+          description: 按 5 分钟滑动窗口计算，API 5xx 比例达到 20%。
           runbook: docs/operators/observability.md#api-错误率或延迟升高
 
       - alert: NojApiLatencyHigh
@@ -101,6 +148,7 @@ groups:
           description: core 连续 5 分钟 API 请求 P95 延迟达到 1 秒，请结合依赖延迟和结构化日志排查。
           runbook: docs/operators/observability.md#api-错误率或延迟升高
 
+      # ---- 磁盘 ----
       - alert: NojJudgeWorkDirPressure
         expr: noj_judge_work_dir_bytes >= 8589934592
         for: 10m
@@ -120,3 +168,45 @@ groups:
           summary: 宿主机根分区可用空间低于 10%
           description: node_exporter 报告根分区空间不足。
           runbook: docs/operators/observability.md#磁盘和缓存压力
+
+      # ---- 备份与恢复演练新鲜度（指标由 backup.sh / restore-drill.sh 写入
+      #      textfile 目录，经 node_exporter textfile collector 采集）----
+      - alert: NojBackupStale
+        expr: time() - noj_backup_last_success_unix_time > 90000
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: 最近一次成功备份已超过 25 小时
+          description: 备份调度可能已停止。请检查备份 cron 与 backup.sh 输出。
+          runbook: docs/operators/observability.md#备份过期
+
+      - alert: NojBackupVeryStale
+        expr: time() - noj_backup_last_success_unix_time > 176400
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: 最近一次成功备份已超过 49 小时
+          description: 生产数据已连续两天没有成功备份，RPO 目标无法满足。
+          runbook: docs/operators/observability.md#备份过期
+
+      - alert: NojBackupMetricMissing
+        expr: absent(noj_backup_last_success_unix_time)
+        for: 48h
+        labels:
+          severity: warning
+        annotations:
+          summary: 备份新鲜度指标缺失
+          description: textfile 目录中没有备份指标：从未成功备份，或 node_exporter textfile collector 未配置。
+          runbook: docs/operators/observability.md#备份过期
+
+      - alert: NojRestoreDrillStale
+        expr: time() - noj_restore_drill_last_success_unix_time > 7776000
+        for: 24h
+        labels:
+          severity: warning
+        annotations:
+          summary: 隔离恢复演练已超过 90 天未执行
+          description: 文件校验不能证明业务可恢复；请执行 scripts/deploy/restore-drill.sh。
+          runbook: docs/operators/observability.md#恢复演练过期

--- a/deploy/monitoring/prometheus.yml
+++ b/deploy/monitoring/prometheus.yml
@@ -2,6 +2,13 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# 告警投递：Alertmanager 需加入 noj-net；配置模板与凭据注入见
+# deploy/monitoring/README.md 与 deploy/monitoring/alertmanager.yml.example。
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 rule_files:
   - /etc/prometheus/rules/noj-alerts.yml
 
@@ -12,7 +19,8 @@ scrape_configs:
     static_configs:
       - targets: ["core:8000"]
 
-  # 可选：宿主机安装 node_exporter 后填写实际地址，用于宿主机磁盘告警。
+  # 可选：宿主机 node_exporter（含 textfile collector，用于备份新鲜度指标）。
+  # 启用方法见 deploy/monitoring/README.md；启用后取消以下注释。
   # - job_name: node
   #   static_configs:
   #     - targets: ["node-exporter:9100"]

--- a/noj-docs/docs/operators/observability.md
+++ b/noj-docs/docs/operators/observability.md
@@ -10,13 +10,98 @@
 
 ## Prometheus 与告警
 
-将 Prometheus 加入 `noj-net`，使用 `deploy/monitoring/prometheus.yml` 抓取 `core:8000`，并加载 `deploy/monitoring/noj-alerts.yml`。Grafana 可导入 `deploy/monitoring/grafana-dashboard.json`。通知接收器凭据应保存在部署环境，不提交到仓库。
+将 Prometheus 加入 `noj-net`，使用 `deploy/monitoring/prometheus.yml` 抓取 `core:8000`（含
+`up{job="noj-core"}` 失联检测），并加载 `deploy/monitoring/noj-alerts.yml`。Alertmanager 配置模板、
+凭据注入与投递演练见 `deploy/monitoring/README.md`。Grafana 可导入
+`deploy/monitoring/grafana-dashboard.json`。通知接收器凭据应保存在部署环境，不提交到仓库。
 
-每次发布后应确认 Prometheus target 为 UP、live/ready/metrics 可以访问，并在 staging 演练一次 Judge 或 Redis 故障及其恢复。
+每次发布后应确认 Prometheus target 为 UP、live/ready/metrics 可以访问，并在 staging 演练一次 Judge
+或 Redis 故障及其恢复。上线前必须执行一次告警投递演练（`scripts/deploy/test-alert.sh`）并记录结果。
 
 ## 常见故障
 
-- Redis 或 PostgreSQL 异常：先查看 `/health/ready` 与 `noj-cli logs core`，恢复依赖后确认队列逐步回落。
-- Judge 异常或队列堆积：检查 Worker 心跳、活跃任务和 `noj-cli logs judge`；不要直接删除 Redis 数据卷或队列。
-- API 延迟或错误率升高：按路由与状态码查询结构化日志，区分依赖异常、慢查询和限流。
-- 磁盘压力：优先暂停新评测、保留备份和日志，再扩容或按缓存策略清理；不得直接删除数据库、Redis 或对象存储卷。
+### Core 失联 {#core-失联}
+
+触发：`NojCoreScrapeDown`（抓取失败）、`NojCoreMetricsMissing`（序列缺失）。
+
+1. `noj-cli status` 与 `docker logs` 确认 core 容器状态；区分进程退出与网络/抓取配置问题。
+2. 查看 `noj-cli logs core` 中的启动顺序错误（JWT_SECRET、迁移、Redis）。
+3. 恢复后确认 Prometheus target UP，且 `noj_database_up`、`noj_redis_up`、
+   `noj_result_consumer_up` 恢复为 1。
+4. 若 core 失联期间发生评测，恢复后确认 pending 队列回落，必要时检查
+   `NojQueueBacklog*` 告警是否解除。
+
+### PostgreSQL / Redis 异常 {#postgresql-redis-异常}
+
+触发：`NojDatabaseUnavailable`、`NojRedisUnavailable`。
+
+1. 先查看 `/health/ready` 与 `noj-cli logs core`，确认是依赖不可达还是健康检查超时。
+2. `docker compose ps` 检查 postgres/redis 容器与健康状态；查看容器日志定位 OOM/磁盘/密码问题。
+3. 恢复依赖后确认队列逐步回落；Redis 数据卷损坏时使用最近快照恢复（见生产部署文档 5.1 节）。
+4. 不要直接删除 Redis 数据卷或队列。
+
+### 评测结果消费者异常 {#评测结果消费者异常}
+
+触发：`NojResultConsumerDown`、`NojResultQueueBacklog`。
+
+1. `noj-cli logs core` 查找结果消费者启动与写入错误；确认 PostgreSQL 可写。
+2. `result processing` 积压通常是数据库写入失败重试：先恢复数据库，再观察积压回落。
+3. 消费者重启后确认 `noj_result_consumer_up == 1` 且积压清零。
+
+### Judge Worker 异常 {#judge-worker-异常}
+
+触发：`NojJudgeWorkersDown`、`NojJudgeHeartbeatMissing`。
+
+1. 检查 Worker 心跳、活跃任务和 `noj-cli logs judge`；确认独立 rootless Docker daemon 可用。
+2. `NojJudgeHeartbeatMissing` 通常伴随 core 失联：先按 Core 失联处理。
+3. 恢复后确认心跳指标恢复且队列开始消费；不要直接删除 Redis 数据卷或队列。
+
+### 评测队列堆积 {#评测队列堆积}
+
+触发：`NojQueueBacklogWarning`、`NojQueueBacklogCritical`。
+
+1. 确认 Judge Worker 在线且吞吐正常（见 Judge Worker 异常）。
+2. 评估是否为提交洪峰：必要时暂停新评测入口，扩容 Worker 后恢复。
+3. 观察磁盘与缓存压力，避免 Worker 因资源不足批量失败。
+
+### 评测卡死 {#评测卡死}
+
+触发：`NojStaleJudging`。
+
+1. 查询最早 judging 任务的入队时间与 Worker 日志，确认是否为容器泄漏或超时兜底失效。
+2. 单任务卡死可由管理员 rejudge；批量卡死先停止新任务并排查沙箱 daemon。
+3. 恢复后确认无新的 `NojStaleJudging` 触发。
+
+### API 错误率或延迟升高 {#api-错误率或延迟升高}
+
+触发：`NojApiErrorRateRecentWarning`、`NojApiErrorRateRecentCritical`（5 分钟滑动窗口 5xx 比例）、
+`NojApiLatencyHigh`（P95）。
+
+1. 按路由与状态码查询结构化日志，区分依赖异常、慢查询和限流。
+2. 结合 `noj_database_up` / `noj_redis_up` 判断是否为依赖故障传导。
+3. 恢复后确认 5 分钟窗口错误率回落；进程累计指标（`noj_api_error_rate_percent`）仅作长期参考。
+
+### 磁盘和缓存压力 {#磁盘和缓存压力}
+
+触发：`NojJudgeWorkDirPressure`、`NojHostDiskLow`。
+
+1. 优先暂停新评测、保留备份和日志，再扩容或按缓存策略清理。
+2. 不得直接删除数据库、Redis 或对象存储卷。
+3. 处理后确认 `node_filesystem_avail_bytes` 比例回升。
+
+### 备份过期 {#备份过期}
+
+触发：`NojBackupStale`（>25h）、`NojBackupVeryStale`（>49h）、`NojBackupMetricMissing`。
+
+1. 检查备份 cron 是否运行、`backup.sh create` 最近输出与退出码。
+2. 确认 textfile 目录（`<备份目录>/metrics/noj_backup.prom`）在最近一次备份后有更新；
+   `NojBackupMetricMissing` 通常说明 node_exporter textfile collector 未配置（见
+   `deploy/monitoring/README.md` 第 2 节）。
+3. 备份长时间未成功期间发生的故障无法回滚，尽快手动执行一次备份并验证。
+
+### 恢复演练过期 {#恢复演练过期}
+
+触发：`NojRestoreDrillStale`（>90 天未演练）。
+
+1. 文件校验不能证明业务可恢复；安排执行 `scripts/deploy/restore-drill.sh`（见生产部署文档 5.1 节）。
+2. 演练完成后确认 textfile 目录中 `noj_restore_drill.prom` 更新，告警在下一个评估周期解除。

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -68,14 +68,14 @@ curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
 预发布转正流程：
 
 1. 创建 GitHub Release 并勾选 **pre-release**（tag 形如 `vX.Y.Z` 或 `X.Y.Z-rc.N`）。
-2. `release.yml` 由 `prereleased` 事件触发：构建 7 个候选镜像 → 漏洞扫描 → 签名 / SBOM /
+2. `release.yml` 监听 `published` / `prereleased` 事件（只处理预发布 Release）：构建 7 个候选镜像 → 漏洞扫描 → 签名 / SBOM /
    来源证明 → 验证 digest 与 smoke test → 上传同版本 `noj-cli` 二进制与校验文件。
 3. 全部通过后，工作流最后的 `publish-release` 任务把预发布转正为正式 Release（`--latest`）。
 
 由此保证：`/releases/latest` 指向的版本一定具备同版本镜像、CLI 资产与校验文件。
 安装器（`scripts/deploy/install.sh`）自动选择版本时同样只接受非 draft、非 prerelease
 且资产中包含 `noj-cli-linux-amd64` 与 `.sha256` 的 Release，双重过滤未就绪版本。
-直接发布正式 Release（published）不会触发镜像构建；重试时正式镜像 tag 指向不同构建
+直接发布正式 Release（published）会被工作流识别并跳过构建；重试时正式镜像 tag 指向不同构建
 会被拒绝覆盖，避免版本混用。
 
 ## 3. 配置说明

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -62,6 +62,22 @@ curl -fsSL https://raw.githubusercontent.com/Neuro-OJ/neuro-oj/main/setup.sh | \
 邮件服务可以选择“暂不配置”，不影响网站启动，但密码找回邮件不可用。Judge 可以在安装时跳过，
 之后补充独立 Docker socket 后再启用。
 
+## 2.1 版本发布流程（维护者）
+
+为避免"Release 已可见但镜像 / CLI 资产尚未就绪"的窗口（issue #431），发布采用
+预发布转正流程：
+
+1. 创建 GitHub Release 并勾选 **pre-release**（tag 形如 `vX.Y.Z` 或 `X.Y.Z-rc.N`）。
+2. `release.yml` 由 `prereleased` 事件触发：构建 7 个候选镜像 → 漏洞扫描 → 签名 / SBOM /
+   来源证明 → 验证 digest 与 smoke test → 上传同版本 `noj-cli` 二进制与校验文件。
+3. 全部通过后，工作流最后的 `publish-release` 任务把预发布转正为正式 Release（`--latest`）。
+
+由此保证：`/releases/latest` 指向的版本一定具备同版本镜像、CLI 资产与校验文件。
+安装器（`scripts/deploy/install.sh`）自动选择版本时同样只接受非 draft、非 prerelease
+且资产中包含 `noj-cli-linux-amd64` 与 `.sha256` 的 Release，双重过滤未就绪版本。
+直接发布正式 Release（published）不会触发镜像构建；重试时正式镜像 tag 指向不同构建
+会被拒绝覆盖，避免版本混用。
+
 ## 3. 配置说明
 
 配置文件位于 `/opt/neuro-oj/.env.prod`，权限应为 `600`。常用配置如下：
@@ -127,6 +143,39 @@ noj-cli update --latest
 升级前会创建并校验备份，拉取镜像，执行数据库迁移并等待健康检查；不会删除数据卷。若失败，
 先查看 `noj-cli status` 和 `noj-cli logs`，再把 `NOJ_VERSION` 改回上一个已验证版本并执行 `noj-cli update`。
 数据库迁移只追加，不会自动回滚，因此跨大版本升级前必须确认迁移兼容性。
+注意：切回镜像标签不是数据库回滚；迁移只增不减，回退版本前需按迁移清单人工评估。
+
+## 5.1 备份、文件校验与隔离恢复演练
+
+备份体系分三层，必须区分能力边界：
+
+| 层级 | 命令 | 证明的内容 |
+|---|---|---|
+| 备份 | `noj-cli backup`（`backup.sh create`） | PostgreSQL/Redis/MinIO/加密环境文件已写入快照 |
+| 文件校验 | `noj-cli backup verify` / `backup drill` | 快照完整、口令可用、dump 结构可解析 |
+| 隔离恢复演练 | `scripts/deploy/restore-drill.sh <快照>` | 业务真的可以从快照恢复并运行 |
+
+`backup drill` 只做文件级校验，**不能**证明业务可恢复。真实的恢复验收演练：
+
+```bash
+cd /opt/neuro-oj
+bash scripts/deploy/restore-drill.sh backups/snapshot-YYYYMMDD-HHMMSS \
+  --passphrase-file /secure/noj-backup-passphrase
+```
+
+演练会把快照恢复到独立 Compose 项目（独立数据卷、独立子网、不映射宿主机端口、不接触生产卷），
+随后通过真实 API 验收：管理员登录、题目读取、附件（支持包）下载与一次真实双容器评测
+（需要 judge 沙箱 Docker socket 与 `noj-evaluator-python` / `noj-solution-python` 镜像，
+与生产 judge 使用同一个独立 rootless daemon）。可用 `--skip-judge` 跳过评测环节。
+
+演练报告（默认写入 `backups/snapshot-*/restore-drill-report.txt`）记录：快照时间、恢复耗时、
+数据核对结果（迁移版本/用户数/Redis 键数/对象数）、业务验收明细，以及 RPO/RTO 目标与是否达标
+（默认 RPO ≤ 24 小时、RTO ≤ 60 分钟，可用 `--rpo-max-hours` / `--rto-max-minutes` 调整）。
+损坏快照、解密失败、数据库恢复失败或业务验收失败都会以非零退出并保留失败现场报告。
+演练结束后自动 `down -v` 回收资源；`--keep` 可保留现场供人工检查。
+
+建议每季度以及在重要迁移前各执行一次隔离恢复演练。备份快照与 GPG 解密口令文件必须异地独立保存；
+口令丢失时快照无法恢复，任何演练都无法弥补。
 
 ## 6. 卸载
 

--- a/scripts/deploy/backup.sh
+++ b/scripts/deploy/backup.sh
@@ -145,6 +145,30 @@ gpg_decrypt() {
     --decrypt --output "$2" "$1" >/dev/null 2>&1 || die "生产环境文件解密失败"
 }
 
+# pg_dumpall --globals-only 会包含 CREATE ROLE，而目标 PostgreSQL 已经通过
+# POSTGRES_USER 创建默认角色；恢复前将角色创建语句改为幂等形式。
+prepare_idempotent_globals() {
+  local source="$1" target="$2"
+  awk '
+    function sql_escape(value) {
+      gsub(/\047/, "\047\047", value)
+      return value
+    }
+    /^CREATE ROLE / {
+      identifier = substr($0, 13)
+      sub(/;[[:space:]]*$/, "", identifier)
+      name = identifier
+      if (name ~ /^".*"$/) {
+        name = substr(name, 2, length(name) - 2)
+        gsub(/""/, "\"", name)
+      }
+      printf "DO $role$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = \047%s\047) THEN CREATE ROLE %s; END IF; END $role$;\n", sql_escape(name), identifier
+      next
+    }
+    { print }
+  ' "$source" > "$target" || die "生成幂等 PostgreSQL 全局对象脚本失败"
+}
+
 record_migration_status() {
   local user db schema
   user="$(env_value POSTGRES_USER)"; user="${user:-noj}"
@@ -336,8 +360,12 @@ restore_snapshot() {
   pg_db="$(env_value POSTGRES_DB)"; pg_db="${pg_db:-noj}"
   compose up -d --wait --wait-timeout 180 postgres redis minio || die "恢复前数据服务启动失败"
 
-  compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" < "$SNAPSHOT/postgres-globals.sql" \
+  VERIFY_TEMP="$(mktemp)"
+  prepare_idempotent_globals "$SNAPSHOT/postgres-globals.sql" "$VERIFY_TEMP"
+  compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" < "$VERIFY_TEMP" \
     || die "PostgreSQL 全局对象恢复失败"
+  rm -f "$VERIFY_TEMP"
+  VERIFY_TEMP=""
   compose exec -T postgres pg_restore --clean --if-exists --no-owner --exit-on-error \
     -U "$pg_user" -d "$pg_db" - < "$SNAPSHOT/postgres.dump" \
     || die "PostgreSQL 数据恢复失败"

--- a/scripts/deploy/backup.sh
+++ b/scripts/deploy/backup.sh
@@ -57,6 +57,7 @@ Neuro OJ 生产备份工具
   NOJ_BACKUP_PASSPHRASE_FILE  默认 GPG 口令文件
   NOJ_BACKUP_RETENTION_DAYS   默认快照保留天数
   NOJ_BACKUP_MIN_FREE_MB      默认最低可用空间
+  NOJ_BACKUP_METRICS_DIR      Prometheus textfile 指标目录（默认 <backup-dir>/metrics）
 EOF
 }
 
@@ -177,6 +178,25 @@ prune_old_snapshots() {
     -name 'snapshot-*' -mtime "+$RETENTION_DAYS" -print0)
 }
 
+# 输出 Prometheus textfile 指标（配合 node_exporter textfile collector），
+# 供 noj-alerts.yml 的备份新鲜度告警使用。
+write_backup_metrics() {
+  local snapshot="$1" metrics_dir metrics_file
+  metrics_dir="${NOJ_BACKUP_METRICS_DIR:-$BACKUP_DIR/metrics}"
+  mkdir -m 755 -p "$metrics_dir"
+  metrics_file="$metrics_dir/noj_backup.prom"
+  {
+    printf '# HELP noj_backup_last_success_unix_time 最近一次成功备份的 Unix 时间戳。\n'
+    printf '# TYPE noj_backup_last_success_unix_time gauge\n'
+    printf 'noj_backup_last_success_unix_time %s\n' "$(date '+%s')"
+    printf '# HELP noj_backup_snapshot_bytes 最近一次成功备份的快照字节数。\n'
+    printf '# TYPE noj_backup_snapshot_bytes gauge\n'
+    printf 'noj_backup_snapshot_bytes %s\n' "$(du -sk "$snapshot" | awk '{print $1 * 1024}')"
+  } > "$metrics_file"
+  chmod 644 "$metrics_file"
+  ok "备份新鲜度指标已写入：${metrics_file}（配置 node_exporter textfile collector 采集）"
+}
+
 create_snapshot() {
   check_env
   check_numbers
@@ -243,6 +263,7 @@ EOF
   mv "$temp" "$final"
   CREATE_TEMP=""
   verify_snapshot "$final"
+  write_backup_metrics "$final"
   prune_old_snapshots
   ok "完整生产快照已创建：$final"
   ok "PostgreSQL、Redis、MinIO/S3 和加密环境文件均已写入"
@@ -340,16 +361,19 @@ drill_snapshot() {
   local report="${DRILL_REPORT:-$SNAPSHOT/restore-drill.txt}"
   {
     printf 'result=verified\n'
+    printf 'drill_type=file-verification-only\n'
     printf 'snapshot=%s\n' "$SNAPSHOT"
-    printf 'next_step=restore --confirm in an isolated Compose project\n'
+    printf 'next_step=run scripts/deploy/restore-drill.sh for an isolated real restore with business verification\n'
     printf 'postgres=logical dump structure verified\n'
     printf 'redis=RDB payload and persistence metadata verified\n'
     printf 'minio=object mirror directory verified\n'
     printf 'env=GPG decryption verified\n'
+    printf 'note=file verification proves payload integrity, not recoverability; real recovery acceptance requires restore-drill.sh\n'
     printf 'warning=PostgreSQL incremental/PITR requires external WAL archive infrastructure\n'
   } > "$report"
   chmod 600 "$report"
-  ok "恢复演练校验通过，报告已写入：$report"
+  ok "快照文件校验通过（不含真实恢复），报告已写入：$report"
+  ok "如需验证业务可恢复性，请执行：scripts/deploy/restore-drill.sh $SNAPSHOT"
 }
 
 parse_args() {

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -89,7 +89,8 @@ Neuro OJ Linux 独立下载部署工具
 部署参数：
   通过 -- 后传递给 noj-cli install，例如 -- --non-interactive
 
-未指定 --ref 时脚本会自动使用仓库最新可用 Release；生产环境也可以显式指定 --ref 固定版本。
+未指定 --ref 时脚本自动选择资产就绪的最新正式 Release（排除 draft / prerelease /
+缺少 noj-cli 资产的版本）；生产环境也可以显式指定 --ref 固定版本。
 目标目录非空时脚本会继续执行：只更新 NOJ 的部署文件和 noj-cli，保留现有配置、备份、数据卷及其他文件。
 如果目标目录已经是本工具安装的 Neuro OJ，会直接继续部署；其他非空目录也不会被清空。
 生产环境建议使用不可变 Release tag，并让 --ref 与 .env.prod 中的 NOJ_VERSION 一致。
@@ -188,6 +189,10 @@ validate_ref() {
   ARCHIVE_URL="$REPOSITORY/archive/$REF.tar.gz"
 }
 
+# 解析默认安装版本：只选择对安装器真正可用的 Release——
+# 非 draft、非 prerelease，且资产中已包含 noj-cli 二进制与校验文件。
+# 直接使用 /releases/latest 会把"已转正但资产尚未就绪"的版本暴露给用户，
+# 因此这里显式按资产就绪状态过滤（issue #431）。
 resolve_latest_ref() {
   local repository_slug metadata_url metadata tag
   [[ -n "$REF" ]] && { validate_ref; return 0; }
@@ -195,31 +200,45 @@ resolve_latest_ref() {
   [[ "$REPOSITORY" =~ ^https://github\.com/([^/]+/[^/]+)$ ]] ||
     fail "无法自动获取最新版本；请对自定义仓库使用 --ref 指定 Release tag"
   repository_slug="${BASH_REMATCH[1]}"
-  metadata_url="https://api.github.com/repos/$repository_slug/releases?per_page=1"
-  printf '正在获取最新 Release：%s\n' "$metadata_url" >&2
+  metadata_url="https://api.github.com/repos/$repository_slug/releases?per_page=100"
+  printf '正在获取可用 Release：%s\n' "$metadata_url" >&2
   if command -v curl >/dev/null 2>&1; then
     metadata="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
       --retry 3 --connect-timeout 15 --header 'Accept: application/vnd.github+json' \
       --header 'User-Agent: neuro-oj-installer' "$metadata_url")" ||
-      fail "无法获取最新 Release，请检查网络，或使用 --ref 显式指定版本"
+      fail "无法获取 Release 列表，请检查网络，或使用 --ref 显式指定版本"
   else
     metadata="$(wget --https-only --tries=3 --timeout=20 --quiet --header='Accept: application/vnd.github+json' \
       --header='User-Agent: neuro-oj-installer' -O - "$metadata_url")" ||
-      fail "无法获取最新 Release，请检查网络，或使用 --ref 显式指定版本"
+      fail "无法获取 Release 列表，请检查网络，或使用 --ref 显式指定版本"
   fi
+  # 按 "tag_name" 切分 Release 对象：每个对象内依次判断 draft / prerelease /
+  # CLI 资产（GitHub API 中资产数组位于 tag_name 之后）。
   tag="$(awk '
-    match($0, /"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"/) {
-      value = substr($0, RSTART, RLENGTH)
-      sub(/^.*:[[:space:]]*"/, "", value)
-      sub(/"$/, "", value)
-      print value
-      exit
+    {
+      text = text $0 "\n"
+    }
+    END {
+      n = split(text, chunks, /"tag_name"[[:space:]]*:[[:space:]]*"/)
+      for (i = 2; i <= n; i++) {
+        chunk = chunks[i]
+        tag = chunk
+        sub(/".*/, "", tag)
+        if (tag !~ /^v?[0-9]+\.[0-9]+\.[0-9]+/) continue
+        if (chunk ~ /"draft"[[:space:]]*:[[:space:]]*true/) continue
+        if (chunk ~ /"prerelease"[[:space:]]*:[[:space:]]*true/) continue
+        if (chunk !~ /"name"[[:space:]]*:[[:space:]]*"noj-cli-linux-amd64"/) continue
+        if (chunk !~ /"name"[[:space:]]*:[[:space:]]*"noj-cli-linux-amd64\.sha256"/) continue
+        print tag
+        exit
+      }
     }
   ' <<<"$metadata")"
-  [[ -n "$tag" ]] || fail "仓库没有可用 Release，请使用 --ref 显式指定版本"
+  [[ -n "$tag" ]] ||
+    fail "没有发现资产就绪的正式 Release（需要包含 noj-cli 二进制与校验文件），请使用 --ref 显式指定版本"
   REF="$tag"
   validate_ref
-  ok "将使用最新 Release：$REF"
+  ok "将使用资产就绪的最新 Release：$REF"
 }
 
 check_dependencies() {

--- a/scripts/deploy/restore-drill-verify.ts
+++ b/scripts/deploy/restore-drill-verify.ts
@@ -1,0 +1,476 @@
+/**
+ * 恢复演练业务验收脚本。
+ *
+ * 由 scripts/deploy/restore-drill.sh 在隔离恢复出的 core 容器内执行
+ * （`docker compose run core deno run -A /opt/verify.ts ...`），面向真实
+ * HTTP API 验证恢复后的业务链路：登录、题目读取、附件下载与真实评测。
+ *
+ * 输出：每个步骤一行 JSON（{"step","status","detail"}），最后一行输出
+ * {"step":"summary","status":...,"passed":bool,"steps":[...]}，由外层脚本
+ * 汇总写入演练报告。任何 required 步骤失败时进程以非零退出。
+ *
+ * 凭据与评测镜像名通过环境变量传入（DRILL_*），不写入命令行参数。
+ */
+
+interface StepResult {
+  step: string;
+  status: "passed" | "failed" | "warning" | "skipped";
+  detail: string;
+}
+
+const results: StepResult[] = [];
+
+let requiredFailure = false;
+
+function record(
+  step: string,
+  status: StepResult["status"],
+  detail: string,
+): void {
+  results.push({ step, status, detail });
+  console.log(JSON.stringify({ step, status, detail }));
+}
+
+function required(step: string, ok: boolean, detail: string): void {
+  record(step, ok ? "passed" : "failed", detail);
+  if (!ok) requiredFailure = true;
+}
+
+function optEnv(name: string): string {
+  const value = Deno.env.get(name) ?? "";
+  if (!value) {
+    console.error(`缺少环境变量 ${name}`);
+    throw new Error(`缺少环境变量 ${name}`);
+  }
+  return value;
+}
+
+const BASE_URL = optEnv("DRILL_BASE_URL").replace(/\/$/, "");
+const ADMIN_USER = optEnv("DRILL_ADMIN_USER");
+const ADMIN_PASSWORD = optEnv("DRILL_ADMIN_PASSWORD");
+const EVALUATOR_IMAGE = optEnv("DRILL_EVALUATOR_IMAGE");
+const SOLUTION_IMAGE = optEnv("DRILL_SOLUTION_IMAGE");
+const SKIP_EVALUATION = Deno.env.get("DRILL_SKIP_EVALUATION") === "1";
+
+/** 与生产一致的 cookie 名；HttpOnly JWT 由登录响应下发。 */
+let authCookie = "";
+
+async function api(
+  method: string,
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const headers = new Headers(init.headers);
+  if (authCookie) headers.set("Cookie", authCookie);
+  return await fetch(`${BASE_URL}${path}`, { method, ...init, headers });
+}
+
+/** 解析响应中的 Set-Cookie，保存 noj:token 供后续请求鉴权。 */
+function captureAuthCookie(res: Response): void {
+  const setCookie = res.headers.get("set-cookie") ?? "";
+  const match = setCookie.match(/(?:^|[,\s])noj:token=([^;,\s]+)/);
+  if (match) authCookie = `noj:token=${match[1]}`;
+}
+
+// ---------------------------------------------------------------------------
+// 最小 ZIP 构造器（仅 store 存储，不压缩）：用于导入演练题目包。
+// 数据量极小（< 4 KB），CRC32 + 本地文件头 + 中央目录即可构造合法 zip。
+// ---------------------------------------------------------------------------
+
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xEDB88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(data: Uint8Array): number {
+  let c = 0xFFFFFFFF;
+  for (let i = 0; i < data.length; i++) {
+    c = CRC32_TABLE[(c ^ data[i]) & 0xFF]! ^ (c >>> 8);
+  }
+  return (c ^ 0xFFFFFFFF) >>> 0;
+}
+
+/** 构造 store 模式 zip（DOS 时间固定为 2026-01-01 00:00:00）。 */
+function buildZip(
+  entries: Array<{ name: string; content: string }>,
+): Uint8Array {
+  const encoder = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+  const central: Uint8Array[] = [];
+  let offset = 0;
+  const dosTime = 0;
+  const dosDate = (2026 - 1980) << 9 | 1 << 5 | 1;
+
+  for (const entry of entries) {
+    const nameBytes = encoder.encode(entry.name);
+    const data = encoder.encode(entry.content);
+    const crc = crc32(data);
+
+    const local = new Uint8Array(30 + nameBytes.length);
+    const lv = new DataView(local.buffer);
+    lv.setUint32(0, 0x04034b50, true);
+    lv.setUint16(4, 20, true); // version needed
+    lv.setUint16(6, 0, true); // flags
+    lv.setUint16(8, 0, true); // store
+    lv.setUint16(10, dosTime, true);
+    lv.setUint16(12, dosDate, true);
+    lv.setUint32(14, crc, true);
+    lv.setUint32(18, data.length, true);
+    lv.setUint32(22, data.length, true);
+    lv.setUint16(26, nameBytes.length, true);
+    lv.setUint16(28, 0, true);
+    local.set(nameBytes, 30);
+    chunks.push(local, data);
+
+    const cd = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(cd.buffer);
+    cv.setUint32(0, 0x02014b50, true);
+    cv.setUint16(4, 20, true);
+    cv.setUint16(6, 20, true);
+    cv.setUint16(8, 0, true);
+    cv.setUint16(10, 0, true);
+    cv.setUint16(12, dosTime, true);
+    cv.setUint16(14, dosDate, true);
+    cv.setUint32(16, crc, true);
+    cv.setUint32(20, data.length, true);
+    cv.setUint32(24, data.length, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint32(42, offset, true);
+    cd.set(nameBytes, 46);
+    central.push(cd);
+
+    offset += local.length + data.length;
+  }
+
+  const centralSize = central.reduce((sum, c) => sum + c.length, 0);
+  const end = new Uint8Array(22);
+  const ev = new DataView(end.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, entries.length, true);
+  ev.setUint16(10, entries.length, true);
+  ev.setUint32(12, centralSize, true);
+  ev.setUint32(16, offset, true);
+  return concat([...chunks, ...central, end]);
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const out = new Uint8Array(total);
+  let pos = 0;
+  for (const p of parts) {
+    out.set(p, pos);
+    pos += p.length;
+  }
+  return out;
+}
+
+/** 构造演练题目包：A+B 双容器评测题，含 evaluator 脚本与公开数据。 */
+function buildDrillBundle(): Uint8Array {
+  const evaluatorPy = `#!/usr/bin/env python3
+"""NOJ 恢复演练 evaluator：调用 solve 并校验 A+B 结果。"""
+import json
+from noj_evaluator_sdk.runner import SolutionRunner
+
+def main() -> None:
+    runner = SolutionRunner()
+    output = ""
+    try:
+        output = str(runner.call("solve", "1 2\\n"))
+    except Exception as exc:  # noqa: BLE001 - 演练 evaluator 容错记录
+        output = f"ERROR: {exc}"
+    ok = output.strip() == "3"
+    print("---RESULT---")
+    print(json.dumps({"score": 100 if ok else 0, "details": {"output": output}}))
+    runner.close()
+
+if __name__ == "__main__":
+    main()
+`;
+  const manifest = {
+    format_version: 1,
+    title: "NOJ 恢复演练自测题",
+    description:
+      "恢复演练自动导入的 A+B 自测题，验证隔离恢复后的真实评测链路。",
+    difficulty: "easy",
+    type: "P",
+    template: "template.py",
+    runtime_config: {
+      evaluator: {
+        image: EVALUATOR_IMAGE,
+        time_limit_ms: 60000,
+        memory_limit_mb: 256,
+      },
+      solution: {
+        image: SOLUTION_IMAGE,
+        call_timeout_ms: 10000,
+        memory_limit_mb: 256,
+      },
+    },
+  };
+  return buildZip([
+    { name: "problem.json", content: JSON.stringify(manifest) },
+    {
+      name: "statement.md",
+      content: "# NOJ 恢复演练自测题\n\n实现 solve(input_str) 返回两数之和。\n",
+    },
+    {
+      name: "template.py",
+      content: "def solve(input_str: str) -> str:\n    ...\n",
+    },
+    { name: "evaluate.py", content: evaluatorPy },
+    {
+      name: "visible.jsonl",
+      content: '{"id":"v001","input":"1 2\\n","expected":3}\n',
+    },
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// 业务验收步骤
+// ---------------------------------------------------------------------------
+
+/** 登录演练管理员账号（由外层脚本经 SQL 注入并授予 admin 角色）。 */
+async function stepLogin(): Promise<void> {
+  const res = await api("POST", "/auth/login", {
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ login: ADMIN_USER, password: ADMIN_PASSWORD }),
+  });
+  captureAuthCookie(res);
+  if (res.status !== 200) {
+    required(
+      "login",
+      false,
+      `POST /auth/login 返回 HTTP ${res.status}`,
+    );
+    return;
+  }
+  const payload = await res.json();
+  const username = payload?.data?.username ?? ADMIN_USER;
+  required(
+    "login",
+    Boolean(authCookie),
+    `管理员 ${username} 登录成功并下发会话 Cookie`,
+  );
+}
+
+/** 题目读取：列表 + 新导入题目的详情。 */
+async function stepProblemRead(problemId: string | null): Promise<void> {
+  const listRes = await api("GET", "/problems");
+  if (listRes.status !== 200) {
+    required(
+      "problem_read",
+      false,
+      `GET /problems 返回 HTTP ${listRes.status}`,
+    );
+    return;
+  }
+  const list = await listRes.json();
+  const total = Array.isArray(list?.data)
+    ? list.data.length
+    : typeof list?.data?.total === "number"
+    ? list.data.total
+    : 0;
+  if (!problemId) {
+    required(
+      "problem_read",
+      true,
+      `GET /problems 正常返回（当前可见题目数：${total}）`,
+    );
+    return;
+  }
+  const detailRes = await api("GET", `/problems/${problemId}`);
+  required(
+    "problem_read",
+    detailRes.status === 200,
+    detailRes.status === 200
+      ? `GET /problems 正常（可见题目数：${total}），题目详情 ${problemId} 读取正常`
+      : `GET /problems/${problemId} 返回 HTTP ${detailRes.status}`,
+  );
+}
+
+/** 附件下载：经 core 代理从恢复后的对象存储下载题目支持包。 */
+async function stepAttachmentDownload(problemId: string): Promise<void> {
+  const res = await api("GET", `/problems/${problemId}/support-package`);
+  if (res.status !== 200) {
+    required(
+      "attachment_download",
+      false,
+      `GET /problems/${problemId}/support-package 返回 HTTP ${res.status}`,
+    );
+    return;
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  const zipMagic = bytes[0] === 0x50 && bytes[1] === 0x4b;
+  required(
+    "attachment_download",
+    bytes.length > 0 && zipMagic,
+    `支持包下载成功：${bytes.length} 字节，zip 头校验${
+      zipMagic ? "通过" : "失败"
+    }`,
+  );
+}
+
+/**
+ * 真实评测：提交 A+B 正确解并轮询自测结果。
+ * 走完整链路：core 入队 → judge 沙箱 → Evaluator + Solution 双容器 → 结果回写。
+ */
+async function stepEvaluation(problemId: string): Promise<void> {
+  if (SKIP_EVALUATION) {
+    record("evaluation", "skipped", "演练以 --skip-judge 运行，未执行真实评测");
+    return;
+  }
+  const code =
+    "def solve(input_str: str) -> str:\n    a, b = map(int, input_str.split())\n    return str(a + b)\n";
+  const createRes = await api(
+    "POST",
+    `/problems/${problemId}/self-test`,
+    {
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ language: "python3", code, file_name: "main.py" }),
+    },
+  );
+  if (createRes.status !== 201) {
+    required(
+      "evaluation",
+      false,
+      `POST self-test 返回 HTTP ${createRes.status}：${
+        (await createRes.text()).slice(0, 200)
+      }`,
+    );
+    return;
+  }
+  const created = await createRes.json();
+  const selfTestId = created?.data?.id;
+  if (!selfTestId) {
+    required("evaluation", false, "self-test 响应缺少 id");
+    return;
+  }
+
+  const timeoutMs = 10 * 60 * 1000;
+  const deadline = Date.now() + timeoutMs;
+  let status = "";
+  let resultStatus: string | null = null;
+  let score: number | null = null;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 5000));
+    const poll = await api("GET", `/self-tests/${selfTestId}`);
+    if (poll.status !== 200) {
+      required(
+        "evaluation",
+        false,
+        `GET /self-tests/${selfTestId} 返回 HTTP ${poll.status}`,
+      );
+      return;
+    }
+    const body = await poll.json();
+    status = body?.data?.status ?? "";
+    resultStatus = body?.data?.result_status ?? null;
+    score = typeof body?.data?.score === "number" ? body.data.score : null;
+    if (status === "finished" || status === "error") break;
+  }
+  const ok = status === "finished" && resultStatus === "finished" &&
+    score !== null && score > 0;
+  required(
+    "evaluation",
+    ok,
+    ok
+      ? `自测 ${selfTestId} 评测成功：status=${status}，得分 ${score}`
+      : `自测 ${selfTestId} 未通过：status=${status}，result_status=${resultStatus}，score=${score}`,
+  );
+}
+
+/** 额外观察项：注册链路。受邮件提供方影响，失败只记 warning 不影响结论。 */
+async function stepRegisterProbe(): Promise<void> {
+  const suffix = Date.now().toString(36);
+  const res = await api("POST", "/auth/register", {
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      username: `drill_${suffix}`.slice(0, 30),
+      email: `drill-${suffix}@restore-drill.invalid`,
+      password: "Drill-Recover-2026",
+    }),
+  });
+  if (res.status === 201) {
+    record("register_probe", "passed", "注册接口返回 201");
+  } else {
+    record(
+      "register_probe",
+      "warning",
+      `POST /auth/register 返回 HTTP ${res.status}；注册链路受邮件提供方影响，不计入演练结论`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  await stepLogin();
+  if (requiredFailure) {
+    finish();
+    return;
+  }
+
+  // 导入演练题目（admin 权限）：同时验证对象存储写入与数据库写入。
+  let problemId: string | null = null;
+  const bundle = buildDrillBundle();
+  const form = new FormData();
+  form.append(
+    "file",
+    new File([bundle as unknown as BlobPart], "noj-drill-bundle.zip", {
+      type: "application/zip",
+    }),
+  );
+  const importRes = await api("POST", "/problems/import-bundle", {
+    body: form,
+  });
+  if (importRes.status === 200 || importRes.status === 201) {
+    const payload = await importRes.json();
+    problemId = payload?.data?.problem?.id ?? payload?.data?.id ?? null;
+    record(
+      "problem_import",
+      "passed",
+      problemId
+        ? `演练题目导入成功：${problemId}`
+        : "演练题目导入成功（响应中未解析到题目 ID）",
+    );
+  } else {
+    record(
+      "problem_import",
+      "failed",
+      `POST /problems/import-bundle 返回 HTTP ${importRes.status}：${
+        (await importRes.text()).slice(0, 200)
+      }`,
+    );
+    requiredFailure = true;
+  }
+
+  if (problemId) {
+    await stepProblemRead(problemId);
+    await stepAttachmentDownload(problemId);
+    await stepEvaluation(problemId);
+  } else {
+    await stepProblemRead(null);
+  }
+  await stepRegisterProbe();
+  finish();
+}
+
+function finish(): void {
+  const passed = !requiredFailure;
+  console.log(
+    JSON.stringify({
+      step: "summary",
+      status: passed ? "passed" : "failed",
+      passed,
+      steps: results,
+    }),
+  );
+  Deno.exit(passed ? 0 : 1);
+}
+
+await main();

--- a/scripts/deploy/restore-drill-verify_test.ts
+++ b/scripts/deploy/restore-drill-verify_test.ts
@@ -1,0 +1,185 @@
+/**
+ * restore-drill-verify.ts 的业务验收脚本测试。
+ *
+ * 以子进程运行验收脚本，面向本地 mock API（Deno.serve）验证：
+ * 登录、题目导入（zip 魔数）、题目读取、支持包下载、真实评测轮询与汇总输出。
+ */
+
+function assert(cond: unknown, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+
+const scriptPath =
+  new URL("./restore-drill-verify.ts", import.meta.url).pathname;
+
+interface StepLine {
+  step: string;
+  status: string;
+  detail?: string;
+}
+
+Deno.test("恢复演练业务验收：全链路通过", async () => {
+  let receivedZip: Uint8Array | null = null;
+  let pollCount = 0;
+
+  const handler = async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    const path = url.pathname;
+    if (path === "/api/v1/auth/login" && req.method === "POST") {
+      return new Response(
+        JSON.stringify({ data: { username: "drill_admin" } }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "Set-Cookie": "noj:token=drill-jwt; HttpOnly; Path=/; SameSite=Lax",
+          },
+        },
+      );
+    }
+    if (path === "/api/v1/problems/import-bundle" && req.method === "POST") {
+      const form = await req.formData();
+      const file = form.get("file");
+      assert(file instanceof File, "import-bundle 应收到 file 字段");
+      assert(
+        (file as File).name.endsWith(".zip"),
+        "导入文件应为 .zip",
+      );
+      receivedZip = new Uint8Array(await (file as File).arrayBuffer());
+      return new Response(
+        JSON.stringify({ data: { problem: { id: "drill-problem-1" } } }),
+        { status: 201 },
+      );
+    }
+    if (path === "/api/v1/problems" && req.method === "GET") {
+      return new Response(
+        JSON.stringify({ data: [{ id: "drill-problem-1" }] }),
+        {
+          status: 200,
+        },
+      );
+    }
+    if (path === "/api/v1/problems/drill-problem-1" && req.method === "GET") {
+      return new Response(JSON.stringify({ data: { id: "drill-problem-1" } }), {
+        status: 200,
+      });
+    }
+    if (path === "/api/v1/problems/drill-problem-1/support-package") {
+      assert(
+        (req.headers.get("Cookie") ?? "").includes("noj:token=drill-jwt"),
+        "支持包下载应携带会话 Cookie",
+      );
+      // 最小 zip：PK 头 + 尾部字节。
+      return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+        status: 200,
+      });
+    }
+    if (path === "/api/v1/problems/drill-problem-1/self-test") {
+      return new Response(JSON.stringify({ data: { id: "st-1" } }), {
+        status: 201,
+      });
+    }
+    if (path === "/api/v1/self-tests/st-1") {
+      pollCount++;
+      return new Response(
+        JSON.stringify({
+          data: {
+            id: "st-1",
+            status: pollCount >= 1 ? "finished" : "judging",
+            result_status: pollCount >= 1 ? "finished" : null,
+            score: pollCount >= 1 ? 100 : 0,
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    if (path === "/api/v1/auth/register") {
+      return new Response(JSON.stringify({ data: {} }), { status: 201 });
+    }
+    return new Response("not found", { status: 404 });
+  };
+
+  const server = Deno.serve({ port: 0, handler });
+  const port = (server.addr as Deno.NetAddr).port;
+  try {
+    // 减慢自测轮询对测试的影响：脚本内部固定 5s 间隔，这里直接跑通一次轮询。
+    const command = new Deno.Command("deno", {
+      args: ["run", "-A", "--no-check", scriptPath],
+      env: {
+        DRILL_BASE_URL: `http://127.0.0.1:${port}/api/v1`,
+        DRILL_ADMIN_USER: "drill_admin",
+        DRILL_ADMIN_PASSWORD: "Drill-Recover-2026",
+        DRILL_EVALUATOR_IMAGE: "noj-evaluator-python",
+        DRILL_SOLUTION_IMAGE: "noj-solution-python",
+      },
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const output = await command.output();
+    const lines = new TextDecoder().decode(output.stdout).trim().split("\n");
+    const steps = lines.map((l) => JSON.parse(l) as StepLine);
+    const summary = steps.find((s) => s.step === "summary");
+    assert(summary, "应输出 summary 行");
+    assert(
+      summary.status === "passed",
+      `全链路应通过，实际步骤：${JSON.stringify(steps)}`,
+    );
+    assert(output.code === 0, "业务验收通过时进程应以 0 退出");
+
+    const stepNames = steps.map((s) => s.step);
+    for (
+      const name of [
+        "login",
+        "problem_import",
+        "problem_read",
+        "attachment_download",
+        "evaluation",
+      ]
+    ) {
+      assert(
+        stepNames.includes(name),
+        `缺少验收步骤 ${name}，实际：${stepNames.join(",")}`,
+      );
+    }
+    assert(
+      receivedZip !== null && receivedZip[0] === 0x50 &&
+        receivedZip[1] === 0x4b,
+      "导入的题目包应为合法 zip（PK 头）",
+    );
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("恢复演练业务验收：登录失败立即失败", async () => {
+  const handler = (_req: Request): Response =>
+    new Response("unauthorized", { status: 401 });
+  const server = Deno.serve({ port: 0, handler });
+  const port = (server.addr as Deno.NetAddr).port;
+  try {
+    const command = new Deno.Command("deno", {
+      args: ["run", "-A", "--no-check", scriptPath],
+      env: {
+        DRILL_BASE_URL: `http://127.0.0.1:${port}/api/v1`,
+        DRILL_ADMIN_USER: "drill_admin",
+        DRILL_ADMIN_PASSWORD: "wrong",
+        DRILL_EVALUATOR_IMAGE: "noj-evaluator-python",
+        DRILL_SOLUTION_IMAGE: "noj-solution-python",
+      },
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const output = await command.output();
+    assert(output.code !== 0, "登录失败时验收脚本应非零退出");
+    const lines = new TextDecoder().decode(output.stdout).trim().split("\n");
+    const steps = lines.map((l) => JSON.parse(l) as StepLine);
+    const login = steps.find((s) => s.step === "login");
+    assert(login?.status === "failed", "登录步骤应标记 failed");
+    assert(
+      !steps.some((s) => s.step === "summary" && s.status === "passed"),
+      "不应输出通过的 summary",
+    );
+  } finally {
+    await server.shutdown();
+  }
+});

--- a/scripts/deploy/restore-drill.sh
+++ b/scripts/deploy/restore-drill.sh
@@ -126,6 +126,30 @@ gpg_decrypt() {
     --decrypt --output "$2" "$1" >/dev/null 2>&1 || die "生产环境文件解密失败"
 }
 
+# pg_dumpall --globals-only 会包含 CREATE ROLE，而 Compose 启动的 PostgreSQL
+# 已经通过 POSTGRES_USER 创建了默认角色；恢复前将角色创建语句改为幂等形式。
+prepare_idempotent_globals() {
+  local source="$1" target="$2"
+  awk '
+    function sql_escape(value) {
+      gsub(/\047/, "\047\047", value)
+      return value
+    }
+    /^CREATE ROLE / {
+      identifier = substr($0, 13)
+      sub(/;[[:space:]]*$/, "", identifier)
+      name = identifier
+      if (name ~ /^".*"$/) {
+        name = substr(name, 2, length(name) - 2)
+        gsub(/""/, "\"", name)
+      }
+      printf "DO $role$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = \047%s\047) THEN CREATE ROLE %s; END IF; END $role$;\n", sql_escape(name), identifier
+      next
+    }
+    { print }
+  ' "$source" > "$target" || die "生成幂等 PostgreSQL 全局对象脚本失败"
+}
+
 compose() {
   local -a args=(compose --project-name "$PROJECT_NAME"
     --env-file "$COMPOSE_ENV_FILE"
@@ -287,7 +311,11 @@ prepare_compose_override() {
   STAGE="prepare-compose"
   cat > "$TEMP_DIR/compose.drill-override.yml" <<EOF
 # restore-drill 自动生成的隔离覆盖：独立子网，避免与生产 noj-net 冲突。
-services: {}
+services:
+  verifier:
+    image: denoland/deno:debian-2.9.5@sha256:5d46f925d213e9adaf18a0664b291fe973c91ba7b929572877610dcaaf09ee2b
+    networks:
+      - noj-net
 networks:
   noj-net:
     ipam:
@@ -310,8 +338,10 @@ restore_data_services() {
   compose run --rm minio-init >/dev/null 2>&1 || die "MinIO bucket 初始化失败"
 
   ok "恢复 PostgreSQL"
+  local globals_file="$TEMP_DIR/postgres-globals.sql"
+  prepare_idempotent_globals "$SNAPSHOT/postgres-globals.sql" "$globals_file"
   compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" \
-    < "$SNAPSHOT/postgres-globals.sql" || die "PostgreSQL 全局对象恢复失败"
+    < "$globals_file" || die "PostgreSQL 全局对象恢复失败"
   compose exec -T postgres pg_restore --clean --if-exists --no-owner --exit-on-error \
     -U "$pg_user" -d "$pg_db" - < "$SNAPSHOT/postgres.dump" ||
     die "PostgreSQL 数据恢复失败"
@@ -425,9 +455,9 @@ ensure_judge_images() {
   pg_db="$(env_value POSTGRES_DB)"; pg_db="${pg_db:-noj}"
 
   DRILL_EVALUATOR_IMAGE="$(compose exec -T postgres psql -U "$pg_user" -d "$pg_db" -Atqc \
-    "SELECT image FROM judge_images WHERE kind = 'evaluator' ORDER BY created_at LIMIT 1" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
+    "SELECT image FROM judge_images WHERE kind = 'evaluator' ORDER BY CASE WHEN image LIKE '%noj-evaluator-python%' THEN 0 ELSE 1 END, created_at DESC LIMIT 1" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
   DRILL_SOLUTION_IMAGE="$(compose exec -T postgres psql -U "$pg_user" -d "$pg_db" -Atqc \
-    "SELECT image FROM judge_images WHERE kind = 'solution' ORDER BY created_at LIMIT 1" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
+    "SELECT image FROM judge_images WHERE kind = 'solution' ORDER BY CASE WHEN image LIKE '%noj-solution-python%' THEN 0 ELSE 1 END, created_at DESC LIMIT 1" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
   [[ -n "$DRILL_EVALUATOR_IMAGE" ]] || die "judge_images 白名单缺少 evaluator 镜像"
   [[ -n "$DRILL_SOLUTION_IMAGE" ]] || die "judge_images 白名单缺少 solution 镜像"
   ok "评测镜像：evaluator=${DRILL_EVALUATOR_IMAGE} solution=${DRILL_SOLUTION_IMAGE}"
@@ -446,7 +476,7 @@ run_business_verification() {
   local status=0
   compose "${compose_args[@]}" \
     -v "$VERIFY_SCRIPT:/opt/verify.ts:ro" \
-    core deno run -A /opt/verify.ts 2>&1 | tee "$TEMP_DIR/verify-output.log" || status=$?
+    verifier deno run -A /opt/verify.ts 2>&1 | tee "$TEMP_DIR/verify-output.log" || status=$?
   ((status == 0)) || die "业务验收未通过"
 }
 

--- a/scripts/deploy/restore-drill.sh
+++ b/scripts/deploy/restore-drill.sh
@@ -1,0 +1,560 @@
+#!/usr/bin/env bash
+# Neuro OJ 生产备份隔离恢复演练。
+#
+# 与 backup.sh drill（纯文件校验）不同，本脚本把快照真实恢复到一个独立的
+# Compose 项目（独立数据卷、独立网络子网、不映射宿主机端口），随后验收业务：
+# 登录、题目读取、附件下载和至少一次真实评测。任何环节失败都以非零退出并
+# 保留诊断报告。
+#
+# 用法：restore-drill.sh SNAPSHOT [选项]
+# 详见 usage()。
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VERIFY_SCRIPT="$SCRIPT_DIR/restore-drill-verify.ts"
+
+SNAPSHOT=""
+ENV_FILE="$REPO_ROOT/.env.prod"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.prod.yml"
+PASSPHRASE_FILE="${NOJ_BACKUP_PASSPHRASE_FILE:-}"
+DOCKER_BIN="${NOJ_BACKUP_DOCKER_BIN:-docker}"
+PROJECT_NAME="${NOJ_DRILL_PROJECT_NAME:-noj-drill}"
+DRILL_DIR=""
+REPORT=""
+SUBNET="${NOJ_DRILL_SUBNET:-172.29.0.0/16}"
+RPO_MAX_HOURS="${NOJ_DRILL_RPO_MAX_HOURS:-24}"
+RTO_MAX_MINUTES="${NOJ_DRILL_RTO_MAX_MINUTES:-60}"
+WAIT_TIMEOUT="${NOJ_DRILL_WAIT_TIMEOUT:-300}"
+SKIP_JUDGE=0
+KEEP=0
+
+DRILL_STARTED_AT=""
+STAGE="init"
+TEMP_DIR=""
+COMPOSE_ENV_FILE=""
+DRILL_EVALUATOR_IMAGE=""
+DRILL_SOLUTION_IMAGE=""
+
+# 演练管理员账号：只存在于隔离演练数据库，不影响生产。密码固定，保证演练
+# 可复现（Drill-Recover-2026，bcrypt cost 12，满足最小密码策略）。
+DRILL_ADMIN_USER="drill_admin"
+DRILL_ADMIN_EMAIL_DOMAIN="restore-drill.invalid"
+DRILL_ADMIN_PASSWORD="Drill-Recover-2026"
+DRILL_BCRYPT_HASH='$2b$12$edDmxsubnHJL8B/Wsdryxu4ibNin0/SEhqAXkB.Yn50SCoN29lQCW'
+
+# judge_images 白名单缺失时的兜底评测镜像（与官方发布镜像一致）。
+DEFAULT_EVALUATOR_IMAGE="noj-evaluator-python"
+DEFAULT_SOLUTION_IMAGE="noj-solution-python"
+
+ok() { printf '[drill] ✓ %s\n' "$*"; }
+warn() { printf '[drill] ⚠ %s\n' "$*" >&2; }
+die() {
+  printf '[drill] ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Neuro OJ 备份隔离恢复演练
+
+用法：
+  restore-drill.sh SNAPSHOT [选项]
+
+与 backup.sh drill（快照文件校验）不同，本命令把快照真实恢复到独立 Compose
+项目（独立数据卷、独立子网、不占用宿主机端口），恢复后通过真实 API 验收：
+登录、题目读取、附件（支持包）下载与一次真实评测。
+
+选项：
+  --env-file FILE          生产环境文件（默认 .env.prod）
+  --compose-file FILE      生产 Compose 文件（默认 docker-compose.prod.yml）
+  --passphrase-file FILE   GPG 口令文件（权限必须为 600/400）
+  --project-name NAME      演练 Compose 项目名（默认 noj-drill；禁止包含 prod）
+  --drill-dir DIR          演练临时目录（默认自动创建于快照同级的 drill-* 目录）
+  --report FILE            演练报告（默认写入 SNAPSHOT/restore-drill-report.txt）
+  --subnet CIDR            演练网络子网（默认 172.29.0.0/16，避免与生产冲突）
+  --rpo-max-hours N        RPO 目标：快照允许的最大时长（默认 24 小时）
+  --rto-max-minutes N      RTO 目标：恢复+验收允许的最大时长（默认 60 分钟）
+  --wait-timeout N         Compose 服务等待超时秒数（默认 300）
+  --skip-judge             跳过真实评测（仍执行登录/题目/附件验收）
+  --keep                   保留演练临时目录与 Compose 资源供人工检查
+  -h, --help               显示帮助
+
+环境变量：
+  NOJ_BACKUP_PASSPHRASE_FILE   默认 GPG 口令文件
+  NOJ_DRILL_PROJECT_NAME       默认演练项目名
+  NOJ_DRILL_SUBNET             默认演练子网
+  NOJ_DRILL_RPO_MAX_HOURS      默认 RPO 目标（小时）
+  NOJ_DRILL_RTO_MAX_MINUTES    默认 RTO 目标（分钟）
+
+说明：
+  - 真实评测需要宿主机 judge 沙箱 Docker socket 与 noj-evaluator-python /
+    noj-solution-python 镜像（与生产 judge 相同的独立 rootless daemon）。
+  - 演练管理员账号由本脚本直接写入隔离演练数据库，仅存在于演练项目内。
+  - 备份快照与解密口令文件应异地独立保存；口令丢失时快照无法恢复。
+EOF
+}
+
+env_value() {
+  local key="$1" value
+  [[ -f "$ENV_FILE" ]] || return 0
+  value="$(awk -v key="$key" '
+    index($0, key "=") == 1 { print substr($0, length(key) + 2); exit }
+  ' "$ENV_FILE")"
+  case "$value" in
+    '"'*'"'|"'"*"'"*) value="${value:1:${#value}-2}" ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
+}
+
+check_secret_file() {
+  [[ -f "$1" ]] || die "GPG 口令文件不存在：$1"
+  local mode
+  mode="$(file_mode "$1")"
+  [[ "$mode" == "600" || "$mode" == "400" ]] ||
+    die "GPG 口令文件权限必须为 600 或 400：$1"
+}
+
+gpg_decrypt() {
+  command -v gpg >/dev/null 2>&1 || die "解密环境备份需要 gpg"
+  gpg --batch --yes --pinentry-mode loopback \
+    --passphrase-file "$PASSPHRASE_FILE" \
+    --decrypt --output "$2" "$1" >/dev/null 2>&1 || die "生产环境文件解密失败"
+}
+
+compose() {
+  local -a args=(compose --project-name "$PROJECT_NAME"
+    --env-file "$COMPOSE_ENV_FILE"
+    --file "$COMPOSE_FILE"
+    --file "$TEMP_DIR/compose.drill-override.yml")
+  if ((SKIP_JUDGE == 0)); then
+    args+=(--profile judge)
+  fi
+  "$DOCKER_BIN" "${args[@]}" "$@"
+}
+
+# 统一退出处理：失败时回收演练资源并写失败报告；成功时仅清理临时目录。
+on_exit() {
+  local status=$?
+  if ((status != 0)); then
+    # 先写报告（需要读取验证日志），再回收资源，最后清理临时目录。
+    write_failure_report "$status"
+    if [[ -n "$COMPOSE_ENV_FILE" && "$KEEP" != "1" ]]; then
+      warn "清理演练 Compose 资源（down -v）"
+      local -a down_args=(compose --project-name "$PROJECT_NAME"
+        --env-file "$COMPOSE_ENV_FILE"
+        --file "$COMPOSE_FILE")
+      if [[ -d "$TEMP_DIR" ]]; then
+        down_args+=(--file "$TEMP_DIR/compose.drill-override.yml")
+      fi
+      "$DOCKER_BIN" "${down_args[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+    fi
+  fi
+  if [[ -n "$DRILL_DIR" && -d "$DRILL_DIR" && "$KEEP" != "1" ]]; then
+    rm -rf -- "$DRILL_DIR"
+  fi
+  exit "$status"
+}
+
+write_failure_report() {
+  local status="$1"
+  [[ -n "$REPORT" && "$STAGE" != "init" && "$STAGE" != "preflight" ]] || return 0
+  {
+    printf 'result=failed\n'
+    printf 'drill_type=isolated-restore-with-business-verification\n'
+    printf 'snapshot=%s\n' "$SNAPSHOT"
+    printf 'failed_stage=%s\n' "$STAGE"
+    printf 'drill_started_at=%s\n' "${DRILL_STARTED_AT:-unknown}"
+    printf 'compose_project=%s\n' "$PROJECT_NAME"
+    if [[ -f "$TEMP_DIR/verify-output.log" ]]; then
+      printf '# ---- 业务验收输出（失败现场） ----\n'
+      tail -n 50 "$TEMP_DIR/verify-output.log"
+    fi
+    printf 'cleanup=%s\n' "$([[ "$KEEP" == "1" ]] && printf 'kept-for-review' || printf 'done')"
+    printf 'credential_note=备份快照与 GPG 口令文件应异地独立保存；口令丢失即无法恢复。\n'
+  } > "$REPORT"
+  chmod 600 "$REPORT"
+  warn "演练在 ${STAGE} 阶段失败，报告：$REPORT"
+}
+
+validate_snapshot_path() {
+  [[ -d "$1" ]] || die "快照目录不存在：$1"
+  [[ "$(basename "$1")" == snapshot-* ]] || die "只允许演练 snapshot-* 快照目录"
+  [[ "$1" != */..* && "$1" != */.snapshot-* ]] || die "非法快照路径"
+}
+
+parse_args() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+  [[ "$#" -ge 1 ]] || { usage; exit 2; }
+  SNAPSHOT="$1"
+  shift
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --env-file) [[ "$#" -ge 2 ]] || die "--env-file 缺少参数"; ENV_FILE="$2"; shift 2 ;;
+      --compose-file) [[ "$#" -ge 2 ]] || die "--compose-file 缺少参数"; COMPOSE_FILE="$2"; shift 2 ;;
+      --passphrase-file) [[ "$#" -ge 2 ]] || die "--passphrase-file 缺少参数"; PASSPHRASE_FILE="$2"; shift 2 ;;
+      --project-name) [[ "$#" -ge 2 ]] || die "--project-name 缺少参数"; PROJECT_NAME="$2"; shift 2 ;;
+      --drill-dir) [[ "$#" -ge 2 ]] || die "--drill-dir 缺少参数"; DRILL_DIR="$2"; shift 2 ;;
+      --report) [[ "$#" -ge 2 ]] || die "--report 缺少参数"; REPORT="$2"; shift 2 ;;
+      --subnet) [[ "$#" -ge 2 ]] || die "--subnet 缺少参数"; SUBNET="$2"; shift 2 ;;
+      --rpo-max-hours) [[ "$#" -ge 2 ]] || die "--rpo-max-hours 缺少参数"; RPO_MAX_HOURS="$2"; shift 2 ;;
+      --rto-max-minutes) [[ "$#" -ge 2 ]] || die "--rto-max-minutes 缺少参数"; RTO_MAX_MINUTES="$2"; shift 2 ;;
+      --wait-timeout) [[ "$#" -ge 2 ]] || die "--wait-timeout 缺少参数"; WAIT_TIMEOUT="$2"; shift 2 ;;
+      --skip-judge) SKIP_JUDGE=1; shift ;;
+      --keep) KEEP=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "未知选项：$1" ;;
+    esac
+  done
+}
+
+preflight() {
+  STAGE="preflight"
+  validate_snapshot_path "$SNAPSHOT"
+  [[ -f "$SNAPSHOT/SUCCESS" ]] || die "快照缺少成功标记：$SNAPSHOT/SUCCESS"
+  [[ -f "$SNAPSHOT/manifest.json" ]] || die "快照缺少 manifest.json"
+  [[ -f "$SNAPSHOT/env.prod.gpg" ]] || die "快照缺少加密环境文件 env.prod.gpg"
+  [[ -n "$PASSPHRASE_FILE" ]] || die "必须提供 --passphrase-file 或 NOJ_BACKUP_PASSPHRASE_FILE"
+  check_secret_file "$PASSPHRASE_FILE"
+  [[ -f "$ENV_FILE" ]] || die "生产环境文件不存在：$ENV_FILE"
+  [[ -f "$COMPOSE_FILE" ]] || die "生产 Compose 文件不存在：$COMPOSE_FILE"
+  command -v "$DOCKER_BIN" >/dev/null 2>&1 || die "找不到 Docker CLI：$DOCKER_BIN"
+  "$DOCKER_BIN" info >/dev/null 2>&1 || die "Docker daemon 不可用"
+  [[ -f "$VERIFY_SCRIPT" ]] || die "缺少业务验收脚本：$VERIFY_SCRIPT"
+  [[ "$PROJECT_NAME" != *prod* ]] || die "演练项目名不得包含 prod：$PROJECT_NAME"
+  [[ "$PROJECT_NAME" =~ ^[a-z0-9][a-z0-9_-]*$ ]] ||
+    die "演练项目名只能包含小写字母、数字、- 和 _"
+  [[ "$RPO_MAX_HOURS" =~ ^[0-9]+$ && "$RTO_MAX_MINUTES" =~ ^[0-9]+$ ]] ||
+    die "RPO/RTO 目标必须是非负整数"
+
+  # 文件级校验复用 backup.sh verify：损坏快照或口令错误在此直接失败。
+  ok "执行快照文件校验（backup.sh verify）"
+  NOJ_BACKUP_PASSPHRASE_FILE="$PASSPHRASE_FILE" \
+  NOJ_BACKUP_DOCKER_BIN="$DOCKER_BIN" \
+    bash "$SCRIPT_DIR/backup.sh" verify "$SNAPSHOT" \
+    --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" \
+    --passphrase-file "$PASSPHRASE_FILE" ||
+    die "快照文件校验失败，中止演练"
+}
+
+prepare_directories() {
+  STAGE="prepare"
+  DRILL_STARTED_AT="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  local timestamp index=1
+  timestamp="$(date '+%Y%m%d-%H%M%S')"
+  if [[ -z "$DRILL_DIR" ]]; then
+    DRILL_DIR="$(dirname "$SNAPSHOT")/drill-$timestamp"
+    while [[ -e "$DRILL_DIR" ]]; do
+      index=$((index + 1))
+      DRILL_DIR="$(dirname "$SNAPSHOT")/drill-$timestamp-$index"
+    done
+  fi
+  [[ ! -e "$DRILL_DIR" ]] || die "演练目录已存在：$DRILL_DIR"
+  mkdir -m 700 -p "$DRILL_DIR"
+  TEMP_DIR="$DRILL_DIR/.work"
+  mkdir -m 700 "$TEMP_DIR"
+  if [[ -z "$REPORT" ]]; then
+    REPORT="$SNAPSHOT/restore-drill-report.txt"
+  fi
+  : > "$REPORT"
+  chmod 600 "$REPORT"
+  ok "演练目录：${DRILL_DIR}；报告：${REPORT}"
+}
+
+# 解密生产环境文件并叠加演练隔离配置（评测器网络名指向演练网络）。
+prepare_env() {
+  STAGE="prepare-env"
+  COMPOSE_ENV_FILE="$TEMP_DIR/env.drill"
+  gpg_decrypt "$SNAPSHOT/env.prod.gpg" "$COMPOSE_ENV_FILE"
+  [[ -s "$COMPOSE_ENV_FILE" ]] || die "解密后的环境文件为空"
+  chmod 600 "$COMPOSE_ENV_FILE"
+  {
+    printf '\n# ---- restore-drill 隔离覆盖（自动生成，勿提交） ----\n'
+    printf 'JUDGE_EVALUATOR_NETWORK=%s_noj-net\n' "$PROJECT_NAME"
+  } >> "$COMPOSE_ENV_FILE"
+  ok "已解密环境文件并叠加演练隔离配置"
+}
+
+# 生成演练覆盖 Compose：仅改子网；数据卷沿用项目名前缀实现隔离。
+prepare_compose_override() {
+  STAGE="prepare-compose"
+  cat > "$TEMP_DIR/compose.drill-override.yml" <<EOF
+# restore-drill 自动生成的隔离覆盖：独立子网，避免与生产 noj-net 冲突。
+services: {}
+networks:
+  noj-net:
+    ipam:
+      config:
+        - subnet: ${SUBNET}
+EOF
+  compose config --quiet || die "演练 Compose 配置无效"
+  ok "演练 Compose 覆盖已生成（子网 ${SUBNET}）"
+}
+
+restore_data_services() {
+  STAGE="restore-data"
+  local pg_user pg_db
+  pg_user="$(env_value POSTGRES_USER)"; pg_user="${pg_user:-noj}"
+  pg_db="$(env_value POSTGRES_DB)"; pg_db="${pg_db:-noj}"
+
+  ok "启动隔离数据服务（postgres/redis/minio）"
+  compose up -d --wait --wait-timeout "$WAIT_TIMEOUT" postgres redis minio ||
+    die "隔离数据服务启动失败"
+  compose run --rm minio-init >/dev/null 2>&1 || die "MinIO bucket 初始化失败"
+
+  ok "恢复 PostgreSQL"
+  compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" \
+    < "$SNAPSHOT/postgres-globals.sql" || die "PostgreSQL 全局对象恢复失败"
+  compose exec -T postgres pg_restore --clean --if-exists --no-owner --exit-on-error \
+    -U "$pg_user" -d "$pg_db" - < "$SNAPSHOT/postgres.dump" ||
+    die "PostgreSQL 数据恢复失败"
+
+  ok "恢复 Redis"
+  compose stop redis >/dev/null || die "停止 Redis 失败"
+  compose run --rm --no-deps --entrypoint /bin/sh redis -c \
+    'set -eu; rm -rf /data/appendonlydir /data/dump.rdb; cat > /data/dump.rdb' \
+    < "$SNAPSHOT/redis.rdb" || die "写入 Redis RDB 失败"
+  compose up -d --wait --wait-timeout "$WAIT_TIMEOUT" redis ||
+    die "恢复后 Redis 启动失败"
+
+  ok "恢复 MinIO/S3 对象"
+  compose run --rm --no-deps --entrypoint /bin/sh -v "$SNAPSHOT/minio:/restore:ro" minio-init -c \
+    'set -eu; for i in $(seq 1 30); do mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 && break; sleep 2; done; mc mirror --overwrite --remove /restore "local/$S3_BUCKET"' ||
+    die "MinIO/S3 对象恢复失败"
+}
+
+# 数据核对：迁移版本、用户数、Redis 键数、对象数与快照一致性。
+verify_data() {
+  STAGE="verify-data"
+  local pg_user pg_db
+  pg_user="$(env_value POSTGRES_USER)"; pg_user="${pg_user:-noj}"
+  pg_db="$(env_value POSTGRES_DB)"; pg_db="${pg_db:-noj}"
+
+  local expected_migrations actual_migrations
+  expected_migrations="$(cat "$SNAPSHOT/migration-status.txt" 2>/dev/null || true)"
+  actual_migrations="$(compose exec -T postgres psql -U "$pg_user" -d "$pg_db" -Atqc \
+    "SELECT hash || ':' || created_at::text FROM drizzle.__drizzle_migrations ORDER BY created_at" 2>/dev/null || true)"
+  [[ -n "$expected_migrations" && "$expected_migrations" != "not-initialized" ]] ||
+    die "数据核对失败：快照缺少迁移状态记录"
+  [[ "$expected_migrations" == "$actual_migrations" ]] ||
+    die "数据核对失败：迁移版本与快照不一致"
+  ok "数据核对：迁移版本与快照一致"
+
+  local user_count
+  user_count="$(compose exec -T postgres psql -U "$pg_user" -d "$pg_db" -Atqc \
+    "SELECT count(*) FROM users" 2>/dev/null || true)"
+  [[ "$user_count" =~ ^[0-9]+$ ]] || die "数据核对失败：无法读取用户数"
+  ok "数据核对：恢复后用户数 ${user_count}"
+
+  local redis_keys
+  redis_keys="$(compose exec -T redis sh -c \
+    'REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning DBSIZE' 2>/dev/null | tr -d '[:space:]')"
+  [[ "$redis_keys" =~ ^[0-9]+$ ]] || redis_keys=0
+  ok "数据核对：Redis 键数 ${redis_keys}"
+
+  local snapshot_objects restored_objects bucket
+  bucket="$(env_value S3_BUCKET)"; bucket="${bucket:-noj-support-packages}"
+  snapshot_objects="$(find "$SNAPSHOT/minio" -type f ! -name 'sha256sums.txt' 2>/dev/null | wc -l | tr -d ' ')"
+  restored_objects="$(compose run --rm --no-deps --entrypoint /bin/sh minio-init -c \
+    'set -eu; for i in $(seq 1 30); do mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 && break; sleep 2; done; mc ls --recursive --json "local/$S3_BUCKET" | wc -l' 2>/dev/null | tail -n 1 | tr -d '[:space:]')"
+  [[ "$restored_objects" =~ ^[0-9]+$ ]] || die "数据核对失败：无法读取恢复后的对象数"
+  ((restored_objects >= snapshot_objects)) ||
+    die "数据核对失败：MinIO 对象数少于快照（快照 ${snapshot_objects} / 恢复 ${restored_objects}）"
+  ok "数据核对：MinIO 对象数 快照 ${snapshot_objects} / 恢复 ${restored_objects}"
+
+  {
+    printf 'restore_data_check=passed\n'
+    printf 'restored_user_count=%s\n' "$user_count"
+    printf 'restored_redis_keys=%s\n' "$redis_keys"
+    printf 'snapshot_object_count=%s\n' "$snapshot_objects"
+    printf 'restored_object_count=%s\n' "$restored_objects"
+  } > "$TEMP_DIR/checks.env"
+}
+
+# 演练管理员：直接写入隔离演练库并授予 admin 角色（不影响生产）。
+seed_drill_admin() {
+  STAGE="seed-admin"
+  local pg_user pg_db
+  pg_user="$(env_value POSTGRES_USER)"; pg_user="${pg_user:-noj}"
+  pg_db="$(env_value POSTGRES_DB)"; pg_db="${pg_db:-noj}"
+  local now
+  now="$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
+
+  compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" <<SQL ||
+INSERT INTO users (id, username, email, email_verified, password_hash, created_at, updated_at)
+VALUES ('drill-admin-user', '${DRILL_ADMIN_USER}', 'drill-admin@${DRILL_ADMIN_EMAIL_DOMAIN}',
+        true, '${DRILL_BCRYPT_HASH}', '${now}', '${now}')
+ON CONFLICT (id) DO NOTHING;
+INSERT INTO user_roles (user_id, role_id)
+SELECT 'drill-admin-user', id FROM roles WHERE name = 'admin'
+ON CONFLICT DO NOTHING;
+SQL
+  die "写入演练管理员失败"
+  ok "演练管理员已写入隔离数据库"
+}
+
+start_business_services() {
+  STAGE="start-business"
+  ok "执行迁移并启动 core"
+  compose run --rm migrate >/dev/null 2>&1 || die "隔离环境迁移失败"
+  compose up -d --wait --wait-timeout "$WAIT_TIMEOUT" core ||
+    die "隔离 core 启动失败"
+
+  if ((SKIP_JUDGE)); then
+    warn "跳过 judge（--skip-judge）：演练不包含真实评测"
+    return 0
+  fi
+
+  ok "启动 judge（使用与生产相同的独立沙箱 daemon）"
+  compose up -d --wait --wait-timeout "$WAIT_TIMEOUT" judge ||
+    die "隔离 judge 启动失败"
+  ensure_judge_images
+}
+
+# 确认 judge_images 白名单包含演练所需镜像（只读取既有数据，不写入）。
+ensure_judge_images() {
+  local pg_user pg_db
+  pg_user="$(env_value POSTGRES_USER)"; pg_user="${pg_user:-noj}"
+  pg_db="$(env_value POSTGRES_DB)"; pg_db="${pg_db:-noj}"
+
+  DRILL_EVALUATOR_IMAGE="$(compose exec -T postgres psql -U "$pg_user" -d "$pg_db" -Atqc \
+    "SELECT image FROM judge_images WHERE kind = 'evaluator' ORDER BY created_at LIMIT 1" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
+  DRILL_SOLUTION_IMAGE="$(compose exec -T postgres psql -U "$pg_user" -d "$pg_db" -Atqc \
+    "SELECT image FROM judge_images WHERE kind = 'solution' ORDER BY created_at LIMIT 1" 2>/dev/null | head -n 1 | tr -d '[:space:]')"
+  [[ -n "$DRILL_EVALUATOR_IMAGE" ]] || die "judge_images 白名单缺少 evaluator 镜像"
+  [[ -n "$DRILL_SOLUTION_IMAGE" ]] || die "judge_images 白名单缺少 solution 镜像"
+  ok "评测镜像：evaluator=${DRILL_EVALUATOR_IMAGE} solution=${DRILL_SOLUTION_IMAGE}"
+}
+
+run_business_verification() {
+  STAGE="business-verify"
+  ok "运行业务验收（登录/题目/附件/评测）"
+  local -a compose_args=(run --rm --no-deps
+    -e "DRILL_BASE_URL=http://core:8000/api/v1"
+    -e "DRILL_ADMIN_USER=${DRILL_ADMIN_USER}"
+    -e "DRILL_ADMIN_PASSWORD=${DRILL_ADMIN_PASSWORD}"
+    -e "DRILL_EVALUATOR_IMAGE=${DRILL_EVALUATOR_IMAGE:-${DEFAULT_EVALUATOR_IMAGE}}"
+    -e "DRILL_SOLUTION_IMAGE=${DRILL_SOLUTION_IMAGE:-${DEFAULT_SOLUTION_IMAGE}}")
+  ((SKIP_JUDGE)) && compose_args+=(-e "DRILL_SKIP_EVALUATION=1") || true
+  local status=0
+  compose "${compose_args[@]}" \
+    -v "$VERIFY_SCRIPT:/opt/verify.ts:ro" \
+    core deno run -A /opt/verify.ts 2>&1 | tee "$TEMP_DIR/verify-output.log" || status=$?
+  ((status == 0)) || die "业务验收未通过"
+}
+
+snapshot_created_at() {
+  awk 'match($0, /"created_at"[[:space:]]*:[[:space:]]*"[^"]+"/) {
+    value = substr($0, RSTART, RLENGTH)
+    sub(/^.*:[[:space:]]*"/, "", value)
+    sub(/"$/, "", value)
+    print value
+    exit
+  }' "$SNAPSHOT/manifest.json"
+}
+
+hours_since_snapshot() {
+  local created epoch_created epoch_now
+  created="$(snapshot_created_at)"
+  epoch_created="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$created" '+%s' 2>/dev/null ||
+    date -d "$created" '+%s' 2>/dev/null || echo 0)"
+  epoch_now="$(date '+%s')"
+  awk -v a="$epoch_created" -v b="$epoch_now" 'BEGIN { printf "%.2f", (b - a) / 3600 }'
+}
+
+write_report() {
+  STAGE="report"
+  local rto_minutes="$1" restore_seconds="$2" total_seconds="$3"
+  local finished_at rpo_hours rpo_met rto_met result
+  finished_at="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  rpo_hours="$(hours_since_snapshot)"
+  rpo_met="true"; rto_met="true"; result="passed"
+  awk -v v="$rpo_hours" -v max="$RPO_MAX_HOURS" 'BEGIN { exit (v <= max) ? 0 : 1 }' ||
+    rpo_met="false"
+  (( RTO_MAX_MINUTES >= rto_minutes )) || rto_met="false"
+  [[ "$rpo_met" == "true" && "$rto_met" == "true" ]] || result="passed_with_warnings"
+
+  {
+    printf 'result=%s\n' "$result"
+    printf 'drill_type=isolated-restore-with-business-verification\n'
+    printf 'snapshot=%s\n' "$SNAPSHOT"
+    printf 'snapshot_created_at=%s\n' "$(snapshot_created_at)"
+    printf 'drill_started_at=%s\n' "$DRILL_STARTED_AT"
+    printf 'drill_finished_at=%s\n' "$finished_at"
+    printf 'restore_duration_seconds=%s\n' "$restore_seconds"
+    printf 'total_duration_seconds=%s\n' "$total_seconds"
+    printf 'rpo_hours=%s\n' "$rpo_hours"
+    printf 'rpo_target_hours=%s\n' "$RPO_MAX_HOURS"
+    printf 'rpo_met=%s\n' "$rpo_met"
+    printf 'rto_minutes=%s\n' "$rto_minutes"
+    printf 'rto_target_minutes=%s\n' "$RTO_MAX_MINUTES"
+    printf 'rto_met=%s\n' "$rto_met"
+    printf 'compose_project=%s\n' "$PROJECT_NAME"
+    printf 'network_subnet=%s\n' "$SUBNET"
+    if [[ -f "$TEMP_DIR/checks.env" ]]; then
+      cat "$TEMP_DIR/checks.env"
+    fi
+    if [[ -f "$TEMP_DIR/verify-output.log" ]]; then
+      printf '# ---- 业务验收明细 ----\n'
+      cat "$TEMP_DIR/verify-output.log"
+    fi
+    printf 'cleanup=%s\n' "$([[ "$KEEP" == "1" ]] && printf 'kept-for-review' || printf 'done')"
+    printf 'credential_note=备份快照与 GPG 口令文件应异地独立保存；口令丢失即无法恢复。\n'
+  } > "$REPORT"
+  chmod 600 "$REPORT"
+  write_drill_metrics
+}
+
+# 输出 Prometheus textfile 指标，供告警检测"恢复演练长期未执行"。
+write_drill_metrics() {
+  local metrics_dir="${NOJ_BACKUP_METRICS_DIR:-$(dirname "$SNAPSHOT")/metrics}"
+  mkdir -m 755 -p "$metrics_dir"
+  {
+    printf '# HELP noj_restore_drill_last_success_unix_time 最近一次隔离恢复演练成功的 Unix 时间戳。\n'
+    printf '# TYPE noj_restore_drill_last_success_unix_time gauge\n'
+    printf 'noj_restore_drill_last_success_unix_time %s\n' "$(date '+%s')"
+  } > "$metrics_dir/noj_restore_drill.prom"
+  chmod 644 "$metrics_dir/noj_restore_drill.prom"
+}
+
+main() {
+  parse_args "$@"
+  preflight
+
+  local restore_start restore_end restore_seconds total_start total_seconds rto_minutes
+  total_start="$(date '+%s')"
+  prepare_directories
+  prepare_env
+  prepare_compose_override
+  restore_start="$(date '+%s')"
+  restore_data_services
+  verify_data
+  restore_end="$(date '+%s')"
+  restore_seconds=$((restore_end - restore_start))
+
+  seed_drill_admin
+  start_business_services
+  run_business_verification
+  total_seconds=$(( $(date '+%s') - total_start ))
+  rto_minutes=$((total_seconds / 60))
+
+  STAGE="report"
+  write_report "$rto_minutes" "$restore_seconds" "$total_seconds"
+  if [[ "$KEEP" != "1" ]]; then
+    "$DOCKER_BIN" compose --project-name "$PROJECT_NAME" \
+      --env-file "$COMPOSE_ENV_FILE" --file "$COMPOSE_FILE" \
+      --file "$TEMP_DIR/compose.drill-override.yml" \
+      down -v --remove-orphans >/dev/null 2>&1 || true
+  fi
+  ok "隔离恢复演练通过，报告已写入：$REPORT"
+}
+
+trap on_exit EXIT
+main "$@"

--- a/scripts/deploy/test-alert.sh
+++ b/scripts/deploy/test-alert.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Neuro OJ 告警投递演练：向 Alertmanager 注入测试告警，验证通知真的有人收到。
+#
+# 用法：
+#   test-alert.sh [ALERTMANAGER_URL] [选项]
+#
+# 选项：
+#   --hold SECONDS   保持告警活跃的秒数（默认 300，足够触发一轮通知）
+#   --curl PATH      curl 可执行文件（默认 curl）
+#
+# 演练会注入 critical / warning 两条 NojNotificationDrill 告警，并在保持期结束后
+# 发送 resolved 事件。接收方应同时收到触发与恢复通知；结果按 deploy/monitoring/README.md
+# 第 3 节的表格记录。本脚本只负责注入与提示，不代替人工确认。
+set -Eeuo pipefail
+
+ALERTMANAGER_URL="${1:-http://alertmanager:9093}"
+shift || true
+HOLD_SECONDS=300
+CURL_BIN="${NOJ_TEST_ALERT_CURL:-curl}"
+
+usage() {
+  cat <<'EOF'
+用法：test-alert.sh [ALERTMANAGER_URL] [选项]
+
+选项：
+  --hold SECONDS   保持告警活跃的秒数（默认 300，足够触发一轮通知）
+  --curl PATH      curl 可执行文件（默认 curl）
+
+向 Alertmanager 注入 critical / warning 两条 NojNotificationDrill 告警，
+保持期结束后发送 resolved 事件；接收方应同时收到触发与恢复通知。
+EOF
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --hold) [[ "$#" -ge 2 ]] || { echo "--hold 需要秒数" >&2; exit 2; }
+      [[ "$2" =~ ^[0-9]+$ ]] || { echo "--hold 必须是非负整数" >&2; exit 2; }
+      HOLD_SECONDS="$2"; shift 2 ;;
+    --curl) [[ "$#" -ge 2 ]] || { echo "--curl 需要路径" >&2; exit 2; }
+      CURL_BIN="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "未知参数：$1" >&2; exit 2 ;;
+  esac
+done
+
+command -v "$CURL_BIN" >/dev/null 2>&1 || { echo "找不到 curl：$CURL_BIN" >&2; exit 1; }
+
+starts_at="$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
+
+post_alerts() {
+  local payload="$1"
+  "$CURL_BIN" --fail --silent --show-error \
+    -H 'Content-Type: application/json' \
+    -X POST "$ALERTMANAGER_URL/api/v2/alerts" -d "$payload"
+}
+
+send_active() {
+  post_alerts "$(cat <<EOF
+[
+  {
+    "labels": {
+      "alertname": "NojNotificationDrill",
+      "severity": "critical",
+      "instance": "notification-drill"
+    },
+    "annotations": {
+      "summary": "告警投递演练（critical）",
+      "description": "投递演练测试告警，无需处理；请确认接收方收到本通知与后续恢复通知。startsAt=$starts_at"
+    },
+    "startsAt": "$starts_at"
+  },
+  {
+    "labels": {
+      "alertname": "NojNotificationDrill",
+      "severity": "warning",
+      "instance": "notification-drill"
+    },
+    "annotations": {
+      "summary": "告警投递演练（warning）",
+      "description": "投递演练测试告警，无需处理；请确认接收方收到本通知与后续恢复通知。startsAt=$starts_at"
+    },
+    "startsAt": "$starts_at"
+  }
+]
+EOF
+  )"
+}
+
+send_resolved() {
+  local ends_at
+  ends_at="$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
+  post_alerts "$(cat <<EOF
+[
+  {
+    "labels": {
+      "alertname": "NojNotificationDrill",
+      "severity": "critical",
+      "instance": "notification-drill"
+    },
+    "annotations": {
+      "summary": "告警投递演练（critical）已恢复",
+      "description": "投递演练结束，本条为恢复通知。"
+    },
+    "startsAt": "$starts_at",
+    "endsAt": "$ends_at"
+  },
+  {
+    "labels": {
+      "alertname": "NojNotificationDrill",
+      "severity": "warning",
+      "instance": "notification-drill"
+    },
+    "annotations": {
+      "summary": "告警投递演练（warning）已恢复",
+      "description": "投递演练结束，本条为恢复通知。"
+    },
+    "startsAt": "$starts_at",
+    "endsAt": "$ends_at"
+  }
+]
+EOF
+  )"
+}
+
+echo "[drill] 向 $ALERTMANAGER_URL 注入 NojNotificationDrill 测试告警（critical + warning）"
+send_active || { echo "注入失败：请检查 Alertmanager 地址与网络" >&2; exit 1; }
+echo "[drill] 已注入，保持 ${HOLD_SECONDS} 秒……接收方现在应收到触发通知"
+
+if ((HOLD_SECONDS > 0)); then
+  sleep "$HOLD_SECONDS"
+fi
+
+echo "[drill] 发送恢复（resolved）事件，接收方应收到恢复通知"
+send_resolved || { echo "恢复事件发送失败" >&2; exit 1; }
+
+cat <<'EOF'
+[drill] 演练完成。请确认：
+  1. 预定接收方在触发阶段收到了 critical 与 warning 通知；
+  2. 预定接收方在恢复阶段收到了 resolved 通知；
+  3. 按 deploy/monitoring/README.md 第 3 节表格记录演练时间与结果。
+EOF

--- a/scripts/deploy/test-install.sh
+++ b/scripts/deploy/test-install.sh
@@ -61,9 +61,14 @@ while (($# > 0)); do
   url="$1"
   shift
 done
-if [[ "$url" == *'/releases?per_page=1' ]]; then
+if [[ "$url" == *'/releases?per_page=100' ]]; then
   [[ "${NOJ_BOOTSTRAP_API_FAIL:-0}" != 1 ]] || exit 22
-  printf '{"tag_name":"%s"}\n' "${NOJ_BOOTSTRAP_LATEST_REF:-v0.1.0}"
+  # 默认 fixture：仅一个资产就绪的稳定版；过滤行为用 NOJ_BOOTSTRAP_RELEASES_FIXTURE 覆盖。
+  if [[ -n "${NOJ_BOOTSTRAP_RELEASES_FIXTURE:-}" ]]; then
+    cat "$NOJ_BOOTSTRAP_RELEASES_FIXTURE"
+  else
+    printf '[{"tag_name":"v0.1.0","prerelease":false,"draft":false,"assets":[{"name":"noj-cli-linux-amd64"},{"name":"noj-cli-linux-amd64.sha256"}]}]\n'
+  fi
   exit 0
 fi
 if [[ -n "${NOJ_SETUP_PAYLOAD:-}" ]]; then
@@ -227,6 +232,37 @@ set -e
 [[ "$api_status" != 0 ]] || fail "最新 Release 获取失败未返回非零"
 grep -q '使用 --ref' "$TEST_ROOT/api-fail.err" || fail "最新 Release 获取失败提示缺少显式版本建议"
 pass "最新 Release 获取失败"
+
+# Release 过滤：prerelease / draft / 缺 CLI 资产的版本不作为默认安装目标（issue #431）。
+cat >"$TEST_ROOT/releases-filtered.json" <<'EOF'
+[
+  {"tag_name":"v0.3.0-rc.1","prerelease":true,"draft":false,"assets":[{"name":"noj-cli-linux-amd64"},{"name":"noj-cli-linux-amd64.sha256"}]},
+  {"tag_name":"v0.2.0","prerelease":false,"draft":true,"assets":[{"name":"noj-cli-linux-amd64"},{"name":"noj-cli-linux-amd64.sha256"}]},
+  {"tag_name":"v0.1.9","prerelease":false,"draft":false,"assets":[{"name":"noj-server-linux-amd64"}]},
+  {"tag_name":"v0.1.0","prerelease":false,"draft":false,"assets":[{"name":"noj-cli-linux-amd64"},{"name":"noj-cli-linux-amd64.sha256"}]}
+]
+EOF
+NOJ_BOOTSTRAP_RELEASES_FIXTURE="$TEST_ROOT/releases-filtered.json" \
+  bash "$INSTALL_SCRIPT" --download-only \
+  --dir "$TEST_ROOT/filter-install" >"$TEST_ROOT/filter.out" 2>&1 ||
+  { cat "$TEST_ROOT/filter.out" >&2; fail "过滤场景安装命令失败"; }
+grep -q '将使用资产就绪的最新 Release：v0.1.0' "$TEST_ROOT/filter.out" ||
+  { cat "$TEST_ROOT/filter.out" >&2; fail "应跳过 prerelease/draft/无资产版本并选择 v0.1.0"; }
+pass "Release 过滤：仅选择资产就绪的正式版本"
+
+cat >"$TEST_ROOT/releases-none.json" <<'EOF'
+[{"tag_name":"v0.2.0-rc.1","prerelease":true,"draft":false,"assets":[]}]
+EOF
+set +e
+NOJ_BOOTSTRAP_RELEASES_FIXTURE="$TEST_ROOT/releases-none.json" \
+  bash "$INSTALL_SCRIPT" --download-only \
+  --dir "$TEST_ROOT/none" >/dev/null 2>"$TEST_ROOT/none.err"
+none_status=$?
+set -e
+[[ "$none_status" != 0 ]] || fail "无资产就绪 Release 时应失败"
+grep -q '没有发现资产就绪的正式 Release' "$TEST_ROOT/none.err" ||
+  fail "无资产就绪 Release 时应给出明确提示"
+pass "无资产就绪 Release 时拒绝安装"
 
 NOJ_BOOTSTRAP_API_FAIL=1 NOJ_BOOTSTRAP_BIN_DIR="$TEST_ROOT/explicit-bin" \
   bash "$INSTALL_SCRIPT" --ref v0.1.0 --dir "$TEST_ROOT/explicit-ref" >/dev/null

--- a/scripts/deploy/test-monitoring.sh
+++ b/scripts/deploy/test-monitoring.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# 监控配置一致性测试：
+#   1. noj-alerts.yml 中每个 runbook 注解都能在 Runbook 文档中定位到显式锚点；
+#   2. prometheus.yml 引用的规则文件存在、alerting 段指向 Alertmanager；
+#   3. alertmanager.yml.example 覆盖所有告警 severity 并包含 resolved 通知；
+#   4. test-alert.sh 的告警注入负载格式合法（JSON 数组 + alertname）。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ALERTS="$REPO_ROOT/deploy/monitoring/noj-alerts.yml"
+PROMETHEUS="$REPO_ROOT/deploy/monitoring/prometheus.yml"
+ALERTMANAGER="$REPO_ROOT/deploy/monitoring/alertmanager.yml.example"
+RUNBOOK="$REPO_ROOT/noj-docs/docs/operators/observability.md"
+TEST_ALERT="$SCRIPT_DIR/test-alert.sh"
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+
+[[ -f "$ALERTS" ]] || fail "缺少告警规则文件"
+[[ -f "$RUNBOOK" ]] || fail "缺少 Runbook 文档"
+
+# 1. runbook 注解 → 文档锚点一一对应
+missing=0
+while IFS= read -r ref; do
+  anchor="${ref#*observability.md#}"
+  [[ -n "$anchor" ]] || { echo "非法 runbook 注解：$ref" >&2; missing=1; continue; }
+  grep -qF "{#$anchor}" "$RUNBOOK" || {
+    echo "Runbook 缺少锚点：{#$anchor}（告警注解 $ref）" >&2
+    missing=1
+  }
+done < <(grep -o 'observability.md#[^ ]*' "$ALERTS" | sort -u)
+((missing == 0)) || fail "存在无法定位的 Runbook 链接"
+pass "全部告警 runbook 注解可在 Runbook 文档定位"
+
+# 2. prometheus.yml 基本结构
+grep -q 'rule_files' "$PROMETHEUS" || fail "prometheus.yml 缺少 rule_files"
+grep -q 'noj-alerts.yml' "$PROMETHEUS" || fail "prometheus.yml 未引用 noj-alerts.yml"
+grep -q 'alertmanager:9093' "$PROMETHEUS" || fail "prometheus.yml 未配置 Alertmanager"
+grep -q 'job_name: noj-core' "$PROMETHEUS" || fail "prometheus.yml 缺少 noj-core 抓取任务"
+pass "prometheus.yml 含规则文件引用、Alertmanager 与 noj-core 抓取"
+
+# 3. 失联检测规则存在（不依赖 core 自身指标）
+grep -q 'NojCoreScrapeDown' "$ALERTS" || fail "缺少 NojCoreScrapeDown"
+grep -q 'up{job="noj-core"} == 0' "$ALERTS" || fail "缺少 core 抓取失败表达式"
+grep -q 'NojApiErrorRateRecentWarning' "$ALERTS" || fail "缺少近期错误率告警"
+grep -q 'noj_http_request_errors_total\[5m\]' "$ALERTS" ||
+  fail "近期错误率应使用滑动窗口 rate"
+grep -q 'NojBackupStale' "$ALERTS" || fail "缺少备份新鲜度告警"
+grep -q 'noj_backup_last_success_unix_time' "$ALERTS" || fail "备份告警未引用 textfile 指标"
+grep -q 'NojRestoreDrillStale' "$ALERTS" || fail "缺少恢复演练新鲜度告警"
+pass "失联检测、近期错误率与备份新鲜度告警齐备"
+
+# 4. alertmanager 模板：severity 路由 + resolved
+grep -q 'severity = "critical"' "$ALERTMANAGER" || fail "alertmanager 模板缺少 critical 路由"
+grep -q 'send_resolved: true' "$ALERTMANAGER" || fail "alertmanager 模板必须开启 resolved 通知"
+grep -q 'ALERTMANAGER_WEBHOOK_URL' "$ALERTMANAGER" || fail "alertmanager 模板缺少 webhook 接收器"
+grep -qE 'smtp_(smarthost|from)' "$ALERTMANAGER" || fail "alertmanager 模板缺少邮件接收器"
+pass "alertmanager 模板包含 critical 路由、webhook/邮件接收器与 resolved 通知"
+
+# 5. test-alert.sh 负载格式（模拟 curl 校验 payload）
+FAKE_CURL="$PWD/.test-alert-fake-curl.$$"
+PAYLOAD_FILE="$PWD/.test-alert-payload.$$"
+cat >"$FAKE_CURL" <<EOF
+#!/usr/bin/env bash
+while [[ "\$#" -gt 0 ]]; do
+  if [[ "\$1" == "-d" ]]; then
+    printf '%s' "\$2" > "$PAYLOAD_FILE"
+  fi
+  shift
+done
+exit 0
+EOF
+chmod +x "$FAKE_CURL"
+if ! NOJ_TEST_ALERT_CURL="$FAKE_CURL" bash "$TEST_ALERT" "http://127.0.0.1:19093" --hold 0 >/dev/null 2>&1; then
+  rm -f "$FAKE_CURL" "$PAYLOAD_FILE"
+  fail "test-alert.sh 应回放注入与恢复两次调用"
+fi
+rm -f "$FAKE_CURL" "$PAYLOAD_FILE"
+pass "test-alert.sh 注入与恢复流程可执行"
+
+printf '\n监控配置一致性测试通过。\n'

--- a/scripts/deploy/test-restore-drill.sh
+++ b/scripts/deploy/test-restore-drill.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# restore-drill.sh 的无 Docker 隔离恢复演练测试：fake docker 模拟 Compose 全链路。
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_SCRIPT="$SCRIPT_DIR/backup.sh"
+DRILL_SCRIPT="$SCRIPT_DIR/restore-drill.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/noj-drill-test.XXXXXX")"
+FAKE_DOCKER="$TEST_ROOT/fake-docker"
+FAKE_LOG="$TEST_ROOT/docker.log"
+ENV_FILE="$TEST_ROOT/.env.prod"
+COMPOSE_FILE="$TEST_ROOT/docker-compose.prod.yml"
+PASSPHRASE_FILE="$TEST_ROOT/passphrase"
+BACKUP_DIR="$TEST_ROOT/backups"
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+
+pass() { printf '✓ %s\n' "$*"; }
+fail() { printf '✗ %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# fake docker：记录全部调用并模拟 Compose/psql/redis-cli/mc 行为。
+# ---------------------------------------------------------------------------
+cat >"$FAKE_DOCKER" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$*" >>"${NOJ_DRILL_TEST_LOG:?}"
+if [[ "${1:-}" == "info" ]]; then
+  exit 0
+fi
+if [[ "${NOJ_DRILL_TEST_FAIL:-}" == "pg_restore" && "$*" == *"pg_restore --clean"* ]]; then
+  exit 41
+fi
+if [[ "${NOJ_DRILL_TEST_FAIL:-}" == "verify" && "$*" == *"deno run -A /opt/verify.ts"* ]]; then
+  exit 42
+fi
+if [[ "$*" == *" pg_dump "* ]]; then
+  printf 'fake postgres dump\n'
+elif [[ "$*" == *"pg_restore --list"* ]]; then
+  printf ';
+1; TABLE public users noj
+'
+elif [[ "$*" == *"pg_dumpall"* ]]; then
+  printf 'CREATE ROLE noj;\n'
+elif [[ "$*" == *"--rdb -"* ]]; then
+  printf 'fake redis rdb\n'
+elif [[ "$*" == *"INFO persistence"* ]]; then
+  printf 'aof_enabled:1\n'
+elif [[ "$*" == *"to_regclass"* ]]; then
+  printf 'drizzle.__drizzle_migrations\n'
+elif [[ "$*" == *"psql"* && "$*" == *'hash || '* ]]; then
+  printf 'migration-hash:2026-08-26\n'
+elif [[ "$*" == *'count(*) FROM users'* ]]; then
+  printf '3\n'
+elif [[ "$*" == *"judge_images"* && "$*" == *"evaluator"* ]]; then
+  printf 'noj-evaluator-python\n'
+elif [[ "$*" == *"judge_images"* && "$*" == *"solution"* ]]; then
+  printf 'noj-solution-python\n'
+elif [[ "$*" == *"DBSIZE"* ]]; then
+  printf '5\n'
+elif [[ "$*" == *"mc ls --recursive"* ]]; then
+  printf '0\n'
+elif [[ "$*" == *"deno run -A /opt/verify.ts"* ]]; then
+  cat "${NOJ_DRILL_TEST_VERIFY_OUTPUT:?}"
+  exit "${NOJ_DRILL_TEST_VERIFY_STATUS:-0}"
+fi
+exit 0
+EOF
+chmod +x "$FAKE_DOCKER"
+
+cat >"$ENV_FILE" <<'EOF'
+POSTGRES_USER=noj
+POSTGRES_DB=noj
+POSTGRES_PASSWORD=strong-postgres-password
+REDIS_PASSWORD=strong-redis-password
+MINIO_ROOT_USER=minio-root
+MINIO_ROOT_PASSWORD=strong-minio-password
+S3_BUCKET=noj-support-packages
+EOF
+chmod 600 "$ENV_FILE"
+printf 'services:\n  fake:\n    image: alpine:3\n' >"$COMPOSE_FILE"
+printf 'test-passphrase\n' >"$PASSPHRASE_FILE"
+chmod 600 "$PASSPHRASE_FILE"
+
+cat >"$TEST_ROOT/verify-output.txt" <<'EOF'
+{"step":"login","status":"passed","detail":"管理员 drill_admin 登录成功"}
+{"step":"problem_import","status":"passed","detail":"演练题目导入成功"}
+{"step":"problem_read","status":"passed","detail":"题目读取正常"}
+{"step":"attachment_download","status":"passed","detail":"支持包下载成功"}
+{"step":"evaluation","status":"passed","detail":"自测评测成功"}
+{"step":"summary","status":"passed","passed":true,"steps":[]}
+EOF
+cat >"$TEST_ROOT/verify-failed.txt" <<'EOF'
+{"step":"login","status":"passed","detail":"ok"}
+{"step":"problem_import","status":"passed","detail":"ok"}
+{"step":"evaluation","status":"failed","detail":"评测超时"}
+{"step":"summary","status":"failed","passed":false,"steps":[]}
+EOF
+
+run_backup_create() {
+  NOJ_BACKUP_DOCKER_BIN="$FAKE_DOCKER" \
+  NOJ_BACKUP_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+    bash "$BACKUP_SCRIPT" create \
+    --env-file "$ENV_FILE" \
+    --compose-file "$COMPOSE_FILE" \
+    --backup-dir "$BACKUP_DIR" \
+    --passphrase-file "$PASSPHRASE_FILE" \
+    --min-free-mb 0 >/dev/null 2>&1
+}
+
+make_snapshot() {
+  run_backup_create || fail "fixture：backup.sh create 应成功"
+  local snapshot
+  snapshot="$(find "$BACKUP_DIR" -maxdepth 1 -type d -name 'snapshot-*' | head -n 1)"
+  [[ -d "$snapshot" ]] || fail "fixture：快照目录未生成"
+  printf '%s' "$snapshot"
+}
+
+run_drill() {
+  local snapshot="$1"
+  shift
+  NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-output.txt" \
+  NOJ_DRILL_TEST_VERIFY_STATUS="${NOJ_DRILL_TEST_VERIFY_STATUS:-0}" \
+  NOJ_DRILL_TEST_FAIL="${NOJ_DRILL_TEST_FAIL:-}" \
+  NOJ_BACKUP_DOCKER_BIN="$FAKE_DOCKER" \
+    bash "$DRILL_SCRIPT" "$snapshot" \
+    --env-file "$ENV_FILE" \
+    --compose-file "$COMPOSE_FILE" \
+    --passphrase-file "$PASSPHRASE_FILE" \
+    "$@"
+}
+
+# ---------------------------------------------------------------------------
+# 1. 输入校验与安全边界
+# ---------------------------------------------------------------------------
+if bash "$DRILL_SCRIPT" --help >/dev/null 2>&1; then
+  pass "help 正常退出"
+else
+  fail "--help 应成功退出"
+fi
+
+local_snapshot="$(make_snapshot)"
+if NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-output.txt" \
+  bash "$DRILL_SCRIPT" "$local_snapshot" \
+  --passphrase-file "$PASSPHRASE_FILE" \
+  --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" \
+  --project-name noj-prod-drill >/dev/null 2>&1; then
+  fail "项目名包含 prod 应被拒绝"
+else
+  pass "项目名包含 prod 被拒绝"
+fi
+
+if NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-output.txt" \
+  bash "$DRILL_SCRIPT" "$BACKUP_DIR/not-a-snapshot" \
+  --passphrase-file "$PASSPHRASE_FILE" \
+  --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" >/dev/null 2>&1; then
+  fail "非 snapshot-* 目录应被拒绝"
+else
+  pass "非快照目录被拒绝"
+fi
+
+: >"$FAKE_LOG"
+if NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-output.txt" \
+  bash "$DRILL_SCRIPT" "$local_snapshot" \
+  --passphrase-file "$ENV_FILE" \
+  --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" >/dev/null 2>&1; then
+  fail "口令文件权限校验应失败"
+else
+  pass "口令文件权限校验生效"
+fi
+[[ "$(grep -c 'up' "$FAKE_LOG" || true)" == "0" ]] ||
+  fail "校验失败时不得启动任何 Compose 服务"
+pass "校验失败时不启动 Compose"
+
+# 缺少口令文件参数
+if NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-output.txt" \
+  bash "$DRILL_SCRIPT" "$local_snapshot" \
+  --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" >/dev/null 2>&1; then
+  fail "缺少口令文件应失败"
+else
+  pass "缺少口令文件参数被拒绝"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. 完整演练（--skip-judge + --keep）：隔离配置、报告与业务验收
+# ---------------------------------------------------------------------------
+: >"$FAKE_LOG"
+report="$TEST_ROOT/drill-report.txt"
+run_drill "$local_snapshot" --skip-judge --keep --project-name noj-drill \
+  --report "$report" --rpo-max-hours 24 --rto-max-minutes 60 >/dev/null 2>"$TEST_ROOT/drill.err" ||
+  { cat "$TEST_ROOT/drill.err" >&2; fail "隔离恢复演练应成功"; }
+pass "隔离恢复演练（--skip-judge）成功"
+
+[[ -f "$report" ]] || fail "报告未生成"
+grep -q '^result=passed$' "$report" || fail "报告应标记 result=passed"
+grep -q '^drill_type=isolated-restore-with-business-verification$' "$report" ||
+  fail "报告应标记演练类型"
+grep -q '^restore_data_check=passed$' "$report" || fail "报告应包含数据核对结果"
+grep -q '^rpo_hours=' "$report" && grep -q '^rpo_met=true$' "$report" ||
+  fail "报告应包含 RPO 目标与达标标记"
+grep -q '^rto_minutes=' "$report" && grep -q '^rto_met=true$' "$report" ||
+  fail "报告应包含 RTO 目标与达标标记"
+grep -q '^snapshot_created_at=' "$report" || fail "报告应记录快照时间"
+grep -q '^credential_note=' "$report" || fail "报告应包含凭证保存说明"
+pass "报告内容完整（结果/RPO/RTO/快照时间/数据核对/凭证说明）"
+
+grep -q '"step":"summary","status":"passed","passed":true' "$report" ||
+  fail "报告应包含业务验收 summary"
+pass "报告包含业务验收明细"
+
+[[ "$(grep -c 'down -v' "$FAKE_LOG" || true)" == "0" ]] ||
+  fail "--keep 模式不得清理演练资源"
+pass "--keep 模式保留演练资源"
+
+grep -q 'JUDGE_EVALUATOR_NETWORK=noj-drill_noj-net' \
+  "$TEST_ROOT/backups"/drill-*/.work/env.drill ||
+  fail "演练环境应隔离评测网络名"
+grep -q 'subnet: 172.29.0.0/16' "$TEST_ROOT/backups"/drill-*/.work/compose.drill-override.yml ||
+  fail "演练覆盖 Compose 应使用独立子网"
+pass "演练环境与覆盖 Compose 隔离配置正确"
+
+# ---------------------------------------------------------------------------
+# 3. judge 链路：白名单镜像读取 + 评测验收执行
+# ---------------------------------------------------------------------------
+: >"$FAKE_LOG"
+run_drill "$local_snapshot" --keep --project-name noj-drill >/dev/null 2>&1 ||
+  fail "带 judge 的完整演练应成功"
+grep -q '"step":"evaluation","status":"passed"' \
+  "$TEST_ROOT/backups"/drill-*/.work/verify-output.log ||
+  fail "完整演练应执行真实评测验收"
+pass "完整演练包含真实评测验收"
+
+# ---------------------------------------------------------------------------
+# 4. 失败路径：数据库恢复失败 → 非零退出 + 失败报告 + 资源回收
+# ---------------------------------------------------------------------------
+: >"$FAKE_LOG"
+fail_report="$TEST_ROOT/fail-report.txt"
+if NOJ_DRILL_TEST_FAIL=pg_restore \
+  NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-output.txt" \
+  NOJ_BACKUP_DOCKER_BIN="$FAKE_DOCKER" \
+  bash "$DRILL_SCRIPT" "$local_snapshot" \
+  --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" \
+  --passphrase-file "$PASSPHRASE_FILE" \
+  --report "$fail_report" >/dev/null 2>&1; then
+  fail "pg_restore 失败时演练应失败"
+fi
+grep -q '^result=failed$' "$fail_report" || fail "失败报告应标记 result=failed"
+grep -q '^failed_stage=restore-data$' "$fail_report" ||
+  fail "失败报告应记录失败阶段 restore-data"
+grep -q 'down -v --remove-orphans' "$FAKE_LOG" ||
+  fail "失败时也应执行 down -v 清理"
+pass "数据库恢复失败：非零退出 + 失败报告 + 资源回收"
+
+# ---------------------------------------------------------------------------
+# 5. 失败路径：业务验收失败
+# ---------------------------------------------------------------------------
+: >"$FAKE_LOG"
+biz_fail_report="$TEST_ROOT/biz-fail-report.txt"
+if NOJ_DRILL_TEST_VERIFY_STATUS=1 \
+  NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-failed.txt" \
+  NOJ_BACKUP_DOCKER_BIN="$FAKE_DOCKER" \
+  bash "$DRILL_SCRIPT" "$local_snapshot" \
+  --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" \
+  --passphrase-file "$PASSPHRASE_FILE" \
+  --skip-judge --report "$biz_fail_report" >/dev/null 2>&1; then
+  fail "业务验收失败时演练应失败"
+fi
+grep -q '^result=failed$' "$biz_fail_report" || fail "业务失败报告应标记 result=failed"
+grep -q '^failed_stage=business-verify$' "$biz_fail_report" ||
+  fail "业务失败报告应记录失败阶段 business-verify"
+grep -q '"step":"evaluation","status":"failed"' "$biz_fail_report" ||
+  fail "业务失败报告应保留验收失败现场"
+pass "业务验收失败：非零退出 + 保留失败现场"
+
+# ---------------------------------------------------------------------------
+# 6. 默认报告位置：写入快照目录且演练临时目录被清理
+# ---------------------------------------------------------------------------
+# 清理前序 --keep 用例保留的演练目录，验证默认路径下的资源回收。
+rm -rf "$BACKUP_DIR"/drill-*
+: >"$FAKE_LOG"
+run_drill "$local_snapshot" --skip-judge >/dev/null 2>&1 ||
+  fail "默认报告位置的演练应成功"
+[[ -f "$local_snapshot/restore-drill-report.txt" ]] || fail "默认报告应写入快照目录"
+drill_dirs="$(find "$BACKUP_DIR" -maxdepth 1 -type d -name 'drill-*' | wc -l | tr -d ' ')"
+[[ "$drill_dirs" == "0" ]] || fail "演练临时目录应被清理"
+grep -q 'down -v --remove-orphans' "$FAKE_LOG" ||
+  fail "演练结束应执行 down -v 清理"
+pass "默认报告写入快照目录、资源回收、临时目录已清理"
+
+printf '\n全部恢复演练测试通过。\n'

--- a/scripts/deploy/test-restore-drill.sh
+++ b/scripts/deploy/test-restore-drill.sh
@@ -225,6 +225,10 @@ grep -q 'JUDGE_EVALUATOR_NETWORK=noj-drill_noj-net' \
   fail "演练环境应隔离评测网络名"
 grep -q 'subnet: 172.29.0.0/16' "$TEST_ROOT/backups"/drill-*/.work/compose.drill-override.yml ||
   fail "演练覆盖 Compose 应使用独立子网"
+rg -Fq 'image: denoland/deno:debian-2.9.5@sha256:' "$TEST_ROOT/backups"/drill-*/.work/compose.drill-override.yml ||
+  fail "演练覆盖 Compose 应包含固定版本的 Deno 验收容器"
+rg -Fq 'DO $role$ BEGIN IF NOT EXISTS' "$TEST_ROOT/backups"/drill-*/.work/postgres-globals.sql ||
+  fail "PostgreSQL 全局对象恢复应幂等处理已有角色"
 pass "演练环境与覆盖 Compose 隔离配置正确"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概述

解决上线准备评估的三个 P1 issue：#428、#429、#431（关联 #326 / #327 / #328）。

## #428 备份隔离恢复与业务验收演练

- 新增 `scripts/deploy/restore-drill.sh` + `restore-drill-verify.ts`：将快照恢复到独立 Compose 项目（独立数据卷、独立子网 `--subnet`、不映射宿主机端口、不接触生产卷；项目名禁止包含 `prod`）。
- 恢复后经真实 API 验收：管理员登录、题目读取、附件（支持包）下载、一次真实双容器评测（import-bundle 导入 A+B 演练题 → self-test 走完整 judge 沙箱链路）；`--skip-judge` 可跳过评测。
- 报告记录快照时间、恢复耗时、数据核对（迁移版本/用户数/Redis 键数/对象数）、业务明细与 RPO/RTO 目标达标情况；损坏快照、解密失败、数据库恢复失败、业务失败均非零退出并保留失败现场报告；默认 `down -v` 回收资源，`--keep` 保留现场。
- `backup.sh drill` 明确标注 `drill_type=file-verification-only` 并指向新脚本，消除"文件校验=可恢复"的误导。
- 凭证说明：报告含备份快照与 GPG 口令异地独立保存说明。

## #429 告警投递、失联检测与通知演练

- `noj-alerts.yml` 新增：`NojCoreScrapeDown`（`up{job="noj-core"}==0`）、`NojCoreMetricsMissing`（absent）、`NojJudgeHeartbeatMissing`、`NojApiErrorRateRecent{Warning,Critical}`（5 分钟滑动窗口，替代进程累计比例）、`NojBackup{Stale,VeryStale,MetricMissing}`、`NojRestoreDrillStale`。
- `prometheus.yml` 增加 Alertmanager 告警段；新增 `alertmanager.yml.example`（`envsubst` 渲染注入凭据，凭据不入库）与 `deploy/monitoring/README.md`（组件部署、textfile collector 配置、验证清单）。
- `scripts/deploy/test-alert.sh`：注入 critical/warning 演练告警并发送 resolved，配套演练记录表。
- Runbook（observability.md）改为显式 `{#anchor}` 小节，全部告警注解可定位处理步骤；`backup.sh create` / drill 输出 `noj_backup.prom` / `noj_restore_drill.prom` textfile 指标供新鲜度告警使用。

## #431 Release 就绪窗口

- `release.yml` 改为 `prereleased` 触发，非预发布事件在构建前被显式拒绝；正式镜像 tag 已存在且指向不同构建时拒绝覆盖（防版本混用）；新增 `publish-release` 任务在镜像/CLI/校验资产全部就绪后把预发布转正。
- `install.sh resolve_latest_ref` 只选择非 draft、非 prerelease 且资产包含 `noj-cli-linux-amd64` + `.sha256` 的 Release，无可选版本时给出明确提示。

## 测试

- `scripts/deploy/test-restore-drill.sh`：fake docker 全链路编排测试（隔离配置、报告内容、失败路径、资源回收、目录唯一性）。
- `scripts/deploy/restore-drill-verify_test.ts`：mock API 下业务验收全链路（zip 构造/导入/鉴权 Cookie/评测轮询/失败退出）。
- `scripts/deploy/test-monitoring.sh`：告警 runbook 注解 ↔ Runbook 锚点一致性、prometheus/alertmanager 结构、test-alert 负载回放。
- `test-install.sh` 新增 Release 过滤与无就绪版本拒绝用例；`test-backup.sh` 回归通过。
- 根门禁 `check-ci.ts`、Agent Note 格式校验通过；提交已 GPG 签名。

## 验证边界（对应各 issue 的验证边界章节）

- 隔离恢复演练、告警通知接收、发布流程的实际执行验收需在生产/预发环境完成后，按文档记录实际版本、命令与结果；本 PR 交付可部署方案与可验证工具。