### PR TITLE
feat(core): 完善邮件退信与送达质量监控 (#449)

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-06-restore-drill-pg-stdin.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-06-restore-drill-pg-stdin.md
@@ -1,0 +1,42 @@
+# Agent Note: 修复隔离恢复演练的 PostgreSQL 标准输入读取
+
+Status: implemented
+
+## Problem
+
+在 sng 的真实隔离恢复演练中，`restore-drill.sh` 将自定义格式 PostgreSQL dump
+通过标准输入重定向给 `pg_restore`，同时又额外传入了 `-`。目标环境的 `pg_restore`
+将该参数解释为容器内文件路径而非标准输入，导致恢复在 PostgreSQL 数据阶段失败。
+修复后继续演练时，用户传入的相对快照路径又被 Compose 解释为具名 volume，导致
+MinIO 快照目录无法作为 bind mount 挂载。
+继续演练还发现 sng 的历史快照早于邮箱验证迁移，`users` 表没有
+`email_verified` 字段，演练管理员种子写入因此失败。
+旧版 core 的登录接口还会在 JSON 响应中返回 token，而不是直接下发 Cookie；验收脚本
+此前只接受 Cookie，因而把成功登录错误标记为失败。
+
+## Decision
+
+省略 `pg_restore` 的文件位置参数，仅保留宿主机快照到 `docker compose exec -T` 的
+标准输入重定向；在通过快照目录安全校验后规范化为绝对路径，再用于 Compose bind
+mount。补充 fake Docker 演练测试，断言恢复命令以 `-d <database>` 结束且不再传入
+字面量 `-`，并覆盖相对快照路径及不依赖 `email_verified` 字段的管理员种子写入。
+业务验收同时兼容 Cookie 与 JSON token，并在直连 core 时附带 Bearer token。
+
+## Alternatives considered
+
+- 保留 `-` 并针对特定 PostgreSQL 版本加兼容分支：增加环境差异，且不符合
+  `pg_restore` 省略文件参数时读取标准输入的通用用法。
+- 先将 dump 拷贝进 PostgreSQL 容器再传入容器路径：需要额外临时文件、清理与权限
+  处理，扩大演练现场和失败恢复面。
+- 要求调用者始终传绝对路径：容易遗漏，且脚本既支持相对快照目录就应在边界统一
+  规范化，避免把可预防的运行时错误交给运维人员。
+- 为旧 schema 单独查询字段并拼接 SQL：可以工作，但新 schema 已为已验证账户提供
+  正确默认值，省略该可选字段即可满足新旧快照，分支更少且不增加 schema 探测失败面。
+- 只在验收容器内保留 Cookie：直连 core 的认证约定是 Authorization，且历史登录
+  响应不一定下发 Cookie，无法覆盖真实恢复出的旧版本服务。
+
+## Consequences
+
+隔离恢复演练可直接读取受保护快照，无需在容器内复制 dump，且从仓库目录运行时
+可安全传入相对快照路径。未部署 Judge 的开源轻量环境可显式使用 `--skip-judge`，
+完成恢复、数据核对、登录和题目读取验收；附件与双容器评测只在启用 Judge 时验收。

--- a/.agents/notes/implemented/feature/2026-09-06-email-delivery-quality.md
+++ b/.agents/notes/implemented/feature/2026-09-06-email-delivery-quality.md
@@ -1,0 +1,25 @@
+# Agent Note: 邮件退信与送达质量监控
+
+Status: implemented
+
+## Problem
+
+现有邮件模块只负责调用阿里云 DirectMail、腾讯云 SES 或 mock 发信，没有统一的送达事件、坏地址抑制、事件幂等和脱敏告警。两家 Provider 的回调协议尚未在仓库或生产配置中确定，直接猜测 webhook 会造成伪造回调或误封地址风险。
+
+## Decision
+
+- 建立内部 `delivery`、`temporary_failure`、`permanent_bounce`、`complaint` 事件模型。
+- 持久化事件和抑制清单；收件邮箱只保存哈希与脱敏值，事件按 `(provider, provider_event_id)` 幂等。
+- 永久退信/投诉抑制验证和密码重置邮件，临时失败只记录并告警。
+- 提供 `EmailDeliveryAdapter` 接口和 fixture-only HMAC 适配器，包含签名、时间戳和事件 ID 校验；阿里云/腾讯云未确认协议时不假装已实现生产 webhook。
+- 通过低基数 Prometheus 指标和现有告警规则接入退信、投诉、临时失败监控；不在指标/日志暴露邮箱。
+
+## Alternatives considered
+
+- 直接套用通用 webhook：字段和签名并不代表阿里云/腾讯云协议，可能接受伪造或错误封禁，因此拒绝。
+- 仅在 Redis 保存坏地址：重启丢失且管理端无法审计，改用 PostgreSQL 持久化。
+- 立即永久封禁临时失败：会误伤短时 Provider 故障，临时失败仅告警。
+
+## Consequences
+
+本变更完成内部事件处理与 fixture 验证，但真实阿里云/腾讯云 webhook 仍需按官方协议另行实现并完成 sandbox/生产验收。抑制解除是显式管理员操作，解除前需确认地址已修正。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,8 @@ git pull --ff-only
 git switch -c docs/contributing-guide
 ```
 
+完成修改后请创建 Pull Request，并将目标分支设置为 `main`；不要直接向 `main` 推送贡献提交。
+
 提交 Pull Request 前请确认：
 
 - 改动范围与 Issue 描述一致，并在 PR 中关联 Issue，例如 `Closes #433`；

--- a/deploy/monitoring/noj-alerts.yml
+++ b/deploy/monitoring/noj-alerts.yml
@@ -148,6 +148,37 @@ groups:
           description: core 连续 5 分钟 API 请求 P95 延迟达到 1 秒，请结合依赖延迟和结构化日志排查。
           runbook: docs/operators/observability.md#api-错误率或延迟升高
 
+      # ---- 邮件送达质量 ----
+      - alert: NojEmailPermanentBounce
+        expr: sum(rate(noj_email_delivery_events_total{event_type="permanent_bounce"}[15m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 检测到邮件永久退信
+          description: 最近 15 分钟出现永久退信；相关地址已进入抑制清单，请检查发件域名和坏地址比例。
+          runbook: docs/operators/email-delivery.md#告警处置
+
+      - alert: NojEmailComplaint
+        expr: sum(rate(noj_email_delivery_events_total{event_type="complaint"}[15m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: 检测到邮件投诉
+          description: 最近 15 分钟出现投诉事件；相关地址已停止验证和密码重置邮件重发。
+          runbook: docs/operators/email-delivery.md#告警处置
+
+      - alert: NojEmailTemporaryFailure
+        expr: sum(rate(noj_email_temporary_failures_total[15m])) > 0.01
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 邮件临时失败持续出现
+          description: 最近 15 分钟临时失败速率超过 0.01/s，请检查 Provider 限流、网络和发件域名信誉。
+          runbook: docs/operators/email-delivery.md#告警处置
+
       # ---- 磁盘 ----
       - alert: NojJudgeWorkDirPressure
         expr: noj_judge_work_dir_bytes >= 8589934592

--- a/dev-docs/engineering/route-catalog.md
+++ b/dev-docs/engineering/route-catalog.md
@@ -89,6 +89,7 @@
 | GET | `/contests/:id/submissions` | noj-core/src/domains/contest/routes/admin-contests.ts |
 | GET | `/dashboard/observability` | noj-core/src/domains/query/routes/admin-dashboard.ts |
 | GET | `/dashboard/stats` | noj-core/src/domains/query/routes/admin-dashboard.ts |
+| GET | `/email-delivery/suppressions` | noj-core/src/domains/system/routes/admin-email-delivery.ts |
 | GET | `/events` | noj-core/src/domains/messaging/routes/conversations.ts |
 | GET | `/events` | noj-core/src/domains/system/routes/announcements.ts |
 | GET | `/feed` | noj-core/src/domains/community/routes/community.ts |
@@ -146,6 +147,7 @@
 | GET | `jti` | noj-core/src/domains/identity/routes/auth.ts |
 | GET | `NOJ_ENV` | noj-core/src/domains/identity/routes/auth.ts |
 | GET | `NOJ_ENV` | noj-core/src/domains/identity/routes/auth.ts |
+| GET | `NOJ_ENV` | noj-core/src/domains/system/routes/email-delivery.ts |
 | GET | `NOJ_ENV` | noj-core/src/routes/health.ts |
 | GET | `NOJ_ENV` | noj-core/src/routes/health.ts |
 | GET | `NOJ_LLM_GATEWAY_URL` | noj-core/src/domains/gateway/routes/admin-llm.ts |
@@ -241,6 +243,7 @@
 | GET | `userId` | noj-core/src/domains/submission/routes/admin-submissions.ts |
 | GET | `userId` | noj-core/src/domains/submission/routes/sse.ts |
 | GET | `userId` | noj-core/src/domains/submission/routes/submissions.ts |
+| GET | `userId` | noj-core/src/domains/system/routes/admin-email-delivery.ts |
 | GET | `userId` | noj-core/src/domains/system/routes/admin-settings.ts |
 | GET | `userId` | noj-core/src/domains/system/routes/admin-settings.ts |
 | GET | `userRole` | noj-core/src/domains/catalog/routes/problems.ts |
@@ -297,6 +300,8 @@
 | POST | `/contests` | noj-core/src/domains/contest/routes/admin-contests.ts |
 | POST | `/contests/:id/participants` | noj-core/src/domains/contest/routes/admin-contests.ts |
 | POST | `/contests/:id/ranking-snapshots` | noj-core/src/domains/contest/routes/admin-contests.ts |
+| POST | `/email-delivery/suppressions/:id/clear` | noj-core/src/domains/system/routes/admin-email-delivery.ts |
+| POST | `/email-events/:provider` | noj-core/src/domains/system/routes/email-delivery.ts |
 | POST | `/email/resend` | noj-core/src/domains/identity/routes/auth.ts |
 | POST | `/email/verify` | noj-core/src/domains/identity/routes/auth.ts |
 | POST | `/forgot-password` | noj-core/src/domains/identity/routes/auth.ts |

--- a/noj-core/.env.example
+++ b/noj-core/.env.example
@@ -121,6 +121,8 @@ TENCENT_SECRET_ID=
 TENCENT_SECRET_KEY=
 TENCENT_FROM_EMAIL=
 TENCENT_REGION=ap-guangzhou
+# 仅供内部 fixture 回调演练；阿里云/腾讯云生产回调必须实现各自官方适配器
+EMAIL_WEBHOOK_SECRET=
 
 # ── 对象存储 ──────────────────────────────────────────
 # 存储 Provider：local（开发测试用）或 s3（生产环境）

--- a/noj-core/drizzle/0068_nebulous_juggernaut.sql
+++ b/noj-core/drizzle/0068_nebulous_juggernaut.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "email_delivery_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"provider" text NOT NULL,
+	"provider_event_id" text NOT NULL,
+	"event_type" text NOT NULL,
+	"recipient_hash" text NOT NULL,
+	"recipient_masked" text NOT NULL,
+	"reason_code" text,
+	"reason" text,
+	"occurred_at" text NOT NULL,
+	"received_at" text NOT NULL,
+	CONSTRAINT "email_delivery_events_provider_event_unique" UNIQUE("provider","provider_event_id"),
+	CONSTRAINT "email_delivery_events_event_type_check" CHECK ("email_delivery_events"."event_type" IN ('delivery', 'temporary_failure', 'permanent_bounce', 'complaint'))
+);
+--> statement-breakpoint
+CREATE TABLE "email_suppressions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"recipient_hash" text NOT NULL,
+	"recipient_masked" text NOT NULL,
+	"reason" text NOT NULL,
+	"provider" text NOT NULL,
+	"source_event_id" text NOT NULL,
+	"suppressed_at" text NOT NULL,
+	"cleared_at" text,
+	"cleared_by" text
+);
+--> statement-breakpoint
+CREATE INDEX "idx_email_delivery_events_recipient_hash" ON "email_delivery_events" USING btree ("recipient_hash");--> statement-breakpoint
+CREATE INDEX "idx_email_delivery_events_occurred_at" ON "email_delivery_events" USING btree ("occurred_at");--> statement-breakpoint
+CREATE INDEX "idx_email_suppressions_recipient_hash" ON "email_suppressions" USING btree ("recipient_hash");--> statement-breakpoint
+CREATE UNIQUE INDEX "email_suppressions_active_recipient_unique" ON "email_suppressions" USING btree ("recipient_hash") WHERE "email_suppressions"."cleared_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "idx_email_suppressions_suppressed_at" ON "email_suppressions" USING btree ("suppressed_at");

--- a/noj-core/drizzle/meta/0068_snapshot.json
+++ b/noj-core/drizzle/meta/0068_snapshot.json
@@ -1,0 +1,6541 @@
+{
+  "id": "5f06a730-a2a6-4ab2-bbde-ee10eac9e707",
+  "prevId": "a75e4380-662d-4f6b-9815-399388b16756",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ann-' || substr(md5(random()::text), 1, 8)"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_announcements_active_pinned_created": {
+          "name": "idx_announcements_active_pinned_created",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "announcements_public_id_unique": {
+          "name": "announcements_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audit_logs_admin_id_idx": {
+          "name": "audit_logs_admin_id_idx",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_admin_id_users_id_fk": {
+          "name": "audit_logs_admin_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'users.role_change',\n        'users.ban',\n        'users.unban',\n        'users.delete',\n        'problems.delete',\n        'problems.runtime_config_changed',\n        'problems.imported',\n        'tags.create',\n        'tags.update',\n        'tags.delete',\n        'tags.merge',\n        'submissions.rejudge',\n        'submissions.queue_removed',\n        'settings.update',\n        'ip_ban.create',\n        'ip_ban.delete',\n        'auth.login_success',\n        'auth.login_failure',\n        'auth.register',\n        'auth.email_verified',\n        'auth.delete_account',\n        'auth.change_password',\n        'auth.forgot_password_request',\n        'auth.password_reset',\n        'auth.tfa_setup',\n        'auth.tfa_enabled',\n        'auth.tfa_disabled',\n        'auth.tfa_recovery_regenerated',\n        'auth.tfa_recovery_used',\n        'community.post_moderated',\n        'community.report_resolved',\n        'community.sanction_created',\n        'community.sanction_revoked',\n        'community.preset_applied',\n        'announcement.create',\n        'announcement.update',\n        'announcement.delete',\n        'review.queued',\n        'review.rejected',\n        'review.resolved',\n        'contest.ranking_snapshot'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.check_ins": {
+      "name": "check_ins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkin_date": {
+          "name": "checkin_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streak": {
+          "name": "streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "check_ins_user_id_users_id_fk": {
+          "name": "check_ins_user_id_users_id_fk",
+          "tableFrom": "check_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "check_ins_user_date_unique": {
+          "name": "check_ins_user_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "checkin_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_activity_events": {
+      "name": "community_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_activity_events_actor": {
+          "name": "idx_community_activity_events_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_activity_events_actor_id_users_id_fk": {
+          "name": "community_activity_events_actor_id_users_id_fk",
+          "tableFrom": "community_activity_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_activity_events_dedupe_unique": {
+          "name": "community_activity_events_dedupe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "type",
+            "subject_type",
+            "subject_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "community_activity_events_type_check": {
+          "name": "community_activity_events_type_check",
+          "value": "\"community_activity_events\".\"type\" IN ('first_accepted', 'solution_published', 'contest_joined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_board_role_grants": {
+      "name": "community_board_role_grants",
+      "schema": "",
+      "columns": {
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_read": {
+          "name": "can_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_post": {
+          "name": "can_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_moderate": {
+          "name": "can_moderate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_community_board_role_grants_role": {
+          "name": "idx_community_board_role_grants_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_board_role_grants_board_id_community_boards_id_fk": {
+          "name": "community_board_role_grants_board_id_community_boards_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_board_role_grants_role_id_roles_id_fk": {
+          "name": "community_board_role_grants_role_id_roles_id_fk",
+          "tableFrom": "community_board_role_grants",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_board_role_grants_board_id_role_id_pk": {
+          "name": "community_board_role_grants_board_id_role_id_pk",
+          "columns": [
+            "board_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_boards": {
+      "name": "community_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_boards_sort": {
+          "name": "idx_community_boards_sort",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_boards_slug_unique": {
+          "name": "community_boards_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_bookmarks": {
+      "name": "community_bookmarks",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_bookmarks_user": {
+          "name": "idx_community_bookmarks_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_bookmarks_post_id_community_posts_id_fk": {
+          "name": "community_bookmarks_post_id_community_posts_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_bookmarks_user_id_users_id_fk": {
+          "name": "community_bookmarks_user_id_users_id_fk",
+          "tableFrom": "community_bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_bookmarks_post_id_user_id_pk": {
+          "name": "community_bookmarks_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comment_likes": {
+      "name": "community_comment_likes",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comment_likes_user": {
+          "name": "idx_community_comment_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comment_likes_comment_id_community_comments_id_fk": {
+          "name": "community_comment_likes_comment_id_community_comments_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comment_likes_user_id_users_id_fk": {
+          "name": "community_comment_likes_user_id_users_id_fk",
+          "tableFrom": "community_comment_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_comment_likes_comment_id_user_id_pk": {
+          "name": "community_comment_likes_comment_id_user_id_pk",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_comments_post": {
+          "name": "idx_community_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_author": {
+          "name": "idx_community_comments_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_comments_parent": {
+          "name": "idx_community_comments_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_author_id_users_id_fk": {
+          "name": "community_comments_author_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_comments_parent_id_community_comments_id_fk": {
+          "name": "community_comments_parent_id_community_comments_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_comments_status_check": {
+          "name": "community_comments_status_check",
+          "value": "\"community_comments\".\"status\" IN ('pending', 'published', 'hidden', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_follows": {
+      "name": "community_follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followee_id": {
+          "name": "followee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_follows_followee": {
+          "name": "idx_community_follows_followee",
+          "columns": [
+            {
+              "expression": "followee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_follows_follower_id_users_id_fk": {
+          "name": "community_follows_follower_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_follows_followee_id_users_id_fk": {
+          "name": "community_follows_followee_id_users_id_fk",
+          "tableFrom": "community_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_follows_follower_id_followee_id_pk": {
+          "name": "community_follows_follower_id_followee_id_pk",
+          "columns": [
+            "follower_id",
+            "followee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_follows_not_self_check": {
+          "name": "community_follows_not_self_check",
+          "value": "\"community_follows\".\"follower_id\" <> \"community_follows\".\"followee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_moderation_actions": {
+      "name": "community_moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_moderation_actions_target": {
+          "name": "idx_community_moderation_actions_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_moderation_actions_moderator": {
+          "name": "idx_community_moderation_actions_moderator",
+          "columns": [
+            {
+              "expression": "moderator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_moderation_actions_moderator_id_users_id_fk": {
+          "name": "community_moderation_actions_moderator_id_users_id_fk",
+          "tableFrom": "community_moderation_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_notifications": {
+      "name": "community_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_notifications_recipient": {
+          "name": "idx_community_notifications_recipient",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_unread": {
+          "name": "idx_community_notifications_unread",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_actor": {
+          "name": "idx_community_notifications_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_post": {
+          "name": "idx_community_notifications_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_notifications_comment": {
+          "name": "idx_community_notifications_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_notifications_recipient_id_users_id_fk": {
+          "name": "community_notifications_recipient_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_notifications_actor_id_users_id_fk": {
+          "name": "community_notifications_actor_id_users_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_post_id_community_posts_id_fk": {
+          "name": "community_notifications_post_id_community_posts_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_notifications_comment_id_community_comments_id_fk": {
+          "name": "community_notifications_comment_id_community_comments_id_fk",
+          "tableFrom": "community_notifications",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_notifications_type_check": {
+          "name": "community_notifications_type_check",
+          "value": "\"community_notifications\".\"type\" IN ('reply', 'like', 'follow', 'moderation', 'clarification', 'report', 'ban')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_post_likes": {
+      "name": "community_post_likes",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_post_likes_user": {
+          "name": "idx_community_post_likes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_post_likes_post_id_community_posts_id_fk": {
+          "name": "community_post_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_post_likes_user_id_users_id_fk": {
+          "name": "community_post_likes_user_id_users_id_fk",
+          "tableFrom": "community_post_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_post_likes_post_id_user_id_pk": {
+          "name": "community_post_likes_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post-' || substr(md5(random()::text), 1, 8)"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_posts_author": {
+          "name": "idx_community_posts_author",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_problem": {
+          "name": "idx_community_posts_problem",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_board": {
+          "name": "idx_community_posts_board",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_published": {
+          "name": "idx_community_posts_published",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_posts_pending": {
+          "name": "idx_community_posts_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_posts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_posts_author_id_users_id_fk": {
+          "name": "community_posts_author_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_problem_id_problems_id_fk": {
+          "name": "community_posts_problem_id_problems_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_posts_board_id_community_boards_id_fk": {
+          "name": "community_posts_board_id_community_boards_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "community_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_posts_public_id_unique": {
+          "name": "community_posts_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "community_posts_type_check": {
+          "name": "community_posts_type_check",
+          "value": "\"community_posts\".\"type\" IN ('solution', 'discussion', 'moment')"
+        },
+        "community_posts_status_check": {
+          "name": "community_posts_status_check",
+          "value": "\"community_posts\".\"status\" IN ('draft', 'pending', 'published', 'hidden', 'deleted')"
+        },
+        "community_posts_context_check": {
+          "name": "community_posts_context_check",
+          "value": "(\n        (\"community_posts\".\"type\" = 'solution' AND \"community_posts\".\"problem_id\" IS NOT NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'discussion' AND \"community_posts\".\"board_id\" IS NOT NULL AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"title\" IS NOT NULL)\n        OR (\"community_posts\".\"type\" = 'moment' AND \"community_posts\".\"problem_id\" IS NULL AND \"community_posts\".\"board_id\" IS NULL AND \"community_posts\".\"title\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_reports": {
+      "name": "community_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "sanction_id": {
+          "name": "sanction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_id": {
+          "name": "ban_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'其他'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_community_reports_pending": {
+          "name": "idx_community_reports_pending",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_reports\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_reporter": {
+          "name": "idx_community_reports_reporter",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_post": {
+          "name": "idx_community_reports_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_comment": {
+          "name": "idx_community_reports_comment",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_reports_message": {
+          "name": "idx_community_reports_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_reports_reporter_id_users_id_fk": {
+          "name": "community_reports_reporter_id_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_reports_post_id_community_posts_id_fk": {
+          "name": "community_reports_post_id_community_posts_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_comment_id_community_comments_id_fk": {
+          "name": "community_reports_comment_id_community_comments_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_message_id_messages_id_fk": {
+          "name": "community_reports_message_id_messages_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_sanction_id_community_sanctions_id_fk": {
+          "name": "community_reports_sanction_id_community_sanctions_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "community_sanctions",
+          "columnsFrom": [
+            "sanction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_ban_id_user_bans_id_fk": {
+          "name": "community_reports_ban_id_user_bans_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "user_bans",
+          "columnsFrom": [
+            "ban_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_reports_resolved_by_users_id_fk": {
+          "name": "community_reports_resolved_by_users_id_fk",
+          "tableFrom": "community_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_reports_target_check": {
+          "name": "community_reports_target_check",
+          "value": "num_nonnulls(\"community_reports\".\"post_id\", \"community_reports\".\"comment_id\", \"community_reports\".\"message_id\") = 1"
+        },
+        "community_reports_status_check": {
+          "name": "community_reports_status_check",
+          "value": "\"community_reports\".\"status\" IN ('pending', 'resolved', 'dismissed')"
+        },
+        "community_reports_category_check": {
+          "name": "community_reports_category_check",
+          "value": "\"community_reports\".\"category\" IN ('违法违规', '人身侵权', '涉嫌欺诈', '侵权抄袭', '垃圾信息', '站外风险引流', 'AI生成内容问题', '其他')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_sanctions": {
+      "name": "community_sanctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_community_sanctions_active": {
+          "name": "idx_community_sanctions_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_sanctions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_community_sanctions_creator": {
+          "name": "idx_community_sanctions_creator",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_sanctions_user_id_users_id_fk": {
+          "name": "community_sanctions_user_id_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_created_by_users_id_fk": {
+          "name": "community_sanctions_created_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_sanctions_revoked_by_users_id_fk": {
+          "name": "community_sanctions_revoked_by_users_id_fk",
+          "tableFrom": "community_sanctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_review_queue": {
+      "name": "content_review_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_provider": {
+          "name": "review_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_words": {
+          "name": "hit_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_content_review_queue_pending_status": {
+          "name": "idx_content_review_queue_pending_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_review_queue_type_status": {
+          "name": "idx_content_review_queue_type_status",
+          "columns": [
+            {
+              "expression": "content_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_review_queue_target": {
+          "name": "idx_content_review_queue_target",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_review_queue_reviewed_by_users_id_fk": {
+          "name": "content_review_queue_reviewed_by_users_id_fk",
+          "tableFrom": "content_review_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "content_review_queue_content_type_check": {
+          "name": "content_review_queue_content_type_check",
+          "value": "\"content_review_queue\".\"content_type\" IN ('post', 'comment', 'message')"
+        },
+        "content_review_queue_channel_check": {
+          "name": "content_review_queue_channel_check",
+          "value": "\"content_review_queue\".\"channel\" IN ('ugc', 'dm')"
+        },
+        "content_review_queue_status_check": {
+          "name": "content_review_queue_status_check",
+          "value": "\"content_review_queue\".\"status\" IN ('pending_review', 'approved', 'rejected', 'reviewed', 'dismissed')"
+        },
+        "content_review_queue_verdict_check": {
+          "name": "content_review_queue_verdict_check",
+          "value": "\"content_review_queue\".\"verdict\" IN ('pass', 'review', 'block', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.contest_clarifications": {
+      "name": "contest_clarifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to_id": {
+          "name": "reply_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_clarifications_contest": {
+          "name": "idx_contest_clarifications_contest",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_clarifications_contest_id_contests_id_fk": {
+          "name": "contest_clarifications_contest_id_contests_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_problem_id_problems_id_fk": {
+          "name": "contest_clarifications_problem_id_problems_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_sender_id_users_id_fk": {
+          "name": "contest_clarifications_sender_id_users_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contest_clarifications_reply_to_id_contest_clarifications_id_fk": {
+          "name": "contest_clarifications_reply_to_id_contest_clarifications_id_fk",
+          "tableFrom": "contest_clarifications",
+          "tableTo": "contest_clarifications",
+          "columnsFrom": [
+            "reply_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_participants": {
+      "name": "contest_participants",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_participants_user": {
+          "name": "idx_contest_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_participants_contest_id_contests_id_fk": {
+          "name": "contest_participants_contest_id_contests_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_participants_user_id_users_id_fk": {
+          "name": "contest_participants_user_id_users_id_fk",
+          "tableFrom": "contest_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_participants_contest_id_user_id_pk": {
+          "name": "contest_participants_contest_id_user_id_pk",
+          "columns": [
+            "contest_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_problems": {
+      "name": "contest_problems",
+      "schema": "",
+      "columns": {
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contest_problems_contest_id_contests_id_fk": {
+          "name": "contest_problems_contest_id_contests_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_problems_problem_id_problems_id_fk": {
+          "name": "contest_problems_problem_id_problems_id_fk",
+          "tableFrom": "contest_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contest_problems_contest_id_problem_id_pk": {
+          "name": "contest_problems_contest_id_problem_id_pk",
+          "columns": [
+            "contest_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "contest_problems_contest_label_unique": {
+          "name": "contest_problems_contest_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "label"
+          ]
+        },
+        "contest_problems_contest_sort_order_unique": {
+          "name": "contest_problems_contest_sort_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest_ranking_snapshots": {
+      "name": "contest_ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "rows": {
+          "name": "rows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contest_ranking_snapshots_contest_created": {
+          "name": "idx_contest_ranking_snapshots_contest_created",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contest_ranking_snapshots_contest_id_contests_id_fk": {
+          "name": "contest_ranking_snapshots_contest_id_contests_id_fk",
+          "tableFrom": "contest_ranking_snapshots",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contest_ranking_snapshots_created_by_users_id_fk": {
+          "name": "contest_ranking_snapshots_created_by_users_id_fk",
+          "tableFrom": "contest_ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contest_ranking_snapshots_contest_version_unique": {
+          "name": "contest_ranking_snapshots_contest_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contest_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contests": {
+      "name": "contests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ct-' || substr(md5(random()::text), 1, 8)"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affect_global_ranking": {
+          "name": "affect_global_ranking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "announcement": {
+          "name": "announcement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_contests_created_by": {
+          "name": "idx_contests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_start_time": {
+          "name": "idx_contests_start_time",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contests_end_time": {
+          "name": "idx_contests_end_time",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contests_created_by_users_id_fk": {
+          "name": "contests_created_by_users_id_fk",
+          "tableFrom": "contests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contests_public_id_unique": {
+          "name": "contests_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "contests_type_check": {
+          "name": "contests_type_check",
+          "value": "\"contests\".\"type\" IN ('kaggle')"
+        },
+        "contests_time_check": {
+          "name": "contests_time_check",
+          "value": "\"contests\".\"end_time\" > \"contests\".\"start_time\""
+        },
+        "contests_config_check": {
+          "name": "contests_config_check",
+          "value": "jsonb_typeof(\"contests\".\"config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_preferences": {
+      "name": "conversation_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remark_name": {
+          "name": "remark_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_muted": {
+          "name": "is_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_conversation_preferences_conv": {
+          "name": "idx_conversation_preferences_conv",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_preferences_user_id_users_id_fk": {
+          "name": "conversation_preferences_user_id_users_id_fk",
+          "tableFrom": "conversation_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_preferences_conversation_id_conversations_id_fk": {
+          "name": "conversation_preferences_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_preferences",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_preferences_user_id_conversation_id_pk": {
+          "name": "conversation_preferences_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_reads": {
+      "name": "conversation_reads",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_reads_user_id_users_id_fk": {
+          "name": "conversation_reads_user_id_users_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_reads_conversation_id_conversations_id_fk": {
+          "name": "conversation_reads_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_reads_user_id_conversation_id_pk": {
+          "name": "conversation_reads_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_conversations_user1_id": {
+          "name": "idx_conversations_user1_id",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_user2_id": {
+          "name": "idx_conversations_user2_id",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_last_message_at": {
+          "name": "idx_conversations_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user1_id_users_id_fk": {
+          "name": "conversations_user1_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_user2_id_users_id_fk": {
+          "name": "conversations_user2_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_user_pair_unique": {
+          "name": "conversations_user_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1_id",
+            "user2_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversations_user_order_check": {
+          "name": "conversations_user_order_check",
+          "value": "\"conversations\".\"user1_id\" < \"conversations\".\"user2_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_delivery_events": {
+      "name": "email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_hash": {
+          "name": "recipient_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_masked": {
+          "name": "recipient_masked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_email_delivery_events_recipient_hash": {
+          "name": "idx_email_delivery_events_recipient_hash",
+          "columns": [
+            {
+              "expression": "recipient_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_delivery_events_occurred_at": {
+          "name": "idx_email_delivery_events_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_delivery_events_provider_event_unique": {
+          "name": "email_delivery_events_provider_event_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_delivery_events_event_type_check": {
+          "name": "email_delivery_events_event_type_check",
+          "value": "\"email_delivery_events\".\"event_type\" IN ('delivery', 'temporary_failure', 'permanent_bounce', 'complaint')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_hash": {
+          "name": "recipient_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_masked": {
+          "name": "recipient_masked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleared_by": {
+          "name": "cleared_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_email_suppressions_recipient_hash": {
+          "name": "idx_email_suppressions_recipient_hash",
+          "columns": [
+            {
+              "expression": "recipient_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_active_recipient_unique": {
+          "name": "email_suppressions_active_recipient_unique",
+          "columns": [
+            {
+              "expression": "recipient_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_suppressions\".\"cleared_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_suppressions_suppressed_at": {
+          "name": "idx_email_suppressions_suppressed_at",
+          "columns": [
+            {
+              "expression": "suppressed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eval_results_submission_id": {
+          "name": "idx_eval_results_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eval_results_created_at": {
+          "name": "idx_eval_results_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_submission_id_submissions_id_fk": {
+          "name": "evaluation_results_submission_id_submissions_id_fk",
+          "tableFrom": "evaluation_results",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ip_bans": {
+      "name": "ip_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ip_or_cidr": {
+          "name": "ip_or_cidr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ip_bans_ip_or_cidr": {
+          "name": "idx_ip_bans_ip_or_cidr",
+          "columns": [
+            {
+              "expression": "ip_or_cidr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ip_bans_expires_at": {
+          "name": "idx_ip_bans_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ip_bans_created_by_users_id_fk": {
+          "name": "ip_bans_created_by_users_id_fk",
+          "tableFrom": "ip_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judge_images": {
+      "name": "judge_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exact'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evaluator'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "judge_images_mode_check": {
+          "name": "judge_images_mode_check",
+          "value": "\"judge_images\".\"mode\" IN ('exact', 'all_versions')"
+        },
+        "judge_images_kind_check": {
+          "name": "judge_images_kind_check",
+          "value": "\"judge_images\".\"kind\" IN ('evaluator', 'solution')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_deletions": {
+      "name": "message_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_message_deletions_message_id": {
+          "name": "idx_message_deletions_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_deletions_user_id_users_id_fk": {
+          "name": "message_deletions_user_id_users_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_deletions_message_id_messages_id_fk": {
+          "name": "message_deletions_message_id_messages_id_fk",
+          "tableFrom": "message_deletions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_deletions_user_id_message_id_pk": {
+          "name": "message_deletions_user_id_message_id_pk",
+          "columns": [
+            "user_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_reactions": {
+      "name": "message_reactions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_message_reactions_message_id": {
+          "name": "idx_message_reactions_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_users_id_fk": {
+          "name": "message_reactions_user_id_users_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_reactions_message_id_user_id_emoji_pk": {
+          "name": "message_reactions_message_id_user_id_emoji_pk",
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forwarded_from_user_id": {
+          "name": "forwarded_from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recalled_at": {
+          "name": "recalled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edit_history": {
+          "name": "edit_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_created": {
+          "name": "idx_messages_conversation_created",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_sender_id": {
+          "name": "idx_messages_sender_id",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_users_id_fk": {
+          "name": "messages_sender_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_reply_to_message_id_messages_id_fk": {
+          "name": "messages_reply_to_message_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "reply_to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_forwarded_from_user_id_users_id_fk": {
+          "name": "messages_forwarded_from_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "forwarded_from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messages_type_check": {
+          "name": "messages_type_check",
+          "value": "\"messages\".\"type\" IN ('text', 'image')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_username": {
+          "name": "provider_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_email": {
+          "name": "provider_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_oauth_accounts_user_id": {
+          "name": "idx_oauth_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_identity_unique": {
+          "name": "oauth_accounts_provider_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.objective_questions": {
+      "name": "objective_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_questions_paper_id": {
+          "name": "idx_objective_questions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_questions_paper_id_problems_id_fk": {
+          "name": "objective_questions_paper_id_problems_id_fk",
+          "tableFrom": "objective_questions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_questions_paper_sort_unique": {
+          "name": "objective_questions_paper_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "sort_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_questions_type_check": {
+          "name": "objective_questions_type_check",
+          "value": "\"objective_questions\".\"type\" IN ('single', 'multiple', 'judge')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.objective_submissions": {
+      "name": "objective_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finished'"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_objective_submissions_paper_id": {
+          "name": "idx_objective_submissions_paper_id",
+          "columns": [
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_id": {
+          "name": "idx_objective_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_user_paper_created": {
+          "name": "idx_objective_submissions_user_paper_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paper_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_objective_submissions_contest_id": {
+          "name": "idx_objective_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "objective_submissions_paper_id_problems_id_fk": {
+          "name": "objective_submissions_paper_id_problems_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_user_id_users_id_fk": {
+          "name": "objective_submissions_user_id_users_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "objective_submissions_contest_id_contests_id_fk": {
+          "name": "objective_submissions_contest_id_contests_id_fk",
+          "tableFrom": "objective_submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "objective_submissions_contest_unique": {
+          "name": "objective_submissions_contest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paper_id",
+            "user_id",
+            "contest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "objective_submissions_type_check": {
+          "name": "objective_submissions_type_check",
+          "value": "\"objective_submissions\".\"submission_type\" IN ('practice', 'contest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_password_reset_tokens_user_id": {
+          "name": "idx_password_reset_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_password_reset_tokens_expires_at": {
+          "name": "idx_password_reset_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_resource_action_unique": {
+          "name": "permissions_resource_action_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resource",
+            "action"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_tags": {
+      "name": "problem_tags",
+      "schema": "",
+      "columns": {
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "problem_tags_problem_id_problems_id_fk": {
+          "name": "problem_tags_problem_id_problems_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "problem_tags_tag_id_tags_id_fk": {
+          "name": "problem_tags_tag_id_tags_id_fk",
+          "tableFrom": "problem_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "problem_tags_problem_id_tag_id_pk": {
+          "name": "problem_tags_problem_id_tag_id_pk",
+          "columns": [
+            "problem_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problems": {
+      "name": "problems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "support_package_storage_url": {
+          "name": "support_package_storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_config": {
+          "name": "runtime_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'U'"
+        },
+        "is_objective": {
+          "name": "is_objective",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "submission_mode": {
+          "name": "submission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'code'"
+        },
+        "artifact_max_size_mb": {
+          "name": "artifact_max_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_config": {
+          "name": "llm_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_problems_search_vector": {
+          "name": "idx_problems_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "problems_type_number_unique": {
+          "name": "problems_type_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "problems_type_check": {
+          "name": "problems_type_check",
+          "value": "\"problems\".\"type\" IN ('U', 'P')"
+        },
+        "problems_submission_mode_check": {
+          "name": "problems_submission_mode_check",
+          "value": "\"problems\".\"submission_mode\" IN ('code', 'artifact')"
+        },
+        "problems_runtime_config_check": {
+          "name": "problems_runtime_config_check",
+          "value": "\"problems\".\"runtime_config\" IS NULL OR jsonb_typeof(\"problems\".\"runtime_config\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_roles_parent_id": {
+          "name": "idx_roles_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roles_parent_id_roles_id_fk": {
+          "name": "roles_parent_id_roles_id_fk",
+          "tableFrom": "roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.self_tests": {
+      "name": "self_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_kb": {
+          "name": "memory_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_self_tests_user_id": {
+          "name": "idx_self_tests_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_problem_id": {
+          "name": "idx_self_tests_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_created_at": {
+          "name": "idx_self_tests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_user_id_created_at": {
+          "name": "idx_self_tests_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_self_tests_status_created_at": {
+          "name": "idx_self_tests_status_created_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "self_tests_user_id_users_id_fk": {
+          "name": "self_tests_user_id_users_id_fk",
+          "tableFrom": "self_tests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "self_tests_problem_id_problems_id_fk": {
+          "name": "self_tests_problem_id_problems_id_fk",
+          "tableFrom": "self_tests",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "self_tests_status_check": {
+          "name": "self_tests_status_check",
+          "value": "\"self_tests\".\"status\" IN ('pending', 'judging', 'finished', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sse_events": {
+      "name": "sse_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sse_events_channel_id": {
+          "name": "idx_sse_events_channel_id",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sub-' || substr(md5(random()::text), 1, 8)"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_storage_url": {
+          "name": "artifact_storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_provider_config_id": {
+          "name": "llm_provider_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejudge_seq": {
+          "name": "rejudge_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "judge_started_at": {
+          "name": "judge_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judge_finished_at": {
+          "name": "judge_finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_submissions_user_id": {
+          "name": "idx_submissions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_problem_id": {
+          "name": "idx_submissions_problem_id",
+          "columns": [
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_status": {
+          "name": "idx_submissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_id": {
+          "name": "idx_submissions_contest_id",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_llm_provider_config_id": {
+          "name": "idx_submissions_llm_provider_config_id",
+          "columns": [
+            {
+              "expression": "llm_provider_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_contest_problem_user": {
+          "name": "idx_submissions_contest_problem_user",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "problem_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_user_id_created_at": {
+          "name": "idx_submissions_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_problem_id_problems_id_fk": {
+          "name": "submissions_problem_id_problems_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_contest_id_contests_id_fk": {
+          "name": "submissions_contest_id_contests_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_public_id_unique": {
+          "name": "submissions_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_settings_updated_at": {
+          "name": "idx_system_settings_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tags_kind_check": {
+          "name": "tags_kind_check",
+          "value": "\"tags\".\"kind\" IN ('problem', 'algorithm')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tfa_recovery_codes": {
+      "name": "tfa_recovery_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tfa_recovery_codes_user_id": {
+          "name": "idx_tfa_recovery_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tfa_recovery_codes_user_id_users_id_fk": {
+          "name": "tfa_recovery_codes_user_id_users_id_fk",
+          "tableFrom": "tfa_recovery_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_problems": {
+      "name": "training_problems",
+      "schema": "",
+      "columns": {
+        "training_id": {
+          "name": "training_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_training_problems_training_position": {
+          "name": "idx_training_problems_training_position",
+          "columns": [
+            {
+              "expression": "training_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_problems_training_id_trainings_id_fk": {
+          "name": "training_problems_training_id_trainings_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "trainings",
+          "columnsFrom": [
+            "training_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "training_problems_problem_id_problems_id_fk": {
+          "name": "training_problems_problem_id_problems_id_fk",
+          "tableFrom": "training_problems",
+          "tableTo": "problems",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "training_problems_training_id_problem_id_pk": {
+          "name": "training_problems_training_id_problem_id_pk",
+          "columns": [
+            "training_id",
+            "problem_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "training_problems_training_position_unique": {
+          "name": "training_problems_training_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "training_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trainings": {
+      "name": "trainings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tr-' || substr(md5(random()::text), 1, 8)"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trainings_visibility_pinned_created": {
+          "name": "idx_trainings_visibility_pinned_created",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trainings_created_by": {
+          "name": "idx_trainings_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trainings_created_by_users_id_fk": {
+          "name": "trainings_created_by_users_id_fk",
+          "tableFrom": "trainings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trainings_public_id_unique": {
+          "name": "trainings_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "trainings_visibility_check": {
+          "name": "trainings_visibility_check",
+          "value": "\"trainings\".\"visibility\" IN ('private', 'unlisted', 'public')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_bans": {
+      "name": "user_bans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        },
+        "banned_until": {
+          "name": "banned_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "banned_by": {
+          "name": "banned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_at": {
+          "name": "unbanned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbanned_by": {
+          "name": "unbanned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_bans_user": {
+          "name": "idx_user_bans_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_bans_active": {
+          "name": "idx_user_bans_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "unbanned_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_bans_user_id_users_id_fk": {
+          "name": "user_bans_user_id_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bans_banned_by_users_id_fk": {
+          "name": "user_bans_banned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "banned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_bans_unbanned_by_users_id_fk": {
+          "name": "user_bans_unbanned_by_users_id_fk",
+          "tableFrom": "user_bans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "unbanned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_bans_scope_check": {
+          "name": "user_bans_scope_check",
+          "value": "\"user_bans\".\"scope\" IN ('platform', 'social')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_verify_token": {
+          "name": "email_verify_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verify_expires_at": {
+          "name": "email_verify_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_activity_visibility": {
+          "name": "community_activity_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'following'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tfa_secret_encrypted": {
+          "name": "tfa_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tfa_enabled": {
+          "name": "tfa_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_active_username_unique": {
+          "name": "users_active_username_unique",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_search_vector": {
+          "name": "idx_users_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_community_activity_visibility_check": {
+          "name": "users_community_activity_visibility_check",
+          "value": "\"users\".\"community_activity_visibility\" IN ('hidden', 'following', 'everyone')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/noj-core/drizzle/meta/_journal.json
+++ b/noj-core/drizzle/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1788618762551,
       "tag": "0067_right_colonel_america",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1788687611363,
+      "tag": "0068_nebulous_juggernaut",
+      "breakpoints": true
     }
   ]
 }

--- a/noj-core/src/domains/identity/services/email-verification.ts
+++ b/noj-core/src/domains/identity/services/email-verification.ts
@@ -11,6 +11,7 @@ import {
   logAuthEvent,
   sendEmailVerificationEmail,
 } from "../../system/index.ts";
+import { isEmailSuppressed } from "../../system/services/email-delivery/service.ts";
 
 export const EMAIL_VERIFICATION_TTL_MINUTES = 30;
 
@@ -48,6 +49,13 @@ export async function sendEmailVerification(
   }).from(users).where(and(eq(users.id, userId), isNull(users.deleted_at)))
     .limit(1);
   if (!user || user.verified) return { sent: false, token: null };
+  if (await isEmailSuppressed(user.email)) {
+    logger.warn("邮箱已被送达质量策略抑制，跳过验证邮件", {
+      module: "email-verification",
+      event: "suppressed",
+    });
+    return { sent: false, token: null };
+  }
   if (
     enforceCooldown && user.expiresAt &&
     Date.parse(user.expiresAt) >

--- a/noj-core/src/domains/identity/services/passwordReset.ts
+++ b/noj-core/src/domains/identity/services/passwordReset.ts
@@ -8,6 +8,7 @@ import { BadRequestError } from "./../../../shared/base/errors.ts";
 import { logger } from "./../../../shared/base/logging.ts";
 import { logAuthEvent } from "../../system/index.ts";
 import { validatePasswordStrength } from "./auth.ts";
+import { isEmailSuppressed } from "../../system/services/email-delivery/service.ts";
 
 /** 密码重置令牌有效期（分钟）。OWASP 2025+ 建议 ≤ 15 分钟。 */
 const TOKEN_TTL_MINUTES = 15;
@@ -79,6 +80,15 @@ export async function requestReset(
   }
 
   const userId = userRows[0].id;
+  if (await isEmailSuppressed(email)) {
+    await logAuthEvent(
+      userId,
+      clientIp ?? "unknown",
+      "auth.forgot_password_request",
+      { email_exists: true },
+    );
+    return;
+  }
 
   // 生成 token + hash
   const plainToken = generateResetToken();

--- a/noj-core/src/domains/system/index.ts
+++ b/noj-core/src/domains/system/index.ts
@@ -10,6 +10,8 @@ export * from "./services/storage/mod.ts";
 export * from "./services/email.ts";
 export * from "./services/email-status.ts";
 export * from "./services/email-providers/types.ts";
+export * from "./services/email-delivery/types.ts";
+export * from "./services/email-delivery/service.ts";
 export * from "./services/env-snapshot.ts";
 export * from "./middleware/rate-limit.ts";
 export * from "./types/audit-log.ts";

--- a/noj-core/src/domains/system/routes/admin-email-delivery.ts
+++ b/noj-core/src/domains/system/routes/admin-email-delivery.ts
@@ -1,0 +1,30 @@
+import { Hono } from "hono";
+import type { AuthEnv } from "../../identity/index.ts";
+import { NotFoundError } from "../../../shared/base/errors.ts";
+import {
+  clearEmailSuppression,
+  listEmailSuppressions,
+} from "../services/email-delivery/service.ts";
+
+/** 管理端查看和解除坏地址抑制；地址仅以脱敏值展示。 */
+const router = new Hono<AuthEnv>();
+
+router.get("/email-delivery/suppressions", async (c) => {
+  const rawLimit = Number(c.req.query("limit") ?? "100");
+  return c.json({
+    data: await listEmailSuppressions(
+      Number.isFinite(rawLimit) ? rawLimit : 100,
+    ),
+  });
+});
+
+router.post("/email-delivery/suppressions/:id/clear", async (c) => {
+  const cleared = await clearEmailSuppression(
+    c.req.param("id"),
+    c.get("userId"),
+  );
+  if (!cleared) throw new NotFoundError("抑制记录不存在或已经解除");
+  return c.json({ data: { cleared: true } });
+});
+
+export default router;

--- a/noj-core/src/domains/system/routes/email-delivery.ts
+++ b/noj-core/src/domains/system/routes/email-delivery.ts
@@ -1,0 +1,59 @@
+import { Hono } from "hono";
+import {
+  BadRequestError,
+  ServiceUnavailableError,
+  UnauthorizedError,
+} from "../../../shared/base/errors.ts";
+import { getSetting } from "../services/system-settings.ts";
+import {
+  getEmailDeliveryAdapter,
+  SignedFixtureEmailDeliveryAdapter,
+} from "../services/email-delivery/fixture-adapter.ts";
+import {
+  ingestEmailDeliveryEvent,
+  normalizeEmailDeliveryEvent,
+} from "../services/email-delivery/service.ts";
+import { EmailDeliveryAdapterError } from "../services/email-delivery/types.ts";
+
+/**
+ * 邮件事件接收入口。
+ *
+ * 只有 fixture 适配器已实现；阿里云/腾讯云在官方回调协议确认前明确返回
+ * 503，不把猜测的字段或签名算法暴露为生产接口。
+ */
+const router = new Hono();
+
+router.post("/email-events/:provider", async (c) => {
+  const provider = c.req.param("provider");
+  if (provider === "fixture" && Deno.env.get("NOJ_ENV") === "production") {
+    throw new ServiceUnavailableError(
+      "fixture 邮件回调仅允许本地或测试环境使用",
+    );
+  }
+  const adapter = getEmailDeliveryAdapter(provider);
+  if (!adapter) {
+    throw new ServiceUnavailableError(
+      `Provider ${provider} 的邮件回调适配器尚未配置，请先按官方协议完成适配`,
+    );
+  }
+  const secret = String(getSetting("email_webhook_secret")?.value ?? "");
+  try {
+    const event = await adapter.parse(c.req.raw, secret);
+    const normalized = await normalizeEmailDeliveryEvent(event);
+    const result = await ingestEmailDeliveryEvent(normalized);
+    return c.json({ data: result }, result.duplicate ? 200 : 202);
+  } catch (error) {
+    if (error instanceof EmailDeliveryAdapterError) {
+      if (error.code === "EMAIL_EVENT_SIGNATURE_INVALID") {
+        throw new UnauthorizedError("邮件事件签名无效", error.code);
+      }
+      throw new BadRequestError(error.message, error.code);
+    }
+    throw error;
+  }
+});
+
+/** Fixture 签名格式仅供测试/本地演练导出，避免误认为厂商协议。 */
+export { SignedFixtureEmailDeliveryAdapter };
+
+export default router;

--- a/noj-core/src/domains/system/routes/index.ts
+++ b/noj-core/src/domains/system/routes/index.ts
@@ -5,10 +5,13 @@ import adminAnnouncements from "./admin-announcements.ts";
 import adminAudit from "./admin-audit.ts";
 import adminJudgeImages from "./admin-judge-images.ts";
 import adminSettings from "./admin-settings.ts";
+import emailDelivery from "./email-delivery.ts";
+import adminEmailDelivery from "./admin-email-delivery.ts";
 
 /** system 域公开路由，挂载到 `/api/v1`。 */
 export const systemRouter = new Hono();
 systemRouter.route("/announcements", announcements);
+systemRouter.route("/", emailDelivery);
 // 明确白名单，禁止将完整系统设置暴露给匿名访客。
 systemRouter.get("/data-policy", (c) =>
   c.json({
@@ -24,3 +27,4 @@ systemAdminRouter.route("/announcements", adminAnnouncements);
 systemAdminRouter.route("/", adminAudit);
 systemAdminRouter.route("/", adminJudgeImages);
 systemAdminRouter.route("/", adminSettings);
+systemAdminRouter.route("/", adminEmailDelivery);

--- a/noj-core/src/domains/system/services/email-delivery/fixture-adapter.ts
+++ b/noj-core/src/domains/system/services/email-delivery/fixture-adapter.ts
@@ -1,0 +1,134 @@
+import {
+  type EmailDeliveryAdapter,
+  EmailDeliveryAdapterError,
+  type EmailDeliveryEvent,
+  type EmailDeliveryEventType,
+} from "./types.ts";
+
+const MAX_CLOCK_SKEW_SECONDS = 300;
+const MAX_BODY_BYTES = 32 * 1024;
+const EVENT_TYPES = new Set<EmailDeliveryEventType>([
+  "delivery",
+  "temporary_failure",
+  "permanent_bounce",
+  "complaint",
+]);
+
+async function verifySignature(
+  body: string,
+  secret: string,
+  timestamp: string,
+  signature: string,
+): Promise<boolean> {
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isInteger(timestampSeconds)) return false;
+  if (Math.abs(Date.now() / 1000 - timestampSeconds) > MAX_CLOCK_SKEW_SECONDS) {
+    return false;
+  }
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+  const expected = signature.startsWith("sha256=")
+    ? signature.slice("sha256=".length)
+    : signature;
+  let encoded: Uint8Array;
+  try {
+    encoded = expected.match(/^[0-9a-f]{64}$/i)
+      ? Uint8Array.from(
+        expected.match(/.{2}/g)!.map((part) => parseInt(part, 16)),
+      )
+      : Uint8Array.from(atob(expected), (char) => char.charCodeAt(0));
+  } catch {
+    return false;
+  }
+  return await crypto.subtle.verify(
+    "HMAC",
+    key,
+    encoded as unknown as BufferSource,
+    new TextEncoder().encode(`${timestamp}.${body}`),
+  );
+}
+
+/**
+ * 仅供 fixture/本地演练使用的通用签名 JSON 适配器。
+ *
+ * 它不是阿里云或腾讯云协议实现；真实 Provider 必须提供自己的 adapter，
+ * 以官方字段和签名文档替换本适配器，避免把猜测的 webhook 暴露到生产。
+ */
+export class SignedFixtureEmailDeliveryAdapter implements EmailDeliveryAdapter {
+  readonly provider = "fixture";
+
+  async parse(request: Request, secret: string): Promise<EmailDeliveryEvent> {
+    if (!secret) {
+      throw new EmailDeliveryAdapterError("fixture webhook secret 未配置");
+    }
+    const body = await request.text();
+    if (new TextEncoder().encode(body).byteLength > MAX_BODY_BYTES) {
+      throw new EmailDeliveryAdapterError("邮件事件请求体过大");
+    }
+    const timestamp = request.headers.get("x-noj-timestamp") ?? "";
+    const signature = request.headers.get("x-noj-signature") ?? "";
+    const providerEventId = request.headers.get("x-noj-event-id") ?? "";
+    if (!timestamp || !signature || !providerEventId) {
+      throw new EmailDeliveryAdapterError("邮件事件缺少签名、时间戳或事件 ID");
+    }
+    if (!(await verifySignature(body, secret, timestamp, signature))) {
+      throw new EmailDeliveryAdapterError(
+        "邮件事件签名无效",
+        "EMAIL_EVENT_SIGNATURE_INVALID",
+      );
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(body) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("not object");
+      }
+      payload = parsed as Record<string, unknown>;
+    } catch {
+      throw new EmailDeliveryAdapterError("邮件事件 JSON 无效");
+    }
+    const type = payload.type;
+    const email = typeof payload.email === "string"
+      ? payload.email.trim().toLowerCase()
+      : "";
+    const occurredAt = typeof payload.occurred_at === "string"
+      ? payload.occurred_at
+      : new Date(Number(timestamp) * 1000).toISOString();
+    if (
+      typeof type !== "string" ||
+      !EVENT_TYPES.has(type as EmailDeliveryEventType) ||
+      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ||
+      !Number.isFinite(Date.parse(occurredAt))
+    ) {
+      throw new EmailDeliveryAdapterError("邮件事件字段无效");
+    }
+    return {
+      provider: this.provider,
+      providerEventId,
+      type: type as EmailDeliveryEventType,
+      email,
+      occurredAt: new Date(occurredAt).toISOString(),
+      reasonCode: typeof payload.reason_code === "string"
+        ? payload.reason_code.slice(0, 128)
+        : undefined,
+      reason: typeof payload.reason === "string"
+        ? payload.reason.slice(0, 512)
+        : undefined,
+    };
+  }
+}
+
+/** 生产 Provider 协议未确认前，只注册 fixture；aliyun/tencent 明确返回 null。 */
+export function getEmailDeliveryAdapter(
+  provider: string,
+): EmailDeliveryAdapter | null {
+  return provider === "fixture"
+    ? new SignedFixtureEmailDeliveryAdapter()
+    : null;
+}

--- a/noj-core/src/domains/system/services/email-delivery/service.ts
+++ b/noj-core/src/domains/system/services/email-delivery/service.ts
@@ -1,0 +1,185 @@
+import { and, desc, eq, isNull } from "drizzle-orm";
+import { getDb } from "../../../../shared/db/connection.ts";
+import {
+  emailDeliveryEvents,
+  emailSuppressions,
+} from "../../../../shared/db/schema.ts";
+import { metrics } from "../../../../shared/base/metrics.ts";
+import type {
+  EmailDeliveryEvent,
+  NormalizedEmailDeliveryEvent,
+} from "./types.ts";
+
+function truncate(value: string | undefined, max: number): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized.slice(0, max) : null;
+}
+
+/** 邮箱哈希用于抑制查询，避免数据库保存完整收件地址。 */
+export async function hashEmail(email: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(email.trim().toLowerCase()),
+  );
+  return Array.from(
+    new Uint8Array(digest),
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+export function maskEmail(email: string): string {
+  const [local = "", domain = ""] = email.trim().toLowerCase().split("@", 2);
+  const visible = local.slice(0, 1) || "*";
+  return `${visible}***@${domain}`;
+}
+
+export async function normalizeEmailDeliveryEvent(
+  event: EmailDeliveryEvent,
+): Promise<NormalizedEmailDeliveryEvent> {
+  return {
+    provider: event.provider,
+    providerEventId: event.providerEventId,
+    type: event.type,
+    occurredAt: event.occurredAt,
+    reasonCode: truncate(event.reasonCode, 128) ?? undefined,
+    reason: truncate(event.reason, 512) ?? undefined,
+    recipientHash: await hashEmail(event.email),
+    recipientMasked: maskEmail(event.email),
+  };
+}
+
+export async function ingestEmailDeliveryEvent(
+  event: NormalizedEmailDeliveryEvent,
+): Promise<{ duplicate: boolean; suppressed: boolean }> {
+  const db = getDb();
+  const receivedAt = new Date().toISOString();
+  const inserted = await db.insert(emailDeliveryEvents).values({
+    id: crypto.randomUUID(),
+    provider: event.provider,
+    provider_event_id: event.providerEventId,
+    event_type: event.type,
+    recipient_hash: event.recipientHash,
+    recipient_masked: event.recipientMasked,
+    reason_code: event.reasonCode ?? null,
+    reason: event.reason ?? null,
+    occurred_at: event.occurredAt,
+    received_at: receivedAt,
+  }).onConflictDoNothing({
+    target: [
+      emailDeliveryEvents.provider,
+      emailDeliveryEvents.provider_event_id,
+    ],
+  }).returning({ id: emailDeliveryEvents.id });
+
+  if (inserted.length === 0) {
+    metrics.inc("noj_email_delivery_events_duplicate_total", {
+      provider: event.provider,
+    });
+    return {
+      duplicate: true,
+      suppressed: await isEmailHashSuppressed(event.recipientHash),
+    };
+  }
+
+  metrics.inc("noj_email_delivery_events_total", {
+    provider: event.provider,
+    event_type: event.type,
+  });
+  if (event.type === "temporary_failure") {
+    metrics.inc("noj_email_temporary_failures_total", {
+      provider: event.provider,
+    });
+  }
+
+  if (event.type !== "permanent_bounce" && event.type !== "complaint") {
+    return {
+      duplicate: false,
+      suppressed: await isEmailHashSuppressed(event.recipientHash),
+    };
+  }
+
+  const reason = `${event.type}${
+    event.reasonCode ? `:${event.reasonCode}` : ""
+  }`;
+  const existing = await db.select({ id: emailSuppressions.id }).from(
+    emailSuppressions,
+  )
+    .where(
+      and(
+        eq(emailSuppressions.recipient_hash, event.recipientHash),
+        isNull(emailSuppressions.cleared_at),
+      ),
+    )
+    .limit(1);
+  if (existing.length > 0) {
+    await db.update(emailSuppressions).set({
+      reason,
+      provider: event.provider,
+      source_event_id: event.providerEventId,
+      suppressed_at: receivedAt,
+      recipient_masked: event.recipientMasked,
+    }).where(eq(emailSuppressions.id, existing[0].id));
+  } else {
+    await db.insert(emailSuppressions).values({
+      id: crypto.randomUUID(),
+      recipient_hash: event.recipientHash,
+      recipient_masked: event.recipientMasked,
+      reason,
+      provider: event.provider,
+      source_event_id: event.providerEventId,
+      suppressed_at: receivedAt,
+      cleared_at: null,
+      cleared_by: null,
+    });
+  }
+  metrics.inc("noj_email_suppressions_total", {
+    provider: event.provider,
+    reason: event.type,
+  });
+  return { duplicate: false, suppressed: true };
+}
+
+async function isEmailHashSuppressed(recipientHash: string): Promise<boolean> {
+  const row = await getDb().select({ id: emailSuppressions.id }).from(
+    emailSuppressions,
+  )
+    .where(
+      and(
+        eq(emailSuppressions.recipient_hash, recipientHash),
+        isNull(emailSuppressions.cleared_at),
+      ),
+    )
+    .limit(1);
+  return row.length > 0;
+}
+
+export async function isEmailSuppressed(email: string): Promise<boolean> {
+  return await isEmailHashSuppressed(await hashEmail(email));
+}
+
+export async function listEmailSuppressions(limit = 100) {
+  return await getDb().select({
+    id: emailSuppressions.id,
+    recipient_masked: emailSuppressions.recipient_masked,
+    reason: emailSuppressions.reason,
+    provider: emailSuppressions.provider,
+    source_event_id: emailSuppressions.source_event_id,
+    suppressed_at: emailSuppressions.suppressed_at,
+    cleared_at: emailSuppressions.cleared_at,
+    cleared_by: emailSuppressions.cleared_by,
+  }).from(emailSuppressions).orderBy(desc(emailSuppressions.suppressed_at))
+    .limit(
+      Math.max(1, Math.min(limit, 200)),
+    );
+}
+
+export async function clearEmailSuppression(id: string, clearedBy: string) {
+  const rows = await getDb().update(emailSuppressions).set({
+    cleared_at: new Date().toISOString(),
+    cleared_by: clearedBy,
+  }).where(
+    and(eq(emailSuppressions.id, id), isNull(emailSuppressions.cleared_at)),
+  )
+    .returning({ id: emailSuppressions.id });
+  return rows.length > 0;
+}

--- a/noj-core/src/domains/system/services/email-delivery/types.ts
+++ b/noj-core/src/domains/system/services/email-delivery/types.ts
@@ -1,0 +1,35 @@
+/** 内部统一的邮件送达事件类型；不等同于任一厂商的 webhook 字段。 */
+export type EmailDeliveryEventType =
+  | "delivery"
+  | "temporary_failure"
+  | "permanent_bounce"
+  | "complaint";
+
+export interface EmailDeliveryEvent {
+  provider: string;
+  providerEventId: string;
+  type: EmailDeliveryEventType;
+  email: string;
+  occurredAt: string;
+  reasonCode?: string;
+  reason?: string;
+}
+
+export interface NormalizedEmailDeliveryEvent
+  extends Omit<EmailDeliveryEvent, "email"> {
+  recipientHash: string;
+  recipientMasked: string;
+}
+
+/** 厂商适配器契约；解析前必须完成签名、时间戳和重放校验。 */
+export interface EmailDeliveryAdapter {
+  readonly provider: string;
+  parse(request: Request, secret: string): Promise<EmailDeliveryEvent>;
+}
+
+export class EmailDeliveryAdapterError extends Error {
+  constructor(message: string, readonly code = "EMAIL_EVENT_INVALID") {
+    super(message);
+    this.name = "EmailDeliveryAdapterError";
+  }
+}

--- a/noj-core/src/domains/system/services/email.ts
+++ b/noj-core/src/domains/system/services/email.ts
@@ -17,6 +17,7 @@ import type {
 import { buildEmailVerificationHtml } from "./email-providers/common.ts";
 import { getSetting } from "./system-settings.ts";
 import { logger } from "../../../shared/base/logging.ts";
+import { metrics } from "../../../shared/base/metrics.ts";
 
 /** Provider 名称到模块路径的映射 */
 const PROVIDER_MODULES: Record<string, string> = {
@@ -104,6 +105,10 @@ export async function sendPasswordResetEmail(
   resetLink: string,
   expiresInMinutes = 15,
 ): Promise<void> {
+  metrics.inc("noj_email_send_attempts_total", {
+    provider: String(getSetting("email_provider")?.value ?? "mock"),
+    message_type: "password_reset",
+  });
   const fn = await loadSendFn();
   await fn(email, resetLink, expiresInMinutes);
 }
@@ -114,6 +119,10 @@ export async function sendEmailVerificationEmail(
   verifyLink: string,
   expiresInMinutes = 30,
 ): Promise<boolean> {
+  metrics.inc("noj_email_send_attempts_total", {
+    provider: String(getSetting("email_provider")?.value ?? "mock"),
+    message_type: "verification",
+  });
   const fn = await loadGenericSendFn();
   return await fn(
     email,
@@ -129,6 +138,10 @@ export async function sendEmailVerificationEmail(
  * disabled Provider 会返回 false，临时故障由调用方捕获并反馈。
  */
 export async function sendTestEmail(to: string): Promise<boolean> {
+  metrics.inc("noj_email_send_attempts_total", {
+    provider: String(getSetting("email_provider")?.value ?? "mock"),
+    message_type: "test",
+  });
   const fn = await loadGenericSendFn();
   return await fn(
     to,

--- a/noj-core/src/domains/system/tests/services/email-delivery.test.ts
+++ b/noj-core/src/domains/system/tests/services/email-delivery.test.ts
@@ -1,0 +1,109 @@
+import { assert, assertEquals, assertRejects } from "jsr:@std/assert@^1";
+import {
+  SignedFixtureEmailDeliveryAdapter,
+} from "../../services/email-delivery/fixture-adapter.ts";
+import {
+  clearEmailSuppression,
+  hashEmail,
+  ingestEmailDeliveryEvent,
+  isEmailSuppressed,
+  listEmailSuppressions,
+  maskEmail,
+  normalizeEmailDeliveryEvent,
+} from "../../services/email-delivery/service.ts";
+import { EmailDeliveryAdapterError } from "../../services/email-delivery/types.ts";
+
+async function signFixture(
+  body: string,
+  secret: string,
+  timestamp: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(`${timestamp}.${body}`),
+  );
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+Deno.test("email delivery: 地址只生成稳定哈希和脱敏值", async () => {
+  assertEquals(
+    await hashEmail(" User@Example.COM "),
+    await hashEmail("user@example.com"),
+  );
+  assertEquals(maskEmail("User@Example.COM"), "u***@example.com");
+});
+
+Deno.test("email delivery: fixture 适配器验证签名、时间戳和事件字段", async () => {
+  const adapter = new SignedFixtureEmailDeliveryAdapter();
+  const secret = "fixture-secret";
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const body = JSON.stringify({
+    type: "permanent_bounce",
+    email: "bad@example.com",
+    reason_code: "mailbox_not_found",
+  });
+  const signature = await signFixture(body, secret, timestamp);
+  const request = new Request("http://localhost/email-events/fixture", {
+    method: "POST",
+    body,
+    headers: {
+      "x-noj-timestamp": timestamp,
+      "x-noj-signature": signature,
+      "x-noj-event-id": "evt-1",
+    },
+  });
+  const invalidRequest = request.clone();
+  const event = await adapter.parse(request, secret);
+  assertEquals(event.provider, "fixture");
+  assertEquals(event.type, "permanent_bounce");
+  assertEquals(event.providerEventId, "evt-1");
+
+  await assertRejects(
+    () => adapter.parse(invalidRequest, "wrong-secret"),
+    EmailDeliveryAdapterError,
+    "签名无效",
+  );
+});
+
+Deno.test("email delivery: 永久退信建立抑制且重复事件幂等", async () => {
+  const event = await normalizeEmailDeliveryEvent({
+    provider: "fixture",
+    providerEventId: `evt-${crypto.randomUUID()}`,
+    type: "permanent_bounce",
+    email: "bounce@example.com",
+    occurredAt: new Date().toISOString(),
+    reasonCode: "mailbox_not_found",
+  });
+  const first = await ingestEmailDeliveryEvent(event);
+  const duplicate = await ingestEmailDeliveryEvent(event);
+  assertEquals(first, { duplicate: false, suppressed: true });
+  assertEquals(duplicate, { duplicate: true, suppressed: true });
+  assertEquals(await isEmailSuppressed("bounce@example.com"), true);
+
+  const rows = await listEmailSuppressions();
+  const row = rows.find((item) => item.recipient_masked === "b***@example.com");
+  assert(row);
+  assertEquals(await clearEmailSuppression(row.id, "admin-test"), true);
+  assertEquals(await isEmailSuppressed("bounce@example.com"), false);
+});
+
+Deno.test("email delivery: 临时失败不建立永久抑制", async () => {
+  const event = await normalizeEmailDeliveryEvent({
+    provider: "fixture",
+    providerEventId: `evt-${crypto.randomUUID()}`,
+    type: "temporary_failure",
+    email: "temporary@example.com",
+    occurredAt: new Date().toISOString(),
+  });
+  const result = await ingestEmailDeliveryEvent(event);
+  assertEquals(result.suppressed, false);
+  assertEquals(await isEmailSuppressed("temporary@example.com"), false);
+});

--- a/noj-core/src/shared/base/metrics.ts
+++ b/noj-core/src/shared/base/metrics.ts
@@ -280,6 +280,31 @@ metrics.define(
   "Redis 健康检查失败总数",
   "counter",
 );
+metrics.define(
+  "noj_email_delivery_events_total",
+  "邮件送达事件总数",
+  "counter",
+);
+metrics.define(
+  "noj_email_send_attempts_total",
+  "邮件发送尝试总数",
+  "counter",
+);
+metrics.define(
+  "noj_email_delivery_events_duplicate_total",
+  "重复邮件送达事件总数",
+  "counter",
+);
+metrics.define(
+  "noj_email_temporary_failures_total",
+  "邮件临时失败总数",
+  "counter",
+);
+metrics.define(
+  "noj_email_suppressions_total",
+  "邮件永久抑制总数",
+  "counter",
+);
 
 /**
  * 将请求路径归一化为低基数路由。

--- a/noj-core/src/shared/config/settings-registry.ts
+++ b/noj-core/src/shared/config/settings-registry.ts
@@ -229,6 +229,17 @@ export const CONFIG_DEFINITIONS: readonly SettingDefinition[] = [
     category: "email",
     scope: "bootstrap",
   },
+  {
+    key: "email_webhook_secret",
+    type: "string",
+    default: "",
+    description:
+      "内部 fixture 邮件回调签名密钥；真实 Provider 需按官方协议单独适配",
+    is_secret: true,
+    envKey: "EMAIL_WEBHOOK_SECRET",
+    category: "email",
+    scope: "bootstrap",
+  },
 
   // ── rate_limit ────────────────────────────────────────────
   {

--- a/noj-core/src/shared/db/schema-ddl.ts
+++ b/noj-core/src/shared/db/schema-ddl.ts
@@ -432,6 +432,32 @@ export const SCHEMA_DDL: string[] = [
     unbanned_by TEXT REFERENCES users(id) ON DELETE SET NULL
   )`,
 
+  // 17.1 邮件送达事件和坏地址抑制（issue #449）；只保存哈希与脱敏地址
+  `CREATE TABLE IF NOT EXISTS email_delivery_events (
+    id TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    provider_event_id TEXT NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('delivery', 'temporary_failure', 'permanent_bounce', 'complaint')),
+    recipient_hash TEXT NOT NULL,
+    recipient_masked TEXT NOT NULL,
+    reason_code TEXT,
+    reason TEXT,
+    occurred_at TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    UNIQUE (provider, provider_event_id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS email_suppressions (
+    id TEXT PRIMARY KEY,
+    recipient_hash TEXT NOT NULL,
+    recipient_masked TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    source_event_id TEXT NOT NULL,
+    suppressed_at TEXT NOT NULL,
+    cleared_at TEXT,
+    cleared_by TEXT
+  )`,
+
   // 社区表依赖 RBAC 角色（roles 已在顶部预置，见 SCHEMA_DDL 第 2 项）
 
   `CREATE TABLE IF NOT EXISTS community_boards (
@@ -690,6 +716,11 @@ export const SCHEMA_INDEXES: string[] = [
   "CREATE INDEX IF NOT EXISTS idx_ip_bans_expires_at ON ip_bans (expires_at)",
   "CREATE INDEX IF NOT EXISTS idx_user_bans_user ON user_bans (user_id)",
   "CREATE INDEX IF NOT EXISTS idx_user_bans_active ON user_bans (user_id) WHERE unbanned_at IS NULL",
+  "CREATE INDEX IF NOT EXISTS idx_email_delivery_events_recipient_hash ON email_delivery_events (recipient_hash)",
+  "CREATE INDEX IF NOT EXISTS idx_email_delivery_events_occurred_at ON email_delivery_events (occurred_at)",
+  "CREATE INDEX IF NOT EXISTS idx_email_suppressions_recipient_hash ON email_suppressions (recipient_hash)",
+  "CREATE UNIQUE INDEX IF NOT EXISTS email_suppressions_active_recipient_unique ON email_suppressions (recipient_hash) WHERE cleared_at IS NULL",
+  "CREATE INDEX IF NOT EXISTS idx_email_suppressions_suppressed_at ON email_suppressions (suppressed_at)",
   "CREATE INDEX IF NOT EXISTS idx_community_boards_sort ON community_boards (is_archived, sort_order)",
   "CREATE INDEX IF NOT EXISTS idx_community_board_role_grants_role ON community_board_role_grants (role_id)",
   "CREATE INDEX IF NOT EXISTS idx_community_posts_author ON community_posts (author_id, created_at)",
@@ -792,4 +823,6 @@ export const ALL_TABLES = [
   "community_notifications",
   "announcements",
   "content_review_queue",
+  "email_delivery_events",
+  "email_suppressions",
 ] as const;

--- a/noj-core/src/shared/db/schema/email.ts
+++ b/noj-core/src/shared/db/schema/email.ts
@@ -1,0 +1,67 @@
+import {
+  check,
+  index,
+  pgTable,
+  text,
+  unique,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+
+/** 邮件回调归一化事件；只保存收件地址哈希和脱敏展示值。 */
+export const emailDeliveryEvents = pgTable(
+  "email_delivery_events",
+  {
+    id: text("id").primaryKey(),
+    provider: text("provider").notNull(),
+    provider_event_id: text("provider_event_id").notNull(),
+    event_type: text("event_type").notNull(),
+    recipient_hash: text("recipient_hash").notNull(),
+    recipient_masked: text("recipient_masked").notNull(),
+    reason_code: text("reason_code"),
+    reason: text("reason"),
+    occurred_at: text("occurred_at").notNull(),
+    received_at: text("received_at").notNull(),
+  },
+  (table) => ({
+    providerEventUnique: unique("email_delivery_events_provider_event_unique")
+      .on(table.provider, table.provider_event_id),
+    recipientIdx: index("idx_email_delivery_events_recipient_hash").on(
+      table.recipient_hash,
+    ),
+    occurredIdx: index("idx_email_delivery_events_occurred_at").on(
+      table.occurred_at,
+    ),
+    eventTypeCheck: check(
+      "email_delivery_events_event_type_check",
+      sql`${table.event_type} IN ('delivery', 'temporary_failure', 'permanent_bounce', 'complaint')`,
+    ),
+  }),
+);
+
+/** 永久退信/投诉抑制清单；cleared_at 非空表示管理员已解除抑制。 */
+export const emailSuppressions = pgTable(
+  "email_suppressions",
+  {
+    id: text("id").primaryKey(),
+    recipient_hash: text("recipient_hash").notNull(),
+    recipient_masked: text("recipient_masked").notNull(),
+    reason: text("reason").notNull(),
+    provider: text("provider").notNull(),
+    source_event_id: text("source_event_id").notNull(),
+    suppressed_at: text("suppressed_at").notNull(),
+    cleared_at: text("cleared_at"),
+    cleared_by: text("cleared_by"),
+  },
+  (table) => ({
+    recipientIdx: index("idx_email_suppressions_recipient_hash").on(
+      table.recipient_hash,
+    ),
+    activeUnique: uniqueIndex("email_suppressions_active_recipient_unique")
+      .on(table.recipient_hash)
+      .where(sql`${table.cleared_at} IS NULL`),
+    suppressedAtIdx: index("idx_email_suppressions_suppressed_at").on(
+      table.suppressed_at,
+    ),
+  }),
+);

--- a/noj-core/src/shared/db/schema/index.ts
+++ b/noj-core/src/shared/db/schema/index.ts
@@ -7,3 +7,4 @@ export * from "./submission.ts";
 export * from "./messaging.ts";
 export * from "./community.ts";
 export * from "./content-review.ts";
+export * from "./email.ts";

--- a/noj-docs/docs/operators/email-delivery.md
+++ b/noj-docs/docs/operators/email-delivery.md
@@ -1,0 +1,36 @@
+# 邮件退信与送达质量
+
+## 当前边界
+
+Neuro OJ 当前已实现阿里云 DirectMail 和腾讯云 SES 的发信 Provider，但仓库没有预置真实生产回调地址、secret 或厂商事件协议。两家服务的 webhook 字段、签名和重放规则不能互换，因此代码不会把内部 fixture 格式冒充为厂商协议。
+
+本次实现提供：
+
+- 内部统一事件：`delivery`、`temporary_failure`、`permanent_bounce`、`complaint`。
+- `EmailDeliveryAdapter` 接口和带 HMAC-SHA256、时间戳（5 分钟窗口）、事件 ID 的 fixture 适配器，供测试和本地演练。
+- 事件 ID 幂等；数据库只保存收件地址 SHA-256 哈希和脱敏地址，不保存原始 webhook。
+- 永久退信和投诉进入抑制清单；验证邮件和密码重置邮件发送前查询清单，临时失败不会永久抑制。
+- 管理端查看和解除抑制：`GET /api/v1/admin/email-delivery/suppressions`、`POST /api/v1/admin/email-delivery/suppressions/:id/clear`。
+
+fixture 回调入口为 `POST /api/v1/email-events/fixture`，签名密钥使用 `EMAIL_WEBHOOK_SECRET`。该入口只用于本地/测试，不应暴露到生产公网。
+
+## 生产 Provider 上线清单
+
+确定公测实际 Provider 后，必须基于该 Provider 的官方文档新增适配器，并完成以下验收：
+
+1. 官方签名、时间戳、来源校验和重放窗口测试。
+2. 官方事件 ID、收件地址、事件时间、退信分类和投诉字段 fixture 测试。
+3. 伪造签名、过期事件、重复事件不会写入或重复计数。
+4. 真实 sandbox/生产测试事件能在管理端看到脱敏记录，永久退信地址不会再收到验证/密码重置邮件。
+5. 只把 `noj_email_*` 聚合指标交给 Prometheus；日志、指标和告警不得带完整邮箱。
+6. 在外部 TLS/网关层限制回调来源和速率，回调请求体不得被普通业务日志记录。
+
+阿里云和腾讯云的生产 webhook 适配器未在本变更中声称完成；没有真实账号、回调配置和官方协议就不能宣称“真实事件验收通过”。
+
+## 告警处置
+
+- `NojEmailPermanentBounce`：检查坏地址抑制增长、退信分类和域名 DNS；不要批量解除抑制。
+- `NojEmailComplaint`：按投诉来源暂停相关活动或模板，确认 SPF、DKIM、DMARC 与退订策略。
+- `NojEmailTemporaryFailure`：检查 Provider 限流、网络、配额和域名信誉；临时失败不会自动永久封禁地址。
+
+告警只证明 core 已收到并归一化事件，不能证明 Provider 已发送回调或实际送达。上线前仍需执行一次真实 Provider 回调演练并记录结果。

--- a/scripts/deploy/restore-drill-verify.ts
+++ b/scripts/deploy/restore-drill-verify.ts
@@ -3,7 +3,8 @@
  *
  * 由 scripts/deploy/restore-drill.sh 在隔离恢复出的 core 容器内执行
  * （`docker compose run core deno run -A /opt/verify.ts ...`），面向真实
- * HTTP API 验证恢复后的业务链路：登录、题目读取、附件下载与真实评测。
+ * HTTP API 验证恢复后的业务链路：登录、题目读取；未跳过 Judge 时还会验证附件
+ * 下载与真实评测。
  *
  * 输出：每个步骤一行 JSON（{"step","status","detail"}），最后一行输出
  * {"step":"summary","status":...,"passed":bool,"steps":[...]}，由外层脚本
@@ -52,8 +53,9 @@ const EVALUATOR_IMAGE = optEnv("DRILL_EVALUATOR_IMAGE");
 const SOLUTION_IMAGE = optEnv("DRILL_SOLUTION_IMAGE");
 const SKIP_EVALUATION = Deno.env.get("DRILL_SKIP_EVALUATION") === "1";
 
-/** 与生产一致的 cookie 名；HttpOnly JWT 由登录响应下发。 */
+/** 与生产一致的认证凭据；历史 core 直接在 JSON 响应返回 token。 */
 let authCookie = "";
+let authToken = "";
 
 async function api(
   method: string,
@@ -62,14 +64,23 @@ async function api(
 ): Promise<Response> {
   const headers = new Headers(init.headers);
   if (authCookie) headers.set("Cookie", authCookie);
+  if (authToken) headers.set("Authorization", `Bearer ${authToken}`);
   return await fetch(`${BASE_URL}${path}`, { method, ...init, headers });
 }
 
-/** 解析响应中的 Set-Cookie，保存 noj:token 供后续请求鉴权。 */
-function captureAuthCookie(res: Response): void {
+/** 兼容 Cookie 与 JSON token 两种登录响应，供后续直连 core 的验收请求鉴权。 */
+function captureAuth(res: Response, payload: unknown): void {
   const setCookie = res.headers.get("set-cookie") ?? "";
   const match = setCookie.match(/(?:^|[,\s])noj:token=([^;,\s]+)/);
-  if (match) authCookie = `noj:token=${match[1]}`;
+  if (match) {
+    authToken = match[1];
+    authCookie = `noj:token=${authToken}`;
+    return;
+  }
+  const candidate =
+    (payload as { data?: { token?: unknown }; token?: unknown })?.data
+      ?.token ?? (payload as { token?: unknown })?.token;
+  if (typeof candidate === "string" && candidate) authToken = candidate;
 }
 
 // ---------------------------------------------------------------------------
@@ -242,7 +253,6 @@ async function stepLogin(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ login: ADMIN_USER, password: ADMIN_PASSWORD }),
   });
-  captureAuthCookie(res);
   if (res.status !== 200) {
     required(
       "login",
@@ -252,11 +262,12 @@ async function stepLogin(): Promise<void> {
     return;
   }
   const payload = await res.json();
+  captureAuth(res, payload);
   const username = payload?.data?.username ?? ADMIN_USER;
   required(
     "login",
-    Boolean(authCookie),
-    `管理员 ${username} 登录成功并下发会话 Cookie`,
+    Boolean(authToken),
+    `管理员 ${username} 登录成功并取得认证令牌`,
   );
 }
 
@@ -411,6 +422,15 @@ async function stepRegisterProbe(): Promise<void> {
 async function main(): Promise<void> {
   await stepLogin();
   if (requiredFailure) {
+    finish();
+    return;
+  }
+
+  // 轻量验收不依赖 Judge 镜像白名单：验证恢复后的认证与题目查询即可。
+  // 附件下载和真实评测属于启用 Judge 后的扩展验收。
+  if (SKIP_EVALUATION) {
+    await stepProblemRead(null);
+    await stepRegisterProbe();
     finish();
     return;
   }

--- a/scripts/deploy/restore-drill-verify_test.ts
+++ b/scripts/deploy/restore-drill-verify_test.ts
@@ -27,12 +27,13 @@ Deno.test("恢复演练业务验收：全链路通过", async () => {
     const path = url.pathname;
     if (path === "/api/v1/auth/login" && req.method === "POST") {
       return new Response(
-        JSON.stringify({ data: { username: "drill_admin" } }),
+        JSON.stringify({
+          data: { username: "drill_admin", token: "drill-jwt" },
+        }),
         {
           status: 200,
           headers: {
             "Content-Type": "application/json",
-            "Set-Cookie": "noj:token=drill-jwt; HttpOnly; Path=/; SameSite=Lax",
           },
         },
       );
@@ -66,8 +67,8 @@ Deno.test("恢复演练业务验收：全链路通过", async () => {
     }
     if (path === "/api/v1/problems/drill-problem-1/support-package") {
       assert(
-        (req.headers.get("Cookie") ?? "").includes("noj:token=drill-jwt"),
-        "支持包下载应携带会话 Cookie",
+        req.headers.get("Authorization") === "Bearer drill-jwt",
+        "支持包下载应携带 JSON 登录响应中的 Bearer token",
       );
       // 最小 zip：PK 头 + 尾部字节。
       return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
@@ -121,7 +122,7 @@ Deno.test("恢复演练业务验收：全链路通过", async () => {
     const summary = steps.find((s) => s.step === "summary");
     assert(summary, "应输出 summary 行");
     assert(
-      summary.status === "passed",
+      summary?.status === "passed",
       `全链路应通过，实际步骤：${JSON.stringify(steps)}`,
     );
     assert(output.code === 0, "业务验收通过时进程应以 0 退出");
@@ -178,6 +179,57 @@ Deno.test("恢复演练业务验收：登录失败立即失败", async () => {
     assert(
       !steps.some((s) => s.step === "summary" && s.status === "passed"),
       "不应输出通过的 summary",
+    );
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("恢复演练业务验收：跳过 Judge 时不导入评测题目", async () => {
+  const handler = (req: Request): Response => {
+    const path = new URL(req.url).pathname;
+    if (path === "/api/v1/auth/login") {
+      return Response.json({
+        data: { username: "drill_admin", token: "drill-jwt" },
+      });
+    }
+    if (path === "/api/v1/problems") return Response.json({ data: [] });
+    if (path === "/api/v1/auth/register") {
+      return Response.json({ data: {} }, { status: 201 });
+    }
+    if (path === "/api/v1/problems/import-bundle") {
+      return new Response("轻量验收不应导入评测题目", { status: 500 });
+    }
+    return new Response("not found", { status: 404 });
+  };
+  const server = Deno.serve({ port: 0, handler });
+  const port = (server.addr as Deno.NetAddr).port;
+  try {
+    const output = await new Deno.Command("deno", {
+      args: ["run", "-A", "--no-check", scriptPath],
+      env: {
+        DRILL_BASE_URL: `http://127.0.0.1:${port}/api/v1`,
+        DRILL_ADMIN_USER: "drill_admin",
+        DRILL_ADMIN_PASSWORD: "Drill-Recover-2026",
+        DRILL_EVALUATOR_IMAGE: "noj-evaluator-python",
+        DRILL_SOLUTION_IMAGE: "noj-solution-python",
+        DRILL_SKIP_EVALUATION: "1",
+      },
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const steps = new TextDecoder().decode(output.stdout).trim().split("\n")
+      .map((line) => JSON.parse(line) as StepLine);
+    assert(output.code === 0, "轻量验收应通过");
+    assert(
+      steps.some((step) =>
+        step.step === "problem_read" && step.status === "passed"
+      ),
+      "应读取题目",
+    );
+    assert(
+      !steps.some((step) => step.step === "problem_import"),
+      "不应导入评测题目",
     );
   } finally {
     await server.shutdown();

--- a/scripts/deploy/restore-drill.sh
+++ b/scripts/deploy/restore-drill.sh
@@ -3,8 +3,8 @@
 #
 # 与 backup.sh drill（纯文件校验）不同，本脚本把快照真实恢复到一个独立的
 # Compose 项目（独立数据卷、独立网络子网、不映射宿主机端口），随后验收业务：
-# 登录、题目读取、附件下载和至少一次真实评测。任何环节失败都以非零退出并
-# 保留诊断报告。
+# 登录、题目读取；启用 Judge 时还会验收附件下载与真实评测。任何环节失败都以
+# 非零退出并保留诊断报告。
 #
 # 用法：restore-drill.sh SNAPSHOT [选项]
 # 详见 usage()。
@@ -63,7 +63,7 @@ Neuro OJ 备份隔离恢复演练
 
 与 backup.sh drill（快照文件校验）不同，本命令把快照真实恢复到独立 Compose
 项目（独立数据卷、独立子网、不占用宿主机端口），恢复后通过真实 API 验收：
-登录、题目读取、附件（支持包）下载与一次真实评测。
+登录与题目读取；未使用 --skip-judge 时还会验证附件（支持包）下载与一次真实评测。
 
 选项：
   --env-file FILE          生产环境文件（默认 .env.prod）
@@ -76,7 +76,7 @@ Neuro OJ 备份隔离恢复演练
   --rpo-max-hours N        RPO 目标：快照允许的最大时长（默认 24 小时）
   --rto-max-minutes N      RTO 目标：恢复+验收允许的最大时长（默认 60 分钟）
   --wait-timeout N         Compose 服务等待超时秒数（默认 300）
-  --skip-judge             跳过真实评测（仍执行登录/题目/附件验收）
+  --skip-judge             轻量验收：跳过 Judge、题目导入和附件/评测验收，仅验证登录与题目读取
   --keep                   保留演练临时目录与 Compose 资源供人工检查
   -h, --help               显示帮助
 
@@ -242,6 +242,9 @@ parse_args() {
 preflight() {
   STAGE="preflight"
   validate_snapshot_path "$SNAPSHOT"
+  # Compose 的 bind mount 只能可靠接收绝对宿主机路径；相对路径会被解释为
+  # 具名 volume，导致 MinIO 快照目录无法挂载。
+  SNAPSHOT="$(cd -- "$SNAPSHOT" && pwd -P)"
   [[ -f "$SNAPSHOT/SUCCESS" ]] || die "快照缺少成功标记：$SNAPSHOT/SUCCESS"
   [[ -f "$SNAPSHOT/manifest.json" ]] || die "快照缺少 manifest.json"
   [[ -f "$SNAPSHOT/env.prod.gpg" ]] || die "快照缺少加密环境文件 env.prod.gpg"
@@ -342,8 +345,10 @@ restore_data_services() {
   prepare_idempotent_globals "$SNAPSHOT/postgres-globals.sql" "$globals_file"
   compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" \
     < "$globals_file" || die "PostgreSQL 全局对象恢复失败"
+  # pg_restore 不接受 "-" 作为 stdin 的显式文件名；省略文件参数时才会从
+  # docker compose exec 透传的标准输入读取宿主机快照。
   compose exec -T postgres pg_restore --clean --if-exists --no-owner --exit-on-error \
-    -U "$pg_user" -d "$pg_db" - < "$SNAPSHOT/postgres.dump" ||
+    -U "$pg_user" -d "$pg_db" < "$SNAPSHOT/postgres.dump" ||
     die "PostgreSQL 数据恢复失败"
 
   ok "恢复 Redis"
@@ -417,10 +422,12 @@ seed_drill_admin() {
   local now
   now="$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
 
+  # email_verified 是后续迁移新增的字段，且新 schema 的默认值已是 true。
+  # 不显式写入该字段，才能同时恢复并验收迁移前的历史快照。
   compose exec -T postgres psql -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" <<SQL ||
-INSERT INTO users (id, username, email, email_verified, password_hash, created_at, updated_at)
+INSERT INTO users (id, username, email, password_hash, created_at, updated_at)
 VALUES ('drill-admin-user', '${DRILL_ADMIN_USER}', 'drill-admin@${DRILL_ADMIN_EMAIL_DOMAIN}',
-        true, '${DRILL_BCRYPT_HASH}', '${now}', '${now}')
+        '${DRILL_BCRYPT_HASH}', '${now}', '${now}')
 ON CONFLICT (id) DO NOTHING;
 INSERT INTO user_roles (user_id, role_id)
 SELECT 'drill-admin-user', id FROM roles WHERE name = 'admin'
@@ -465,7 +472,11 @@ ensure_judge_images() {
 
 run_business_verification() {
   STAGE="business-verify"
-  ok "运行业务验收（登录/题目/附件/评测）"
+  if ((SKIP_JUDGE)); then
+    ok "运行轻量业务验收（登录/题目读取）"
+  else
+    ok "运行业务验收（登录/题目/附件/评测）"
+  fi
   local -a compose_args=(run --rm --no-deps
     -e "DRILL_BASE_URL=http://core:8000/api/v1"
     -e "DRILL_ADMIN_USER=${DRILL_ADMIN_USER}"

--- a/scripts/deploy/test-restore-drill.sh
+++ b/scripts/deploy/test-restore-drill.sh
@@ -36,6 +36,13 @@ fi
 if [[ "${NOJ_DRILL_TEST_FAIL:-}" == "verify" && "$*" == *"deno run -A /opt/verify.ts"* ]]; then
   exit 42
 fi
+if [[ "$*" == *"psql -v ON_ERROR_STOP=1"* ]]; then
+  sql_input="$(cat)"
+  if [[ "$sql_input" == *"INSERT INTO users"* && "$sql_input" == *"email_verified"* ]]; then
+    echo "演练管理员写入不得依赖 email_verified 字段" >&2
+    exit 43
+  fi
+fi
 if [[ "$*" == *" pg_dump "* ]]; then
   printf 'fake postgres dump\n'
 elif [[ "$*" == *"pg_restore --list"* ]]; then
@@ -190,7 +197,28 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 2. 完整演练（--skip-judge + --keep）：隔离配置、报告与业务验收
+# 2. 相对快照路径：规范化为绝对路径后再用于 Compose bind mount
+# ---------------------------------------------------------------------------
+: >"$FAKE_LOG"
+relative_snapshot="backups/$(basename "$local_snapshot")"
+canonical_snapshot="$(cd "$local_snapshot" && pwd -P)"
+(
+  cd "$TEST_ROOT"
+  NOJ_DRILL_TEST_LOG="$FAKE_LOG" \
+  NOJ_DRILL_TEST_VERIFY_OUTPUT="$TEST_ROOT/verify-output.txt" \
+  NOJ_BACKUP_DOCKER_BIN="$FAKE_DOCKER" \
+    bash "$DRILL_SCRIPT" "$relative_snapshot" \
+      --env-file "$ENV_FILE" --compose-file "$COMPOSE_FILE" \
+      --passphrase-file "$PASSPHRASE_FILE" \
+      --skip-judge --keep --project-name noj-relative >/dev/null 2>&1
+) || fail "相对快照路径的隔离恢复演练应成功"
+if ! rg -Fq -- "-v $canonical_snapshot/minio:/restore:ro" "$FAKE_LOG"; then
+  fail "MinIO 恢复应使用绝对快照 bind mount"
+fi
+pass "相对快照路径会规范化为绝对 bind mount"
+
+# ---------------------------------------------------------------------------
+# 3. 完整演练（--skip-judge + --keep）：隔离配置、报告与业务验收
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 report="$TEST_ROOT/drill-report.txt"
@@ -198,6 +226,13 @@ run_drill "$local_snapshot" --skip-judge --keep --project-name noj-drill \
   --report "$report" --rpo-max-hours 24 --rto-max-minutes 60 >/dev/null 2>"$TEST_ROOT/drill.err" ||
   { cat "$TEST_ROOT/drill.err" >&2; fail "隔离恢复演练应成功"; }
 pass "隔离恢复演练（--skip-judge）成功"
+
+rg -q 'pg_restore --clean --if-exists --no-owner --exit-on-error -U noj -d noj$' "$FAKE_LOG" ||
+  fail "PostgreSQL 恢复应从标准输入读取快照"
+if rg -q 'pg_restore --clean --if-exists --no-owner --exit-on-error -U noj -d noj -$' "$FAKE_LOG"; then
+  fail "PostgreSQL 恢复不得把 - 当作容器内输入文件"
+fi
+pass "PostgreSQL 恢复从标准输入读取快照"
 
 [[ -f "$report" ]] || fail "报告未生成"
 grep -q '^result=passed$' "$report" || fail "报告应标记 result=passed"
@@ -232,7 +267,7 @@ rg -Fq 'DO $role$ BEGIN IF NOT EXISTS' "$TEST_ROOT/backups"/drill-*/.work/postgr
 pass "演练环境与覆盖 Compose 隔离配置正确"
 
 # ---------------------------------------------------------------------------
-# 3. judge 链路：白名单镜像读取 + 评测验收执行
+# 4. judge 链路：白名单镜像读取 + 评测验收执行
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 run_drill "$local_snapshot" --keep --project-name noj-drill >/dev/null 2>&1 ||
@@ -243,7 +278,7 @@ grep -q '"step":"evaluation","status":"passed"' \
 pass "完整演练包含真实评测验收"
 
 # ---------------------------------------------------------------------------
-# 4. 失败路径：数据库恢复失败 → 非零退出 + 失败报告 + 资源回收
+# 5. 失败路径：数据库恢复失败 → 非零退出 + 失败报告 + 资源回收
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 fail_report="$TEST_ROOT/fail-report.txt"
@@ -265,7 +300,7 @@ grep -q 'down -v --remove-orphans' "$FAKE_LOG" ||
 pass "数据库恢复失败：非零退出 + 失败报告 + 资源回收"
 
 # ---------------------------------------------------------------------------
-# 5. 失败路径：业务验收失败
+# 6. 失败路径：业务验收失败
 # ---------------------------------------------------------------------------
 : >"$FAKE_LOG"
 biz_fail_report="$TEST_ROOT/biz-fail-report.txt"
@@ -287,7 +322,7 @@ grep -q '"step":"evaluation","status":"failed"' "$biz_fail_report" ||
 pass "业务验收失败：非零退出 + 保留失败现场"
 
 # ---------------------------------------------------------------------------
-# 6. 默认报告位置：写入快照目录且演练临时目录被清理
+# 7. 默认报告位置：写入快照目录且演练临时目录被清理
 # ---------------------------------------------------------------------------
 # 清理前序 --keep 用例保留的演练目录，验证默认路径下的资源回收。
 rm -rf "$BACKUP_DIR"/drill-*


### PR DESCRIPTION
## 关联 Issue

Closes #449

## 变更

- 建立 delivery、temporary_failure、permanent_bounce、complaint 四类统一事件模型。
- 增加 HMAC/时间戳校验、事件 ID 幂等和 fixture 适配器。
- 永久退信/投诉抑制验证邮件与密码重置重发，并支持管理端查看与解除。
- 增加脱敏指标、告警、数据库迁移、文档和 Agent Note。
- 未伪造阿里云/腾讯云未在仓库确认的真实 webhook 协议，保留清晰适配器与生产验收边界。

## 验证

- fmt、lint、类型检查通过。
- 迁移生成通过。
- 邮件送达定向测试 4/4 通过，训练路由定向测试 2/2 通过。
- GPG 签名通过。

全量测试受本地缺少 `.env`、Redis 故障隔离用例重连等环境条件影响未完成。
