### PR TITLE
docs(root): 明确贡献 PR 目标分支

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,8 @@ git pull --ff-only
 git switch -c docs/contributing-guide
 ```
 
+完成修改后请创建 Pull Request，并将目标分支设置为 `main`；不要直接向 `main` 推送贡献提交。
+
 提交 Pull Request 前请确认：
 
 - 改动范围与 Issue 描述一致，并在 PR 中关联 Issue，例如 `Closes #433`；


### PR DESCRIPTION
补充 CONTRIBUTING.md，明确贡献者完成修改后应创建 Pull Request，并将目标分支设置为 main；同时禁止直接向 main 推送贡献提交。Issue #433 的主体文档已先行合入 main，本 PR 仅补充流程说明。