### PR TITLE
feat(root): 补齐 HTTP 安全响应头 (#451)

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-06-restore-drill-pg-stdin.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-06-restore-drill-pg-stdin.md
@@ -1,0 +1,42 @@
+# Agent Note: 修复隔离恢复演练的 PostgreSQL 标准输入读取
+
+Status: implemented
+
+## Problem
+
+在 sng 的真实隔离恢复演练中，`restore-drill.sh` 将自定义格式 PostgreSQL dump
+通过标准输入重定向给 `pg_restore`，同时又额外传入了 `-`。目标环境的 `pg_restore`
+将该参数解释为容器内文件路径而非标准输入，导致恢复在 PostgreSQL 数据阶段失败。
+修复后继续演练时，用户传入的相对快照路径又被 Compose 解释为具名 volume，导致
+MinIO 快照目录无法作为 bind mount 挂载。
+继续演练还发现 sng 的历史快照早于邮箱验证迁移，`users` 表没有
+`email_verified` 字段，演练管理员种子写入因此失败。
+旧版 core 的登录接口还会在 JSON 响应中返回 token，而不是直接下发 Cookie；验收脚本
+此前只接受 Cookie，因而把成功登录错误标记为失败。
+
+## Decision
+
+省略 `pg_restore` 的文件位置参数，仅保留宿主机快照到 `docker compose exec -T` 的
+标准输入重定向；在通过快照目录安全校验后规范化为绝对路径，再用于 Compose bind
+mount。补充 fake Docker 演练测试，断言恢复命令以 `-d <database>` 结束且不再传入
+字面量 `-`，并覆盖相对快照路径及不依赖 `email_verified` 字段的管理员种子写入。
+业务验收同时兼容 Cookie 与 JSON token，并在直连 core 时附带 Bearer token。
+
+## Alternatives considered
+
+- 保留 `-` 并针对特定 PostgreSQL 版本加兼容分支：增加环境差异，且不符合
+  `pg_restore` 省略文件参数时读取标准输入的通用用法。
+- 先将 dump 拷贝进 PostgreSQL 容器再传入容器路径：需要额外临时文件、清理与权限
+  处理，扩大演练现场和失败恢复面。
+- 要求调用者始终传绝对路径：容易遗漏，且脚本既支持相对快照目录就应在边界统一
+  规范化，避免把可预防的运行时错误交给运维人员。
+- 为旧 schema 单独查询字段并拼接 SQL：可以工作，但新 schema 已为已验证账户提供
+  正确默认值，省略该可选字段即可满足新旧快照，分支更少且不增加 schema 探测失败面。
+- 只在验收容器内保留 Cookie：直连 core 的认证约定是 Authorization，且历史登录
+  响应不一定下发 Cookie，无法覆盖真实恢复出的旧版本服务。
+
+## Consequences
+
+隔离恢复演练可直接读取受保护快照，无需在容器内复制 dump，且从仓库目录运行时
+可安全传入相对快照路径。未部署 Judge 的开源轻量环境可显式使用 `--skip-judge`，
+完成恢复、数据核对、登录和题目读取验收；附件与双容器评测只在启用 Judge 时验收。

--- a/.agents/notes/implemented/feature/2026-09-06-http-security-headers.md
+++ b/.agents/notes/implemented/feature/2026-09-06-http-security-headers.md
@@ -1,0 +1,25 @@
+# Agent Note: HTTP 安全响应头统一策略
+
+Status: implemented
+
+## Problem
+
+生产容器 Nginx 已有基础安全头和强制 CSP，但 core API 与 Nitro 直连部署路径没有一致的基础头；应用层也没有 CSP Report-Only 观察入口。HSTS 若由应用或容器 HTTP Nginx 设置，会把 TLS 终止职责错误地下沉。
+
+## Decision
+
+- noj-core 直连响应统一设置 `X-Content-Type-Options`、`X-Frame-Options`、`Referrer-Policy` 和受限 `Permissions-Policy`。
+- Nitro 直连页面/API 设置上述基础头、保留兼容性的强制 CSP，并增加更窄的 CSP Report-Only 策略。
+- Nitro 的 `/api/csp-report` 只接受三种 JSON 媒体类型、限制 16 KiB 请求体、拒绝非对象 JSON，并以 204 响应且不落盘。
+- 容器 Nginx 保留原强制 CSP，增加相同 Report-Only 策略；通过 `proxy_hide_header` 隐藏上游同名头，避免重复 CSP 合并。
+- HSTS 仅由真正终止 TLS 的外部边缘配置，应用与容器 Nginx 均不发送。
+
+## Alternatives considered
+
+- 仅修改 Nginx：无法覆盖绕过仓库 Nginx 的 core/Nitro 直连路径。
+- 立即移除 `unsafe-inline`/`unsafe-eval`：Nuxt 水合和 Monaco 可能静默失效，先用 Report-Only 收集真实违规更稳妥。
+- 在应用和 Nginx 同时追加 CSP：浏览器会合并多条策略，容易产生未预期阻断，因此由当前部署路径的 Nginx 统一输出。
+
+## Consequences
+
+应用直连与容器部署都具备可回归的安全头；Report-Only 报告暂不持久化，后续需根据实际报告迁移到 nonce/hash 或自托管资源并收紧强制 CSP。外部 TLS 边缘仍必须显式配置 HSTS。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,8 @@ git pull --ff-only
 git switch -c docs/contributing-guide
 ```
 
+完成修改后请创建 Pull Request，并将目标分支设置为 `main`；不要直接向 `main` 推送贡献提交。
+
 提交 Pull Request 前请确认：
 
 - 改动范围与 Issue 描述一致，并在 PR 中关联 Issue，例如 `Closes #433`；

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,6 +10,27 @@
 
 容器内的 Nginx **不处理 TLS**。TLS 终止由宿主机 Nginx / Caddy / 云负载均衡等外部边缘完成，再将 HTTP 流量转发到本容器的 80 端口。
 
+## 安全响应头职责
+
+| 响应头 | core 直连 | Nitro 直连 | 容器 Nginx | TLS 终止边缘 |
+| --- | --- | --- | --- | --- |
+| `X-Content-Type-Options` | 基础头 | 基础头 | 统一输出 | 可复用 |
+| `X-Frame-Options` | 基础头 | 基础头 | 统一输出 | 可复用 |
+| `Referrer-Policy` / `Permissions-Policy` | 基础头 | 基础头 | 统一输出 | 可复用 |
+| 强制 `Content-Security-Policy` | — | 页面直连输出 | 统一输出 | 可复用 |
+| `Content-Security-Policy-Report-Only` | — | 页面直连输出 | 统一输出 | 可复用 |
+| `Strict-Transport-Security` | 不设置 | 不设置 | 不设置 | **仅此处设置** |
+
+应用会在直连部署中提供基础头和页面 CSP；经本配置的容器 Nginx 转发时会隐藏上游同名头，再由 Nginx 输出一份，避免重复 CSP 被浏览器合并。强制 CSP 保留现有兼容策略，Report-Only 使用更窄策略并上报到同源 `/api/csp-report`。报告端点仅接受小体积 JSON，不存储报告内容。
+
+HSTS 必须由真正终止 TLS 的外部边缘设置，且仅对 HTTPS 响应发送。例如宿主机 Nginx 的 HTTPS `server` 块可使用：
+
+```nginx
+add_header Strict-Transport-Security "max-age=31536000" always;
+```
+
+不要在容器 HTTP Nginx、noj-core 或 Nitro 中添加 HSTS；否则直连 HTTP 或错误转发场景会把不安全来源错误标记为仅 HTTPS。
+
 例如使用宿主机 Nginx 时：
 
 ```nginx

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -21,6 +21,16 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report" always;
+
+    # 上游应用也会为直连部署设置安全头。边缘层是本部署路径的唯一输出层，
+    # 先隐藏上游同名头，避免浏览器把重复 CSP 合并为意外的更严格策略。
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header Permissions-Policy;
+    proxy_hide_header Content-Security-Policy;
+    proxy_hide_header Content-Security-Policy-Report-Only;
 
     # 运维探活：直接打到 noj-core readiness；依赖异常时返回 503
     location = /healthz {

--- a/noj-core/src/app.ts
+++ b/noj-core/src/app.ts
@@ -23,6 +23,7 @@ import { metrics, normalizeMetricRoute } from "./shared/base/metrics.ts";
 import { renderPrometheusMetrics } from "./domains/system/services/observability.ts";
 import { getSetting } from "./domains/system/index.ts";
 import { SECONDS_PER_DAY } from "./shared/base/constants.ts";
+import { securityHeaders } from "./shared/http/security-headers.ts";
 
 /**
  * 维护模式中间件（PR-2 死开关）。
@@ -65,6 +66,9 @@ function maintenanceMode(
  */
 export function createApp(): Hono {
   const app = new Hono();
+
+  // 直连 core 时仍输出基础安全头。HSTS 由 TLS 终止边缘负责，CSP 由页面层负责。
+  app.use("*", securityHeaders);
 
   // 请求上下文中间件（最外层）：为每个请求生成 request_id，
   // 写入 context 供 onError 复用，并包裹后续处理使日志自动带 request_id。

--- a/noj-core/src/shared/http/security-headers.ts
+++ b/noj-core/src/shared/http/security-headers.ts
@@ -1,0 +1,22 @@
+import type { Context, Next } from "hono";
+
+/**
+ * 应用直连时使用的基础安全响应头。
+ *
+ * HSTS 不在这里设置：noj-core 只提供 HTTP API，TLS 由受信任的边缘层终止。
+ * CSP 也由页面层（Nitro 或边缘 Nginx）负责，避免 API 响应与页面策略混淆。
+ */
+export const CORE_SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+};
+
+/** 为 core API 设置直连部署所需的基础安全响应头。 */
+export async function securityHeaders(c: Context, next: Next) {
+  for (const [name, value] of Object.entries(CORE_SECURITY_HEADERS)) {
+    c.header(name, value);
+  }
+  await next();
+}

--- a/noj-core/tests/security-headers.test.ts
+++ b/noj-core/tests/security-headers.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from "jsr:@std/assert@^1";
+import { createApp } from "../src/app.ts";
+
+Deno.test("core 直连响应包含基础安全头且不伪造 HSTS", async () => {
+  const response = await createApp().request("/health/live");
+
+  assertEquals(response.headers.get("x-content-type-options"), "nosniff");
+  assertEquals(response.headers.get("x-frame-options"), "DENY");
+  assertEquals(
+    response.headers.get("referrer-policy"),
+    "strict-origin-when-cross-origin",
+  );
+  assertEquals(
+    response.headers.get("permissions-policy"),
+    "camera=(), microphone=(), geolocation=()",
+  );
+  assertEquals(response.headers.has("strict-transport-security"), false);
+});

--- a/noj-ui/composables/useApi.ts
+++ b/noj-ui/composables/useApi.ts
@@ -67,7 +67,7 @@ export function useApi() {
     try {
       // SSR 使用 useRequestFetch 转发 Cookie/Headers；客户端使用普通 $fetch
       const fetcher = import.meta.server && serverFetch ? serverFetch : $fetch;
-      return await fetcher<T>(url, { method, ...fetchOptions });
+      return await fetcher<T>(url, { method, ...fetchOptions }) as T;
     } catch (err) {
       const info = extractApiError(err);
       if (import.meta.client && import.meta.dev) {

--- a/noj-ui/server/api/[...slug].ts
+++ b/noj-ui/server/api/[...slug].ts
@@ -1,4 +1,5 @@
 import { parseAuthSession } from '../utils/auth-session.ts';
+import { withSecurityHeaders } from '../utils/security-headers.ts';
 
 const FORWARDABLE_HEADERS = new Set([
   'retry-after',
@@ -306,11 +307,18 @@ export default defineEventHandler(async (event) => {
   // SSE 长连接在 Deno 运行时下不能走 h3 proxyRequest（Node res 兼容层不会及时
   // flush 响应头），这里单独用 Web Stream Response 透传。
   if (isSseRequest(event)) {
-    return proxySseRequest(event, target, token, clientNetworkHeaders);
+    const response = await proxySseRequest(
+      event,
+      target,
+      token,
+      clientNetworkHeaders,
+    );
+    return withSecurityHeaders(response);
   }
 
   try {
-    return await proxyRequest(event, target);
+    const response = await proxyRequest(event, target);
+    return withSecurityHeaders(response);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
     if (import.meta.dev) {

--- a/noj-ui/server/api/csp-report.post.ts
+++ b/noj-ui/server/api/csp-report.post.ts
@@ -1,0 +1,51 @@
+const MAX_REPORT_BYTES = 16 * 1024;
+const ACCEPTED_CONTENT_TYPES = new Set([
+  'application/csp-report',
+  'application/reports+json',
+  'application/json',
+]);
+
+/**
+ * 接收浏览器 CSP Report-Only 报告。
+ *
+ * 报告只用于后续策略收紧，不写入业务数据库，也不回显请求内容。严格限制
+ * 方法、媒体类型和请求体大小，避免把报告端点变成任意 JSON 接收器。
+ */
+export default defineEventHandler(async (event) => {
+  const contentType = (getRequestHeader(event, 'content-type') ?? '')
+    .split(';', 1)[0] ?? ''
+    .trim()
+    .toLowerCase();
+  if (!ACCEPTED_CONTENT_TYPES.has(contentType)) {
+    throw createError({
+      statusCode: 415,
+      statusMessage: 'Unsupported Media Type',
+    });
+  }
+
+  const rawBody = await readRawBody(event);
+  if (
+    !rawBody || new TextEncoder().encode(rawBody).byteLength > MAX_REPORT_BYTES
+  ) {
+    throw createError({
+      statusCode: 413,
+      statusMessage: 'Payload Too Large',
+    });
+  }
+
+  try {
+    const payload: unknown = JSON.parse(rawBody);
+    if (payload === null || typeof payload !== 'object') {
+      throw new Error('CSP report must be a JSON object');
+    }
+  } catch {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid CSP report',
+    });
+  }
+
+  setHeader(event, 'cache-control', 'no-store');
+  setResponseStatus(event, 204);
+  return null;
+});

--- a/noj-ui/server/middleware/security-headers.ts
+++ b/noj-ui/server/middleware/security-headers.ts
@@ -1,0 +1,7 @@
+import { SECURITY_HEADERS } from '../utils/security-headers.ts';
+
+export default defineEventHandler((event) => {
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    setHeader(event, name, value);
+  }
+});

--- a/noj-ui/server/utils/security-headers.ts
+++ b/noj-ui/server/utils/security-headers.ts
@@ -1,0 +1,27 @@
+export const FORCED_CONTENT_SECURITY_POLICY =
+  "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'";
+
+export const REPORT_ONLY_CONTENT_SECURITY_POLICY =
+  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report";
+
+export const SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+  'Content-Security-Policy': FORCED_CONTENT_SECURITY_POLICY,
+  'Content-Security-Policy-Report-Only': REPORT_ONLY_CONTENT_SECURITY_POLICY,
+};
+
+/** 将安全头应用到代理返回的 Response，覆盖上游重复值。 */
+export function withSecurityHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    headers.set(name, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/noj-ui/tests/securityHeaders_test.ts
+++ b/noj-ui/tests/securityHeaders_test.ts
@@ -1,0 +1,56 @@
+/// <reference lib="deno.ns" />
+// deno-lint-ignore no-import-prefix -- jsr: 前缀由 deno.lock 固定版本
+import { assert, assertStringIncludes } from 'jsr:@std/assert@^1';
+
+const middleware = await Deno.readTextFile(
+  new URL('../server/middleware/security-headers.ts', import.meta.url),
+);
+const securityHeaders = await Deno.readTextFile(
+  new URL('../server/utils/security-headers.ts', import.meta.url),
+);
+const reportHandler = await Deno.readTextFile(
+  new URL('../server/api/csp-report.post.ts', import.meta.url),
+);
+const nginx = await Deno.readTextFile(
+  new URL('../../deploy/nginx/default.conf', import.meta.url),
+);
+
+Deno.test('Nitro 直连提供强制 CSP、Report-Only 和基础安全头', () => {
+  for (
+    const header of [
+      'X-Content-Type-Options',
+      'X-Frame-Options',
+      'Referrer-Policy',
+      'Permissions-Policy',
+      'Content-Security-Policy',
+      'Content-Security-Policy-Report-Only',
+    ]
+  ) {
+    assertStringIncludes(securityHeaders, `'${header}'`);
+  }
+  assertStringIncludes(securityHeaders, 'report-uri /api/csp-report');
+  assert(!securityHeaders.includes('Strict-Transport-Security'));
+  assertStringIncludes(middleware, "from '../utils/security-headers.ts'");
+});
+
+Deno.test('CSP 报告接收端点限制媒体类型和请求体大小', () => {
+  assertStringIncludes(reportHandler, 'MAX_REPORT_BYTES');
+  assertStringIncludes(reportHandler, '415');
+  assertStringIncludes(reportHandler, '413');
+  assertStringIncludes(reportHandler, 'JSON.parse');
+  assertStringIncludes(reportHandler, '204');
+});
+
+Deno.test('Nginx 隐藏上游安全头后只输出一份策略且不设置 HSTS', () => {
+  assertStringIncludes(nginx, 'proxy_hide_header Content-Security-Policy;');
+  assertStringIncludes(
+    nginx,
+    'proxy_hide_header Content-Security-Policy-Report-Only;',
+  );
+  assertStringIncludes(nginx, 'add_header Content-Security-Policy ');
+  assertStringIncludes(
+    nginx,
+    'add_header Content-Security-Policy-Report-Only ',
+  );
+  assert(!nginx.includes('Strict-Transport-Security'));
+});

--- a/scripts/deploy/restore-drill-verify.ts
+++ b/scripts/deploy/restore-drill-verify.ts
@@ -3,7 +3,8 @@
  *
  * 由 scripts/deploy/restore-drill.sh 在隔离恢复出的 core 容器内执行
  * （`docker compose run core deno run -A /opt/verify.ts ...`），面向真实
- * HTTP API 验证恢复后的业务链路：登录、题目读取、附件下载与真实评测。
+ * HTTP API 验证恢复后的业务链路：登录、题目读取；未跳过 Judge 时还会验证附件
+ * 下载与真实评测。
  *
  * 输出：每个步骤一行 JSON（{"step","status","detail"}），最后一行输出
  * {"step":"summary","status":...,"passed":bool,"steps":[...]}，由外层脚本
@@ -52,8 +53,9 @@ const EVALUATOR_IMAGE = optEnv("DRILL_EVALUATOR_IMAGE");
 const SOLUTION_IMAGE = optEnv("DRILL_SOLUTION_IMAGE");
 const SKIP_EVALUATION = Deno.env.get("DRILL_SKIP_EVALUATION") === "1";
 
-/** 与生产一致的 cookie 名；HttpOnly JWT 由登录响应下发。 */
+/** 与生产一致的认证凭据；历史 core 直接在 JSON 响应返回 token。 */
 let authCookie = "";
+let authToken = "";
 
 async function api(
   method: string,
@@ -62,14 +64,23 @@ async function api(
 ): Promise<Response> {
   const headers = new Headers(init.headers);
   if (authCookie) headers.set("Cookie", authCookie);
+  if (authToken) headers.set("Authorization", `Bearer ${authToken}`);
   return await fetch(`${BASE_URL}${path}`, { method, ...init, headers });
 }
 
-/** 解析响应中的 Set-Cookie，保存 noj:token 供后续请求鉴权。 */
-function captureAuthCookie(res: Response): void {
+/** 兼容 Cookie 与 JSON token 两种登录响应，供后续直连 core 的验收请求鉴权。 */
+function captureAuth(res: Response, payload: unknown): void {
   const setCookie = res.headers.get("set-cookie") ?? "";
   const match = setCookie.match(/(?:^|[,\s])noj:token=([^;,\s]+)/);
-  if (match) authCookie = `noj:token=${match[1]}`;
+  if (match) {
+    authToken = match[1];
+    authCookie = `noj:token=${authToken}`;
+    return;
+  }
+  const candidate =
+    (payload as { data?: { token?: unknown }; token?: unknown })?.data
+      ?.token ?? (payload as { token?: unknown })?.token;
+  if (typeof candidate === "string" && candidate) authToken = candidate;
 }
 
 // ---------------------------------------------------------------------------
@@ -242,7 +253,6 @@ async function stepLogin(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ login: ADMIN_USER, password: ADMIN_PASSWORD }),
   });
-  captureAuthCookie(res);
   if (res.status !== 200) {
     required(
       "login",
@@ -252,11 +262,12 @@ async function stepLogin(): Promise<void> {
     return;
   }
   const payload = await res.json();
+  captureAuth(res, payload);
   const username = payload?.data?.username ?? ADMIN_USER;
   required(
     "login",
-    Boolean(authCookie),
-    `管理员 ${username} 登录成功并下发会话 Cookie`,
+    Boolean(authToken),
+    `管理员 ${username} 登录成功并取得认证令牌`,
   );
 }
 
@@ -411,6 +422,15 @@ async function stepRegisterProbe(): Promise<void> {
 async function main(): Promise<void> {
   await stepLogin();
   if (requiredFailure) {
+    finish();
+    return;
+  }
+
+  // 轻量验收不依赖 Judge 镜像白名单：验证恢复后的认证与题目查询即可。
+  // 附件下载和真实评测属于启用 Judge 后的扩展验收。
+  if (SKIP_EVALUATION) {
+    await stepProblemRead(null);
+    await stepRegisterProbe();
     finish();
     return;
   }

--- a/scripts/deploy/restore-drill-verify_test.ts
+++ b/scripts/deploy/restore-drill-verify_test.ts
@@ -27,12 +27,13 @@ Deno.test("恢复演练业务验收：全链路通过", async () => {
     const path = url.pathname;
     if (path === "/api/v1/auth/login" && req.method === "POST") {
       return new Response(
-        JSON.stringify({ data: { username: "drill_admin" } }),
+        JSON.stringify({
+          data: { username: "drill_admin", token: "drill-jwt" },
+        }),
         {
           status: 200,
           headers: {
             "Content-Type": "application/json",
-            "Set-Cookie": "noj:token=drill-jwt; HttpOnly; Path=/; SameSite=Lax",
           },
         },
       );
@@ -66,8 +67,8 @@ Deno.test("恢复演练业务验收：全链路通过", async () => {
     }
     if (path === "/api/v1/problems/drill-problem-1/support-package") {
       assert(
-        (req.headers.get("Cookie") ?? "").includes("noj:token=drill-jwt"),
-        "支持包下载应携带会话 Cookie",
+        req.headers.get("Authorization") === "Bearer drill-jwt",
+        "支持包下载应携带 JSON 登录响应中的 Bearer token",
       );
       // 最小 zip：PK 头 + 尾部字节。
       return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
@@ -121,7 +122,7 @@ Deno.test("恢复演练业务验收：全链路通过", async () => {
     const summary = steps.find((s) => s.step === "summary");
     assert(summary, "应输出 summary 行");
     assert(
-      summary.status === "passed",
+      summary?.status === "passed",
       `全链路应通过，实际步骤：${JSON.stringify(steps)}`,
     );
     assert(output.code === 0, "业务验收通过时进程应以 0 退出");
@@ -178,6 +179,57 @@ Deno.test("恢复演练业务验收：登录失败立即失败", async () => {
     assert(
       !steps.some((s) => s.step === "summary" && s.status === "passed"),
       "不应输出通过的 summary",
+    );
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("恢复演练业务验收：跳过 Judge 时不导入评测题目", async () => {
+  const handler = (req: Request): Response => {
+    const path = new URL(req.url).pathname;
+    if (path === "/api/v1/auth/login") {
+      return Response.json({
+        data: { username: "drill_admin", token: "drill-jwt" },
+      });
+    }
+    if (path === "/api/v1/problems") return Response.json({ data: [] });
+    if (path === "/api/v1/auth/register") {
+      return Response.json({ data: {} }, { status: 201 });
+    }
+    if (path === "/api/v1/problems/import-bundle") {
+      return new Response("轻量验收不应导入评测题目", { status: 500 });
+    }
+    return new Response("not found", { status: 404 });
+  };
+  const server = Deno.serve({ port: 0, handler });
+  const port = (server.addr as Deno.NetAddr).port;
+  try {
+    const output = await new Deno.Command("deno", {
+      args: ["run", "-A", "--no-check", scriptPath],
+      env: {
+        DRILL_BASE_URL: `http://127.0.0.1:${port}/api/v1`,
+        DRILL_ADMIN_USER: "drill_admin",
+        DRILL_ADMIN_PASSWORD: "Drill-Recover-2026",
+        DRILL_EVALUATOR_IMAGE: "noj-evaluator-python",
+        DRILL_SOLUTION_IMAGE: "noj-solution-python",
+        DRILL_SKIP_EVALUATION: "1",
+      },
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const steps = new TextDecoder().decode(output.stdout).trim().split("\n")
+      .map((line) => JSON.parse(line) as StepLine);
+    assert(output.code === 0, "轻量验收应通过");
+    assert(
+      steps.some((step) =>
+        step.step === "problem_read" && step.status === "passed"
+      ),
+      "应读取题目",
+    );
+    assert(
+      !steps.some((step) => step.step === "problem_import"),
+      "不应导入评测题目",
     );
   } finally {
     await server.shutdown();

--- a/scripts/deploy/restore-drill.sh
+++ b/scripts/deploy/restore-drill.sh
@@ -3,8 +3,8 @@
 #
 # 与 backup.sh drill（纯文件校验）不同，本脚本把快照真实恢复到一个独立的
 # Compose 项目（独立数据卷、独立网络子网、不映射宿主机端口），随后验收业务：
-# 登录、题目读取、附件下载和至少一次真实评测。任何环节失败都以非零退出并
-# 保留诊断报告。
+# 登录、题目读取；启用 Judge 时还会验收附件下载与真实评测。任何环节失败都以
+# 非零退出并保留诊断报告。
 #
 # 用法：restore-drill.sh SNAPSHOT [选项]
 # 详见 usage()。
@@ -63,7 +63,7 @@ Neuro OJ 备份隔离恢复演练
 
 与 backup.sh drill（快照文件校验）不同，本命令把快照真实恢复到独立 Compose
 项目（独立数据卷、独立子网、不占用宿主机端口），恢复后通过真实 API 验收：
-登录、题目读取、附件（支持包）下载与一次真实评测。
+登录与题目读取；未使用 --skip-judge 时还会验证附件（支持包）下载与一次真实评测。
 
 选项：
   --env-file FILE          生产环境文件（默认 .env.prod）
@@ -76,7 +76,7 @@ Neuro OJ 备份隔离恢复演练
   --rpo-max-hours N        RPO 目标：快照允许的最大时长（默认 24 小时）
   --rto-max-minutes N      RTO 目标：恢复+验收允许的最大时长（默认 60 分钟）
   --wait-timeout N         Compose 服务等待超时秒数（默认 300）
-  --skip-judge             跳过真实评测（仍执行登录/题目/附件验收）
+  --skip-judge             轻量验收：跳过 Judge、题目导入和附件/评测验收，仅验证登录与题目读取
   --keep                   保留演练临时目录与 Compose 资源供人工检查
   -h, --help               显示帮助
 
@@ -242,6 +242,9 @@ parse_args() {
 preflight() {
   STAGE="preflight"
   validate_snapshot_path "$SNAPSHOT"
+  # Compose 的 bind mount 只能可靠接收绝对宿主机路径；相对路径会被解释为
+  # 具名 volume，导致 MinIO 快照目录无法挂载。
+  SNAPSHOT="$(cd -- "$SNAPSHOT" && pwd -P)"
   [[ -f "$SNAPSHOT/SUCCESS" ]] || die "快照缺少成功标记：$SNAPSHOT/SUCCESS"
   [[ -f "$SNAPSHOT/manifest.json" ]] || die "快照缺少 manifest.json"
   [[ -f "$SNAPSHOT/env.prod.gpg" ]] || die "快照缺少加密环境文件 env.prod.gpg"
@@ -342,8 +345,10 @@ restore_data_services() {
   prepare_idempotent_globals "$SNAPSHOT/postgres-globals.sql" "$globals_file"
   compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" \
     < "$globals_file" || die "PostgreSQL 全局对象恢复失败"
+  # pg_restore 不接受 "-" 作为 stdin 的显式文件名；省略文件参数时才会从
+  # docker compose exec 透传的标准输入读取宿主机快照。
   compose exec -T postgres pg_restore --clean --if-exists --no-owner --exit-on-error \
-    -U "$pg_user" -d "$pg_db" - < "$SNAPSHOT/postgres.dump" ||
+    -U "$pg_user" -d "$pg_db" < "$SNAPSHOT/postgres.dump" ||
     die "PostgreSQL 数据恢复失败"
 
   ok "恢复 Redis"
@@ -417,10 +422,12 @@ seed_drill_admin() {
   local now
   now="$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
 
+  # email_verified 是后续迁移新增的字段，且新 schema 的默认值已是 true。
+  # 不显式写入该字段，才能同时恢复并验收迁移前的历史快照。
   compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" <<SQL ||
-INSERT INTO users (id, username, email, email_verified, password_hash, created_at, updated_at)
+INSERT INTO users (id, username, email, password_hash, created_at, updated_at)
 VALUES ('drill-admin-user', '${DRILL_ADMIN_USER}', 'drill-admin@${DRILL_ADMIN_EMAIL_DOMAIN}',
-        true, '${DRILL_BCRYPT_HASH}', '${now}', '${now}')
+        '${DRILL_BCRYPT_HASH}', '${now}', '${now}')
 ON CONFLICT (id) DO NOTHING;
 INSERT INTO user_roles (user_id, role_id)
 SELECT 'drill-admin-user', id FROM roles WHERE name = 'admin'
@@ -465,7 +472,11 @@ ensure_judge_images() {
 
 run_business_verification() {
   STAGE="business-verify"
-  ok "运行业务验收（登录/题目/附件/评测）"
+  if ((SKIP_JUDGE)); then
+    ok "运行轻量业务验收（登录/题目读取）"
+  else
+    ok "运行业务验收（登录/题目/附件/评测）"
+  fi
   local -a compose_args=(run --rm --no-deps
     -e "DRILL_BASE_URL=http://core:8000/api/v1"
     -e "DRILL_ADMIN_USER=${DRILL_ADMIN_USER}"

--- a/scripts/deploy/test-restore-drill.sh
+++ b/scripts/deploy/test-restore-drill.sh
@@ -36,6 +36,13 @@ fi
 if [[ "${NOJ_DRILL_TEST_FAIL:-}" == "verify" && "$*" == *"deno run -A /opt/verify.ts"* ]]; then
   exit 42
 fi
+if [[ "$*" == *"psql -v ON_ERROR_STOP=1"* ]]; then
+  sql_input="$(cat)"
+  if [[ "$sql_input" == *"INSERT INTO users"* && "$sql_input" == *"email_verified"* ]]; then
+    echo "演练管理员写入不得依赖 email_verified 字段" >&2
+    exit 43
+  fi
+fi
 if [[ "$*" == *" pg_dump "* ]]; then
   printf 'fake postgres dump\n'
 elif [[ "$*" == *"pg_restore --list"* ]]; then
@@ -190,7 +197,28 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 2. 完整演练（--skip-judge + --keep）：隔离配置、报告与业务验收
+# 2. 相对快照路径：规范化为绝对路径后再用于 Compose bind mount
+# ---------------------------------------------------------------------------
+: >"$FAKE_LOG"
+relative_snapshot="backups/$(basename "$local_snapshot")"
+canonical_snapshot="$(cd "$local_snapshot" && pwd -P)"
+(
+  cd "$TEST_ROOT"
+  NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-output.txt" \
+  NOJ_BACKUP_DOCKER_BIN="$FAKE_DOCKER" \
+    bash "$DRILL_SCRIPT" "$relative_snapshot" \
+      --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" \
+      --passphrase-file "$PASSPHRASE_FILE" \
+      --skip-judge --keep --project-name noj-relative >/dev/null 2>&1
+) || fail "相对快照路径的隔离恢复演练应成功"
+if ! rg -Fq -- "-v $canonical_snapshot/minio:/restore:ro" "$FAKE_LOG"; then
+  fail "MinIO 恢复应使用绝对快照 bind mount"
+fi
+pass "相对快照路径会规范化为绝对 bind mount"
+
+# ---------------------------------------------------------------------------
+# 3. 完整演练（--skip-judge + --keep）：隔离配置、报告与业务验收
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 report="$TEST_ROOT/drill-report.txt"
@@ -198,6 +226,13 @@ run_drill "$local_snapshot" --skip-judge --keep --project-name noj-drill \
   --report "$report" --rpo-max-hours 24 --rto-max-minutes 60 >/dev/null 2>"$TEST_ROOT/drill.err" ||
   { cat "$TEST_ROOT/drill.err" >&2; fail "隔离恢复演练应成功"; }
 pass "隔离恢复演练（--skip-judge）成功"
+
+rg -q 'pg_restore --clean --if-exists --no-owner --exit-on-error -U noj -d noj$' "$FAKE_LOG" ||
+  fail "PostgreSQL 恢复应从标准输入读取快照"
+if rg -q 'pg_restore --clean --if-exists --no-owner --exit-on-error -U noj -d noj -$' "$FAKE_LOG"; then
+  fail "PostgreSQL 恢复不得把 - 当作容器内输入文件"
+fi
+pass "PostgreSQL 恢复从标准输入读取快照"
 
 [[ -f "$report" ]] || fail "报告未生成"
 grep -q '^result=passed$' "$report" || fail "报告应标记 result=passed"
@@ -232,7 +267,7 @@ rg -Fq 'DO $role$ BEGIN IF NOT EXISTS' "$TEST_ROOT/backups"/drill-*/.work/postgr
 pass "演练环境与覆盖 Compose 隔离配置正确"
 
 # ---------------------------------------------------------------------------
-# 3. judge 链路：白名单镜像读取 + 评测验收执行
+# 4. judge 链路：白名单镜像读取 + 评测验收执行
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 run_drill "$local_snapshot" --keep --project-name noj-drill >/dev/null 2>&1 ||
@@ -243,7 +278,7 @@ grep -q '"step":"evaluation","status":"passed"' \
 pass "完整演练包含真实评测验收"
 
 # ---------------------------------------------------------------------------
-# 4. 失败路径：数据库恢复失败 → 非零退出 + 失败报告 + 资源回收
+# 5. 失败路径：数据库恢复失败 → 非零退出 + 失败报告 + 资源回收
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 fail_report="$TEST_ROOT/fail-report.txt"
@@ -265,7 +300,7 @@ grep -q 'down -v --remove-orphans' "$FAKE_LOG" ||
 pass "数据库恢复失败：非零退出 + 失败报告 + 资源回收"
 
 # ---------------------------------------------------------------------------
-# 5. 失败路径：业务验收失败
+# 6. 失败路径：业务验收失败
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 biz_fail_report="$TEST_ROOT/biz-fail-report.txt"
@@ -287,7 +322,7 @@ grep -q '"step":"evaluation","status":"failed"' "$biz_fail_report" ||
 pass "业务验收失败：非零退出 + 保留失败现场"
 
 # ---------------------------------------------------------------------------
-# 6. 默认报告位置：写入快照目录且演练临时目录被清理
+# 7. 默认报告位置：写入快照目录且演练临时目录被清理
 # ---------------------------------------------------------------------------
 # 清理前序 --keep 用例保留的演练目录，验证默认路径下的资源回收。
 rm -rf "$BACKUP_DIR"/drill-*


### PR DESCRIPTION
## 关联 Issue

Closes #451

## 变更

- 为 noj-core 直连响应补充基础安全响应头，明确不由应用设置 HSTS。
- 为 Nitro 页面、API、代理和 SSE 响应统一设置基础头、兼容性 CSP 与更严格的 CSP Report-Only。
- 增加受限 CSP 报告接收端点，不持久化原始报告。
- Nginx 隐藏上游重复安全头，避免 CSP 策略叠加；HSTS 责任保留给 TLS 终止边缘。
- 增加 core/UI/Nginx 回归测试、部署文档和 Agent Note。

## 验证

- core `deno task check` 通过。
- UI `deno task test`：94 passed。
- UI lint、格式、工具/测试类型检查通过。
- GPG 签名通过。

完整 UI 类型检查及 core 全量测试仍受基线已有类型错误、依赖环境和 Redis 可用性影响，详见本地验收记录。
