### PR TITLE
fix(root): 兼容轻量恢复演练

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-06-restore-drill-pg-stdin.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-06-restore-drill-pg-stdin.md
@@ -1,0 +1,42 @@
+# Agent Note: 修复隔离恢复演练的 PostgreSQL 标准输入读取
+
+Status: implemented
+
+## Problem
+
+在 sng 的真实隔离恢复演练中，`restore-drill.sh` 将自定义格式 PostgreSQL dump
+通过标准输入重定向给 `pg_restore`，同时又额外传入了 `-`。目标环境的 `pg_restore`
+将该参数解释为容器内文件路径而非标准输入，导致恢复在 PostgreSQL 数据阶段失败。
+修复后继续演练时，用户传入的相对快照路径又被 Compose 解释为具名 volume，导致
+MinIO 快照目录无法作为 bind mount 挂载。
+继续演练还发现 sng 的历史快照早于邮箱验证迁移，`users` 表没有
+`email_verified` 字段，演练管理员种子写入因此失败。
+旧版 core 的登录接口还会在 JSON 响应中返回 token，而不是直接下发 Cookie；验收脚本
+此前只接受 Cookie，因而把成功登录错误标记为失败。
+
+## Decision
+
+省略 `pg_restore` 的文件位置参数，仅保留宿主机快照到 `docker compose exec -T` 的
+标准输入重定向；在通过快照目录安全校验后规范化为绝对路径，再用于 Compose bind
+mount。补充 fake Docker 演练测试，断言恢复命令以 `-d <database>` 结束且不再传入
+字面量 `-`，并覆盖相对快照路径及不依赖 `email_verified` 字段的管理员种子写入。
+业务验收同时兼容 Cookie 与 JSON token，并在直连 core 时附带 Bearer token。
+
+## Alternatives considered
+
+- 保留 `-` 并针对特定 PostgreSQL 版本加兼容分支：增加环境差异，且不符合
+  `pg_restore` 省略文件参数时读取标准输入的通用用法。
+- 先将 dump 拷贝进 PostgreSQL 容器再传入容器路径：需要额外临时文件、清理与权限
+  处理，扩大演练现场和失败恢复面。
+- 要求调用者始终传绝对路径：容易遗漏，且脚本既支持相对快照目录就应在边界统一
+  规范化，避免把可预防的运行时错误交给运维人员。
+- 为旧 schema 单独查询字段并拼接 SQL：可以工作，但新 schema 已为已验证账户提供
+  正确默认值，省略该可选字段即可满足新旧快照，分支更少且不增加 schema 探测失败面。
+- 只在验收容器内保留 Cookie：直连 core 的认证约定是 Authorization，且历史登录
+  响应不一定下发 Cookie，无法覆盖真实恢复出的旧版本服务。
+
+## Consequences
+
+隔离恢复演练可直接读取受保护快照，无需在容器内复制 dump，且从仓库目录运行时
+可安全传入相对快照路径。未部署 Judge 的开源轻量环境可显式使用 `--skip-judge`，
+完成恢复、数据核对、登录和题目读取验收；附件与双容器评测只在启用 Judge 时验收。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,8 @@ git pull --ff-only
 git switch -c docs/contributing-guide
 ```
 
+完成修改后请创建 Pull Request，并将目标分支设置为 `main`；不要直接向 `main` 推送贡献提交。
+
 提交 Pull Request 前请确认：
 
 - 改动范围与 Issue 描述一致，并在 PR 中关联 Issue，例如 `Closes #433`；

--- a/scripts/deploy/restore-drill-verify.ts
+++ b/scripts/deploy/restore-drill-verify.ts
@@ -3,7 +3,8 @@
  *
  * 由 scripts/deploy/restore-drill.sh 在隔离恢复出的 core 容器内执行
  * （`docker compose run core deno run -A /opt/verify.ts ...`），面向真实
