### PR TITLE
fix(root): 升级与 noj-cli 版本解析补齐 Release 资产就绪过滤

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-06-release-update-asset-ready-filter.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-06-release-update-asset-ready-filter.md
@@ -1,0 +1,48 @@
+# Agent Note: 升级路径与 noj-cli 补齐 Release 资产就绪过滤
+
+Status: implemented
+
+## Problem
+
+issue #431 的主体修复（#442）只把"资产就绪"过滤加到了安装器
+`install.sh resolve_latest_ref`；两条仍然使用 `/releases/latest` 的路径
+可以在维护者绕过预发布流程直接发布正式 Release 时选中缺少 CLI 资产的版本：
+
+1. `noj-cli update --latest`（`scripts/deploy/production.sh
+   latest_release_version`）只校验 draft / prerelease 标记，不校验资产，
+   违反"安装与升级使用同一版本集合"的验收标准。
+2. `noj-cli` 内部的 `resolveLatestVersion`（deploy init 向导与
+   `ensureNojServerBinary` 的默认版本解析）同样未过滤。
+
+## Decision
+
+- `production.sh latest_release_version` 默认改用 `/releases?per_page=100`
+  列表端点，用与 `install.sh resolve_latest_ref` 完全相同的 awk 过滤规则
+  （稳定 tag + 非 draft + 非 prerelease + `noj-cli-linux-amd64` 与
+  `.sha256` 资产齐全）选择版本；无可选版本时明确报错并提示固定版本升级。
+  保留 `NOJ_UPDATE_API_URL` 自定义端点：响应为 JSON 数组时走列表过滤，
+  单个对象时维持原有 draft / prerelease 校验（兼容既有测试钩子）。
+- `noj-cli/src/runtime/download.ts resolveLatestVersion` 同步改为列表
+  过滤，规则与安装器一致；无资产就绪版本时抛出明确错误。
+- 测试：`test-noj.sh` 新增"拒绝缺少 CLI 资产的最新 Release"与"选择资产
+  就绪的旧版本"两个用例（mock curl 支持 `NOJ_UPDATE_TEST_LIST` 返回
+  列表 JSON）；`download_test.ts` 重写 `resolveLatestVersion` 用例，
+  覆盖跳过 prerelease / draft / 缺资产版本、无可选版本抛错。
+- 文档：`noj-docs/docs/operators/production-deploy.md` §5 说明
+  `update --latest` 与安装器使用同一过滤规则。
+
+## Alternatives considered
+
+- 仅依赖预发布转正流程、不改升级路径：转正后的正式 Release 一定带资产，
+  但维护者手动 published 的版本会绕过门禁成为 `/releases/latest` 的候选；
+  双重过滤需要在所有默认选版本入口保持一致。
+- 在 `resolveLatestVersion` 之外新增独立的"资产就绪版本解析"函数：调用方
+  （deploy init 向导）没有需要区分的场景，两套入口反而容易漂移。
+
+## Consequences
+
+- `update --latest` 与安装器一样要求 Release 已上传 noj-cli 资产；如果
+  未来引入其他分发渠道（不含 noj-cli 资产的正式 Release），需要同步调整
+  `install.sh`、`production.sh`、`download.ts` 三处过滤规则。
+- `resolveLatestVersion` 现在解析整个 Release 列表，请求体积从单对象变为
+  分页列表（per_page=100），对公开仓库可接受。

--- a/noj-cli/src/runtime/download.ts
+++ b/noj-cli/src/runtime/download.ts
@@ -9,20 +9,44 @@ const API_BASE = `https://api.github.com/repos/${REPO}`;
 /** 当前内置默认版本（网络不可用时的回退值）。 */
 export const DEFAULT_NOJ_SERVER_VERSION = "0.1.0";
 
-/** 解析 GitHub 最新 Release 的精确版本号（去掉前导 v）。 */
+/** GitHub Release 列表条目中本模块需要的字段。 */
+interface ReleaseSummary {
+  tag_name?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  assets?: { name?: string }[];
+}
+
+/**
+ * 解析 GitHub 最新稳定 Release 的精确版本号（去掉前导 v）。
+ *
+ * 与 scripts/deploy/install.sh 的过滤规则一致：只选择非 draft、非 prerelease
+ * 且资产中已包含 noj-cli 二进制与校验文件的 Release（issue #431），
+ * 避免选中"已发布但镜像 / CLI 资产尚未就绪"的版本。
+ */
 export async function resolveLatestVersion(): Promise<string> {
-  const res = await fetch(`${API_BASE}/releases/latest`, {
+  const res = await fetch(`${API_BASE}/releases?per_page=100`, {
     headers: { Accept: "application/vnd.github+json" },
   });
   if (!res.ok) {
     throw new Error(`解析最新版本失败: GitHub API ${res.status}`);
   }
-  const data = await res.json() as { tag_name?: string };
-  const tag = data.tag_name;
-  if (!tag) {
-    throw new Error("解析最新版本失败: 响应缺少 tag_name");
+  const releases = await res.json() as ReleaseSummary[];
+  if (!Array.isArray(releases)) {
+    throw new Error("解析最新版本失败: 响应不是 Release 列表");
   }
-  return tag.replace(/^v/, "");
+  for (const release of releases) {
+    const tag = release.tag_name ?? "";
+    if (!/^v?[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) continue;
+    if (release.draft || release.prerelease) continue;
+    const names = new Set((release.assets ?? []).map((asset) => asset.name));
+    if (!names.has("noj-cli-linux-amd64")) continue;
+    if (!names.has("noj-cli-linux-amd64.sha256")) continue;
+    return tag.replace(/^v/, "");
+  }
+  throw new Error(
+    "没有发现资产就绪的正式 Release（需要包含 noj-cli 二进制与校验文件），请显式指定版本",
+  );
 }
 
 /** 确保 install_dir/bin/noj-server 存在且版本匹配；缺失时自动下载并校验。 */

--- a/noj-cli/src/runtime/download_test.ts
+++ b/noj-cli/src/runtime/download_test.ts
@@ -27,19 +27,73 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+/** 构造一个资产就绪的稳定 Release 条目。 */
+function readyRelease(tag: string): Record<string, unknown> {
+  return {
+    tag_name: tag,
+    draft: false,
+    prerelease: false,
+    assets: [
+      { name: "noj-cli-linux-amd64" },
+      { name: "noj-cli-linux-amd64.sha256" },
+    ],
+  };
+}
+
 Deno.test("resolveLatestVersion: 去掉前导 v 并返回 tag", async () => {
   try {
     const calls: string[] = [];
     mockFetch((url) => {
       calls.push(String(url));
-      return jsonResponse({ tag_name: "v0.2.0" });
+      return jsonResponse([readyRelease("v0.2.0")]);
     });
     const version = await resolveLatestVersion();
     assertEquals(version, "0.2.0");
     assertEquals(calls.length, 1);
     assertEquals(
       calls[0],
-      "https://api.github.com/repos/Neuro-OJ/neuro-oj/releases/latest",
+      "https://api.github.com/repos/Neuro-OJ/neuro-oj/releases?per_page=100",
+    );
+  } finally {
+    restoreFetch();
+  }
+});
+
+Deno.test("resolveLatestVersion: 跳过预发布、草稿和缺少 CLI 资产的版本", async () => {
+  try {
+    mockFetch(() =>
+      jsonResponse([
+        { tag_name: "v0.3.0-rc.1", draft: false, prerelease: true, assets: [] },
+        { tag_name: "v0.3.0", draft: true, prerelease: false, assets: [] },
+        { tag_name: "v0.2.5", draft: false, prerelease: false, assets: [] },
+        {
+          tag_name: "v0.2.4",
+          draft: false,
+          prerelease: false,
+          assets: [{ name: "noj-cli-linux-amd64" }],
+        },
+        readyRelease("v0.2.3"),
+      ])
+    );
+    const version = await resolveLatestVersion();
+    assertEquals(version, "0.2.3");
+  } finally {
+    restoreFetch();
+  }
+});
+
+Deno.test("resolveLatestVersion: 没有资产就绪的正式 Release 时抛错", async () => {
+  try {
+    mockFetch(() =>
+      jsonResponse([
+        { tag_name: "v0.2.0", draft: false, prerelease: false, assets: [] },
+        { tag_name: "v0.3.0-rc.1", draft: false, prerelease: true, assets: [] },
+      ])
+    );
+    await assertRejects(
+      () => resolveLatestVersion(),
+      Error,
+      "没有发现资产就绪的正式 Release",
     );
   } finally {
     restoreFetch();
@@ -59,13 +113,13 @@ Deno.test("resolveLatestVersion: HTTP 非 2xx 抛错", async () => {
   }
 });
 
-Deno.test("resolveLatestVersion: 缺少 tag_name 抛错", async () => {
+Deno.test("resolveLatestVersion: 响应不是 Release 列表时抛错", async () => {
   try {
-    mockFetch(() => jsonResponse({}));
+    mockFetch(() => jsonResponse({ tag_name: "v0.2.0" }));
     await assertRejects(
       () => resolveLatestVersion(),
       Error,
-      "缺少 tag_name",
+      "响应不是 Release 列表",
     );
   } finally {
     restoreFetch();

--- a/noj-docs/docs/operators/production-deploy.md
+++ b/noj-docs/docs/operators/production-deploy.md
@@ -142,6 +142,10 @@ noj-cli update
 noj-cli update --latest
 ```
 
+`update --latest` 与安装器使用同一过滤规则（issue #431）：只选择非 draft、
+非 prerelease 且资产中包含 `noj-cli-linux-amd64` 与 `.sha256` 的 Release，
+保证安装与升级使用同一版本集合，不会选中资产未就绪的版本。
+
 升级前会创建并校验备份，拉取镜像，执行数据库迁移并等待健康检查；不会删除数据卷。若失败，
 先查看 `noj-cli status` 和 `noj-cli logs`，再把 `NOJ_VERSION` 改回上一个已验证版本并执行 `noj-cli update`。
 数据库迁移只追加，不会自动回滚，因此跨大版本升级前必须确认迁移兼容性。

--- a/scripts/deploy/production.sh
+++ b/scripts/deploy/production.sh
@@ -260,31 +260,62 @@ latest_release_version() {
   else
     [[ "$repository" =~ ^https://github\.com/([^/]+/[^/]+)$ ]] ||
       fail "无法自动获取最新版本；请使用 NOJ_UPDATE_API_URL 或固定版本升级"
-    metadata_url="https://api.github.com/repos/${BASH_REMATCH[1]}/releases/latest"
+    # 与 install.sh 保持一致：按 Release 列表过滤，而不是 /releases/latest，
+    # 避免升级选中"已发布但镜像 / CLI 资产尚未就绪"的版本（issue #431），
+    # 保证安装与升级使用同一版本集合。
+    metadata_url="https://api.github.com/repos/${BASH_REMATCH[1]}/releases?per_page=100"
   fi
   [[ "$metadata_url" == https://* ]] ||
     fail "最新版本 API 地址必须使用 HTTPS"
 
-  printf '正在获取最新稳定 Release\n' >&2
+  printf '正在获取可用 Release\n' >&2
   if command -v curl >/dev/null 2>&1; then
     metadata="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
       --retry 3 --connect-timeout 15 --header 'Accept: application/vnd.github+json' \
       --header 'User-Agent: neuro-oj-updater' "$metadata_url")" ||
-      fail "无法获取最新稳定 Release，请检查网络，或使用固定版本重试"
+      fail "无法获取 Release 列表，请检查网络，或使用固定版本升级"
   elif command -v wget >/dev/null 2>&1; then
     metadata="$(wget --https-only --tries=3 --timeout=20 --quiet \
       --header='Accept: application/vnd.github+json' --header='User-Agent: neuro-oj-updater' \
       -O - "$metadata_url")" ||
-      fail "无法获取最新稳定 Release，请检查网络，或使用固定版本重试"
+      fail "无法获取 Release 列表，请检查网络，或使用固定版本升级"
   else
     fail "需要 curl 或 wget 才能查询最新稳定 Release"
   fi
 
-  tag="$(json_field tag_name <<<"$metadata")"
-  draft="$(json_field draft <<<"$metadata")"
-  prerelease="$(json_field prerelease <<<"$metadata")"
-  [[ -n "$tag" && "$draft" == false && "$prerelease" == false ]] ||
-    fail "GitHub 返回的最新 Release 无效或仍是预发布版本"
+  if [[ "$metadata" == \[* ]]; then
+    # Release 列表：只选择非 draft、非 prerelease 且 CLI 资产（二进制与校验
+    # 文件）就绪的版本，过滤规则与 install.sh 的 resolve_latest_ref 一致。
+    tag="$(awk '
+      {
+        text = text $0 "\n"
+      }
+      END {
+        n = split(text, chunks, /"tag_name"[[:space:]]*:[[:space:]]*"/)
+        for (i = 2; i <= n; i++) {
+          chunk = chunks[i]
+          tag = chunk
+          sub(/".*/, "", tag)
+          if (tag !~ /^v?[0-9]+\.[0-9]+\.[0-9]+/) continue
+          if (chunk ~ /"draft"[[:space:]]*:[[:space:]]*true/) continue
+          if (chunk ~ /"prerelease"[[:space:]]*:[[:space:]]*true/) continue
+          if (chunk !~ /"name"[[:space:]]*:[[:space:]]*"noj-cli-linux-amd64"/) continue
+          if (chunk !~ /"name"[[:space:]]*:[[:space:]]*"noj-cli-linux-amd64\.sha256"/) continue
+          print tag
+          exit
+        }
+      }
+    ' <<<"$metadata")"
+    [[ -n "$tag" ]] ||
+      fail "没有发现资产就绪的正式 Release（需要包含 noj-cli 二进制与校验文件），请使用固定版本升级"
+  else
+    # 单个 Release 对象（自定义 API 地址）：仅校验稳定版本标记。
+    tag="$(json_field tag_name <<<"$metadata")"
+    draft="$(json_field draft <<<"$metadata")"
+    prerelease="$(json_field prerelease <<<"$metadata")"
+    [[ -n "$tag" && "$draft" == false && "$prerelease" == false ]] ||
+      fail "GitHub 返回的最新 Release 无效或仍是预发布版本"
+  fi
   validate_release_tag "$tag"
   printf '%s\n' "$tag"
 }

--- a/scripts/deploy/test-noj.sh
+++ b/scripts/deploy/test-noj.sh
@@ -45,6 +45,7 @@ chmod 755 "$TEST_ROOT/scripts/deploy/install.sh"
 printf '%s\n' '#!/usr/bin/env bash' \
   'set -Eeuo pipefail' \
   'if [[ "${NOJ_UPDATE_TEST_API_FAIL:-0}" == 1 ]]; then exit 22; fi' \
+  'if [[ "${NOJ_UPDATE_TEST_LIST:-0}" == 1 ]]; then printf "%s\n" "${NOJ_UPDATE_TEST_LIST_JSON:-[]}"; exit 0; fi' \
   'printf '\''{"tag_name":"%s","draft":false,"prerelease":false}\n'\'' "${NOJ_UPDATE_TEST_LATEST_TAG:-v0.2.0}"' \
   >"$TEST_ROOT/curl"
 chmod 755 "$TEST_ROOT/curl"
@@ -182,6 +183,23 @@ after_rc_log="$(wc -l <"$LOG_FILE")"
 [[ "$before_rc_log" == "$after_rc_log" ]] || fail "RC 标签被拒绝前不应进入升级流程"
 grep -E -q '不是稳定版本标签|无效或仍是预发布版本' "$TEST_ROOT/latest-rc.out" || fail "RC 标签拒绝提示不清晰"
 pass "update --latest 拒绝 RC 标签"
+
+# 升级与安装使用同一版本集合：/releases 列表中缺少 CLI 资产的版本不可被选中（issue #431）
+cp "$TEST_ROOT/.env.prod" "$TEST_ROOT/asset-filter.env"
+before_asset_filter="$(sha256sum "$TEST_ROOT/asset-filter.env" 2>/dev/null || shasum "$TEST_ROOT/asset-filter.env")"
+if NOJ_UPDATE_TEST_LIST=1 NOJ_UPDATE_TEST_LIST_JSON='[{"tag_name":"v0.3.0","draft":false,"prerelease":false,"assets":[]},{"tag_name":"v0.2.0-rc.1","draft":false,"prerelease":true,"assets":[]}]' \
+  run_noj update --latest --env-file "$TEST_ROOT/asset-filter.env" >"$TEST_ROOT/latest-asset-filter.out" 2>&1; then
+  fail "升级不应选择缺少 CLI 资产的 Release"
+fi
+after_asset_filter="$(sha256sum "$TEST_ROOT/asset-filter.env" 2>/dev/null || shasum "$TEST_ROOT/asset-filter.env")"
+[[ "$before_asset_filter" == "$after_asset_filter" ]] || fail "缺少资产 Release 被拒绝时修改了生产配置"
+grep -q '没有发现资产就绪的正式 Release' "$TEST_ROOT/latest-asset-filter.out" || fail "缺少资产 Release 的拒绝提示不清晰"
+pass "update --latest 拒绝缺少 CLI 资产的 Release"
+
+NOJ_UPDATE_TEST_LIST=1 NOJ_UPDATE_TEST_LIST_JSON='[{"tag_name":"v0.3.0","draft":false,"prerelease":false,"assets":[]},{"tag_name":"v0.2.0","draft":false,"prerelease":false,"assets":[{"name":"noj-cli-linux-amd64"},{"name":"noj-cli-linux-amd64.sha256"}]}]' \
+  run_noj update --latest >"$TEST_ROOT/latest-asset-ready.out"
+grep -q '最新稳定版本：v0.2.0' "$TEST_ROOT/latest-asset-ready.out" || fail "升级未选择资产就绪的旧版本"
+pass "update --latest 选择资产就绪的版本"
 
 cp "$TEST_ROOT/.env.prod" "$TEST_ROOT/api-failure.env"
 before_api_failure="$(sha256sum "$TEST_ROOT/api-failure.env" 2>/dev/null || shasum "$TEST_ROOT/api-failure.env")"


### PR DESCRIPTION
## 关联 Issue

Relates to #431（#442 已完成主体修复；本 PR 补齐剩余的升级路径缺口。issue 保持开放至"干净 Linux 环境安装验收"完成后关闭）

## 变更摘要

- `noj-cli update --latest`（`scripts/deploy/production.sh latest_release_version`）与 noj-cli 内部 `resolveLatestVersion` 原先直接使用 `/releases/latest`，只校验 draft / prerelease 标记；维护者绕过预发布流程直接发布正式 Release 时，升级会选中缺少 CLI 资产的版本。现统一改为 `/releases?per_page=100` 列表过滤，规则与 `install.sh resolve_latest_ref` 完全一致（稳定 tag + 非 draft + 非 prerelease + `noj-cli-linux-amd64` 与 `.sha256` 资产齐全），无可选版本时明确报错。
- 保留 `NOJ_UPDATE_API_URL` 自定义端点兼容：响应为 JSON 数组时走列表过滤，单个对象时维持原有校验（兼容既有测试钩子）。

## 变更类型

- [x] `fix` Bug 修复
- [x] `test` 测试
- [x] `docs` 文档

## 影响范围

- [x] 文档（README / noj-docs）

## 验证清单

- [x] `deno fmt` 已运行（noj-cli）
- [x] `deno lint` 已运行
- [x] 本地 `deno task test` 通过（noj-cli 179 通过）
- [x] 新功能 / 修复有对应测试
- [x] 提交信息符合 Conventional Commits（`<type>(<scope>): 中文描述`）
- [x] 非平凡变更包含 Agent Note（`.agents/notes/implemented/bug-fix/2026-09-06-release-update-asset-ready-filter.md`）
- [x] 相关文档已同步（`noj-docs/docs/operators/production-deploy.md` §5）
- [x] GPG 签名可用

测试明细：

- `scripts/deploy/test-noj.sh` 新增两个用例：拒绝缺少 CLI 资产的最新 Release（保护 `.env.prod` 不被修改）、选择资产就绪的旧版本；mock curl 支持 `NOJ_UPDATE_TEST_LIST` 返回列表 JSON。
- `noj-cli/src/runtime/download_test.ts` 重写 `resolveLatestVersion` 用例：跳过 prerelease / draft / 缺资产版本、无可选版本抛错、列表端点 URL 断言。
- `deno task check`（fmt + lint + check）无警告。

## 补充说明（可选）

- 修改 `scripts/deploy/production.sh` 后 `install.sh`（未改动）行为不变，两者过滤规则保持一致，均指向 issue #431 注释。
- 风险：`update --latest` 与安装器一样要求 Release 已上传 noj-cli 资产；若未来引入不含该资产的分发渠道，需同步调整 `install.sh`、`production.sh`、`download.ts` 三处规则（已在 Agent Note 记录）。
- 回滚方案：整体 revert 本 PR 即可，无数据或部署状态变更。