- * HTTP API 验证恢复后的业务链路：登录、题目读取、附件下载与真实评测。
+ * HTTP API 验证恢复后的业务链路：登录、题目读取；未跳过 Judge 时还会验证附件
+ * 下载与真实评测。
  *
  * 输出：每个步骤一行 JSON（{"step","status","detail"}），最后一行输出
  * {"step":"summary","status":...,"passed":bool,"steps":[...]}，由外层脚本
@@ -52,8 +53,9 @@ const EVALUATOR_IMAGE = optEnv("DRILL_EVALUATOR_IMAGE");
 const SOLUTION_IMAGE = optEnv("DRILL_SOLUTION_IMAGE");
 const SKIP_EVALUATION = Deno.env.get("DRILL_SKIP_EVALUATION") === "1";
 
-/** 与生产一致的 cookie 名；HttpOnly JWT 由登录响应下发。 */
+/** 与生产一致的认证凭据；历史 core 直接在 JSON 响应返回 token。 */
 let authCookie = "";
+let authToken = "";
 
 async function api(
   method: string,
@@ -62,14 +64,23 @@ async function api(
 ): Promise<Response> {
   const headers = new Headers(init.headers);
   if (authCookie) headers.set("Cookie", authCookie);
+  if (authToken) headers.set("Authorization", `Bearer ${authToken}`);
   return await fetch(`${BASE_URL}${path}`, { method, ...init, headers });
 }
 
-/** 解析响应中的 Set-Cookie，保存 noj:token 供后续请求鉴权。 */
-function captureAuthCookie(res: Response): void {
+/** 兼容 Cookie 与 JSON token 两种登录响应，供后续直连 core 的验收请求鉴权。 */
+function captureAuth(res: Response, payload: unknown): void {
   const setCookie = res.headers.get("set-cookie") ?? "";
   const match = setCookie.match(/(?:^|[,\s])noj:token=([^;,\s]+)/);
-  if (match) authCookie = `noj:token=${match[1]}`;
+  if (match) {
+    authToken = match[1];
+    authCookie = `noj:token=${authToken}`;
+    return;
+  }
+  const candidate =
+    (payload as { data?: { token?: unknown }; token?: unknown })?.data
+      ?.token ?? (payload as { token?: unknown })?.token;
+  if (typeof candidate === "string" && candidate) authToken = candidate;
 }
 
 // ---------------------------------------------------------------------------
@@ -242,7 +253,6 @@ async function stepLogin(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ login: ADMIN_USER, password: ADMIN_PASSWORD }),
   });
-  captureAuthCookie(res);
   if (res.status !== 200) {
     required(
       "login",
@@ -252,11 +262,12 @@ async function stepLogin(): Promise<void> {
     return;
   }
   const payload = await res.json();
+  captureAuth(res, payload);
   const username = payload?.data?.username ?? ADMIN_USER;
   required(
     "login",
-    Boolean(authCookie),
-    `管理员 ${username} 登录成功并下发会话 Cookie`,
+    Boolean(authToken),
+    `管理员 ${username} 登录成功并取得认证令牌`,
   );
 }
 
@@ -411,6 +422,15 @@ async function stepRegisterProbe(): Promise<void> {
 async function main(): Promise<void> {
   await stepLogin();
   if (requiredFailure) {
+    finish();
+    return;
+  }
+
+  // 轻量验收不依赖 Judge 镜像白名单：验证恢复后的认证与题目查询即可。
+  // 附件下载和真实评测属于启用 Judge 后的扩展验收。
+  if (SKIP_EVALUATION) {
+    await stepProblemRead(null);
+    await stepRegisterProbe();
     finish();
     return;
   }

--- a/scripts/deploy/restore-drill-verify_test.ts
+++ b/scripts/deploy/restore-drill-verify_test.ts
@@ -27,12 +27,13 @@ Deno.test("恢复演练业务验收：全链路通过", async () => {
     const path = url.pathname;
     if (path === "/api/v1/auth/login" && req.method === "POST") {
       return new Response(
-        JSON.stringify({ data: { username: "drill_admin" } }),
+        JSON.stringify({
+          data: { username: "drill_admin", token: "drill-jwt" },
+        }),
         {
           status: 200,
           headers: {
             "Content-Type": "application/json",
-            "Set-Cookie": "noj:token=drill-jwt; HttpOnly; Path=/; SameSite=Lax",
           },
         },
       );
@@ -66,8 +67,8 @@ Deno.test("恢复演练业务验收：全链路通过", async () => {
     }
     if (path === "/api/v1/problems/drill-problem-1/support-package") {
       assert(
-        (req.headers.get("Cookie") ?? "").includes("noj:token=drill-jwt"),
-        "支持包下载应携带会话 Cookie",
+        req.headers.get("Authorization") === "Bearer drill-jwt",
+        "支持包下载应携带 JSON 登录响应中的 Bearer token",
       );
       // 最小 zip：PK 头 + 尾部字节。
       return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
@@ -121,7 +122,7 @@ Deno.test("恢复演练业务验收：全链路通过", async () => {
     const summary = steps.find((s) => s.step === "summary");
     assert(summary, "应输出 summary 行");
     assert(
-      summary.status === "passed",
+      summary?.status === "passed",
       `全链路应通过，实际步骤：${JSON.stringify(steps)}`,
     );
     assert(output.code === 0, "业务验收通过时进程应以 0 退出");
@@ -178,6 +179,57 @@ Deno.test("恢复演练业务验收：登录失败立即失败", async () => {
     assert(
       !steps.some((s) => s.step === "summary" && s.status === "passed"),
       "不应输出通过的 summary",
+    );
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("恢复演练业务验收：跳过 Judge 时不导入评测题目", async () => {
+  const handler = (req: Request): Response => {
+    const path = new URL(req.url).pathname;
+    if (path === "/api/v1/auth/login") {
+      return Response.json({
+        data: { username: "drill_admin", token: "drill-jwt" },
+      });
+    }
+    if (path === "/api/v1/problems") return Response.json({ data: [] });
+    if (path === "/api/v1/auth/register") {
+      return Response.json({ data: {} }, { status: 201 });
+    }
+    if (path === "/api/v1/problems/import-bundle") {
+      return new Response("轻量验收不应导入评测题目", { status: 500 });
+    }
+    return new Response("not found", { status: 404 });
+  };
+  const server = Deno.serve({ port: 0, handler });
+  const port = (server.addr as Deno.NetAddr).port;
+  try {
+    const output = await new Deno.Command("deno", {
+      args: ["run", "-A", "--no-check", scriptPath],
+      env: {
+        DRILL_BASE_URL: `http://127.0.0.1:${port}/api/v1`,
+        DRILL_ADMIN_USER: "drill_admin",
+        DRILL_ADMIN_PASSWORD: "Drill-Recover-2026",
+        DRILL_EVALUATOR_IMAGE: "noj-evaluator-python",
+        DRILL_SOLUTION_IMAGE: "noj-solution-python",
+        DRILL_SKIP_EVALUATION: "1",
+      },
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const steps = new TextDecoder().decode(output.stdout).trim().split("\n")
+      .map((line) => JSON.parse(line) as StepLine);
+    assert(output.code === 0, "轻量验收应通过");
+    assert(
+      steps.some((step) =>
+        step.step === "problem_read" && step.status === "passed"
+      ),
+      "应读取题目",
+    );
+    assert(
+      !steps.some((step) => step.step === "problem_import"),
+      "不应导入评测题目",
     );
   } finally {
     await server.shutdown();

--- a/scripts/deploy/restore-drill.sh
+++ b/scripts/deploy/restore-drill.sh
@@ -3,8 +3,8 @@
 #
 # 与 backup.sh drill（纯文件校验）不同，本脚本把快照真实恢复到一个独立的
 # Compose 项目（独立数据卷、独立网络子网、不映射宿主机端口），随后验收业务：
-# 登录、题目读取、附件下载和至少一次真实评测。任何环节失败都以非零退出并
-# 保留诊断报告。
+# 登录、题目读取；启用 Judge 时还会验收附件下载与真实评测。任何环节失败都以
+# 非零退出并保留诊断报告。
 #
 # 用法：restore-drill.sh SNAPSHOT [选项]
 # 详见 usage()。
@@ -63,7 +63,7 @@ Neuro OJ 备份隔离恢复演练
 
 与 backup.sh drill（快照文件校验）不同，本命令把快照真实恢复到独立 Compose
 项目（独立数据卷、独立子网、不占用宿主机端口），恢复后通过真实 API 验收：
-登录、题目读取、附件（支持包）下载与一次真实评测。
+登录与题目读取；未使用 --skip-judge 时还会验证附件（支持包）下载与一次真实评测。
 
 选项：
   --env-file FILE          生产环境文件（默认 .env.prod）
@@ -76,7 +76,7 @@ Neuro OJ 备份隔离恢复演练
   --rpo-max-hours N        RPO 目标：快照允许的最大时长（默认 24 小时）
   --rto-max-minutes N      RTO 目标：恢复+验收允许的最大时长（默认 60 分钟）
   --wait-timeout N         Compose 服务等待超时秒数（默认 300）
-  --skip-judge             跳过真实评测（仍执行登录/题目/附件验收）
+  --skip-judge             轻量验收：跳过 Judge、题目导入和附件/评测验收，仅验证登录与题目读取
   --keep                   保留演练临时目录与 Compose 资源供人工检查
   -h, --help               显示帮助
 
@@ -242,6 +242,9 @@ parse_args() {
 preflight() {
   STAGE="preflight"
   validate_snapshot_path "$SNAPSHOT"
+  # Compose 的 bind mount 只能可靠接收绝对宿主机路径；相对路径会被解释为
+  # 具名 volume，导致 MinIO 快照目录无法挂载。
+  SNAPSHOT="$(cd -- "$SNAPSHOT" && pwd -P)"
   [[ -f "$SNAPSHOT/SUCCESS" ]] || die "快照缺少成功标记：$SNAPSHOT/SUCCESS"
   [[ -f "$SNAPSHOT/manifest.json" ]] || die "快照缺少 manifest.json"
   [[ -f "$SNAPSHOT/env.prod.gpg" ]] || die "快照缺少加密环境文件 env.prod.gpg"
@@ -342,8 +345,10 @@ restore_data_services() {
   prepare_idempotent_globals "$SNAPSHOT/postgres-globals.sql" "$globals_file"
   compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" \
     < "$globals_file" || die "PostgreSQL 全局对象恢复失败"
+  # pg_restore 不接受 "-" 作为 stdin 的显式文件名；省略文件参数时才会从
+  # docker compose exec 透传的标准输入读取宿主机快照。
   compose exec -T postgres pg_restore --clean --if-exists --no-owner --exit-on-error \
-    -U "$pg_user" -d "$pg_db" - < "$SNAPSHOT/postgres.dump" ||
+    -U "$pg_user" -d "$pg_db" < "$SNAPSHOT/postgres.dump" ||
     die "PostgreSQL 数据恢复失败"
 
   ok "恢复 Redis"
@@ -417,10 +422,12 @@ seed_drill_admin() {
   local now
   now="$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
 
+  # email_verified 是后续迁移新增的字段，且新 schema 的默认值已是 true。
+  # 不显式写入该字段，才能同时恢复并验收迁移前的历史快照。
   compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" <<SQL ||
-INSERT INTO users (id, username, email, email_verified, password_hash, created_at, updated_at)
+INSERT INTO users (id, username, email, password_hash, created_at, updated_at)
 VALUES ('drill-admin-user', '${DRILL_ADMIN_USER}', 'drill-admin@${DRILL_ADMIN_EMAIL_DOMAIN}',
-        true, '${DRILL_BCRYPT_HASH}', '${now}', '${now}')
+        '${DRILL_BCRYPT_HASH}', '${now}', '${now}')
 ON CONFLICT (id) DO NOTHING;
 INSERT INTO user_roles (user_id, role_id)
 SELECT 'drill-admin-user', id FROM roles WHERE name = 'admin'
@@ -465,7 +472,11 @@ ensure_judge_images() {
 
 run_business_verification() {
   STAGE="business-verify"
-  ok "运行业务验收（登录/题目/附件/评测）"
+  if ((SKIP_JUDGE)); then
+    ok "运行轻量业务验收（登录/题目读取）"
+  else
+    ok "运行业务验收（登录/题目/附件/评测）"
+  fi
   local -a compose_args=(run --rm --no-deps
     -e "DRILL_BASE_URL=http://core:8000/api/v1"
     -e "DRILL_ADMIN_USER=${DRILL_ADMIN_USER}"

--- a/scripts/deploy/test-restore-drill.sh
+++ b/scripts/deploy/test-restore-drill.sh
@@ -36,6 +36,13 @@ fi
 if [[ "${NOJ_DRILL_TEST_FAIL:-}" == "verify" && "$*" == *"deno run -A /opt/verify.ts"* ]]; then
   exit 42
 fi
+if [[ "$*" == *"psql -v ON_ERROR_STOP=1"* ]]; then
+  sql_input="$(cat)"
+  if [[ "$sql_input" == *"INSERT INTO users"* && "$sql_input" == *"email_verified"* ]]; then
+    echo "演练管理员写入不得依赖 email_verified 字段" >&2
+    exit 43
+  fi
+fi
 if [[ "$*" == *" pg_dump "* ]]; then
   printf 'fake postgres dump\n'
 elif [[ "$*" == *"pg_restore --list"* ]]; then
@@ -190,7 +197,28 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 2. 完整演练（--skip-judge + --keep）：隔离配置、报告与业务验收
+# 2. 相对快照路径：规范化为绝对路径后再用于 Compose bind mount
+# ---------------------------------------------------------------------------
+: >"$FAKE_LOG"
+relative_snapshot="backups/$(basename "$local_snapshot")"
+canonical_snapshot="$(cd "$local_snapshot" && pwd -P)"
+(
+  cd "$TEST_ROOT"
+  NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-output.txt" \
+  NOJ_BACKUP_DOCKER_BIN="$FAKE_DOCKER" \
+    bash "$DRILL_SCRIPT" "$relative_snapshot" \
+      --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" \
+      --passphrase-file "$PASSPHRASE_FILE" \
+      --skip-judge --keep --project-name noj-relative >/dev/null 2>&1
+) || fail "相对快照路径的隔离恢复演练应成功"
+if ! rg -Fq -- "-v $canonical_snapshot/minio:/restore:ro" "$FAKE_LOG"; then
+  fail "MinIO 恢复应使用绝对快照 bind mount"
+fi
+pass "相对快照路径会规范化为绝对 bind mount"
+
+# ---------------------------------------------------------------------------
+# 3. 完整演练（--skip-judge + --keep）：隔离配置、报告与业务验收
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 report="$TEST_ROOT/drill-report.txt"
@@ -198,6 +226,13 @@ run_drill "$local_snapshot" --skip-judge --keep --project-name noj-drill \
   --report "$report" --rpo-max-hours 24 --rto-max-minutes 60 >/dev/null 2>"$TEST_ROOT/drill.err" ||
   { cat "$TEST_ROOT/drill.err" >&2; fail "隔离恢复演练应成功"; }
 pass "隔离恢复演练（--skip-judge）成功"
+
+rg -q 'pg_restore --clean --if-exists --no-owner --exit-on-error -U noj -d noj$' "$FAKE_LOG" ||
+  fail "PostgreSQL 恢复应从标准输入读取快照"
+if rg -q 'pg_restore --clean --if-exists --no-owner --exit-on-error -U noj -d noj -$' "$FAKE_LOG"; then
+  fail "PostgreSQL 恢复不得把 - 当作容器内输入文件"
+fi
+pass "PostgreSQL 恢复从标准输入读取快照"
 
 [[ -f "$report" ]] || fail "报告未生成"
 grep -q '^result=passed$' "$report" || fail "报告应标记 result=passed"
@@ -232,7 +267,7 @@ rg -Fq 'DO $role$ BEGIN IF NOT EXISTS' "$TEST_ROOT/backups"/drill-*/.work/postgr
 pass "演练环境与覆盖 Compose 隔离配置正确"
 
 # ---------------------------------------------------------------------------
-# 3. judge 链路：白名单镜像读取 + 评测验收执行
+# 4. judge 链路：白名单镜像读取 + 评测验收执行
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 run_drill "$local_snapshot" --keep --project-name noj-drill >/dev/null 2>&1 ||
@@ -243,7 +278,7 @@ grep -q '"step":"evaluation","status":"passed"' \
 pass "完整演练包含真实评测验收"
 
 # ---------------------------------------------------------------------------
-# 4. 失败路径：数据库恢复失败 → 非零退出 + 失败报告 + 资源回收
+# 5. 失败路径：数据库恢复失败 → 非零退出 + 失败报告 + 资源回收
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 fail_report="$TEST_ROOT/fail-report.txt"
@@ -265,7 +300,7 @@ grep -q 'down -v --remove-orphans' "$FAKE_LOG" ||
 pass "数据库恢复失败：非零退出 + 失败报告 + 资源回收"
 
 # ---------------------------------------------------------------------------
-# 5. 失败路径：业务验收失败
+# 6. 失败路径：业务验收失败
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 biz_fail_report="$TEST_ROOT/biz-fail-report.txt"
@@ -287,7 +322,7 @@ grep -q '"step":"evaluation","status":"failed"' "$biz_fail_report" ||
 pass "业务验收失败：非零退出 + 保留失败现场"
 
 # ---------------------------------------------------------------------------
-# 6. 默认报告位置：写入快照目录且演练临时目录被清理
+# 7. 默认报告位置：写入快照目录且演练临时目录被清理
 # ---------------------------------------------------------------------------
 # 清理前序 --keep 用例保留的演练目录，验证默认路径下的资源回收。
 rm -rf "$BACKUP_DIR"/drill-*


### PR DESCRIPTION
## 概要

- 修复隔离恢复演练在真实 sng 快照中暴露的 PostgreSQL stdin、相对快照挂载、旧用户 schema 与 JSON token 认证兼容问题。
- 增加 `--skip-judge` 轻量验收：验证恢复、数据核对、登录和题目读取，不依赖 Judge daemon 或评测镜像白名单。
- 补充恢复演练与验收脚本的回归测试，以及 Agent Note。

## sng 验证

- 隔离恢复、迁移/用户/Redis/对象核对、登录、题目读取和注册探针通过。
- 恢复 27 秒，总计 40 秒；RTO 达标。
- 演练资源自动清理，未接触 `noj-prod` 卷或网络。
- 快照 RPO 为 161.46 小时，未达到 24 小时目标；#428 保持开放追踪备份调度。

## 验证

- `deno test -A scripts/deploy/restore-drill-verify_test.ts`
- `bash scripts/deploy/test-restore-drill.sh`
- `bash scripts/deploy/test-backup.sh`
- `bash scripts/deploy/test-monitoring.sh`
- `deno run -A scripts/verify-agent-note-format.ts`

关联 #428