### PR TITLE
feat(cli): noj-cli 脚本同步 Phase 1（context/observability/server）

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-08-judge-review-fixes.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-08-judge-review-fixes.md
@@ -1,0 +1,34 @@
+# Agent Note: 修复 judge 命令聚合评审问题
+
+Status: implemented
+
+## Problem
+
+Phase 2 Task 6 的 judge 命令聚合存在 Critical 与若干 Important 问题：缺少交互式
+`install` 初始化、`upgrade --dry-run` 仍会改写环境文件、`logs --follow --dry-run`
+会真正执行 Docker stream、`install` 未按脚本先做基础环境检查，且 `stop`/`logs`
+缺少已安装保护。
+
+## Decision
+
+- 为 `runJudgeCommand` 增加可选 `PromptIO` 参数，实现交互式 `initializeJudgeEnv`：
+  NOJ_VERSION、Redis 来源菜单（已有/本机/稍后）、隐藏 REDIS_URL、队列/并发/
+  socket/UID/GID 等提示，本机 Redis 走 `createLocalRedis`，落盘 `.env.judge` 0600。
+- `upgrade --dry-run` 仅打印 `[dry-run]` 更新提示，不调用 `setJudgeEnv`；缺失环境文件在 dry-run 下同样失败。
+- `logs` 在 `dryRun` 时禁用 `runner.stream` 分支，统一走 `runJudgeCompose` 打印命令。
+- `install` 调整为 `checkBaseEnvironment` → `initializeJudgeEnv` → `writeJudgeCompose` → check。
+- `stop` 增加环境文件存在检查；`logs` 增加 `checkBaseEnvironment` 与环境文件检查；`install-env` 增加 curl 检查。
+- 用 `fileExists` 判断存在性，用显式 `stat` 读取权限位。
+
+## Alternatives considered
+
+- 保持交互安装为硬错误：否决。这不符合 shell 基线，也无法完成无预置配置的首次安装。
+- 在 dry-run 时允许缺失 env 继续：否决。shell 基线对 `upgrade --dry-run` 同样要求已安装配置。
+- 给 `logs --follow --dry-run` 单独打印 stream 命令：否决。统一走 compose dry-run 输出更简单且与基线一致。
+
+## Consequences
+
+- 交互式安装与 shell 脚本提示流程对齐，首次部署不再强制依赖 `--non-interactive` 或预置 env。
+- dry-run 语义保持一致：只显示动作，不修改文件、不执行 Docker。
+- `stop`/`logs` 在未安装时给出友好中文错误。
+- 新增 7 个测试覆盖交互安装、非交互缺参、dry-run 不写入/不执行、缺失配置保护。

--- a/.agents/notes/implemented/simplification/2026-09-07-noj-cli-script-sync-known-defects.md
+++ b/.agents/notes/implemented/simplification/2026-09-07-noj-cli-script-sync-known-defects.md
@@ -1,0 +1,37 @@
+# Agent Note: noj-cli 脚本同步已知缺陷
+
+Status: implemented
+
+## Problem
+
+noj-cli 在替代 `scripts/deploy/*.sh` 和 `scripts/deploy/restore-drill.sh` 的过程中，为控制迁移范围采用了简化实现。当前仍存在与原有 shell 脚本不完全对齐的已知缺陷，需要记录以便后续迭代时逐项补齐。
+
+## Decision
+
+将以下差距记录为已知缺陷，当前不再继续实现，后续按需补全：
+
+1. **`install.sh` 文件同步 / `--files-only` 未实现。**
+   `update` 目前直接执行 `docker compose pull && up -d`，没有先同步同版本部署文件和 noj-cli 二进制。
+
+2. **首次交互安装向导未完整复刻 `deploy.sh` 边界。**
+   已实现基础 PromptIO 引导（核心字段），但“复用旧配置”“面板模式”“配置暂存”等交互边界尚未对齐。
+
+3. **`restore-drill` 的部分脚本能力未完全移植。**
+   失败报告、Prometheus textfile 指标、失败时自动 `down -v --remove-orphans` 清理等细节仍缺失。
+
+4. **生产 `verify` 不等价于原脚本的完整校验。**
+   当前 `verify` 复用 `config check`（配置 + Compose config），未移植镜像 digest / Cosign 签名验证。
+
+5. **`check` 改用 `doctor`。**
+   环境检测已 Deno 化，但与 `install.sh check` 的完整输出/资源摘要细节不完全一致。
+
+## Alternatives considered
+
+- 继续在本次迭代中全部补完：工作量大，且当前 PR 已包含完整可用命令集，先交付并记录缺口更稳妥。
+- 不记录：后续容易遗忘这些 shell parity 差距，导致用户误以为完全等价。
+
+## Consequences
+
+- noj-cli 当前可作为主要运维入口，但以上场景仍需要以脚本兜底或人工补充。
+- 后续迭代有明确的补全清单。
+- 文档与 PR 评论需注明这些已知差异，避免用户误判“完全替代”。

--- a/dev-docs/audit/2026-09-07-noj-cli-script-gap.md
+++ b/dev-docs/audit/2026-09-07-noj-cli-script-gap.md
@@ -1,0 +1,139 @@
+# noj-cli 与部署/功能性脚本差距分析
+
+- 日期：2026-09-07
+- 状态：分析记录（非实施计划）
+- 范围：运维向脚本 + 文档/设计中已承诺但 CLI 未暴露的能力；不讨论 E2E、staging、release、CI 门禁等研发/发布工具的收编。
+
+## 背景
+
+`noj-cli` 是 Neuro OJ 的统一部署与运维 CLI，但当前仓库仍存在多个功能性脚本入口：
+`scripts/deploy/deploy.sh`、`install.sh`、`backup.sh`、`judge-install.sh`、
+`restore-drill.sh`、`test-alert.sh`、`check-observability.sh`，以及服务端管理 CLI
+`noj-core/scripts/noj.ts`（容器内 `/app/bin/noj`）。
+
+本文档记录这些脚本能力与 `noj-cli` 当前命令面的差距，并给出优先补齐建议，供后续设计/计划参考。
+
+## 当前 noj-cli 能力地图
+
+noj-cli 目前包含两套并存的命令族：
+
+| 命令族 | 配置载体 | 覆盖能力 |
+|---|---|---|
+| 生产命令（`install/check/start/stop/restart/status/logs/update/backup/verify/config/uninstall`） | `.env.prod` + `docker-compose.prod.yml` + `scripts/deploy/*.sh` | 生产安装、生命周期、升级、备份、校验、卸载 |
+| JSON 部署命令（`doctor/deploy/maintain/run-server/version`） | `noj-deploy.json` + `noj-secrets.json` | 源码/JSON 编排、环境检测、进程/Docker 混合启动、备份恢复、重置、配置管理 |
+
+因此 noj-cli 并非“没有部署能力”，而是已经覆盖主栈运维 + 一套 JSON 编排方案；差距主要体现在**独立运维脚本**和**服务端管理命令**没有统一入口。
+
+## 功能差距清单
+
+### 1. 独立 Judge Worker 管理没有入口
+
+`scripts/deploy/judge-install.sh` 已具备：
+
+- `install` / `install-env` / `check`
+- `start` / `stop` / `status` / `logs` / `upgrade`
+- `download`
+- rootless Docker socket 安全校验
+- Redis 配置引导
+
+noj-cli 没有 `judge` / `worker` 子命令。生产 `install` 只处理主栈内的 judge 组件；独立 Judge 主机/Worker 的部署者仍需手动执行 `bash scripts/deploy/judge-install.sh ...`。
+
+### 2. 隔离恢复演练（restore-drill）没有暴露
+
+- `noj backup drill` 目前只调用 `backup.sh drill`，是**纯文件校验**（SHA-256、GPG、dump 结构）。
+- `scripts/deploy/restore-drill.sh` 才是真正的隔离恢复演练：独立 Compose 项目、独立子网/数据卷、恢复后真实 API 验收（登录、题目、附件、评测），支持 RPO/RTO、`--skip-judge`、`--keep`。
+
+CLI 没有 `restore-drill` 或 `backup drill --isolated` 入口，运维人员无法用统一入口完成“备份可恢复性”验收。
+
+### 3. 生产观测与告警演练没有入口
+
+- `scripts/monitoring/check-observability.sh`：检查 liveness/readiness/metrics/Alertmanager 前置条件。
+- `scripts/deploy/test-alert.sh`：向 Alertmanager 注入测试告警，验证通知链路。
+
+这两个是明确的日常/演练运维动作，但 noj-cli 没有 `observability` / `alert` 子命令。
+
+### 4. 服务端管理命令需要长命令手动拼接
+
+`noj-core/scripts/noj.ts`（容器内 `/app/bin/noj`）提供：
+
+- `db migrate`
+- `init system`
+- `bootstrap first-admin` / `bootstrap admin`
+- `problems build` / `problems import`
+- `dev-setup`
+
+生产执行方式目前是：
+
+```bash
+docker compose --env-file /opt/neuro-oj/.env.prod -f /opt/neuro-oj/docker-compose.prod.yml \
+  run --rm --entrypoint /app/bin/noj core <子命令>
+```
+
+noj-cli 没有将这些命令包装为 `noj-cli server ...` 或 `noj-cli shell ...` 之类的短命令。文档虽说明两个 CLI 相互独立，但日常操作体验存在断裂。
+
+### 5. 安装器高级子命令没有用户入口
+
+`scripts/deploy/install.sh` 支持：
+
+- `install-env`
+- `--download-only`
+- `--files-only`
+- `--dry-run`
+
+noj-cli 仅暴露 `check` / `install`；`files-only` 只在 `update` 内部使用，`install-env` 与 `download-only` 没有暴露给用户。
+
+### 6. 生产配置管理能力弱于 JSON 模式
+
+- JSON 模式：`maintain config check/show/set`。
+- 生产模式：只有 `config check`，没有 `config show` / `config set`。
+
+对 `.env.prod` 的日常查看/修改仍要直接编辑文件，缺少“脱敏显示、校验后写入”的统一入口。
+
+### 7. 双配置载体、双命令族没有融合
+
+当前 noj-cli 本质上是两个 CLI 拼在一起：
+
+- `.env.prod` + shell 脚本的生产线；
+- `noj-deploy.json` + Deno 的 JSON 编排线。
+
+两者之间没有自动转换/迁移，命令树也不统一。设计文档 `dev-docs/superpowers/specs/2026-08-31-noj-cli-design.md` 的最初目标是统一入口，但现状是“生产命令 + JSON 命令”并行。这个结构性差距影响长期可维护性和用户心智。
+
+### 8. 命令命名/入口混淆
+
+仓库里至少存在三个“noj/noj-cli”：
+
+- 根目录 `noj`（生产运维 shell 入口）；
+- `noj-cli`（Deno 部署/运维 CLI，安装后 `bin/noj-cli`）；
+- `noj-core/scripts/noj.ts` / 容器内 `/app/bin/noj`（服务端管理 CLI）。
+
+它们职责不同但有命名重叠，帮助信息和文档需要额外解释边界。这不算纯功能缺失，但属于“功能性脚本被看见/被使用的差距”。
+
+## 不建议收编进 noj-cli 的脚本
+
+以下脚本建议保持独立或走 CI/研发入口：
+
+- `scripts/e2e/*`：跨模块测试，开发/CI 用途。
+- `scripts/staging/acceptance.sh`：候选版本发布门禁。
+- `scripts/release/*`、`scripts/check-*.ts`、`scripts/deploy/verify-*.ts`、`scripts/deploy/test-*.sh`：CI 门禁和回归测试。
+
+把测试/发布工具塞进运维 CLI 会使其定位模糊，不建议纳入。
+
+## 优先补齐建议
+
+按运维价值排序：
+
+| 优先级 | 建议 | 说明 |
+|---|---|---|
+| P0 | 新增 `noj-cli judge ...` 子命令族 | 包装 `judge-install.sh` 的 install/install-env/check/start/stop/status/logs/upgrade/download |
+| P0 | 新增 `noj-cli restore-drill ...` 或 `backup drill --isolated` | 包装 `restore-drill.sh`，让真实恢复演练成为 CLI 一等公民 |
+| P0 | 新增 `noj-cli observability check` 和 `noj-cli observability alert-drill` | 包装 `check-observability.sh` 和 `test-alert.sh` |
+| P1 | 新增 `noj-cli server <cmd>` | 包装容器内 `/app/bin/noj`，覆盖 db/init/bootstrap/problems |
+| P1 | 生产模式补 `config show/set` | 对齐 JSON 模式的 `maintain config` |
+| P1 | 暴露安装器高级选项 | `install-env`、`download-only`、`files-only`、`dry-run` 至少部分进入 CLI |
+| P2 | 统一命令树/配置载体 | 至少明确“生产模式 vs JSON 模式”的边界，提供双向转换或迁移工具 |
+| P2 | 文档和帮助统一“noj/noj-cli/服务端 noj”的命名说明 | 降低入口混淆 |
+
+## 后续方向
+
+- 选择 P0 之一进入具体设计（例如 `noj-cli judge` 或 `noj-cli restore-drill` 的命令树、参数、测试方式）。
+- 或先补充更细的逐项能力对照矩阵（每个脚本子命令/选项 vs noj-cli 现状）。

--- a/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase1.md
+++ b/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase1.md
@@ -1,0 +1,1293 @@
+# noj-cli 统一命令树 + observability/server 命令（Phase 1）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 noj-cli 建立统一部署上下文解析骨架，并新增 `observability check/alert-drill` 与 `server` 两条 Deno 命令线，使脚本侧这两类能力首次被 CLI 直接支持。
+
+**Architecture:** 新增 `src/context/` 统一识别 production/json/judge 上下文；新增 `src/observability/`（HTTP 客户端 + 健康检查 + 告警演练）和 `src/server_cmd/`（容器内 `/app/bin/noj` 命令包装）；在 `src/cli.ts` 中挂载新顶层命令。现有 JSON/production 命令保持不动，后续计划再逐步把 judge、restore-drill、production Deno 化接入统一命令树。
+
+**Tech Stack:** Deno 2 + TypeScript、`@std/assert`、`@std/path`、Deno 内置 `fetch` / `Deno.Command`。
+
+**Spec:** `dev-docs/superpowers/specs/2026-09-07-noj-cli-script-sync-design.md`
+
+## Global Constraints
+
+- 语言：代码标识符使用英文，注释与提交描述使用中文。
+- 运行环境：仅 Deno 2 + TypeScript 标准环境；不新增第三方运行时依赖。
+- 提交：使用 jj；提交信息格式 `<type>(<scope>): <中文描述>`，scope 使用 `cli`。
+- 测试：通过 `cd noj-cli && deno task test` 运行；代码通过 `deno fmt` 与 `deno lint`。
+- 所有改动必须位于当前 worktree（`.worktrees/noj-cli-improves/`）内，禁止修改主仓库。
+- 不修改 `scripts/deploy/*.sh` 等脚本侧实现；脚本保留为兜底。
+
+---
+
+### Task 1: 部署上下文识别模块
+
+**Files:**
+- Create: `noj-cli/src/context/context.ts`
+- Create: `noj-cli/src/context/context_test.ts`
+- Modify: `noj-cli/src/mod.ts`
+
+**Interfaces:**
+- Consumes: 无。
+- Produces:
+  - `export type ContextKind = "production" | "json" | "judge" | "none"`
+  - `export interface CliContext { cwd: string; kind: ContextKind; dir: string | null }`
+  - `export function detectKind(dir: string): ContextKind | null`
+  - `export function findContextDir(start?: string, kind?: ContextKind): string | null`
+  - `export function resolveContext(opts: { cwd?: string; dir?: string; mode?: ContextKind }): CliContext`
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `noj-cli/src/context/context_test.ts`：
+
+```ts
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  detectKind,
+  findContextDir,
+  type ContextKind,
+  resolveContext,
+} from "./context.ts";
+
+function writeFixture(dir: string, files: Record<string, string>): void {
+  Deno.mkdirSync(dir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    Deno.writeTextFileSync(`${dir}/${name}`, content);
+  }
+}
+
+Deno.test("detectKind: production/json/judge/none", () => {
+  const dir = Deno.makeTempDirSync();
+  writeFixture(dir, {
+    ".env.prod": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.prod.yml": "services: {}\n",
+  });
+  assertEquals(detectKind(dir), "production" as ContextKind);
+
+  const jsonDir = Deno.makeTempDirSync();
+  writeFixture(jsonDir, {
+    "noj-deploy.json": "{}",
+    "noj-secrets.json": "{}",
+  });
+  assertEquals(detectKind(jsonDir), "json" as ContextKind);
+
+  const judgeDir = Deno.makeTempDirSync();
+  writeFixture(judgeDir, {
+    ".env.judge": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.judge.yml": "services: {}\n",
+  });
+  assertEquals(detectKind(judgeDir), "judge" as ContextKind);
+
+  const empty = Deno.makeTempDirSync();
+  assertEquals(detectKind(empty), null);
+});
+
+Deno.test("findContextDir: 向上查找指定上下文", () => {
+  const root = Deno.makeTempDirSync();
+  const prod = `${root}/prod`;
+  writeFixture(prod, {
+    ".env.prod": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.prod.yml": "services: {}\n",
+  });
+  const nested = `${prod}/nested/deep`;
+  Deno.mkdirSync(nested, { recursive: true });
+  assertEquals(findContextDir(nested, "production"), prod);
+  assertEquals(findContextDir(nested), prod);
+});
+
+Deno.test("resolveContext: --dir 显式指定", () => {
+  const dir = Deno.makeTempDirSync();
+  writeFixture(dir, {
+    ".env.prod": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.prod.yml": "services: {}\n",
+  });
+  const ctx = resolveContext({ cwd: "/tmp", dir });
+  assertEquals(ctx.kind, "production");
+  assertEquals(ctx.dir, dir);
+});
+
+Deno.test("resolveContext: --mode 找不到对应上下文时 kind=none", () => {
+  const dir = Deno.makeTempDirSync();
+  const ctx = resolveContext({ cwd: "/tmp", dir, mode: "json" });
+  assertEquals(ctx.kind, "none");
+  assertEquals(ctx.dir, null);
+});
+
+Deno.test("resolveContext: 显式 dir 但 mode 不匹配时抛错", () => {
+  const dir = Deno.makeTempDirSync();
+  writeFixture(dir, {
+    ".env.prod": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.prod.yml": "services: {}\n",
+  });
+  assertThrows(() => resolveContext({ cwd: "/tmp", dir, mode: "json" }));
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/context/context_test.ts`
+Expected: FAIL，报找不到 `./context.ts`。
+
+- [ ] **Step 3: 实现 `src/context/context.ts`**
+
+```ts
+import { dirname, resolve } from "@std/path";
+
+export type ContextKind = "production" | "json" | "judge" | "none";
+
+export interface CliContext {
+  cwd: string;
+  kind: ContextKind;
+  dir: string | null;
+}
+
+function isFile(path: string): boolean {
+  try {
+    return Deno.statSync(path).isFile;
+  } catch {
+    return false;
+  }
+}
+
+export function detectKind(dir: string): ContextKind | null {
+  const prod = isFile(`${dir}/.env.prod`) &&
+    isFile(`${dir}/docker-compose.prod.yml`);
+  if (prod) return "production";
+  const json = isFile(`${dir}/noj-deploy.json`) &&
+    isFile(`${dir}/noj-secrets.json`);
+  if (json) return "json";
+  const judge = isFile(`${dir}/.env.judge`) &&
+    isFile(`${dir}/docker-compose.judge.yml`);
+  if (judge) return "judge";
+  return null;
+}
+
+export function findContextDir(
+  start?: string,
+  kind?: ContextKind,
+): string | null {
+  let current = start ?? Deno.cwd();
+  current = Deno.realPathSync(current);
+  while (true) {
+    const detected = detectKind(current);
+    if (detected !== null && (kind === undefined || detected === kind)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === null || parent === current) return null;
+    current = parent;
+  }
+}
+
+export function resolveContext(opts: {
+  cwd?: string;
+  dir?: string;
+  mode?: ContextKind;
+}): CliContext {
+  const cwd = opts.cwd ?? Deno.cwd();
+  if (opts.dir !== undefined) {
+    const abs = resolve(cwd, opts.dir);
+    const kind = detectKind(abs);
+    if (kind === null) return { cwd, kind: "none", dir: null };
+    if (opts.mode !== undefined && kind !== opts.mode) {
+      throw new Error(`目录 ${abs} 不是 ${opts.mode} 上下文`);
+    }
+    return { cwd, kind, dir: abs };
+  }
+  if (opts.mode !== undefined) {
+    const dir = findContextDir(cwd, opts.mode);
+    return { cwd, kind: dir ? opts.mode : "none", dir };
+  }
+  const dir = findContextDir(cwd);
+  const kind = dir ? detectKind(dir) : "none";
+  return { cwd, kind, dir };
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/context/context_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 在 `src/mod.ts` 导出 context 类型和函数**
+
+在 `src/mod.ts` 末尾追加：
+
+```ts
+// context（Phase 1）
+export type { CliContext, ContextKind } from "./context/context.ts";
+export { detectKind, findContextDir, resolveContext } from "./context/context.ts";
+```
+
+- [ ] **Step 6: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 新增部署上下文识别模块"
+```
+
+---
+
+### Task 2: 可注入 HTTP 客户端
+
+**Files:**
+- Create: `noj-cli/src/observability/http.ts`
+- Create: `noj-cli/src/observability/http_test.ts`
+
+**Interfaces:**
+- Consumes: 无。
+- Produces:
+  - `export interface HttpResult { status: number; body: string }`
+  - `export interface HttpClient { get(url: string): Promise<HttpResult>; postJson(url: string, body: string): Promise<HttpResult> }`
+  - `export function realHttp(): HttpClient`
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `noj-cli/src/observability/http_test.ts`：
+
+```ts
+import { assertEquals } from "@std/assert";
+import { realHttp } from "./http.ts";
+
+Deno.test("realHttp: GET 返回状态与响应体", async () => {
+  const http = realHttp();
+  const res = await http.get("data:text/plain,hello");
+  assertEquals(res.status, 200);
+  assertEquals(res.body, "hello");
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/observability/http_test.ts`
+Expected: FAIL，报找不到 `./http.ts`。
+
+- [ ] **Step 3: 实现 `src/observability/http.ts`**
+
+```ts
+export interface HttpResult {
+  status: number;
+  body: string;
+}
+
+export interface HttpClient {
+  get(url: string): Promise<HttpResult>;
+  postJson(url: string, body: string): Promise<HttpResult>;
+}
+
+export function realHttp(): HttpClient {
+  return {
+    async get(url) {
+      const res = await fetch(url);
+      return { status: res.status, body: await res.text() };
+    },
+    async postJson(url, body) {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      return { status: res.status, body: await res.text() };
+    },
+  };
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/observability/http_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 新增可注入 HTTP 客户端"
+```
+
+---
+
+### Task 3: observability check 命令实现
+
+**Files:**
+- Create: `noj-cli/src/observability/check.ts`
+- Create: `noj-cli/src/observability/check_test.ts`
+
+**Interfaces:**
+- Consumes: `HttpClient`（Task 2）。
+- Produces:
+  - `export interface ObservabilityCheckOptions { baseUrl?: string; checkNotifications?: boolean; alertmanagerUrl?: string; http?: HttpClient }`
+  - `export interface CheckItem { name: string; ok: boolean; detail: string }`
+  - `export interface ObservabilityReport { items: CheckItem[]; pass: boolean }`
+  - `export async function observabilityCheck(opts?: ObservabilityCheckOptions): Promise<ObservabilityReport>`
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `noj-cli/src/observability/check_test.ts`：
+
+```ts
+import { assertEquals } from "@std/assert";
+import type { HttpClient, HttpResult } from "./http.ts";
+import { observabilityCheck } from "./check.ts";
+
+function fakeHttp(routes: Record<string, HttpResult>): HttpClient {
+  return {
+    async get(url) {
+      const res = routes[url];
+      if (!res) return { status: 404, body: "not found" };
+      return res;
+    },
+    async postJson(_url, _body) {
+      return { status: 200, body: "" };
+    },
+  };
+}
+
+Deno.test("observabilityCheck: 全部通过", async () => {
+  const base = "http://noj.test";
+  const http = fakeHttp({
+    [`${base}/health/live`]: { status: 200, body: '{"status":"alive"}' },
+    [`${base}/health/ready`]: { status: 200, body: '{"status":"ready"}' },
+    [`${base}/metrics`]: {
+      status: 200,
+      body: "noj_database_up 1\nnoj_judge_workers 2\n",
+    },
+  });
+  const report = await observabilityCheck({ baseUrl: base, http });
+  assertEquals(report.pass, true);
+  assertEquals(report.items.length, 3);
+});
+
+Deno.test("observabilityCheck: readiness 失败导致整体失败", async () => {
+  const base = "http://noj.test";
+  const http = fakeHttp({
+    [`${base}/health/live`]: { status: 200, body: '{"status":"alive"}' },
+    [`${base}/health/ready`]: { status: 503, body: '{"status":"not_ready"}' },
+    [`${base}/metrics`]: { status: 200, body: "noj_database_up 1\n" },
+  });
+  const report = await observabilityCheck({ baseUrl: base, http });
+  assertEquals(report.pass, false);
+  assertEquals(report.items[1]?.ok, false);
+});
+
+Deno.test("observabilityCheck: --check-notifications 验证 Alertmanager", async () => {
+  const base = "http://noj.test";
+  const am = "http://alertmanager:9093";
+  const http = fakeHttp({
+    [`${base}/health/live`]: { status: 200, body: '{"status":"alive"}' },
+    [`${base}/health/ready`]: { status: 200, body: '{"status":"ready"}' },
+    [`${base}/metrics`]: { status: 200, body: "noj_database_up 1\n" },
+    [`${am}/-/ready`]: { status: 200, body: "OK" },
+  });
+  const report = await observabilityCheck({
+    baseUrl: base,
+    checkNotifications: true,
+    alertmanagerUrl: am,
+    http,
+  });
+  assertEquals(report.pass, true);
+  assertEquals(report.items.length, 4);
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/observability/check_test.ts`
+Expected: FAIL，报找不到 `./check.ts`。
+
+- [ ] **Step 3: 实现 `src/observability/check.ts`**
+
+```ts
+import type { HttpClient } from "./http.ts";
+
+export interface ObservabilityCheckOptions {
+  baseUrl?: string;
+  checkNotifications?: boolean;
+  alertmanagerUrl?: string;
+  http?: HttpClient;
+}
+
+export interface CheckItem {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface ObservabilityReport {
+  items: CheckItem[];
+  pass: boolean;
+}
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:8000";
+
+async function checkEndpoint(
+  http: HttpClient,
+  name: string,
+  url: string,
+  expected: string,
+): Promise<CheckItem> {
+  try {
+    const res = await http.get(url);
+    const ok = res.status === 200 && res.body.includes(expected);
+    return {
+      name,
+      ok,
+      detail: ok ? `${url} 正常` : `${url} 返回 ${res.status} 或缺少 ${expected}`,
+    };
+  } catch (e) {
+    return { name, ok: false, detail: `${url} 访问失败: ${(e as Error).message}` };
+  }
+}
+
+export async function observabilityCheck(
+  opts: ObservabilityCheckOptions = {},
+): Promise<ObservabilityReport> {
+  const http = opts.http ?? (await import("./http.ts")).realHttp();
+  const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+  const items: CheckItem[] = [];
+  items.push(
+    await checkEndpoint(http, "liveness", `${baseUrl}/health/live`, '"status":"alive"'),
+  );
+  items.push(
+    await checkEndpoint(http, "readiness", `${baseUrl}/health/ready`, '"status":"ready"'),
+  );
+
+  const metrics = await http.get(`${baseUrl}/metrics`);
+  const metricsOk = metrics.status === 200 &&
+    metrics.body.includes("noj_database_up") &&
+    metrics.body.includes("noj_judge_workers");
+  items.push({
+    name: "metrics",
+    ok: metricsOk,
+    detail: metricsOk ? "metrics 包含关键指标" : "metrics 缺少 noj_database_up 或 noj_judge_workers",
+  });
+
+  if (opts.checkNotifications) {
+    if (!opts.alertmanagerUrl) {
+      items.push({
+        name: "notifications",
+        ok: false,
+        detail: "checkNotifications 需要 ALERTMANAGER_URL",
+      });
+    } else {
+      const amRes = await http.get(`${opts.alertmanagerUrl}/-/ready`);
+      const amOk = amRes.status === 200;
+      items.push({
+        name: "notifications",
+        ok: amOk,
+        detail: amOk ? `${opts.alertmanagerUrl} 就绪` : `${opts.alertmanagerUrl} 返回 ${amRes.status}`,
+      });
+    }
+  }
+
+  return { items, pass: items.every((i) => i.ok) };
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/observability/check_test.ts`
+Expected: PASS（若 `notifications` 断言因 detail 逻辑不匹配，可调整实现为显式检查状态码后继续）。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 实现 observability check"
+```
+
+---
+
+### Task 4: observability alert-drill 命令实现
+
+**Files:**
+- Create: `noj-cli/src/observability/alert_drill.ts`
+- Create: `noj-cli/src/observability/alert_drill_test.ts`
+
+**Interfaces:**
+- Consumes: `HttpClient`（Task 2）。
+- Produces:
+  - `export interface AlertDrillOptions { alertmanagerUrl?: string; holdSeconds?: number; http?: HttpClient }`
+  - `export interface AlertDrillReport { injected: boolean; resolved: boolean; holdSeconds: number }`
+  - `export async function alertDrill(opts?: AlertDrillOptions): Promise<AlertDrillReport>`
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `noj-cli/src/observability/alert_drill_test.ts`：
+
+```ts
+import { assertEquals } from "@std/assert";
+import type { HttpClient, HttpResult } from "./http.ts";
+import { alertDrill } from "./alert_drill.ts";
+
+function recordingHttp(calls: { url: string; body: string }[]): HttpClient {
+  return {
+    async get(url) {
+      return { status: 200, body: url };
+    },
+    async postJson(url, body) {
+      calls.push({ url, body });
+      return { status: 200, body: "" };
+    },
+  };
+}
+
+Deno.test("alertDrill: 注入并恢复告警", async () => {
+  const calls: { url: string; body: string }[] = [];
+  const http = recordingHttp(calls);
+  const report = await alertDrill({
+    alertmanagerUrl: "http://alertmanager:9093",
+    holdSeconds: 0,
+    http,
+  });
+  assertEquals(report.injected, true);
+  assertEquals(report.resolved, true);
+  assertEquals(calls.length, 2);
+  assertEquals(calls[0]?.url, "http://alertmanager:9093/api/v2/alerts");
+  assertEquals(calls[1]?.url, "http://alertmanager:9093/api/v2/alerts");
+  assertEquals(calls[0]?.body.includes("NojNotificationDrill"), true);
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/observability/alert_drill_test.ts`
+Expected: FAIL，报找不到 `./alert_drill.ts`。
+
+- [ ] **Step 3: 实现 `src/observability/alert_drill.ts`**
+
+```ts
+import type { HttpClient } from "./http.ts";
+
+export interface AlertDrillOptions {
+  alertmanagerUrl?: string;
+  holdSeconds?: number;
+  http?: HttpClient;
+}
+
+export interface AlertDrillReport {
+  injected: boolean;
+  resolved: boolean;
+  holdSeconds: number;
+}
+
+const DEFAULT_ALERTMANAGER_URL = "http://alertmanager:9093";
+
+function activePayload(startsAt: string): string {
+  return JSON.stringify([
+    {
+      labels: {
+        alertname: "NojNotificationDrill",
+        severity: "critical",
+        instance: "notification-drill",
+      },
+      annotations: {
+        summary: "告警投递演练（critical）",
+        description: `投递演练测试告警，无需处理；startsAt=${startsAt}`,
+      },
+      startsAt,
+    },
+    {
+      labels: {
+        alertname: "NojNotificationDrill",
+        severity: "warning",
+        instance: "notification-drill",
+      },
+      annotations: {
+        summary: "告警投递演练（warning）",
+        description: `投递演练测试告警，无需处理；startsAt=${startsAt}`,
+      },
+      startsAt,
+    },
+  ]);
+}
+
+function resolvedPayload(startsAt: string, endsAt: string): string {
+  return JSON.stringify([
+    {
+      labels: {
+        alertname: "NojNotificationDrill",
+        severity: "critical",
+        instance: "notification-drill",
+      },
+      annotations: { summary: "告警投递演练（critical）已恢复" },
+      startsAt,
+      endsAt,
+    },
+    {
+      labels: {
+        alertname: "NojNotificationDrill",
+        severity: "warning",
+        instance: "notification-drill",
+      },
+      annotations: { summary: "告警投递演练（warning）已恢复" },
+      startsAt,
+      endsAt,
+    },
+  ]);
+}
+
+export async function alertDrill(
+  opts: AlertDrillOptions = {},
+): Promise<AlertDrillReport> {
+  const http = opts.http ?? (await import("./http.ts")).realHttp();
+  const alertmanagerUrl = opts.alertmanagerUrl ?? DEFAULT_ALERTMANAGER_URL;
+  const holdSeconds = opts.holdSeconds ?? 300;
+  const startsAt = new Date().toISOString();
+  const url = `${alertmanagerUrl}/api/v2/alerts`;
+
+  const active = await http.postJson(url, activePayload(startsAt));
+  if (active.status !== 200) {
+    throw new Error(`注入告警失败：HTTP ${active.status}`);
+  }
+
+  if (holdSeconds > 0) {
+    await new Promise((resolve) => setTimeout(resolve, holdSeconds * 1000));
+  }
+
+  const resolved = await http.postJson(
+    url,
+    resolvedPayload(startsAt, new Date().toISOString()),
+  );
+  if (resolved.status !== 200) {
+    throw new Error(`恢复告警失败：HTTP ${resolved.status}`);
+  }
+
+  return { injected: true, resolved: true, holdSeconds };
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/observability/alert_drill_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 实现 observability alert-drill"
+```
+
+---
+
+### Task 5: CLI 挂载 observability 命令
+
+**Files:**
+- Modify: `noj-cli/src/cli.ts`
+- Modify: `noj-cli/src/cli_test.ts`
+
+**Interfaces:**
+- Consumes: `observabilityCheck`、`alertDrill`（Task 3/4）。
+- Produces:
+  - `export interface ObservabilityArgs { sub: string; baseUrl?: string; checkNotifications: boolean; alertmanagerUrl?: string; holdSeconds: number }`
+  - `export function parseObservabilityArgs(args: string[]): ObservabilityArgs`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `noj-cli/src/cli_test.ts` 末尾追加：
+
+```ts
+Deno.test("parseObservabilityArgs: check 参数解析", () => {
+  const a = parseObservabilityArgs([
+    "check",
+    "--base-url",
+    "http://noj.test",
+    "--check-notifications",
+    "--alertmanager-url",
+    "http://am:9093",
+  ]);
+  assertEquals(a.sub, "check");
+  assertEquals(a.baseUrl, "http://noj.test");
+  assertEquals(a.checkNotifications, true);
+  assertEquals(a.alertmanagerUrl, "http://am:9093");
+});
+
+Deno.test("parseObservabilityArgs: alert-drill 参数解析", () => {
+  const a = parseObservabilityArgs([
+    "alert-drill",
+    "--alertmanager-url",
+    "http://am:9093",
+    "--hold",
+    "0",
+  ]);
+  assertEquals(a.sub, "alert-drill");
+  assertEquals(a.alertmanagerUrl, "http://am:9093");
+  assertEquals(a.holdSeconds, 0);
+});
+
+Deno.test("observability 无子命令返回 1", async () => {
+  assertEquals(await dispatchCommand("observability", [], ctx), 1);
+});
+```
+
+> 注：`observabilityCheck` / `alertDrill` 的真实行为已在 Task 3/4 测试；这里只验证 CLI 解析和错误码。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/cli_test.ts`
+Expected: FAIL，报 `parseObservabilityArgs` 未定义。
+
+- [ ] **Step 3: 实现 CLI 解析与分发**
+
+在 `src/cli.ts` 顶部 import 后新增：
+
+```ts
+import { alertDrill } from "./observability/alert_drill.ts";
+import { observabilityCheck } from "./observability/check.ts";
+import { realHttp } from "./observability/http.ts";
+```
+
+在 `KNOW_TOP` 集合中加入 `"observability"`：
+
+```ts
+const KNOWN_TOP = new Set([
+  "doctor",
+  "deploy",
+  "maintain",
+  "run-server",
+  "version",
+  "observability",
+]);
+```
+
+在 `parseBackupArgs` 之后新增：
+
+```ts
+export interface ObservabilityArgs {
+  sub: string;
+  baseUrl: string | undefined;
+  checkNotifications: boolean;
+  alertmanagerUrl: string | undefined;
+  holdSeconds: number;
+}
+
+export function parseObservabilityArgs(args: string[]): ObservabilityArgs {
+  const out: ObservabilityArgs = {
+    sub: args[0] ?? "",
+    baseUrl: undefined,
+    checkNotifications: false,
+    alertmanagerUrl: undefined,
+    holdSeconds: 300,
+  };
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i]!;
+    switch (a) {
+      case "--base-url":
+        out.baseUrl = args[++i];
+        break;
+      case "--check-notifications":
+        out.checkNotifications = true;
+        break;
+      case "--alertmanager-url":
+        out.alertmanagerUrl = args[++i];
+        break;
+      case "--hold":
+        out.holdSeconds = Number(args[++i]);
+        break;
+      default:
+        throw new Error(`未知 observability 参数: ${a}`);
+    }
+  }
+  return out;
+}
+```
+
+在 `dispatchCommand` 的 `switch (command)` 中新增分支：
+
+```ts
+case "observability": {
+  const a = parseObservabilityArgs(args);
+  try {
+    if (a.sub === "check") {
+      const report = await observabilityCheck({
+        baseUrl: a.baseUrl,
+        checkNotifications: a.checkNotifications,
+        alertmanagerUrl: a.alertmanagerUrl,
+        http: realHttp(),
+      });
+      for (const item of report.items) {
+        console.log(`${item.ok ? "✓" : "✗"} ${item.name}: ${item.detail}`);
+      }
+      return report.pass ? 0 : 1;
+    }
+    if (a.sub === "alert-drill") {
+      const report = await alertDrill({
+        alertmanagerUrl: a.alertmanagerUrl,
+        holdSeconds: a.holdSeconds,
+        http: realHttp(),
+      });
+      console.log(`告警演练完成：注入=${report.injected} 恢复=${report.resolved}`);
+      return 0;
+    }
+    console.error("observability: 需要子命令 check/alert-drill");
+    return 1;
+  } catch (e) {
+    console.error(`observability: ${(e as Error).message}`);
+    return 1;
+  }
+}
+```
+
+在 `printHelp()` 的 JSON 配置工具段落前追加：
+
+```text
+"  observability check       检查 liveness/readiness/metrics（可选通知链路）",
+"  observability alert-drill 向 Alertmanager 注入告警并发送恢复事件",
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/cli_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 挂载 observability 命令"
+```
+
+---
+
+### Task 6: server 命令运行器
+
+**Files:**
+- Create: `noj-cli/src/server_cmd/server_cmd.ts`
+- Create: `noj-cli/src/server_cmd/server_cmd_test.ts`
+
+**Interfaces:**
+- Consumes: `CliContext`（Task 1）、`CommandRunner`（现有 `src/runtime/command.ts`）。
+- Produces:
+  - `export type ServerSubcommand = readonly [string, ...string[]]`
+  - `export interface ServerCommandOptions { context: CliContext; args: string[]; runner?: CommandRunner }`
+  - `export async function runServerCommand(opts: ServerCommandOptions): Promise<number>`
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `noj-cli/src/server_cmd/server_cmd_test.ts`：
+
+```ts
+import { assertEquals } from "@std/assert";
+import type { CliContext } from "../context/context.ts";
+import type { CommandRunner, SpawnHandle, SpawnOpts } from "../runtime/command.ts";
+import { runServerCommand } from "./server_cmd.ts";
+
+function runnerWithLog(log: string[][]): CommandRunner {
+  return {
+    async run(cmd, args) {
+      log.push([cmd, ...args]);
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    spawn(opts: SpawnOpts): SpawnHandle {
+      log.push([opts.cmd, ...opts.args]);
+      return {
+        pid: 1,
+        async wait() {
+          return 0;
+        },
+        async kill() {},
+      };
+    },
+  };
+}
+
+Deno.test("server: production 上下文调用 docker compose run", async () => {
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = {
+    cwd: "/tmp",
+    kind: "production",
+    dir: "/opt/neuro-oj",
+  };
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["db", "migrate"],
+    runner,
+  });
+  assertEquals(code, 0);
+  const call = log[0]!;
+  assertEquals(call[0], "docker");
+  assertEquals(call.includes("compose"), true);
+  assertEquals(call.includes("run"), true);
+  assertEquals(call.includes("--entrypoint"), true);
+  assertEquals(call.includes("/app/bin/noj"), true);
+  assertEquals(call.includes("core"), true);
+  assertEquals(call[call.length - 1], "migrate");
+});
+
+Deno.test("server: production 上下文透传 bootstrap 参数", async () => {
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = {
+    cwd: "/tmp",
+    kind: "production",
+    dir: "/opt/neuro-oj",
+  };
+  await runServerCommand({
+    context: ctx,
+    args: ["bootstrap", "first-admin", "--username", "admin"],
+    runner,
+  });
+  const call = log[0]!;
+  assertEquals(call.includes("bootstrap"), true);
+  assertEquals(call.includes("first-admin"), true);
+  assertEquals(call.includes("--username"), true);
+  assertEquals(call.includes("admin"), true);
+});
+
+Deno.test("server: 源码上下文调用 deno task", async () => {
+  const root = Deno.makeTempDirSync();
+  Deno.mkdirSync(`${root}/noj-core`, { recursive: true });
+  Deno.writeTextFileSync(`${root}/noj-core/deno.json`, "{}");
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = { cwd: `${root}/noj-core`, kind: "none", dir: null };
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["db", "migrate"],
+    runner,
+  });
+  assertEquals(code, 0);
+  const call = log[0]!;
+  assertEquals(call[0], "deno");
+  assertEquals(call.includes("task"), true);
+  assertEquals(call.includes("db:migrate"), true);
+});
+
+Deno.test("server: 无上下文且找不到源码根目录返回非零", async () => {
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = { cwd: "/tmp", kind: "none", dir: null };
+  const code = await runServerCommand({ context: ctx, args: ["db", "migrate"], runner });
+  assertEquals(code, 1);
+  assertEquals(log.length, 0);
+});
+
+Deno.test("server: judge 上下文返回非零", async () => {
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = { cwd: "/tmp", kind: "judge", dir: "/srv/noj-judge" };
+  const code = await runServerCommand({ context: ctx, args: ["db", "migrate"], runner });
+  assertEquals(code, 1);
+  assertEquals(log.length, 0);
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/server_cmd/server_cmd_test.ts`
+Expected: FAIL，报找不到 `./server_cmd.ts`。
+
+- [ ] **Step 3: 实现 `src/server_cmd/server_cmd.ts`**
+
+```ts
+import { dirname } from "@std/path";
+import type { CliContext } from "../context/context.ts";
+import { realRunner, type CommandRunner } from "../runtime/command.ts";
+
+export interface ServerCommandOptions {
+  context: CliContext;
+  args: string[];
+  runner?: CommandRunner;
+}
+
+const VALID_SUBCOMMANDS = new Set([
+  "db",
+  "init",
+  "bootstrap",
+  "problems",
+  "dev-setup",
+]);
+
+function validateArgs(args: string[]): void {
+  if (args.length === 0) throw new Error("server: 缺少子命令");
+  if (!VALID_SUBCOMMANDS.has(args[0]!)) {
+    throw new Error(`server: 未知子命令 ${args[0]}`);
+  }
+}
+
+function findSourceRoot(start: string): string | null {
+  let current = Deno.realPathSync(start);
+  while (true) {
+    try {
+      if (Deno.statSync(`${current}/noj-core/deno.json`).isFile) {
+        return current;
+      }
+    } catch {
+      // 继续向上
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function sourceCommand(args: string[]): { cmd: string; args: string[] } {
+  const [sub, subsub, ...rest] = args;
+  if (sub === "db" && subsub === "migrate") {
+    return { cmd: "deno", args: ["task", "db:migrate"] };
+  }
+  if (sub === "init" && subsub === "system") {
+    return { cmd: "deno", args: ["task", "init:system"] };
+  }
+  if (sub === "bootstrap") {
+    if (!subsub) throw new Error("server: bootstrap 需要 first-admin 或 admin");
+    return {
+      cmd: "deno",
+      args: [
+        "run",
+        "--env-file=.env",
+        "-A",
+        "scripts/noj.ts",
+        "bootstrap",
+        subsub,
+        ...rest,
+      ],
+    };
+  }
+  if (sub === "problems") {
+    if (subsub === "build") {
+      return { cmd: "deno", args: ["task", "problems:build", "--", ...rest] };
+    }
+    if (subsub === "import") {
+      return { cmd: "deno", args: ["task", "problems:import", "--", ...rest] };
+    }
+  }
+  if (sub === "dev-setup") {
+    return { cmd: "deno", args: ["task", "dev-setup"] };
+  }
+  throw new Error(`server: 不支持的源码子命令 ${args.join(" ")}`);
+}
+
+export async function runServerCommand(
+  opts: ServerCommandOptions,
+): Promise<number> {
+  const runner = opts.runner ?? realRunner();
+  const { context, args } = opts;
+  try {
+    validateArgs(args);
+  } catch (e) {
+    console.error((e as Error).message);
+    return 1;
+  }
+
+  if (context.kind === "production" && context.dir !== null) {
+    const fullArgs = [
+      "compose",
+      "--env-file",
+      `${context.dir}/.env.prod`,
+      "--file",
+      `${context.dir}/docker-compose.prod.yml`,
+      "run",
+      "--rm",
+      "--entrypoint",
+      "/app/bin/noj",
+      "core",
+      ...args,
+    ];
+    const handle = runner.spawn({
+      cmd: "docker",
+      args: fullArgs,
+      cwd: context.dir,
+      env: {},
+    });
+    return await handle.wait();
+  }
+
+  const sourceRoot = findSourceRoot(context.cwd);
+  if (sourceRoot !== null) {
+    try {
+      const launch = sourceCommand(args);
+      const handle = runner.spawn({
+        cmd: launch.cmd,
+        args: launch.args,
+        cwd: `${sourceRoot}/noj-core`,
+        env: {},
+      });
+      return await handle.wait();
+    } catch (e) {
+      console.error((e as Error).message);
+      return 1;
+    }
+  }
+
+  console.error("server: 未找到 production 部署或 noj-core 源码目录");
+  return 1;
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/server_cmd/server_cmd_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 实现 server 命令运行器"
+```
+
+---
+
+### Task 7: CLI 挂载 server 命令
+
+**Files:**
+- Modify: `noj-cli/src/cli.ts`
+- Modify: `noj-cli/src/cli_test.ts`
+
+**Interfaces:**
+- Consumes: `runServerCommand`（Task 6）、`resolveContext`（Task 1）。
+- Produces: 无新导出；`dispatchCommand("server", args, ctx)` 返回进程退出码。
+
+- [ ] **Step 1: 写失败测试**
+
+在 `noj-cli/src/cli_test.ts` 追加：
+
+```ts
+Deno.test("server 无上下文时返回 1", async () => {
+  assertEquals(await dispatchCommand("server", ["db", "migrate"], ctx), 1);
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/cli_test.ts`
+Expected: 当前应 FAIL（`server` 不是已知命令，`dispatchCommand` 走 `switch` 默认返回 1？若现有未知命令测试已覆盖，则此测试实际可能通过；请同时添加 `printHelp` 包含 `server` 的断言确保未实现时失败）。
+
+在 `printHelp` 测试中追加：
+
+```ts
+Deno.test("printHelp 包含 server", () => {
+  assertEquals(printHelp().includes("server"), true);
+});
+```
+
+预期 `server` 尚未加入 help，因此 FAIL。
+
+- [ ] **Step 3: 实现 CLI 挂载**
+
+在 `src/cli.ts`：
+
+- import 增加：
+
+```ts
+import { runServerCommand } from "./server_cmd/server_cmd.ts";
+import { resolveContext } from "./context/context.ts";
+```
+
+- `KNOWN_TOP` 增加 `"server"`：
+
+```ts
+const KNOWN_TOP = new Set([
+  "doctor",
+  "deploy",
+  "maintain",
+  "run-server",
+  "version",
+  "observability",
+  "server",
+]);
+```
+
+- 在 `dispatchCommand` 的 `switch` 中新增：
+
+```ts
+case "server": {
+  const parsedDir = args.includes("--dir")
+    ? args[args.indexOf("--dir") + 1]
+    : undefined;
+  const context = resolveContext({ cwd: ctx.cwd, dir: parsedDir });
+  const serverArgs = args.filter((a) => a !== "--dir" && a !== parsedDir);
+  return await runServerCommand({ context, args: serverArgs });
+}
+```
+
+- 在 `printHelp()` 增加：
+
+```text
+"  server <cmd>            容器内服务端管理命令（db/init/bootstrap/problems/dev-setup）",
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/cli_test.ts`
+Expected: PASS（`server 无上下文` 返回 1，`printHelp` 包含 `server`）。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 挂载 server 命令"
+```
+
+---
+
+### Task 8: 更新命令帮助与 README
+
+**Files:**
+- Modify: `noj-cli/README.md`
+- Modify: `noj-cli/src/cli.ts`（若帮助文本不完整）
+
+**Interfaces:**
+- Consumes: 前序任务产出的命令。
+- Produces: 用户可读的命令文档。
+
+- [ ] **Step 1: 在 README 增加新命令说明**
+
+在 `noj-cli/README.md` 的“生产命令”或“开发与验证”之前补充：
+
+```markdown
+## 新增运维命令（Phase 1）
+
+```bash
+noj-cli observability check [--base-url URL] [--check-notifications]
+noj-cli observability alert-drill [--alertmanager-url URL] [--hold SECONDS]
+noj-cli server db migrate
+noj-cli server init system
+noj-cli server bootstrap first-admin --username <user> --email <email>
+noj-cli server bootstrap admin [--email <email>]
+noj-cli server problems build [--id <id>]
+noj-cli server problems import [--dir <dir>]
+noj-cli server dev-setup
+```
+```
+
+- [ ] **Step 2: 运行仓库 Markdown 链接检查**
+
+Run: `deno run -A scripts/verify-md-links.ts`
+Expected: 通过。
+
+- [ ] **Step 3: 运行全量测试并提交**
+
+Run: `cd noj-cli && deno task test && deno task check`
+Expected: 全部通过。
+
+```bash
+jj commit -m "docs(cli): 更新 observability/server 命令说明"
+```
+
+---
+
+## 后续计划（不在本 Phase 1 内）
+
+- Phase 2：`judge` 命令族（移植 `judge-install.sh`）。
+- Phase 3：`restore-drill` 命令（移植 `restore-drill.sh`）。
+- Phase 4：production Deno 化（移植 `deploy.sh` / `install.sh` / `backup.sh` 的生产路径），并逐步将旧命令别名统一到 `deploy`/`maintain`。
+- Phase 5：脚本标记弃用与清理。

--- a/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase1.md
+++ b/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase1.md
@@ -1208,11 +1208,15 @@ const KNOWN_TOP = new Set([
 
 ```ts
 case "server": {
-  const parsedDir = args.includes("--dir")
-    ? args[args.indexOf("--dir") + 1]
-    : undefined;
+  // 仅支持 `server --dir <path> <子命令>` 形式的全局 --dir；
+  // 子命令自身（如 problems import --dir）的参数原样透传，不在这里剥离。
+  let parsedDir: string | undefined;
+  let serverArgs = args;
+  if (args[0] === "--dir" && args[1] !== undefined) {
+    parsedDir = args[1];
+    serverArgs = args.slice(2);
+  }
   const context = resolveContext({ cwd: ctx.cwd, dir: parsedDir });
-  const serverArgs = args.filter((a) => a !== "--dir" && a !== parsedDir);
   return await runServerCommand({ context, args: serverArgs });
 }
 ```

--- a/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase2.md
+++ b/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase2.md
@@ -1,0 +1,884 @@
+# noj-cli judge 命令族（Phase 2）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 noj-cli 中新增 `judge` 命令族，直接 Deno 化移植 `scripts/deploy/judge-install.sh`，覆盖独立 Judge Worker 的 install/install-env/check/start/stop/status/logs/upgrade/download。
+
+**Architecture:** 新增 `noj-cli/src/judge/` 模块。`options.ts` 负责参数解析；`env.ts` 负责 `.env.judge` 读写；`checks.ts` 负责环境/配置/socket/Redis/镜像检查；`compose.ts` 负责生成并执行 `docker-compose.judge.yml`；`commands.ts` 聚合为 `runJudgeCommand`。CLI 挂载顶层 `judge` 命令。
+
+**Tech Stack:** Deno 2 + TypeScript、`@std/assert`、`@std/path`、现有 `CommandRunner` 与 `PromptIO` 抽象，不新增第三方运行时依赖。
+
+**Spec:** `dev-docs/superpowers/specs/2026-09-07-noj-cli-script-sync-design.md`
+
+## Global Constraints
+
+- 语言：代码标识符使用英文，注释与提交描述使用中文。
+- 运行环境：仅 Deno 2 + TypeScript 标准环境；不新增第三方运行时依赖。
+- 提交：使用 jj；提交信息格式 `<type>(<scope>): <中文描述>`，scope 使用 `cli`。
+- 测试：通过 `cd noj-cli && deno task test` 运行；代码通过 `deno fmt` 与 `deno lint`。
+- 所有改动必须位于当前 worktree（`.worktrees/noj-cli-improves/`）内，禁止修改主仓库。
+- 不修改 `scripts/deploy/*.sh` 等脚本侧实现；脚本保留为兜底。
+- 行为基线：`scripts/deploy/judge-install.sh` 是权威行为来源；Deno 移植必须保留其安全边界（禁止 `/var/run/docker.sock`、配置文件 600/400、密码不回显、非交互必填校验）。
+
+---
+
+## 文件结构
+
+```
+noj-cli/src/judge/
+├── options.ts          # JudgeOptions + parseJudgeArgs
+├── options_test.ts
+├── env.ts              # JudgeEnv 读写/校验
+├── env_test.ts
+├── checks.ts           # 环境/配置/socket/Redis/镜像检查
+├── checks_test.ts
+├── compose.ts          # Compose 生成与 docker compose 执行
+├── compose_test.ts
+├── redis.ts            # 本机 Redis 创建/连接信息（可选）
+├── redis_test.ts
+├── commands.ts         # runJudgeCommand 聚合
+└── commands_test.ts
+```
+
+## Task 1: Judge 参数解析
+
+**Files:**
+- Create: `noj-cli/src/judge/options.ts`
+- Create: `noj-cli/src/judge/options_test.ts`
+
+**Interfaces:**
+- Consumes: 无。
+- Produces:
+  - `export interface JudgeOptions { command: "install" | "install-env" | "check" | "start" | "stop" | "status" | "logs" | "upgrade" | "download"; dir: string; envFile: string; composeFile: string; repo: string; ref: string; version?: string; redisContainer: string; redisPort: number; panel: "auto" | "baota" | "none"; nonInteractive: boolean; downloadOnly: boolean; dryRun: boolean; follow: boolean }`
+  - `export function parseJudgeArgs(args: string[]): JudgeOptions`
+  - `export const DEFAULT_JUDGE_DIR = "/srv/noj-judge"`
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `noj-cli/src/judge/options_test.ts`：
+
+```ts
+import { assertEquals, assertThrows } from "@std/assert";
+import { DEFAULT_JUDGE_DIR, parseJudgeArgs } from "./options.ts";
+
+Deno.test("parseJudgeArgs: 缺省值", () => {
+  const o = parseJudgeArgs(["install"]);
+  assertEquals(o.command, "install");
+  assertEquals(o.dir, DEFAULT_JUDGE_DIR);
+  assertEquals(o.envFile, `${DEFAULT_JUDGE_DIR}/.env.judge`);
+  assertEquals(o.composeFile, `${DEFAULT_JUDGE_DIR}/docker-compose.judge.yml`);
+  assertEquals(o.repo, "https://github.com/Neuro-OJ/neuro-oj");
+  assertEquals(o.ref, "main");
+  assertEquals(o.nonInteractive, false);
+  assertEquals(o.dryRun, false);
+  assertEquals(o.follow, false);
+});
+
+Deno.test("parseJudgeArgs: 解析选项", () => {
+  const o = parseJudgeArgs([
+    "check",
+    "--dir", "/srv/noj",
+    "--env-file", "/tmp/env",
+    "--compose-file", "/tmp/compose.yml",
+    "--version", "v0.2.0",
+    "--panel", "none",
+    "--non-interactive",
+    "--dry-run",
+    "--follow",
+  ]);
+  assertEquals(o.command, "check");
+  assertEquals(o.dir, "/srv/noj");
+  assertEquals(o.envFile, "/tmp/env");
+  assertEquals(o.composeFile, "/tmp/compose.yml");
+  assertEquals(o.version, "v0.2.0");
+  assertEquals(o.panel, "none");
+  assertEquals(o.nonInteractive, true);
+  assertEquals(o.dryRun, true);
+  assertEquals(o.follow, true);
+});
+
+Deno.test("parseJudgeArgs: 非法 panel 抛错", () => {
+  assertThrows(() => parseJudgeArgs(["install", "--panel", "bad"]));
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/judge/options_test.ts`
+Expected: FAIL，报找不到 `./options.ts`。
+
+- [ ] **Step 3: 实现 `src/judge/options.ts`**
+
+```ts
+export const DEFAULT_JUDGE_DIR = "/srv/noj-judge";
+export const DEFAULT_JUDGE_REPO = "https://github.com/Neuro-OJ/neuro-oj";
+export const DEFAULT_JUDGE_REF = "main";
+export const DEFAULT_REDIS_CONTAINER = "noj-judge-redis";
+export const DEFAULT_REDIS_PORT = 16379;
+
+export interface JudgeOptions {
+  command: "install" | "install-env" | "check" | "start" | "stop" | "status" | "logs" | "upgrade" | "download";
+  dir: string;
+  envFile: string;
+  composeFile: string;
+  repo: string;
+  ref: string;
+  version: string | undefined;
+  redisContainer: string;
+  redisPort: number;
+  panel: "auto" | "baota" | "none";
+  nonInteractive: boolean;
+  downloadOnly: boolean;
+  dryRun: boolean;
+  follow: boolean;
+}
+
+const COMMANDS = new Set([
+  "install",
+  "install-env",
+  "check",
+  "start",
+  "stop",
+  "status",
+  "logs",
+  "upgrade",
+  "download",
+]);
+
+export function parseJudgeArgs(args: string[]): JudgeOptions {
+  const out: JudgeOptions = {
+    command: "check",
+    dir: DEFAULT_JUDGE_DIR,
+    envFile: "",
+    composeFile: "",
+    repo: DEFAULT_JUDGE_REPO,
+    ref: DEFAULT_JUDGE_REF,
+    version: undefined,
+    redisContainer: DEFAULT_REDIS_CONTAINER,
+    redisPort: DEFAULT_REDIS_PORT,
+    panel: "auto",
+    nonInteractive: false,
+    downloadOnly: false,
+    dryRun: false,
+    follow: false,
+  };
+  let commandSet = false;
+  const takeValue = (flag: string): string => {
+    const i = args.indexOf(flag);
+    if (i === -1) throw new Error(`judge: ${flag} 缺少参数`);
+    const value = args[i + 1];
+    if (value === undefined) throw new Error(`judge: ${flag} 缺少参数`);
+    return value;
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (COMMANDS.has(a) && !commandSet) {
+      out.command = a as JudgeOptions["command"];
+      commandSet = true;
+      continue;
+    }
+    if (a.startsWith("--dir=")) {
+      out.dir = a.slice(6);
+    } else if (a === "--dir") {
+      out.dir = takeValue(a);
+      i++;
+    } else if (a.startsWith("--env-file=")) {
+      out.envFile = a.slice(11);
+    } else if (a === "--env-file") {
+      out.envFile = takeValue(a);
+      i++;
+    } else if (a.startsWith("--compose-file=")) {
+      out.composeFile = a.slice(15);
+    } else if (a === "--compose-file") {
+      out.composeFile = takeValue(a);
+      i++;
+    } else if (a.startsWith("--repo=")) {
+      out.repo = a.slice(7);
+    } else if (a === "--repo") {
+      out.repo = takeValue(a);
+      i++;
+    } else if (a.startsWith("--ref=")) {
+      out.ref = a.slice(6);
+    } else if (a === "--ref") {
+      out.ref = takeValue(a);
+      i++;
+    } else if (a.startsWith("--version=")) {
+      out.version = a.slice(10);
+    } else if (a === "--version") {
+      out.version = takeValue(a);
+      i++;
+    } else if (a.startsWith("--redis-container=")) {
+      out.redisContainer = a.slice(18);
+    } else if (a === "--redis-container") {
+      out.redisContainer = takeValue(a);
+      i++;
+    } else if (a.startsWith("--redis-port=")) {
+      out.redisPort = Number(a.slice(13));
+    } else if (a === "--redis-port") {
+      out.redisPort = Number(takeValue(a));
+      i++;
+    } else if (a.startsWith("--panel=")) {
+      out.panel = a.slice(8) as JudgeOptions["panel"];
+    } else if (a === "--panel") {
+      out.panel = takeValue(a) as JudgeOptions["panel"];
+      i++;
+    } else if (a === "--non-interactive") {
+      out.nonInteractive = true;
+    } else if (a === "--download-only") {
+      out.downloadOnly = true;
+    } else if (a === "--dry-run") {
+      out.dryRun = true;
+    } else if (a === "--follow" || a === "-f") {
+      out.follow = true;
+    } else if (a === "--help" || a === "-h") {
+      throw new Error("judge --help");
+    } else {
+      throw new Error(`未知 judge 参数: ${a}`);
+    }
+  }
+  if (!commandSet) throw new Error("judge: 需要子命令");
+  if (out.panel !== "auto" && out.panel !== "baota" && out.panel !== "none") {
+    throw new Error(`judge: 非法 panel 模式: ${out.panel}`);
+  }
+  if (out.envFile === "") out.envFile = `${out.dir}/.env.judge`;
+  if (out.composeFile === "") out.composeFile = `${out.dir}/docker-compose.judge.yml`;
+  return out;
+}
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/judge/options_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 新增 judge 参数解析"
+```
+
+---
+
+## Task 2: Judge 环境文件读写
+
+**Files:**
+- Create: `noj-cli/src/judge/env.ts`
+- Create: `noj-cli/src/judge/env_test.ts`
+
+**Interfaces:**
+- Consumes: 无。
+- Produces:
+  - `export interface JudgeEnv { values: Record<string, string> }`
+  - `export function loadJudgeEnv(file: string): JudgeEnv`
+  - `export function saveJudgeEnv(file: string, values: Record<string, string>): void`
+  - `export function setJudgeEnv(file: string, key: string, value: string): void`
+  - `export function envValue(env: JudgeEnv, key: string): string | undefined`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { assertEquals, assertThrows } from "@std/assert";
+import { loadJudgeEnv, saveJudgeEnv, setJudgeEnv } from "./env.ts";
+
+Deno.test("loadJudgeEnv: 解析 KEY=VALUE", () => {
+  const dir = Deno.makeTempDirSync();
+  const file = `${dir}/.env.judge`;
+  Deno.writeTextFileSync(file, "NOJ_VERSION=v0.1.0\nREDIS_URL=redis://x/0\n");
+  const env = loadJudgeEnv(file);
+  assertEquals(envValue(env, "NOJ_VERSION"), "v0.1.0");
+  assertEquals(envValue(env, "REDIS_URL"), "redis://x/0");
+});
+
+Deno.test("saveJudgeEnv: 写文件并保留权限 600", () => {
+  const dir = Deno.makeTempDirSync();
+  const file = `${dir}/.env.judge`;
+  saveJudgeEnv(file, { NOJ_VERSION: "v0.1.0" });
+  assertEquals(Deno.readTextFileSync(file), "NOJ_VERSION=v0.1.0\n");
+  const mode = Deno.statSync(file).mode! & 0o777;
+  assertEquals(mode, 0o600);
+});
+
+Deno.test("setJudgeEnv: 更新已有键", () => {
+  const dir = Deno.makeTempDirSync();
+  const file = `${dir}/.env.judge`;
+  saveJudgeEnv(file, { A: "1" });
+  setJudgeEnv(file, "A", "2");
+  setJudgeEnv(file, "B", "3");
+  const text = Deno.readTextFileSync(file);
+  assertEquals(text.includes("A=2"), true);
+  assertEquals(text.includes("B=3"), true);
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/judge/env_test.ts`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现 `src/judge/env.ts`**
+
+```ts
+export interface JudgeEnv {
+  values: Record<string, string>;
+}
+
+export function envValue(env: JudgeEnv, key: string): string | undefined {
+  return env.values[key];
+}
+
+export function loadJudgeEnv(file: string): JudgeEnv {
+  const values: Record<string, string> = {};
+  try {
+    const text = Deno.readTextFileSync(file);
+    for (const line of text.split(/\r?\n/)) {
+      if (!line.includes("=")) continue;
+      const eq = line.indexOf("=");
+      const key = line.slice(0, eq).trim();
+      let value = line.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (key) values[key] = value;
+    }
+  } catch {
+    // 文件不存在时返回空
+  }
+  return { values };
+}
+
+export function saveJudgeEnv(
+  file: string,
+  values: Record<string, string>,
+): void {
+  const lines = Object.entries(values).map(([k, v]) => `${k}=${v}`);
+  Deno.writeTextFileSync(file, lines.join("\n") + "\n");
+  Deno.chmodSync(file, 0o600);
+}
+
+export function setJudgeEnv(file: string, key: string, value: string): void {
+  const env = loadJudgeEnv(file);
+  env.values[key] = value;
+  saveJudgeEnv(file, env.values);
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/judge/env_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 新增 judge 环境文件读写"
+```
+
+---
+
+## Task 3: Judge 基础环境与配置检查
+
+**Files:**
+- Create: `noj-cli/src/judge/checks.ts`
+- Create: `noj-cli/src/judge/checks_test.ts`
+
+**Interfaces:**
+- Consumes: `JudgeEnv`, `JudgeOptions`, `CommandRunner`（`noj-cli/src/runtime/command.ts`）。
+- Produces:
+  - `export function checkBaseEnvironment(opts: JudgeOptions, runner?: CommandRunner): Promise<void>`
+  - `export function checkConfigValues(env: JudgeEnv): string[]` （返回问题列表）
+  - `export function checkSocket(env: JudgeEnv, runner?: CommandRunner): Promise<string[]>` （返回问题列表）
+  - `export function checkRedis(env: JudgeEnv, runner?: CommandRunner): Promise<string[]>` （返回问题列表）
+  - `export function checkImageArchitecture(env: JudgeEnv, runner?: CommandRunner): Promise<string[]>` （返回问题列表）
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { assertEquals } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import {
+  checkConfigValues,
+  checkSocket,
+  checkBaseEnvironment,
+} from "./checks.ts";
+import type { JudgeOptions } from "./options.ts";
+import type { JudgeEnv } from "./env.ts";
+
+function fakeRunner(): CommandRunner {
+  return {
+    async run() {
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+const baseOpts: JudgeOptions = {
+  command: "check",
+  dir: "/srv/noj-judge",
+  envFile: "/srv/noj-judge/.env.judge",
+  composeFile: "/srv/noj-judge/docker-compose.judge.yml",
+  repo: "https://github.com/Neuro-OJ/neuro-oj",
+  ref: "main",
+  version: undefined,
+  redisContainer: "noj-judge-redis",
+  redisPort: 16379,
+  panel: "none",
+  nonInteractive: true,
+  downloadOnly: false,
+  dryRun: false,
+  follow: false,
+};
+
+function env(values: Record<string, string>): JudgeEnv {
+  return { values };
+}
+
+Deno.test("checkConfigValues: 完整配置无问题", () => {
+  const issues = checkConfigValues(env({
+    NOJ_VERSION: "v0.1.0",
+    REDIS_URL: "redis://127.0.0.1:6379/0",
+    JUDGE_QUEUE: "noj:judge:queue",
+    RESULT_QUEUE: "noj:judge:results",
+    WORK_DIR: "/tmp/noj-judge",
+    JUDGE_MAX_CONCURRENT_JUDGES: "2",
+    JUDGE_IMAGE_PREFIX: "noj-",
+    JUDGE_IMAGE_REGISTRY: "ghcr.io/neuro-oj",
+    JUDGE_DOCKER_SOCKET: "/run/noj-judge/docker.sock",
+    JUDGE_DOCKER_SOCKET_GID: "10001",
+    JUDGE_UID: "10001",
+    JUDGE_GID: "10001",
+    JUDGE_DOCKER_HOST: "unix:///run/noj-judge/docker.sock",
+    JUDGE_REQUIRE_ISOLATED_DOCKER: "true",
+  }));
+  assertEquals(issues, []);
+});
+
+Deno.test("checkConfigValues: 禁止的 socket 与占位值", () => {
+  const issues = checkConfigValues(env({
+    NOJ_VERSION: "latest",
+    REDIS_URL: "change-me",
+    JUDGE_DOCKER_SOCKET: "/var/run/docker.sock",
+    JUDGE_DOCKER_SOCKET_GID: "abc",
+    JUDGE_UID: "0",
+    JUDGE_GID: "0",
+    JUDGE_DOCKER_HOST: "unix:///var/run/docker.sock",
+    JUDGE_REQUIRE_ISOLATED_DOCKER: "false",
+  }));
+  assertEquals(issues.length > 0, true);
+});
+
+Deno.test("checkBaseEnvironment: Linux + docker ok 不抛错", async () => {
+  await checkBaseEnvironment(baseOpts, fakeRunner());
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/judge/checks_test.ts`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现 `src/judge/checks.ts`**
+
+参照 `scripts/deploy/judge-install.sh` 的函数：
+- `check_base_environment`（第 636-682 行）
+- `check_config_values`（第 665-695 行）
+- `check_socket`（第 693-725 行）
+- `check_redis`（第 726-756 行）
+- `check_image_architecture`（第 759-785 行）
+
+实现时使用 `runner.run` 调用 `docker`, `docker compose version`, `docker info`, `redis-cli`/`docker run`，并把 bash `fail` 改为返回 `string[]` 或抛错。`checkConfigValues` 等纯函数返回问题列表；涉及 I/O 的检查返回 Promise<string[]>。`checkBaseEnvironment` 抛错表示阻断。
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/judge/checks_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 实现 judge 环境与配置检查"
+```
+
+---
+
+## Task 4: Judge Compose 生成与执行
+
+**Files:**
+- Create: `noj-cli/src/judge/compose.ts`
+- Create: `noj-cli/src/judge/compose_test.ts`
+
+**Interfaces:**
+- Consumes: `JudgeOptions`, `JudgeEnv`, `CommandRunner`。
+- Produces:
+  - `export function renderJudgeCompose(): string` （返回和 `judge-install.sh` 相同模板）
+  - `export function writeJudgeCompose(file: string, dryRun: boolean): void`
+  - `export function composeArgs(opts: JudgeOptions): string[]`
+  - `export async function runJudgeCompose(opts: JudgeOptions, args: string[], runner?: CommandRunner): Promise<number>`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { assertEquals } from "@std/assert";
+import { renderJudgeCompose, composeArgs, writeJudgeCompose } from "./compose.ts";
+import type { JudgeOptions } from "./options.ts";
+
+const opts: JudgeOptions = {
+  command: "start",
+  dir: "/srv/noj-judge",
+  envFile: "/srv/noj-judge/.env.judge",
+  composeFile: "/srv/noj-judge/docker-compose.judge.yml",
+  repo: "https://github.com/Neuro-OJ/neuro-oj",
+  ref: "main",
+  version: undefined,
+  redisContainer: "noj-judge-redis",
+  redisPort: 16379,
+  panel: "none",
+  nonInteractive: true,
+  downloadOnly: false,
+  dryRun: false,
+  follow: false,
+};
+
+Deno.test("renderJudgeCompose: 包含 noj-judge 镜像与安全配置", () => {
+  const text = renderJudgeCompose();
+  assertEquals(text.includes("noj-judge"), true);
+  assertEquals(text.includes("cap_drop"), true);
+  assertEquals(text.includes("no-new-privileges"), true);
+  assertEquals(text.includes("JUDGE_REQUIRE_ISOLATED_DOCKER"), true);
+});
+
+Deno.test("composeArgs: 使用 project-name/env-file/file", () => {
+  const args = composeArgs(opts);
+  assertEquals(args.includes("--project-name"), true);
+  assertEquals(args.includes("noj-judge-standalone"), true);
+  assertEquals(args.includes("--env-file"), true);
+  assertEquals(args.includes(opts.envFile), true);
+  assertEquals(args.includes("-f"), true);
+  assertEquals(args.includes(opts.composeFile), true);
+});
+
+Deno.test("writeJudgeCompose: 权限 600", () => {
+  const file = `${Deno.makeTempDirSync()}/docker-compose.judge.yml`;
+  writeJudgeCompose(file, false);
+  const mode = Deno.statSync(file).mode! & 0o777;
+  assertEquals(mode, 0o600);
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/judge/compose_test.ts`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现 `src/judge/compose.ts`**
+
+将 `scripts/deploy/judge-install.sh` 中的 `write_compose` 模板原文复制为 `renderJudgeCompose()` 返回值（保持缩进和变量名一致）。`writeJudgeCompose` 用 `Deno.writeTextFileSync` + `chmod 600`。`composeArgs` 返回：
+
+```ts
+[
+  "compose",
+  "--project-name", "noj-judge-standalone",
+  "--env-file", opts.envFile,
+  "-f", opts.composeFile,
+  ...args,
+]
+```
+
+`runJudgeCompose` 在 `dryRun` 时打印命令并返回 0，否则 `runner.run("docker", composeArgs(...))` 并返回 code。
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/judge/compose_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 实现 judge compose 生成与执行"
+```
+
+---
+
+## Task 5: Judge Redis 本机创建
+
+**Files:**
+- Create: `noj-cli/src/judge/redis.ts`
+- Create: `noj-cli/src/judge/redis_test.ts`
+
+**Interfaces:**
+- Consumes: `JudgeOptions`, `JudgeEnv`, `CommandRunner`。
+- Produces:
+  - `export interface RedisConnection { runtimeUrl: string; checkUrl: string; source: "existing" | "local" | "pending" }`
+  - `export function generateRedisPassword(): string`
+  - `export function validateRedisPort(port: number): void`
+  - `export async function createLocalRedis(opts: JudgeOptions, runner?: CommandRunner): Promise<void>` （写入 `.redis-connection.env` 与 `redis-connection.txt`）
+  - `export function redisConnectionFiles(opts: JudgeOptions): { metadata: string; guide: string }`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { assertEquals, assertThrows } from "@std/assert";
+import { generateRedisPassword, validateRedisPort } from "./redis.ts";
+
+Deno.test("generateRedisPassword: 长度大于 32", () => {
+  assertEquals(generateRedisPassword().length >= 32, true);
+});
+
+Deno.test("validateRedisPort: 合法范围", () => {
+  validateRedisPort(16379);
+  assertThrows(() => validateRedisPort(80));
+  assertThrows(() => validateRedisPort(70000));
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/judge/redis_test.ts`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现 `src/judge/redis.ts`**
+
+移植 `scripts/deploy/judge-install.sh` 的 `generate_redis_password`、`validate_redis_port`、`create_local_redis`、`write_redis_connection_files`。用 `crypto.getRandomValues` 生成随机字节，`Deno.writeTextFileSync` 写文件并 `chmod 600`。`runner.run("docker", [...])` 创建容器。
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/judge/redis_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 实现 judge 本机 Redis 管理"
+```
+
+---
+
+## Task 6: Judge 命令聚合实现
+
+**Files:**
+- Create: `noj-cli/src/judge/commands.ts`
+- Create: `noj-cli/src/judge/commands_test.ts`
+
+**Interfaces:**
+- Consumes: `JudgeOptions`, `JudgeEnv`, checks/compose/redis 模块。
+- Produces:
+  - `export async function runJudgeCommand(opts: JudgeOptions, runner?: CommandRunner): Promise<number>`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { assertEquals } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import { runJudgeCommand } from "./commands.ts";
+import type { JudgeOptions } from "./options.ts";
+
+function fakeRunner(): CommandRunner {
+  return {
+    async run() {
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+const opts: JudgeOptions = {
+  command: "check",
+  dir: "/srv/noj-judge",
+  envFile: "/srv/noj-judge/.env.judge",
+  composeFile: "/srv/noj-judge/docker-compose.judge.yml",
+  repo: "https://github.com/Neuro-OJ/neuro-oj",
+  ref: "main",
+  version: undefined,
+  redisContainer: "noj-judge-redis",
+  redisPort: 16379,
+  panel: "none",
+  nonInteractive: true,
+  downloadOnly: false,
+  dryRun: true,
+  follow: false,
+};
+
+Deno.test("judge check dry-run 返回 0", async () => {
+  const code = await runJudgeCommand({ ...opts, dryRun: true }, fakeRunner());
+  assertEquals(code, 0);
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/judge/commands_test.ts`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现 `src/judge/commands.ts`**
+
+按 `scripts/deploy/judge-install.sh` 的 `main()` 映射：
+
+| 命令 | 行为 |
+|---|---|
+| `install` | 初始化 env → 写 compose → check → pull → up |
+| `install-env` | 检查 Docker/Compose 并输出 rootless 准备指引 |
+| `check` | check_base_environment + check_configuration |
+| `start` | check + compose up |
+| `stop` | compose stop |
+| `status` | check + 打印摘要 + compose ps |
+| `logs` | compose logs --tail=200 [--follow] |
+| `upgrade` | 可选更新 NOJ_VERSION → 写 compose → check → pull → up |
+| `download` | 下载 `judge-install.sh` 到目标目录（保留兜底） |
+
+`runJudgeCommand` 返回 0 或非零；错误打印 `judge: ...`。
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/judge/commands_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 实现 judge 命令聚合"
+```
+
+---
+
+## Task 7: CLI 挂载 judge 命令
+
+**Files:**
+- Modify: `noj-cli/src/cli.ts`
+- Modify: `noj-cli/src/cli_test.ts`
+
+**Interfaces:**
+- Consumes: `parseJudgeArgs`, `runJudgeCommand`。
+- Produces: `dispatchCommand("judge", args, ctx)` 返回退出码。
+
+- [ ] **Step 1: 写失败测试**
+
+在 `noj-cli/src/cli_test.ts` 追加：
+
+```ts
+Deno.test("judge 需要子命令时返回非零", async () => {
+  // 无子命令应返回 1
+  assertEquals(await dispatchCommand("judge", [], ctx), 1);
+});
+```
+
+同时更新 `printHelp` 测试，使断言包含 `judge`（建议用 `judge <cmd>` 避免与现有文本误匹配）。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd noj-cli && deno test -A src/cli_test.ts`
+Expected: 当前 `judge` 未挂载，测试失败或 help 断言失败。
+
+- [ ] **Step 3: 实现 CLI 挂载**
+
+- `import { parseJudgeArgs } from "./judge/options.ts";`
+- `import { runJudgeCommand } from "./judge/commands.ts";`
+- 将 `"judge"` 加入 `KNOWN_TOP`。
+- 在 `dispatchCommand` 新增：
+
+```ts
+case "judge": {
+  try {
+    const opts = parseJudgeArgs(args);
+    return await runJudgeCommand(opts);
+  } catch (e) {
+    console.error(`judge: ${(e as Error).message}`);
+    return 1;
+  }
+}
+```
+
+- 在 `printHelp()` 增加：
+
+```text
+"  judge <cmd>            独立 Judge Worker 管理（install/check/start/stop/status/logs/upgrade/download）",
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd noj-cli && deno test -A src/cli_test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 运行 check 并提交**
+
+Run: `cd noj-cli && deno task check`
+Expected: 通过。
+
+```bash
+jj commit -m "feat(cli): 挂载 judge 命令"
+```
+
+---
+
+## Task 8: 更新 README 与帮助
+
+**Files:**
+- Modify: `noj-cli/README.md`
+- Modify: `noj-cli/src/cli.ts`（如帮助文本不完整）
+
+**Interfaces:**
+- Consumes: 前序任务产出的 `judge` 命令。
+- Produces: 用户可读文档。
+
+- [ ] **Step 1: 在 README 增加 judge 命令说明**
+
+在 `noj-cli/README.md` 的“新增运维命令（Phase 1）”之后追加：
+
+```markdown
+## 独立 Judge 管理（Phase 2）
+
+```bash
+noj-cli judge install [--dir /srv/noj-judge]
+noj-cli judge install-env
+noj-cli judge check
+noj-cli judge start
+noj-cli judge stop
+noj-cli judge status
+noj-cli judge logs [--follow]
+noj-cli judge upgrade [--version v0.2.0]
+noj-cli judge download [--dir /srv/noj-judge]
+```
+```
+
+- [ ] **Step 2: 运行验证**
+
+Run: `cd noj-cli && deno task test && deno task check`
+Run: `deno run -A scripts/verify-md-links.ts`
+Expected: 全部通过。
+
+- [ ] **Step 3: 提交**
+
+```bash
+jj commit -m "docs(cli): 更新 judge 命令说明"
+```
+
+---
+
+## 后续
+
+- Phase 3：`restore-drill`
+- Phase 4：production Deno 化与旧命令别名统一
+- Phase 5：脚本弃用与清理

--- a/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase2.md
+++ b/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase2.md
@@ -244,6 +244,7 @@ export function parseJudgeArgs(args: string[]): JudgeOptions {
   if (out.composeFile === "") out.composeFile = `${out.dir}/docker-compose.judge.yml`;
   return out;
 }
+```
 
 - [ ] **Step 4: 运行测试确认通过**
 

--- a/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase3.md
+++ b/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase3.md
@@ -1,0 +1,126 @@
+# noj-cli restore-drill 命令（Phase 3）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) or superpowers:subagent-driven-development (if subagents available).
+
+**Goal:** 在 noj-cli 中新增 `restore-drill` 命令，Deno 化移植 `scripts/deploy/restore-drill.sh`，提供生产备份的隔离恢复演练（独立 Compose 项目、真实数据恢复与业务验收）。
+
+**Architecture:** 新增 `noj-cli/src/restore_drill/` 模块。`options.ts` 解析参数；`snapshot.ts` 负责快照路径/元数据/文件校验；`compose.ts` 负责演练 Compose 覆盖与 docker compose 调用；`drill.ts` 聚合执行 restore → verify data → seed admin → start services → business verify → report → cleanup。业务验收继续复用 `scripts/deploy/restore-drill-verify.ts`（作为只读资产在 verifier 容器内运行）。
+
+**Tech Stack:** Deno 2 + TypeScript、`@std/assert`、`@std/path`、现有 `CommandRunner`、`HttpClient`/HTTP 可选，不新增第三方运行时依赖。
+
+**Spec:** `dev-docs/superpowers/specs/2026-09-07-noj-cli-script-sync-design.md`
+
+## Global Constraints
+
+- 语言：代码标识符使用英文，注释与提交描述使用中文。
+- 运行环境：仅 Deno 2 + TypeScript 标准环境；不新增第三方运行时依赖。
+- 提交：使用 jj；提交信息格式 `<type>(<scope>): <中文描述>`，scope 使用 `cli`。
+- 测试：通过 `cd noj-cli && deno task test` 运行；代码通过 `deno fmt` 与 `deno lint`。
+- 所有改动必须位于当前 worktree（`.worktrees/noj-cli-improves/`）内，禁止修改主仓库。
+- 不修改 `scripts/deploy/*.sh`；脚本保留为兜底。
+- 行为基线：`scripts/deploy/restore-drill.sh` 是权威行为来源；安全边界（口令文件 600/400、禁止 prod 项目名、快照路径校验、RPO/RTO）必须保留。
+
+## 文件结构
+
+```
+noj-cli/src/restore_drill/
+├── options.ts          # RestoreDrillOptions + parseRestoreDrillArgs
+├── options_test.ts
+├── snapshot.ts         # 快照校验、元数据、RPO/RTO 计算
+├── snapshot_test.ts
+├── compose.ts          # 演练 Compose 覆盖生成与 docker compose 执行
+├── compose_test.ts
+└── drill.ts            # runRestoreDrill 编排
+└── drill_test.ts
+```
+
+## Task 1: restore-drill 参数解析
+
+**Files:** `options.ts`, `options_test.ts`
+
+**Interfaces:**
+- `export interface RestoreDrillOptions { snapshot: string; envFile: string; composeFile: string; passphraseFile: string; projectName: string; drillDir?: string; report?: string; subnet: string; rpoMaxHours: number; rtoMaxMinutes: number; waitTimeout: number; skipJudge: boolean; keep: boolean }`
+- `export function parseRestoreDrillArgs(args: string[]): RestoreDrillOptions`
+
+实现要点：按 `scripts/deploy/restore-drill.sh` `parse_args` 解析，默认值与脚本一致；校验 `projectName` 不含 `prod` 且只含小写字母数字 `-_`；RPO/RTO 为非负整数；`skipJudge`/`keep` 为布尔。
+
+测试覆盖：缺省值、选项解析、非法 project name、非法 RPO/RTO。
+
+## Task 2: 快照校验与元数据
+
+**Files:** `snapshot.ts`, `snapshot_test.ts`
+
+**Interfaces:**
+- `export function validateSnapshotPath(snapshot: string): string`（规范化绝对路径，校验 `snapshot-*`、无 `..`）
+- `export function checkSnapshotFiles(snapshot: string): string[]`（SUCCESS/manifest.json/env.prod.gpg 等缺失问题）
+- `export function checkSecretFile(file: string): string[]`（存在且权限 600/400）
+- `export function snapshotCreatedAt(snapshot: string): string`
+- `export function hoursSinceSnapshot(createdAt: string): number`
+- `export async function verifySnapshot(opts: { snapshot: string; envFile: string; composeFile: string; passphraseFile: string; runner?: CommandRunner }): Promise<string[]>`（移植 `backup.sh verify_snapshot`：SHA-256、GPG 解密、必要文件检查）
+
+测试覆盖：合法/非法快照路径、成功标记缺失、RPO/RTO 解析。
+
+## Task 3: 演练 Compose 管理
+
+**Files:** `compose.ts`, `compose_test.ts`
+
+**Interfaces:**
+- `export interface DrillComposePaths { envFile: string; overrideFile: string; }
+- `export function renderDrillOverride(subnet: string): string`（与脚本 `compose.drill-override.yml` 相同）
+- `export function composeArgs(opts: RestoreDrillOptions, paths: DrillComposePaths, extra: string[]): string[]`
+- `export async function runDrillCompose(opts, paths, args, runner?): Promise<number>`
+
+测试覆盖：override 内容、compose args 顺序、dry-run 由上层处理。
+
+## Task 4: 数据恢复与核对
+
+**Files:** `drill.ts` 内部函数或单独 `restore.ts`；测试 `drill_test.ts`
+
+实现函数（可放在 `drill.ts`）：
+- `restoreDataServices(opts, ctx, runner)`
+- `verifyData(opts, ctx, runner)`
+- `seedDrillAdmin(opts, ctx, runner)`
+- `startBusinessServices(opts, ctx, runner)`
+
+这些函数按 `scripts/deploy/restore-drill.sh` 对应函数移植，使用 `ComposeContext`（envFile/override/report/tempDir）传递状态。使用 `CommandRunner` 注入 fake，避免真实 Docker。
+
+测试覆盖：restore 顺序、verify 数据、seed admin、start business 的成功/失败路径。
+
+## Task 5: runRestoreDrill 编排
+
+**Files:** `drill.ts`, `drill_test.ts`
+
+**Interfaces:**
+- `export interface DrillContext { startAt: string; tempDir: string; report: string; composeEnvFile: string; overrideFile: string; keep: boolean; }`
+- `export async function runRestoreDrill(opts: RestoreDrillOptions, runner?: CommandRunner): Promise<number>`
+- 返回 `0` 成功、`1` 失败；失败时尽力清理并写失败报告。
+
+实现流程（按脚本 `main` 顺序）：
+1. `parse` 已由 CLI 完成
+2. preflight（snapshot/passphrase/env/compose/docker/project name）
+3. prepare dirs/env/override
+4. restore + verify data
+5. seed admin + start business services
+6. run business verification
+7. write report + metrics
+8. cleanup (unless keep)
+
+测试覆盖：`--skip-judge`、失败报告、dry-run 不真实执行（如有）。
+
+## Task 6: CLI 挂载与文档
+
+**Files:** `noj-cli/src/cli.ts`, `noj-cli/src/cli_test.ts`, `noj-cli/README.md`
+
+- `KNOWN_TOP` 增加 `"restore-drill"`
+- `case "restore-drill"` 调用 `parseRestoreDrillArgs` 和 `runRestoreDrill`
+- `printHelp()` 增加 `restore-drill`
+- README 增加命令说明
+
+测试：help 包含 restore-drill，无 snapshot 参数返回非零。
+
+---
+
+## 后续
+
+- Phase 4：production Deno 化与旧命令别名统一
+- Phase 5：脚本弃用与清理

--- a/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase4.md
+++ b/dev-docs/superpowers/plans/2026-09-07-noj-cli-script-sync-phase4.md
@@ -1,0 +1,140 @@
+# noj-cli production Deno 化与旧命令别名统一（Phase 4）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) or superpowers:subagent-driven-development (if subagents available).
+
+**Goal:** 将 `scripts/deploy/deploy.sh`、`install.sh`、`backup.sh`、`production.sh` 的生产运维逻辑 Deno 化到 noj-cli，并让旧的顶层命令（`install/start/stop/restart/status/logs/update/backup/verify/config/uninstall`）作为兼容别名路由到统一实现。
+
+**Architecture:** 新增 `noj-cli/src/production/` 模块，按职责拆分为 `env.ts`、`compose.ts`、`lifecycle.ts`、`install.ts`、`backup.ts`、`config.ts`。`src/cli.ts` 的旧生产命令不再直接 `runProduction`，而是走 `src/production/dispatch.ts` 的统一分发。现有 JSON 模式 `deploy/maintain` 保持不变。
+
+**Tech Stack:** Deno 2 + TypeScript、`@std/assert`、`@std/path`、现有 `CommandRunner`/`PromptIO`/context 模块，不新增第三方运行时依赖。
+
+**Spec:** `dev-docs/superpowers/specs/2026-09-07-noj-cli-script-sync-design.md`
+
+## Global Constraints
+
+- 语言：代码标识符使用英文，注释与提交描述使用中文。
+- 运行环境：仅 Deno 2 + TypeScript 标准环境；不新增第三方运行时依赖。
+- 提交：使用 jj；提交信息格式 `<type>(<scope>): <中文描述>`，scope 使用 `cli`。
+- 测试：通过 `cd noj-cli && deno task test` 运行；代码通过 `deno fmt` 与 `deno lint`。
+- 所有改动必须位于当前 worktree（`.worktrees/noj-cli-improves/`）内，禁止修改主仓库。
+- 不修改 `scripts/deploy/*.sh`；脚本保留为兜底。
+- 行为基线：`scripts/deploy/deploy.sh`、`install.sh`、`backup.sh`、`production.sh` 是权威行为来源；安全边界（GPG 口令权限、卸载确认、根目录删除保护、镜像签名、备份原子性）必须保留。
+
+## 文件结构
+
+```
+noj-cli/src/production/
+├── env.ts               # .env.prod 读取/写入/校验
+├── env_test.ts
+├── compose.ts           # docker compose 通用执行/健康等待
+├── compose_test.ts
+├── lifecycle.ts         # start/stop/restart/status/logs
+├── lifecycle_test.ts
+├── install.ts           # install/install-env/update/uninstall
+├── install_test.ts
+├── backup.ts            # backup create/verify/restore/drill
+├── backup_test.ts
+├── config.ts            # config check/show/set
+├── config_test.ts
+└── dispatch.ts          # 旧命令别名到统一实现的映射
+└── dispatch_test.ts
+```
+
+## Task 1: 生产 env 模块
+
+**Files:** `env.ts`, `env_test.ts`
+
+**Interfaces:**
+- `export function loadProdEnv(file: string): Record<string, string>`
+- `export function saveProdEnv(file: string, values: Record<string, string>): void`
+- `export function setProdEnv(file: string, key: string, value: string): void`
+- `export function validateProdEnv(file: string, opts?: { requireSecrets?: boolean }): string[]`（移植 `deploy.sh` `check_required_values` / `check_file_permissions`）
+
+实现要点：KEY=VALUE 解析、引号去除、权限 600/400 校验、必填项与占位值检查、`NOJ_VERSION` 格式校验。复用 `src/judge/env.ts` 的读写风格，但保持独立。
+
+## Task 2: 生产 compose 执行
+
+**Files:** `compose.ts`, `compose_test.ts`
+
+**Interfaces:**
+- `export function prodComposeArgs(opts: { envFile: string; composeFile: string }, args: string[]): string[]`
+- `export async function runProdCompose(opts, args, runner?): Promise<number>`
+- `export async function waitForHealthy(opts, runner?): Promise<void>`（`docker compose up -d --wait`）
+
+实现要点：与 `deploy.sh` 的 `run_compose` 一致；dry-run 由上层控制。
+
+## Task 3: 生产生命周期
+
+**Files:** `lifecycle.ts`, `lifecycle_test.ts`
+
+**Interfaces:**
+- `export interface ProdLifecycleOptions { dir: string; envFile: string; composeFile: string; dryRun?: boolean; follow?: boolean; services?: string[] }`
+- `export async function prodStart(opts, runner?): Promise<number>`
+- `export async function prodStop(opts, runner?): Promise<number>`
+- `export async function prodRestart(opts, runner?): Promise<number>`
+- `export async function prodStatus(opts, runner?): Promise<number>`
+- `export async function prodLogs(opts, runner?): Promise<number>`
+
+实现要点：移植 `deploy.sh` `start/stop/restart/status/logs`；status 输出 Compose ps 摘要；logs 支持 `--follow`。
+
+## Task 4: 生产安装/升级/卸载
+
+**Files:** `install.ts`, `install_test.ts`
+
+**Interfaces:**
+- `export interface ProdInstallOptions { dir: string; envFile: string; composeFile: string; nonInteractive?: boolean; dryRun?: boolean; panel?: "auto"|"baota"|"none" }`
+- `export async function prodInstall(opts, runner?): Promise<number>`
+- `export async function prodUpdate(opts, runner?): Promise<number>`（含 `--latest`）
+- `export async function prodUninstall(opts, runner?): Promise<number>`
+
+实现要点：移植 `deploy.sh` install/upgrade/uninstall 与 `install.sh` 文件同步；交互配置用 `PromptIO`；卸载确认词 `UNINSTALL` / `DELETE ALL`；`--all` 删除前校验 Git/jj 工作区拒绝逻辑。
+
+## Task 5: 生产备份
+
+**Files:** `backup.ts`, `backup_test.ts`
+
+**Interfaces:**
+- `export interface ProdBackupOptions { envFile: string; composeFile: string; backupDir: string; passphraseFile: string; snapshot?: string; confirm?: boolean; report?: string; }`
+- `export async function prodBackupCreate(opts, runner?): Promise<string>`
+- `export async function prodBackupVerify(opts, runner?): Promise<number>`
+- `export async function prodBackupRestore(opts, runner?): Promise<number>`
+- `export async function prodBackupDrill(opts, runner?): Promise<number>`
+
+实现要点：移植 `backup.sh` create/verify/restore/drill；快照目录 `snapshot-*`、SHA-256、GPG AES256、Redis RDB、MinIO mirror、保留策略、Prometheus textfile 指标。
+
+## Task 6: 生产 config
+
+**Files:** `config.ts`, `config_test.ts`
+
+**Interfaces:**
+- `export async function prodConfigCheck(opts, runner?): Promise<number>`
+- `export async function prodConfigShow(opts): Promise<string>`
+- `export async function prodConfigSet(opts, key, value): Promise<number>`
+
+实现要点：`check` 复用 `validateProdEnv` + Compose config；`show` 脱敏显示；`set` 写入前校验并保持权限 600。
+
+## Task 7: 统一别名分发
+
+**Files:** `dispatch.ts`, `dispatch_test.ts`, 修改 `src/cli.ts`
+
+**Interfaces:**
+- `export function isProdAlias(command: string): boolean`
+- `export async function dispatchProdAlias(command: string, args: string[], ctx: { cwd: string }): Promise<number>`
+
+在 `src/cli.ts` 中：保留 `PRODUCTION_COMMANDS` 兼容集合，但改为调用 `dispatchProdAlias`；`start/stop/...` 等别名映射到 `deploy`/`maintain`/`config` 统一模块或 production 模块。所有旧命令必须保持退出码和参数透传行为。
+
+## Task 8: 文档与帮助
+
+- `printHelp()` 增加统一命令树说明，保留旧命令兼容别名列表。
+- `noj-cli/README.md` 更新 Phase 4 说明。
+- 运行 `deno task test`、`deno task check`、`verify-md-links.ts`。
+
+## 风险
+
+- 直接移植 `deploy.sh`/`backup.sh` 工作量大，需分段实施。
+- 行为漂移风险高：以现有 shell 测试为对照基线。
+- 旧生产命令是现有用户入口，必须保持兼容。
+
+## 后续
+
+- Phase 5：脚本弃用与清理。

--- a/dev-docs/superpowers/specs/2026-09-07-noj-cli-script-sync-design.md
+++ b/dev-docs/superpowers/specs/2026-09-07-noj-cli-script-sync-design.md
@@ -1,0 +1,200 @@
+# noj-cli 替代脚本侧（Deno 化）设计
+
+- 日期：2026-09-07
+- 状态：待评审
+- 范围：运维向 shell 脚本 + 容器内服务端管理 CLI
+- 结论：noj-cli 作为唯一对外入口，直接 Deno 化替代脚本侧；脚本保留一段时间作为兜底，不要求反向同步。
+
+## 背景
+
+当前仓库存在多个功能性脚本入口：
+
+- `scripts/deploy/deploy.sh`、`install.sh`、`backup.sh`
+- `scripts/deploy/judge-install.sh`
+- `scripts/deploy/restore-drill.sh`
+- `scripts/deploy/test-alert.sh`
+- `scripts/monitoring/check-observability.sh`
+- `noj-core/scripts/noj.ts`（容器内 `/app/bin/noj`）
+
+`noj-cli` 目前已经覆盖生产主栈运维和 JSON 配置编排，但仍存在“脚本有而 CLI 没有”的能力缺口（见 `dev-docs/audit/2026-09-07-noj-cli-script-gap.md`）。本文档确定如何让 noj-cli 全面替代这些脚本，同时保留脚本作为过渡期兜底。
+
+## 目标 / 非目标
+
+### 目标
+
+- noj-cli 成为运维和服务端管理的唯一对外入口。
+- 将运维 shell 脚本和服务端管理 CLI 的能力直接移植为 Deno 模块。
+- 统一命令树：新增顶层领域命令，旧命令保留为兼容别名。
+- 内部同时支持 `.env.prod` 生产上下文和 `noj-deploy.json` 编排上下文。
+- 脚本侧保留为兜底，但不再作为 noj-cli 的实现依赖。
+
+### 非目标
+
+- 不要求脚本侧反向同步 noj-cli 的新能力。
+- 不在一开始删除脚本；脚本在过渡期继续可用。
+- 暂不纳入 E2E、staging、release、CI 校验脚本。
+- 不强制把 `.env.prod` 迁移到 `noj-deploy.json`；配置载体收敛留作后续决策。
+
+## 决策
+
+### 1. 统一命令树
+
+```
+noj-cli
+├── doctor                       # 环境检测（兼容原 check）
+├── deploy                       # 部署生命周期
+│   ├── install
+│   ├── install-env              # 安装基础工具（移植 install.sh install-env）
+│   ├── download                 # 下载源码/CLI 资产（移植 install.sh --download-only）
+│   ├── init                     # JSON 模式初始化
+│   ├── up / down / restart / status
+│   ├── update [--latest]        # upgrade 为别名
+│   ├── uninstall [--all] [--yes]
+│   └── verify
+├── maintain                     # 运维
+│   ├── logs
+│   ├── config check|show|set
+│   ├── backup create|verify|restore|drill
+│   ├── reset
+│   └── verify
+├── judge                        # 独立 Judge Worker
+│   ├── install / install-env / check
+│   ├── start / stop / status / logs / upgrade
+│   └── download
+├── observability                # 观测与告警演练
+│   ├── check
+│   └── alert-drill
+├── restore-drill                # 隔离恢复演练
+├── server                       # 容器内 /app/bin/noj 服务端管理命令
+│   ├── db migrate
+│   ├── init system
+│   ├── bootstrap first-admin|admin
+│   ├── problems build|import
+│   └── dev-setup
+├── config                       # 配置
+│   ├── check / show / set
+├── run-server                   # 前台运行 noj-server（保留）
+└── version
+```
+
+兼容别名（内部路由到统一实现，不单独维护逻辑）：
+
+| 旧命令 | 统一命令 |
+|---|---|
+| `check` | `doctor` |
+| `install` | `deploy install` |
+| `start` | `deploy up` |
+| `stop` | `deploy down` |
+| `restart` | `deploy restart` |
+| `status` | `deploy status` |
+| `logs` | `maintain logs` |
+| `update` / `upgrade` | `deploy update` |
+| `backup` | `maintain backup` |
+| `verify` | `deploy verify` |
+| `uninstall` | `deploy uninstall` |
+| `config check` | `config check` |
+| `run-server` | `run-server` |
+
+### 2. 脚本能力到 noj-cli 命令的映射
+
+| 脚本入口 | 脚本能力 | noj-cli 命令 |
+|---|---|---|
+| `install.sh` | `check` | `doctor` / `check` |
+| `install.sh` | `install-env` | `deploy install-env` |
+| `install.sh` | `install --download-only --dry-run` | `deploy download` / `deploy install --dry-run` |
+| `install.sh` | `--files-only` | `deploy update` 内部同步逻辑 |
+| `deploy.sh` | 生命周期/升级/卸载/校验 | `deploy ...` |
+| `backup.sh` | create/verify/restore/drill | `maintain backup ...` |
+| `judge-install.sh` | 完整独立 Judge 生命周期 | `judge ...` |
+| `restore-drill.sh` | 隔离恢复演练 + 业务验收 | `restore-drill <snapshot>` |
+| `check-observability.sh` | liveness/readiness/metrics/通知前置 | `observability check` |
+| `test-alert.sh` | Alertmanager 告警投递演练 | `observability alert-drill` |
+| `noj.ts` | db/init/bootstrap/problems/dev-setup | `server ...` |
+
+### 3. 部署上下文解析
+
+新增 `src/context/` 模块统一识别当前操作上下文：
+
+| 目录特征 | 上下文 | 适用命令 |
+|---|---|---|
+| `.env.prod` + `docker-compose.prod.yml` | production | deploy/maintain/config/observability/server/restore-drill |
+| `noj-deploy.json` + `noj-secrets.json` | json | deploy/maintain/config/run-server |
+| `.env.judge` + `docker-compose.judge.yml` | judge | judge |
+
+规则：
+
+- 支持 `--dir` 显式指定。
+- 未指定时沿当前目录向上查找。
+- 同一目录存在多种上下文时，支持 `--mode prod|json|judge` 显式选择；未指定时按默认优先级并给出可读提示。
+- 配置损坏时，`status`、`logs`、`down` 等只做最小检查的命令仍应可用。
+
+**上下文感知命令**：
+
+- `maintain backup` 在 production 上下文使用目录快照格式（`snapshot-*`，与 `backup.sh` 一致）；在 json 上下文使用单文件 `.nojbackup` 格式（与现有 `maintain backup` 一致）。
+- `config` 在 production 上下文读写 `.env.prod`；在 json 上下文读写 `noj-deploy.json` / `noj-secrets.json`。
+- `deploy` 在 production 上下文调用生产实现；在 json 上下文调用 JSON 编排实现。
+
+### 4. 模块划分
+
+```
+noj-cli/src/
+├── cli.ts                 # 统一命令树分发 + 兼容别名
+├── context/               # 部署上下文识别/解析（新增）
+├── deploy/                # 现有 JSON 部署（保留）
+├── maintain/              # 现有 JSON 运维（保留）
+├── production/            # 生产 .env.prod 运维（由 deploy.sh/install.sh 移植，新增）
+├── judge/                 # 独立 Judge Worker（由 judge-install.sh 移植，新增）
+├── observability/         # 观测检查 + 告警演练（新增）
+├── restore_drill/         # 隔离恢复演练（由 restore-drill.sh 移植，新增）
+├── server_cmd/            # 容器内 /app/bin/noj 命令封装（新增）
+└── runtime/               # 进程/Docker/HTTP 命令抽象（扩展）
+```
+
+- 所有迁移逻辑用 Deno TypeScript 实现，直接调用 `docker`、`docker compose`、`deno task`、HTTP API。
+- `scripts/deploy/*.sh`、`scripts/monitoring/*.sh` 保留在仓库和安装目录，标记为“兜底/弃用”，不再被 noj-cli 调用。
+- `setup.sh` 保留为一次性引导入口，只负责获取并校验 `noj-cli`；后续部署逻辑由 noj-cli 完成。
+
+### 5. 服务端管理命令执行方式
+
+`server` 命令按上下文选择执行方式：
+
+- **production 上下文**：执行
+  `docker compose --env-file <...> run --rm --entrypoint /app/bin/noj core <子命令>`
+- **json / 源码上下文**：在 `noj-core/` 下执行对应 `deno task`（如 `db:migrate`、`problems:build`、`dev-setup`）
+- **judge 上下文**：`server` 不适用，明确报错
+
+`bootstrap first-admin` 等交互命令必须保留 TTY 和密码隐藏语义，不接受密码作为命令行参数。
+
+### 6. 迁移顺序建议
+
+按依赖和风险从低到高：
+
+1. **上下文解析骨架**：`src/context/` + 统一命令树 + 兼容别名。
+2. **低风险脚本移植**：`observability`（check/alert-drill）、`server` 命令包装。
+3. **独立 Judge**：`judge` 模块，移植 `judge-install.sh`。
+4. **隔离恢复演练**：`restore_drill` 模块，移植 `restore-drill.sh`。
+5. **生产运维 Deno 化**：`production` 模块，移植 `deploy.sh` / `install.sh` / `backup.sh` 的生产路径。
+6. **收敛清理**：脚本标记弃用，更新文档，逐步移除不再需要的脚本测试依赖。
+
+### 7. 测试策略
+
+- **单元测试**：命令树解析、上下文识别、配置解析、参数解析。
+- **集成测试**：fake docker / fake HTTP 模拟 `judge`、`restore-drill`、`observability`、`server`。
+- **回归基线**：现有 `scripts/deploy/test-*.sh` 继续验证脚本兜底可用；每个 Deno 移植模块提供等价场景测试。
+- **安全测试**：保留并迁移现有安全边界用例（rootless socket、GPG 口令权限、备份篡改、卸载确认、敏感信息不回显）。
+
+### 8. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| 直接 Deno 化工作量大 | 按迁移顺序分阶段实施，每个阶段可独立交付 |
+| Deno 实现与旧脚本行为漂移 | 以现有脚本测试为对照基线，关键场景双跑 |
+| 双配置载体短期增加维护成本 | 统一命令树内部通过 context 抽象隔离，不暴露给用户 |
+| 服务端交互命令包装复杂 | 保留 TTY/密码隐藏语义，用集成测试覆盖 |
+| 脚本兜底与 CLI 并存可能造成文档混乱 | 文档明确标记脚本为弃用/过渡，最终以 noj-cli 为准 |
+
+## 后续待定项
+
+- `.env.prod` 与 `noj-deploy.json` 是否最终收敛为单一配置载体（当前不收敛）。
+- 根目录 `noj` shell 是否在 CLI 完全替代后移除或仅作软链别名。
+- 脚本侧正式废弃的时间点与移除条件。

--- a/noj-cli/README.md
+++ b/noj-cli/README.md
@@ -94,6 +94,20 @@ noj-cli server dev-setup
 原样透传。 `server bootstrap` 不接受 `--password` 命令行参数，请使用
 交互提示或环境变量。
 
+## 独立 Judge 管理（Phase 2）
+
+```bash
+noj-cli judge install [--dir /srv/noj-judge]
+noj-cli judge install-env
+noj-cli judge check
+noj-cli judge start
+noj-cli judge stop
+noj-cli judge status
+noj-cli judge logs [--follow]
+noj-cli judge upgrade [--version v0.2.0]
+noj-cli judge download [--dir /srv/noj-judge]
+```
+
 ## 开发与验证
 
 ```bash

--- a/noj-cli/README.md
+++ b/noj-cli/README.md
@@ -108,6 +108,16 @@ noj-cli judge upgrade [--version v0.2.0]
 noj-cli judge download [--dir /srv/noj-judge]
 ```
 
+## 备份隔离恢复演练（Phase 3）
+
+```bash
+noj-cli restore-drill /path/to/snapshot-20260907 \
+  --env-file /opt/neuro-oj/.env.prod \
+  --compose-file /opt/neuro-oj/docker-compose.prod.yml \
+  --passphrase-file /etc/noj/backup-passphrase \
+  [--skip-judge] [--keep]
+```
+
 ## 开发与验证
 
 ```bash

--- a/noj-cli/README.md
+++ b/noj-cli/README.md
@@ -85,6 +85,15 @@ noj-cli server problems import [--dir <dir>]
 noj-cli server dev-setup
 ```
 
+`observability check` 的 `--base-url` 缺省读取
+`NOJ_OBSERVABILITY_BASE_URL`（默认 `http://127.0.0.1:8000`）；
+`observability check`/`alert-drill` 的 `--alertmanager-url` 缺省读取
+`ALERTMANAGER_URL`。 `server` 支持顶层 `--dir <path>`（如
+`noj-cli server --dir /path/to/neuro-oj db migrate`），可从显式源码/部署
+目录定位 `noj-core`；子命令自身的 `--dir`（如 `problems import --dir`）
+原样透传。 `server bootstrap` 不接受 `--password` 命令行参数，请使用
+交互提示或环境变量。
+
 ## 开发与验证
 
 ```bash

--- a/noj-cli/README.md
+++ b/noj-cli/README.md
@@ -118,6 +118,23 @@ noj-cli restore-drill /path/to/snapshot-20260907 \
   [--skip-judge] [--keep]
 ```
 
+## 生产运维 Deno 化（Phase 4）
+
+旧生产命令已逐步切换到 Deno 统一实现；`check` 仍暂时走脚本兜底。
+
+```bash
+noj-cli start
+noj-cli stop
+noj-cli restart
+noj-cli status
+noj-cli logs core --follow
+noj-cli config check|show|set
+noj-cli install
+noj-cli update [--version v0.2.0]
+noj-cli uninstall --yes
+noj-cli backup create|verify|restore|drill
+```
+
 ## 开发与验证
 
 ```bash

--- a/noj-cli/README.md
+++ b/noj-cli/README.md
@@ -71,6 +71,20 @@ run-server。备份使用单文件 `.nojbackup`（zstd + SHA-256，可选 GPG AE
 与生产 Compose 的快照目录格式不同，不能交叉恢复。 `maintain restore` 是
 `maintain backup restore` 的别名。
 
+## 新增运维命令（Phase 1）
+
+```bash
+noj-cli observability check [--base-url URL] [--check-notifications]
+noj-cli observability alert-drill [--alertmanager-url URL] [--hold SECONDS]
+noj-cli server db migrate
+noj-cli server init system
+noj-cli server bootstrap first-admin --username <user> --email <email>
+noj-cli server bootstrap admin [--email <email>]
+noj-cli server problems build [--id <id>]
+noj-cli server problems import [--dir <dir>]
+noj-cli server dev-setup
+```
+
 ## 开发与验证
 
 ```bash

--- a/noj-cli/src/cli.ts
+++ b/noj-cli/src/cli.ts
@@ -80,14 +80,16 @@ export function printHelp(): string {
     "  uninstall     卸载生产服务；--all 删除全部数据，需确认",
     "",
     "JSON 配置部署工具（noj-deploy.json / noj-secrets.json）：",
-    "  observability check       检查 liveness/readiness/metrics（可选通知链路）",
-    "  observability alert-drill 向 Alertmanager 注入告警并发送恢复事件",
     "  doctor        环境检测",
     "  deploy        部署生命周期 init/up/down/restart/status",
     "  maintain      运维 logs/config/verify/reset/backup(create/verify/restore/drill)",
     "  run-server    前台运行 noj-server 二进制",
-    "  server <cmd>            容器内服务端管理命令（db/init/bootstrap/problems/dev-setup）",
     "  version       显示版本",
+    "",
+    "运维与观测命令：",
+    "  observability check       检查 liveness/readiness/metrics（可选通知链路）",
+    "  observability alert-drill 向 Alertmanager 注入告警并发送恢复事件",
+    "  server <cmd>            容器内服务端管理命令（db/init/bootstrap/problems/dev-setup）",
     "",
   ].join("\n");
 }
@@ -258,23 +260,55 @@ export function parseObservabilityArgs(args: string[]): ObservabilityArgs {
   for (let i = 1; i < args.length; i++) {
     const a = args[i]!;
     switch (a) {
-      case "--base-url":
-        out.baseUrl = args[++i];
+      case "--base-url": {
+        const value = args[i + 1];
+        if (value === undefined) throw new Error("--base-url 缺少值");
+        out.baseUrl = value;
+        i++;
         break;
+      }
       case "--check-notifications":
         out.checkNotifications = true;
         break;
-      case "--alertmanager-url":
-        out.alertmanagerUrl = args[++i];
+      case "--alertmanager-url": {
+        const value = args[i + 1];
+        if (value === undefined) throw new Error("--alertmanager-url 缺少值");
+        out.alertmanagerUrl = value;
+        i++;
         break;
-      case "--hold":
-        out.holdSeconds = Number(args[++i]);
+      }
+      case "--hold": {
+        const value = args[i + 1];
+        if (value === undefined) throw new Error("--hold 缺少值");
+        if (!/^\d+$/.test(value)) {
+          throw new Error(
+            `非法 --hold: ${value}，需要非负整数`,
+          );
+        }
+        out.holdSeconds = Number(value);
+        i++;
         break;
+      }
       default:
         throw new Error(`未知 observability 参数: ${a}`);
     }
   }
   return out;
+}
+
+/** server 顶层参数解析结果：仅剥离开头的全局 --dir；子命令内部 --dir 原样保留。 */
+export interface ServerCliArgs {
+  dir: string | undefined;
+  args: string[];
+}
+
+/** 解析 server 顶层参数：支持 `server --dir <path> <子命令>`。 */
+export function parseServerArgs(args: string[]): ServerCliArgs {
+  if (args[0] !== "--dir") return { dir: undefined, args };
+  if (args[1] === undefined) {
+    throw new Error("server: --dir 缺少目录参数");
+  }
+  return { dir: args[1], args: args.slice(2) };
 }
 
 /** 将命令分发到对应处理函数。供测试与 run 共用。 */
@@ -573,8 +607,8 @@ export async function dispatchCommand(
       return 1;
     }
     case "observability": {
-      const a = parseObservabilityArgs(args);
       try {
+        const a = parseObservabilityArgs(args);
         if (a.sub === "check") {
           const report = await observabilityCheck({
             baseUrl: a.baseUrl,
@@ -583,7 +617,9 @@ export async function dispatchCommand(
             http: realHttp(),
           });
           for (const item of report.items) {
-            console.log(`${item.ok ? "✓" : "✗"} ${item.name}: ${item.detail}`);
+            console.log(
+              `${item.ok ? "✓" : "✗"} ${item.name}: ${item.detail}`,
+            );
           }
           return report.pass ? 0 : 1;
         }
@@ -608,14 +644,19 @@ export async function dispatchCommand(
     case "server": {
       // 仅支持 `server --dir <path> <子命令>` 形式的全局 --dir；
       // 子命令自身（如 problems import --dir）的参数原样透传，不在这里剥离。
-      let parsedDir: string | undefined;
-      let serverArgs = args;
-      if (args[0] === "--dir" && args[1] !== undefined) {
-        parsedDir = args[1];
-        serverArgs = args.slice(2);
+      let parsed: ServerCliArgs;
+      try {
+        parsed = parseServerArgs(args);
+      } catch (e) {
+        console.error((e as Error).message);
+        return 1;
       }
-      const context = resolveContext({ cwd: ctx.cwd, dir: parsedDir });
-      return await runServerCommand({ context, args: serverArgs });
+      const context = resolveContext({ cwd: ctx.cwd, dir: parsed.dir });
+      return await runServerCommand({
+        context,
+        args: parsed.args,
+        sourceDir: parsed.dir,
+      });
     }
     case "run-server": {
       let dirOverride: string | undefined;

--- a/noj-cli/src/cli.ts
+++ b/noj-cli/src/cli.ts
@@ -37,6 +37,8 @@ import { runServerCommand } from "./server_cmd/server_cmd.ts";
 import { resolveContext } from "./context/context.ts";
 import { parseJudgeArgs } from "./judge/options.ts";
 import { runJudgeCommand } from "./judge/commands.ts";
+import { parseRestoreDrillArgs } from "./restore_drill/options.ts";
+import { runRestoreDrill } from "./restore_drill/drill.ts";
 
 /** CLI 执行上下文，供各子命令共享。 */
 export interface CommandContext {
@@ -93,6 +95,7 @@ export function printHelp(): string {
     "  observability alert-drill 向 Alertmanager 注入告警并发送恢复事件",
     "  server <cmd>            容器内服务端管理命令（db/init/bootstrap/problems/dev-setup）",
     "  judge <cmd>            独立 Judge Worker 管理（install/install-env/check/start/stop/status/logs/upgrade/download）",
+    "  restore-drill <snapshot>  备份隔离恢复演练（真实恢复 + 业务验收）",
     "",
   ].join("\n");
 }
@@ -106,6 +109,7 @@ const KNOWN_TOP = new Set([
   "observability",
   "server",
   "judge",
+  "restore-drill",
 ]);
 
 /** 解析 --port <n>，缺省 8080；非法值抛错。 */
@@ -668,6 +672,22 @@ export async function dispatchCommand(
         return await runJudgeCommand(opts);
       } catch (e) {
         console.error(`judge: ${(e as Error).message}`);
+        return 1;
+      }
+    }
+    case "restore-drill": {
+      try {
+        const opts = parseRestoreDrillArgs(args);
+        if (!opts.envFile || !opts.composeFile) {
+          const context = resolveContext({ cwd: ctx.cwd });
+          if (context.kind === "production" && context.dir !== null) {
+            opts.envFile ??= `${context.dir}/.env.prod`;
+            opts.composeFile ??= `${context.dir}/docker-compose.prod.yml`;
+          }
+        }
+        return await runRestoreDrill(opts);
+      } catch (e) {
+        console.error(`restore-drill: ${(e as Error).message}`);
         return 1;
       }
     }

--- a/noj-cli/src/cli.ts
+++ b/noj-cli/src/cli.ts
@@ -29,7 +29,7 @@ import {
 import { maintainReset } from "./maintain/reset.ts";
 import { realDriver } from "./maintain/backup_driver.ts";
 import { runServerForeground } from "./runtime/process.ts";
-import { PRODUCTION_COMMANDS, runProduction } from "./production.ts";
+import { PRODUCTION_COMMANDS } from "./production.ts";
 import { alertDrill } from "./observability/alert_drill.ts";
 import { observabilityCheck } from "./observability/check.ts";
 import { realHttp } from "./observability/http.ts";
@@ -75,6 +75,7 @@ export function printHelp(): string {
     "",
     "命令:",
     "  install       生产安装（.env.prod + Docker Compose；以下命令支持 --dir）",
+    "  install-env   检查生产环境并输出安装准备指引",
     "  check         生产环境检测",
     "  start/stop/restart/status  生产服务生命周期",
     "  update [--latest]  同步部署文件、备份并升级生产服务（upgrade 为别名）",
@@ -327,8 +328,10 @@ export async function dispatchCommand(
   ctx: CommandContext,
 ): Promise<number> {
   if (PRODUCTION_COMMANDS.has(command)) {
-    // Phase 4 过渡：check 仍走脚本兜底，其余生产命令走 Deno 统一分发。
-    if (command === "check") return await runProduction(command, args);
+    // check 复用 doctor 环境检测（已 Deno 化）。
+    if (command === "check") {
+      return await dispatchCommand("doctor", args, ctx);
+    }
     return await dispatchProdAlias(command, args, { cwd: ctx.cwd });
   }
   switch (command) {

--- a/noj-cli/src/cli.ts
+++ b/noj-cli/src/cli.ts
@@ -30,6 +30,9 @@ import { maintainReset } from "./maintain/reset.ts";
 import { realDriver } from "./maintain/backup_driver.ts";
 import { runServerForeground } from "./runtime/process.ts";
 import { PRODUCTION_COMMANDS, runProduction } from "./production.ts";
+import { alertDrill } from "./observability/alert_drill.ts";
+import { observabilityCheck } from "./observability/check.ts";
+import { realHttp } from "./observability/http.ts";
 
 /** CLI 执行上下文，供各子命令共享。 */
 export interface CommandContext {
@@ -75,6 +78,8 @@ export function printHelp(): string {
     "  uninstall     卸载生产服务；--all 删除全部数据，需确认",
     "",
     "JSON 配置部署工具（noj-deploy.json / noj-secrets.json）：",
+    "  observability check       检查 liveness/readiness/metrics（可选通知链路）",
+    "  observability alert-drill 向 Alertmanager 注入告警并发送恢复事件",
     "  doctor        环境检测",
     "  deploy        部署生命周期 init/up/down/restart/status",
     "  maintain      运维 logs/config/verify/reset/backup(create/verify/restore/drill)",
@@ -90,6 +95,7 @@ const KNOWN_TOP = new Set([
   "maintain",
   "run-server",
   "version",
+  "observability",
 ]);
 
 /** 解析 --port <n>，缺省 8080；非法值抛错。 */
@@ -224,6 +230,46 @@ export function parseBackupArgs(args: string[]): BackupArgs {
     }
   }
   out.snapshot = positional[0];
+  return out;
+}
+
+/** observability 子命令参数解析结果。 */
+export interface ObservabilityArgs {
+  sub: string;
+  baseUrl: string | undefined;
+  checkNotifications: boolean;
+  alertmanagerUrl: string | undefined;
+  holdSeconds: number;
+}
+
+/** 解析 observability 参数：子命令 + base-url/check-notifications/alertmanager-url/hold。 */
+export function parseObservabilityArgs(args: string[]): ObservabilityArgs {
+  const out: ObservabilityArgs = {
+    sub: args[0] ?? "",
+    baseUrl: undefined,
+    checkNotifications: false,
+    alertmanagerUrl: undefined,
+    holdSeconds: 300,
+  };
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i]!;
+    switch (a) {
+      case "--base-url":
+        out.baseUrl = args[++i];
+        break;
+      case "--check-notifications":
+        out.checkNotifications = true;
+        break;
+      case "--alertmanager-url":
+        out.alertmanagerUrl = args[++i];
+        break;
+      case "--hold":
+        out.holdSeconds = Number(args[++i]);
+        break;
+      default:
+        throw new Error(`未知 observability 参数: ${a}`);
+    }
+  }
   return out;
 }
 
@@ -521,6 +567,39 @@ export async function dispatchCommand(
         "maintain: 需要子命令 logs/backup/restore/verify/reset/config",
       );
       return 1;
+    }
+    case "observability": {
+      const a = parseObservabilityArgs(args);
+      try {
+        if (a.sub === "check") {
+          const report = await observabilityCheck({
+            baseUrl: a.baseUrl,
+            checkNotifications: a.checkNotifications,
+            alertmanagerUrl: a.alertmanagerUrl,
+            http: realHttp(),
+          });
+          for (const item of report.items) {
+            console.log(`${item.ok ? "✓" : "✗"} ${item.name}: ${item.detail}`);
+          }
+          return report.pass ? 0 : 1;
+        }
+        if (a.sub === "alert-drill") {
+          const report = await alertDrill({
+            alertmanagerUrl: a.alertmanagerUrl,
+            holdSeconds: a.holdSeconds,
+            http: realHttp(),
+          });
+          console.log(
+            `告警演练完成：注入=${report.injected} 恢复=${report.resolved}`,
+          );
+          return 0;
+        }
+        console.error("observability: 需要子命令 check/alert-drill");
+        return 1;
+      } catch (e) {
+        console.error(`observability: ${(e as Error).message}`);
+        return 1;
+      }
     }
     case "run-server": {
       let dirOverride: string | undefined;

--- a/noj-cli/src/cli.ts
+++ b/noj-cli/src/cli.ts
@@ -33,6 +33,8 @@ import { PRODUCTION_COMMANDS, runProduction } from "./production.ts";
 import { alertDrill } from "./observability/alert_drill.ts";
 import { observabilityCheck } from "./observability/check.ts";
 import { realHttp } from "./observability/http.ts";
+import { runServerCommand } from "./server_cmd/server_cmd.ts";
+import { resolveContext } from "./context/context.ts";
 
 /** CLI 执行上下文，供各子命令共享。 */
 export interface CommandContext {
@@ -84,6 +86,7 @@ export function printHelp(): string {
     "  deploy        部署生命周期 init/up/down/restart/status",
     "  maintain      运维 logs/config/verify/reset/backup(create/verify/restore/drill)",
     "  run-server    前台运行 noj-server 二进制",
+    "  server <cmd>            容器内服务端管理命令（db/init/bootstrap/problems/dev-setup）",
     "  version       显示版本",
     "",
   ].join("\n");
@@ -96,6 +99,7 @@ const KNOWN_TOP = new Set([
   "run-server",
   "version",
   "observability",
+  "server",
 ]);
 
 /** 解析 --port <n>，缺省 8080；非法值抛错。 */
@@ -600,6 +604,18 @@ export async function dispatchCommand(
         console.error(`observability: ${(e as Error).message}`);
         return 1;
       }
+    }
+    case "server": {
+      // 仅支持 `server --dir <path> <子命令>` 形式的全局 --dir；
+      // 子命令自身（如 problems import --dir）的参数原样透传，不在这里剥离。
+      let parsedDir: string | undefined;
+      let serverArgs = args;
+      if (args[0] === "--dir" && args[1] !== undefined) {
+        parsedDir = args[1];
+        serverArgs = args.slice(2);
+      }
+      const context = resolveContext({ cwd: ctx.cwd, dir: parsedDir });
+      return await runServerCommand({ context, args: serverArgs });
     }
     case "run-server": {
       let dirOverride: string | undefined;

--- a/noj-cli/src/cli.ts
+++ b/noj-cli/src/cli.ts
@@ -39,6 +39,7 @@ import { parseJudgeArgs } from "./judge/options.ts";
 import { runJudgeCommand } from "./judge/commands.ts";
 import { parseRestoreDrillArgs } from "./restore_drill/options.ts";
 import { runRestoreDrill } from "./restore_drill/drill.ts";
+import { dispatchProdAlias } from "./production/dispatch.ts";
 
 /** CLI 执行上下文，供各子命令共享。 */
 export interface CommandContext {
@@ -326,7 +327,9 @@ export async function dispatchCommand(
   ctx: CommandContext,
 ): Promise<number> {
   if (PRODUCTION_COMMANDS.has(command)) {
-    return await runProduction(command, args);
+    // Phase 4 过渡：check 仍走脚本兜底，其余生产命令走 Deno 统一分发。
+    if (command === "check") return await runProduction(command, args);
+    return await dispatchProdAlias(command, args, { cwd: ctx.cwd });
   }
   switch (command) {
     case "version":

--- a/noj-cli/src/cli.ts
+++ b/noj-cli/src/cli.ts
@@ -92,7 +92,7 @@ export function printHelp(): string {
     "  observability check       检查 liveness/readiness/metrics（可选通知链路）",
     "  observability alert-drill 向 Alertmanager 注入告警并发送恢复事件",
     "  server <cmd>            容器内服务端管理命令（db/init/bootstrap/problems/dev-setup）",
-    "  judge <cmd>            独立 Judge Worker 管理（install/check/start/stop/status/logs/upgrade/download）",
+    "  judge <cmd>            独立 Judge Worker 管理（install/install-env/check/start/stop/status/logs/upgrade/download）",
     "",
   ].join("\n");
 }

--- a/noj-cli/src/cli.ts
+++ b/noj-cli/src/cli.ts
@@ -35,6 +35,8 @@ import { observabilityCheck } from "./observability/check.ts";
 import { realHttp } from "./observability/http.ts";
 import { runServerCommand } from "./server_cmd/server_cmd.ts";
 import { resolveContext } from "./context/context.ts";
+import { parseJudgeArgs } from "./judge/options.ts";
+import { runJudgeCommand } from "./judge/commands.ts";
 
 /** CLI 执行上下文，供各子命令共享。 */
 export interface CommandContext {
@@ -90,6 +92,7 @@ export function printHelp(): string {
     "  observability check       检查 liveness/readiness/metrics（可选通知链路）",
     "  observability alert-drill 向 Alertmanager 注入告警并发送恢复事件",
     "  server <cmd>            容器内服务端管理命令（db/init/bootstrap/problems/dev-setup）",
+    "  judge <cmd>            独立 Judge Worker 管理（install/check/start/stop/status/logs/upgrade/download）",
     "",
   ].join("\n");
 }
@@ -102,6 +105,7 @@ const KNOWN_TOP = new Set([
   "version",
   "observability",
   "server",
+  "judge",
 ]);
 
 /** 解析 --port <n>，缺省 8080；非法值抛错。 */
@@ -657,6 +661,15 @@ export async function dispatchCommand(
         args: parsed.args,
         sourceDir: parsed.dir,
       });
+    }
+    case "judge": {
+      try {
+        const opts = parseJudgeArgs(args);
+        return await runJudgeCommand(opts);
+      } catch (e) {
+        console.error(`judge: ${(e as Error).message}`);
+        return 1;
+      }
     }
     case "run-server": {
       let dirOverride: string | undefined;

--- a/noj-cli/src/cli_test.ts
+++ b/noj-cli/src/cli_test.ts
@@ -7,6 +7,7 @@ import {
   parseMaintainArgs,
   parseObservabilityArgs,
   parsePort,
+  parseServerArgs,
   printHelp,
   run,
 } from "./cli.ts";
@@ -237,4 +238,103 @@ Deno.test("server 无上下文时返回 1", async () => {
 
 Deno.test("printHelp 包含 server", () => {
   assertEquals(printHelp().includes("server <cmd>"), true);
+});
+
+Deno.test("parseObservabilityArgs: 未知参数抛错", () => {
+  let threw = false;
+  try {
+    parseObservabilityArgs(["check", "--unknown"]);
+  } catch (e) {
+    threw = true;
+    assertEquals((e as Error).message.includes("未知 observability"), true);
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("parseObservabilityArgs: 缺少 --base-url/--alertmanager-url/--hold 值抛错", () => {
+  for (
+    const args of [
+      ["check", "--base-url"],
+      ["alert-drill", "--alertmanager-url"],
+      ["alert-drill", "--hold"],
+    ]
+  ) {
+    let threw = false;
+    try {
+      parseObservabilityArgs(args);
+    } catch (e) {
+      threw = true;
+      assertEquals((e as Error).message.includes("缺少值"), true);
+    }
+    assertEquals(threw, true, `应抛错: ${args.join(" ")}`);
+  }
+});
+
+Deno.test("parseObservabilityArgs: --hold 必须是非负整数", () => {
+  for (const bad of ["-1", "1.5", "abc", "0x10"]) {
+    let threw = false;
+    try {
+      parseObservabilityArgs(["alert-drill", "--hold", bad]);
+    } catch (e) {
+      threw = true;
+      assertEquals((e as Error).message.includes("非负整数"), true);
+    }
+    assertEquals(threw, true, `非法 --hold 应抛错: ${bad}`);
+  }
+});
+
+Deno.test("dispatch observability 参数错误返回 1", async () => {
+  assertEquals(await dispatchCommand("observability", ["--unknown"], ctx), 1);
+  assertEquals(
+    await dispatchCommand("observability", ["check", "--base-url"], ctx),
+    1,
+  );
+});
+
+Deno.test("parseServerArgs: 无全局 --dir 时原样透传", () => {
+  assertEquals(parseServerArgs(["db", "migrate"]), {
+    dir: undefined,
+    args: ["db", "migrate"],
+  });
+});
+
+Deno.test("parseServerArgs: 全局 --dir 被剥离并记录目录", () => {
+  assertEquals(parseServerArgs(["--dir", "/src", "db", "migrate"]), {
+    dir: "/src",
+    args: ["db", "migrate"],
+  });
+});
+
+Deno.test("parseServerArgs: 子命令内部 --dir 不被剥离", () => {
+  assertEquals(
+    parseServerArgs(["problems", "import", "--dir", "/data"]),
+    {
+      dir: undefined,
+      args: ["problems", "import", "--dir", "/data"],
+    },
+  );
+});
+
+Deno.test("parseServerArgs/server dispatch: 缺少 --dir 值时返回清晰错误并返回 1", async () => {
+  let threw = false;
+  try {
+    parseServerArgs(["--dir"]);
+  } catch (e) {
+    threw = true;
+    assertEquals((e as Error).message.includes("--dir 缺少目录参数"), true);
+  }
+  assertEquals(threw, true);
+  assertEquals(await dispatchCommand("server", ["--dir"], ctx), 1);
+});
+
+Deno.test("printHelp 将 observability/server 放在运维与观测分组", () => {
+  const help = printHelp();
+  const obsIndex = help.indexOf("observability check");
+  const serverIndex = help.indexOf("server <cmd>");
+  const jsonIndex = help.indexOf("JSON 配置部署工具");
+  const opsIndex = help.indexOf("运维与观测命令");
+  assertEquals(obsIndex > jsonIndex, true);
+  assertEquals(serverIndex > jsonIndex, true);
+  assertEquals(opsIndex !== -1 && opsIndex < obsIndex, true);
+  assertEquals(opsIndex !== -1 && opsIndex < serverIndex, true);
 });

--- a/noj-cli/src/cli_test.ts
+++ b/noj-cli/src/cli_test.ts
@@ -5,6 +5,7 @@ import {
   parseDeployArgs,
   parseInitOptions,
   parseMaintainArgs,
+  parseObservabilityArgs,
   parsePort,
   printHelp,
   run,
@@ -196,4 +197,36 @@ Deno.test("parseBackupArgs: drill report 旗标", () => {
   const a = parseBackupArgs(["drill", "x.nojbackup", "--report", "/r.json"]);
   assertEquals(a.sub, "drill");
   assertEquals(a.report, "/r.json");
+});
+
+Deno.test("parseObservabilityArgs: check 参数解析", () => {
+  const a = parseObservabilityArgs([
+    "check",
+    "--base-url",
+    "http://noj.test",
+    "--check-notifications",
+    "--alertmanager-url",
+    "http://am:9093",
+  ]);
+  assertEquals(a.sub, "check");
+  assertEquals(a.baseUrl, "http://noj.test");
+  assertEquals(a.checkNotifications, true);
+  assertEquals(a.alertmanagerUrl, "http://am:9093");
+});
+
+Deno.test("parseObservabilityArgs: alert-drill 参数解析", () => {
+  const a = parseObservabilityArgs([
+    "alert-drill",
+    "--alertmanager-url",
+    "http://am:9093",
+    "--hold",
+    "0",
+  ]);
+  assertEquals(a.sub, "alert-drill");
+  assertEquals(a.alertmanagerUrl, "http://am:9093");
+  assertEquals(a.holdSeconds, 0);
+});
+
+Deno.test("observability 无子命令返回 1", async () => {
+  assertEquals(await dispatchCommand("observability", [], ctx), 1);
 });

--- a/noj-cli/src/cli_test.ts
+++ b/noj-cli/src/cli_test.ts
@@ -249,6 +249,14 @@ Deno.test("judge 需要子命令时返回非零", async () => {
   assertEquals(await dispatchCommand("judge", [], ctx), 1);
 });
 
+Deno.test("printHelp 包含 restore-drill", () => {
+  assertEquals(printHelp().includes("restore-drill"), true);
+});
+
+Deno.test("restore-drill 缺少 snapshot 返回非零", async () => {
+  assertEquals(await dispatchCommand("restore-drill", [], ctx), 1);
+});
+
 Deno.test("parseObservabilityArgs: 未知参数抛错", () => {
   let threw = false;
   try {

--- a/noj-cli/src/cli_test.ts
+++ b/noj-cli/src/cli_test.ts
@@ -230,3 +230,11 @@ Deno.test("parseObservabilityArgs: alert-drill 参数解析", () => {
 Deno.test("observability 无子命令返回 1", async () => {
   assertEquals(await dispatchCommand("observability", [], ctx), 1);
 });
+
+Deno.test("server 无上下文时返回 1", async () => {
+  assertEquals(await dispatchCommand("server", ["db", "migrate"], ctx), 1);
+});
+
+Deno.test("printHelp 包含 server", () => {
+  assertEquals(printHelp().includes("server <cmd>"), true);
+});

--- a/noj-cli/src/cli_test.ts
+++ b/noj-cli/src/cli_test.ts
@@ -240,6 +240,15 @@ Deno.test("printHelp 包含 server", () => {
   assertEquals(printHelp().includes("server <cmd>"), true);
 });
 
+Deno.test("printHelp 包含 judge", () => {
+  assertEquals(printHelp().includes("judge <cmd>"), true);
+});
+
+Deno.test("judge 需要子命令时返回非零", async () => {
+  // 无子命令应返回 1
+  assertEquals(await dispatchCommand("judge", [], ctx), 1);
+});
+
 Deno.test("parseObservabilityArgs: 未知参数抛错", () => {
   let threw = false;
   try {

--- a/noj-cli/src/context/context.ts
+++ b/noj-cli/src/context/context.ts
@@ -1,0 +1,71 @@
+import { dirname, resolve } from "@std/path";
+
+export type ContextKind = "production" | "json" | "judge" | "none";
+
+export interface CliContext {
+  cwd: string;
+  kind: ContextKind;
+  dir: string | null;
+}
+
+function isFile(path: string): boolean {
+  try {
+    return Deno.statSync(path).isFile;
+  } catch {
+    return false;
+  }
+}
+
+export function detectKind(dir: string): ContextKind | null {
+  const prod = isFile(`${dir}/.env.prod`) &&
+    isFile(`${dir}/docker-compose.prod.yml`);
+  if (prod) return "production";
+  const json = isFile(`${dir}/noj-deploy.json`) &&
+    isFile(`${dir}/noj-secrets.json`);
+  if (json) return "json";
+  const judge = isFile(`${dir}/.env.judge`) &&
+    isFile(`${dir}/docker-compose.judge.yml`);
+  if (judge) return "judge";
+  return null;
+}
+
+export function findContextDir(
+  start?: string,
+  kind?: ContextKind,
+): string | null {
+  let current = start ?? Deno.cwd();
+  current = Deno.realPathSync(current);
+  while (true) {
+    const detected = detectKind(current);
+    if (detected !== null && (kind === undefined || detected === kind)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === null || parent === current) return null;
+    current = parent;
+  }
+}
+
+export function resolveContext(opts: {
+  cwd?: string;
+  dir?: string;
+  mode?: ContextKind;
+}): CliContext {
+  const cwd = opts.cwd ?? Deno.cwd();
+  if (opts.dir !== undefined) {
+    const abs = resolve(cwd, opts.dir);
+    const kind = detectKind(abs);
+    if (kind === null) return { cwd, kind: "none", dir: null };
+    if (opts.mode !== undefined && kind !== opts.mode) {
+      throw new Error(`目录 ${abs} 不是 ${opts.mode} 上下文`);
+    }
+    return { cwd, kind, dir: abs };
+  }
+  if (opts.mode !== undefined) {
+    const dir = findContextDir(cwd, opts.mode);
+    return { cwd, kind: dir ? opts.mode : "none", dir };
+  }
+  const dir = findContextDir(cwd);
+  const kind = dir ? detectKind(dir) ?? "none" : "none";
+  return { cwd, kind, dir };
+}

--- a/noj-cli/src/context/context.ts
+++ b/noj-cli/src/context/context.ts
@@ -34,7 +34,11 @@ export function findContextDir(
   kind?: ContextKind,
 ): string | null {
   let current = start ?? Deno.cwd();
-  current = Deno.realPathSync(current);
+  try {
+    current = Deno.realPathSync(current);
+  } catch {
+    return null;
+  }
   while (true) {
     const detected = detectKind(current);
     if (detected !== null && (kind === undefined || detected === kind)) {
@@ -55,7 +59,7 @@ export function resolveContext(opts: {
   if (opts.dir !== undefined) {
     const abs = resolve(cwd, opts.dir);
     const kind = detectKind(abs);
-    if (kind === null) return { cwd, kind: "none", dir: null };
+    if (kind === null) return { cwd, kind: "none", dir: abs };
     if (opts.mode !== undefined && kind !== opts.mode) {
       throw new Error(`目录 ${abs} 不是 ${opts.mode} 上下文`);
     }

--- a/noj-cli/src/context/context_test.ts
+++ b/noj-cli/src/context/context_test.ts
@@ -1,0 +1,80 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  type ContextKind,
+  detectKind,
+  findContextDir,
+  resolveContext,
+} from "./context.ts";
+
+function writeFixture(dir: string, files: Record<string, string>): void {
+  Deno.mkdirSync(dir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    Deno.writeTextFileSync(`${dir}/${name}`, content);
+  }
+}
+
+Deno.test("detectKind: production/json/judge/none", () => {
+  const dir = Deno.makeTempDirSync();
+  writeFixture(dir, {
+    ".env.prod": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.prod.yml": "services: {}\n",
+  });
+  assertEquals(detectKind(dir), "production" as ContextKind);
+
+  const jsonDir = Deno.makeTempDirSync();
+  writeFixture(jsonDir, {
+    "noj-deploy.json": "{}",
+    "noj-secrets.json": "{}",
+  });
+  assertEquals(detectKind(jsonDir), "json" as ContextKind);
+
+  const judgeDir = Deno.makeTempDirSync();
+  writeFixture(judgeDir, {
+    ".env.judge": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.judge.yml": "services: {}\n",
+  });
+  assertEquals(detectKind(judgeDir), "judge" as ContextKind);
+
+  const empty = Deno.makeTempDirSync();
+  assertEquals(detectKind(empty), null);
+});
+
+Deno.test("findContextDir: 向上查找指定上下文", () => {
+  const root = Deno.makeTempDirSync();
+  const prod = `${root}/prod`;
+  writeFixture(prod, {
+    ".env.prod": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.prod.yml": "services: {}\n",
+  });
+  const nested = `${prod}/nested/deep`;
+  Deno.mkdirSync(nested, { recursive: true });
+  assertEquals(findContextDir(nested, "production"), prod);
+  assertEquals(findContextDir(nested), prod);
+});
+
+Deno.test("resolveContext: --dir 显式指定", () => {
+  const dir = Deno.makeTempDirSync();
+  writeFixture(dir, {
+    ".env.prod": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.prod.yml": "services: {}\n",
+  });
+  const ctx = resolveContext({ cwd: "/tmp", dir });
+  assertEquals(ctx.kind, "production");
+  assertEquals(ctx.dir, dir);
+});
+
+Deno.test("resolveContext: --mode 找不到对应上下文时 kind=none", () => {
+  const dir = Deno.makeTempDirSync();
+  const ctx = resolveContext({ cwd: "/tmp", dir, mode: "json" });
+  assertEquals(ctx.kind, "none");
+  assertEquals(ctx.dir, null);
+});
+
+Deno.test("resolveContext: 显式 dir 但 mode 不匹配时抛错", () => {
+  const dir = Deno.makeTempDirSync();
+  writeFixture(dir, {
+    ".env.prod": "NOJ_VERSION=v0.1.0\n",
+    "docker-compose.prod.yml": "services: {}\n",
+  });
+  assertThrows(() => resolveContext({ cwd: "/tmp", dir, mode: "json" }));
+});

--- a/noj-cli/src/context/context_test.ts
+++ b/noj-cli/src/context/context_test.ts
@@ -13,68 +13,109 @@ function writeFixture(dir: string, files: Record<string, string>): void {
   }
 }
 
-Deno.test("detectKind: production/json/judge/none", () => {
+function withTempDir(fn: (dir: string) => void): void {
   const dir = Deno.makeTempDirSync();
-  writeFixture(dir, {
-    ".env.prod": "NOJ_VERSION=v0.1.0\n",
-    "docker-compose.prod.yml": "services: {}\n",
-  });
-  assertEquals(detectKind(dir), "production" as ContextKind);
+  try {
+    fn(dir);
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+}
 
-  const jsonDir = Deno.makeTempDirSync();
-  writeFixture(jsonDir, {
-    "noj-deploy.json": "{}",
-    "noj-secrets.json": "{}",
+Deno.test("detectKind: production/json/judge/none", () => {
+  withTempDir((dir) => {
+    writeFixture(dir, {
+      ".env.prod": "NOJ_VERSION=v0.1.0\n",
+      "docker-compose.prod.yml": "services: {}\n",
+    });
+    assertEquals(detectKind(dir), "production" as ContextKind);
   });
-  assertEquals(detectKind(jsonDir), "json" as ContextKind);
-
-  const judgeDir = Deno.makeTempDirSync();
-  writeFixture(judgeDir, {
-    ".env.judge": "NOJ_VERSION=v0.1.0\n",
-    "docker-compose.judge.yml": "services: {}\n",
+  withTempDir((dir) => {
+    writeFixture(dir, {
+      "noj-deploy.json": "{}",
+      "noj-secrets.json": "{}",
+    });
+    assertEquals(detectKind(dir), "json" as ContextKind);
   });
-  assertEquals(detectKind(judgeDir), "judge" as ContextKind);
-
-  const empty = Deno.makeTempDirSync();
-  assertEquals(detectKind(empty), null);
+  withTempDir((dir) => {
+    writeFixture(dir, {
+      ".env.judge": "NOJ_VERSION=v0.1.0\n",
+      "docker-compose.judge.yml": "services: {}\n",
+    });
+    assertEquals(detectKind(dir), "judge" as ContextKind);
+  });
+  withTempDir((dir) => {
+    assertEquals(detectKind(dir), null);
+  });
 });
 
 Deno.test("findContextDir: 向上查找指定上下文", () => {
-  const root = Deno.makeTempDirSync();
-  const prod = `${root}/prod`;
-  writeFixture(prod, {
-    ".env.prod": "NOJ_VERSION=v0.1.0\n",
-    "docker-compose.prod.yml": "services: {}\n",
+  withTempDir((root) => {
+    const prod = `${root}/prod`;
+    writeFixture(prod, {
+      ".env.prod": "NOJ_VERSION=v0.1.0\n",
+      "docker-compose.prod.yml": "services: {}\n",
+    });
+    const nested = `${prod}/nested/deep`;
+    Deno.mkdirSync(nested, { recursive: true });
+    assertEquals(findContextDir(nested, "production"), prod);
+    assertEquals(findContextDir(nested), prod);
   });
-  const nested = `${prod}/nested/deep`;
-  Deno.mkdirSync(nested, { recursive: true });
-  assertEquals(findContextDir(nested, "production"), prod);
-  assertEquals(findContextDir(nested), prod);
+});
+
+Deno.test("findContextDir: 不存在的起始目录返回 null", () => {
+  assertEquals(findContextDir("/definitely/not/a/real/path"), null);
 });
 
 Deno.test("resolveContext: --dir 显式指定", () => {
-  const dir = Deno.makeTempDirSync();
-  writeFixture(dir, {
-    ".env.prod": "NOJ_VERSION=v0.1.0\n",
-    "docker-compose.prod.yml": "services: {}\n",
+  withTempDir((dir) => {
+    writeFixture(dir, {
+      ".env.prod": "NOJ_VERSION=v0.1.0\n",
+      "docker-compose.prod.yml": "services: {}\n",
+    });
+    const ctx = resolveContext({ cwd: "/tmp", dir });
+    assertEquals(ctx.kind, "production");
+    assertEquals(ctx.dir, dir);
   });
-  const ctx = resolveContext({ cwd: "/tmp", dir });
-  assertEquals(ctx.kind, "production");
-  assertEquals(ctx.dir, dir);
 });
 
-Deno.test("resolveContext: --mode 找不到对应上下文时 kind=none", () => {
-  const dir = Deno.makeTempDirSync();
-  const ctx = resolveContext({ cwd: "/tmp", dir, mode: "json" });
-  assertEquals(ctx.kind, "none");
-  assertEquals(ctx.dir, null);
+Deno.test("resolveContext: --dir 显式指定但无上下文标记时保留目录", () => {
+  withTempDir((dir) => {
+    const ctx = resolveContext({ cwd: "/tmp", dir });
+    assertEquals(ctx.kind, "none");
+    assertEquals(ctx.dir, dir);
+  });
+});
+
+Deno.test("resolveContext: --mode 找不到对应上下文时 kind=none 且保留目录", () => {
+  withTempDir((dir) => {
+    const ctx = resolveContext({ cwd: "/tmp", dir, mode: "json" });
+    assertEquals(ctx.kind, "none");
+    assertEquals(ctx.dir, dir);
+  });
 });
 
 Deno.test("resolveContext: 显式 dir 但 mode 不匹配时抛错", () => {
-  const dir = Deno.makeTempDirSync();
-  writeFixture(dir, {
-    ".env.prod": "NOJ_VERSION=v0.1.0\n",
-    "docker-compose.prod.yml": "services: {}\n",
+  withTempDir((dir) => {
+    writeFixture(dir, {
+      ".env.prod": "NOJ_VERSION=v0.1.0\n",
+      "docker-compose.prod.yml": "services: {}\n",
+    });
+    assertThrows(() => resolveContext({ cwd: "/tmp", dir, mode: "json" }));
   });
-  assertThrows(() => resolveContext({ cwd: "/tmp", dir, mode: "json" }));
+});
+
+Deno.test("resolveContext: 未指定 --dir 时自动向上识别上下文", () => {
+  withTempDir((root) => {
+    const prod = `${root}/prod`;
+    writeFixture(prod, {
+      ".env.prod": "NOJ_VERSION=v0.1.0\n",
+      "docker-compose.prod.yml": "services: {}\n",
+    });
+    const nested = `${prod}/nested/deep`;
+    Deno.mkdirSync(nested, { recursive: true });
+    const ctx = resolveContext({ cwd: nested });
+    assertEquals(ctx.kind, "production");
+    assertEquals(ctx.dir, prod);
+  });
 });

--- a/noj-cli/src/judge/checks.ts
+++ b/noj-cli/src/judge/checks.ts
@@ -1,4 +1,4 @@
-import type { CommandRunner } from "../runtime/command.ts";
+import type { CmdResult, CommandRunner } from "../runtime/command.ts";
 import { realRunner } from "../runtime/command.ts";
 import type { JudgeEnv } from "./env.ts";
 import { envValue } from "./env.ts";
@@ -20,12 +20,15 @@ const REQUIRED_CONFIG_KEYS = [
   "JUDGE_GID",
 ] as const;
 
-function isPlaceholder(value: string): boolean {
+function isPlaceholder(value: string, key?: string): boolean {
   if (value === "") return true;
-  return /change-me|changeme|example|placeholder|replace-me|your-|latest|main|xxx/
-    .test(
-      value,
-    );
+  if (/change-me|changeme|example|placeholder|replace-me|your-/.test(value)) {
+    return true;
+  }
+  if (value === "latest" || value === "main") return true;
+  // 队列名允许使用 xxx-* 这类真实业务前缀；版本等其余字段仍按 shell 的 xxx* 识别为占位值。
+  if (key === "JUDGE_QUEUE" || key === "RESULT_QUEUE") return false;
+  return value.startsWith("xxx");
 }
 
 function isReleaseVersion(value: string): boolean {
@@ -44,6 +47,22 @@ async function unameValue(
     // 命令不可用时回退到 Deno 编译期信息
   }
   return fallback;
+}
+
+/** 执行 docker 命令；docker 二进制缺失时转换为友好错误。 */
+async function runDocker(
+  runner: CommandRunner,
+  args: string[],
+  opts?: { env?: Record<string, string> },
+): Promise<CmdResult> {
+  try {
+    return await runner.run("docker", args, opts);
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      throw new Error("缺少依赖：docker");
+    }
+    throw e;
+  }
 }
 
 function expectedArch(machine: string): string | undefined {
@@ -88,6 +107,33 @@ function checkMemoryWarning(): void {
   }
 }
 
+function detectPanel(opts: JudgeOptions): string {
+  if (opts.panel === "baota") return "baota";
+  if (opts.panel === "none") return "none";
+  try {
+    if (Deno.statSync("/www/server/panel").isDirectory) return "baota";
+  } catch {
+    // 未检测到宝塔目录
+  }
+  try {
+    const bt = Deno.statSync("/usr/bin/bt");
+    if ((bt.mode ?? 0) & 0o111) return "baota";
+  } catch {
+    // 未检测到宝塔命令
+  }
+  return "none";
+}
+
+function showPanelGuidance(panelName: string): void {
+  if (panelName !== "baota") return;
+  console.log(
+    "已检测到宝塔面板。脚本会直接使用宝塔管理的标准 Docker/Compose，不调用宝塔 API。\n" +
+      "请在宝塔的 Docker 页面确认 Docker 已安装并运行；部署完成后可以在那里查看本机 Redis 和 Judge 容器。\n" +
+      "脚本不会修改已有站点、反向代理、容器或面板配置，Judge 也不需要公开端口。\n" +
+      "安全提醒：Judge 仍必须使用只服务于 Judge 的 rootless Docker socket，不能填写 /run/docker.sock 或 /var/run/docker.sock。",
+  );
+}
+
 export async function checkBaseEnvironment(
   opts: JudgeOptions,
   runner: CommandRunner = realRunner(),
@@ -96,6 +142,7 @@ export async function checkBaseEnvironment(
   if (os !== "linux") {
     throw new Error("独立 Judge 部署目前只支持 Linux");
   }
+  showPanelGuidance(detectPanel(opts));
 
   const machine = (await unameValue(runner, "-m", Deno.build.arch))
     .toLowerCase();
@@ -106,17 +153,17 @@ export async function checkBaseEnvironment(
     );
   }
 
-  const dockerVersion = await runner.run("docker", ["--version"]);
+  const dockerVersion = await runDocker(runner, ["--version"]);
   if (dockerVersion.code !== 0) {
     throw new Error("缺少依赖：docker");
   }
 
-  const dockerInfo = await runner.run("docker", ["info"]);
+  const dockerInfo = await runDocker(runner, ["info"]);
   if (dockerInfo.code !== 0) {
     throw new Error("Docker daemon 未运行或当前用户无权限");
   }
 
-  const composeVersion = await runner.run("docker", ["compose", "version"]);
+  const composeVersion = await runDocker(runner, ["compose", "version"]);
   if (composeVersion.code !== 0) {
     throw new Error("Docker Compose v2 不可用");
   }
@@ -139,7 +186,7 @@ export function checkConfigValues(env: JudgeEnv): string[] {
   const value = (key: string): string => envValue(env, key) ?? "";
 
   for (const key of REQUIRED_CONFIG_KEYS) {
-    if (isPlaceholder(value(key))) {
+    if (isPlaceholder(value(key), key)) {
       issues.push(`${key} 未配置或仍是占位值`);
     }
   }
@@ -174,27 +221,6 @@ export function checkConfigValues(env: JudgeEnv): string[] {
   }
 
   return issues;
-}
-
-function canReadWriteSocket(info: Deno.FileInfo): boolean {
-  if (Deno.uid() === 0) return true;
-  const mode = info.mode ?? 0;
-  const perm = mode & 0o777;
-  const uid = Deno.uid();
-  const gid = Deno.gid();
-  let read = false;
-  let write = false;
-  if (info.uid === uid) {
-    read = (perm & 0o400) !== 0;
-    write = (perm & 0o200) !== 0;
-  } else if (info.gid === gid) {
-    read = (perm & 0o040) !== 0;
-    write = (perm & 0o020) !== 0;
-  } else {
-    read = (perm & 0o004) !== 0;
-    write = (perm & 0o002) !== 0;
-  }
-  return read && write;
 }
 
 /** 检查专用 Docker socket；返回问题列表。 */
@@ -232,7 +258,13 @@ export async function checkSocket(
     issues.push(`专用 Docker socket 不存在或不是 Unix socket：${socketPath}`);
     return issues;
   }
-  if (!canReadWriteSocket(stat)) {
+  const readOk = await runner.run("test", ["-r", socketPath])
+    .then((r) => r.code === 0)
+    .catch(() => false);
+  const writeOk = await runner.run("test", ["-w", socketPath])
+    .then((r) => r.code === 0)
+    .catch(() => false);
+  if (!readOk || !writeOk) {
     issues.push(`当前用户无法读写专用 Docker socket：${socketPath}`);
     return issues;
   }
@@ -245,9 +277,19 @@ export async function checkSocket(
     return issues;
   }
 
-  const r = await runner.run("docker", ["info"], {
-    env: { DOCKER_HOST: `unix://${socketPath}` },
-  });
+  let r;
+  try {
+    r = await runDocker(runner, ["info"], {
+      env: { DOCKER_HOST: `unix://${socketPath}` },
+    });
+  } catch (e) {
+    if (e instanceof Error && e.message === "缺少依赖：docker") {
+      issues.push("缺少依赖：docker");
+    } else {
+      issues.push(`专用 rootless Docker daemon 不可连接：${socketPath}`);
+    }
+    return issues;
+  }
   if (r.code !== 0) {
     issues.push(`专用 rootless Docker daemon 不可连接：${socketPath}`);
   }
@@ -401,9 +443,15 @@ export async function checkImageArchitecture(
           `Worker 镜像没有当前主机架构 linux/${expected}：${image}`,
         );
       }
+    } else {
+      console.warn(
+        `无法预先读取 Worker manifest，将由 docker pull 报告网络、认证或架构错误：${image}`,
+      );
     }
   } catch {
-    // 无法读取 manifest 时不阻断，交由 docker pull 报告实际错误
+    console.warn(
+      `无法预先读取 Worker manifest，将由 docker pull 报告网络、认证或架构错误：${image}`,
+    );
   }
   return issues;
 }

--- a/noj-cli/src/judge/checks.ts
+++ b/noj-cli/src/judge/checks.ts
@@ -1,0 +1,409 @@
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import type { JudgeEnv } from "./env.ts";
+import { envValue } from "./env.ts";
+import type { JudgeOptions } from "./options.ts";
+
+/** 必需配置项：未配置或仍为占位值时视为问题。 */
+const REQUIRED_CONFIG_KEYS = [
+  "NOJ_VERSION",
+  "REDIS_URL",
+  "JUDGE_QUEUE",
+  "RESULT_QUEUE",
+  "WORK_DIR",
+  "JUDGE_MAX_CONCURRENT_JUDGES",
+  "JUDGE_IMAGE_PREFIX",
+  "JUDGE_IMAGE_REGISTRY",
+  "JUDGE_DOCKER_SOCKET",
+  "JUDGE_DOCKER_SOCKET_GID",
+  "JUDGE_UID",
+  "JUDGE_GID",
+] as const;
+
+function isPlaceholder(value: string): boolean {
+  if (value === "") return true;
+  return /change-me|changeme|example|placeholder|replace-me|your-|latest|main|xxx/
+    .test(
+      value,
+    );
+}
+
+function isReleaseVersion(value: string): boolean {
+  return /^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$/.test(value);
+}
+
+async function unameValue(
+  runner: CommandRunner,
+  flag: string,
+  fallback: string,
+): Promise<string> {
+  try {
+    const r = await runner.run("uname", [flag]);
+    if (r.code === 0 && r.stdout.trim() !== "") return r.stdout.trim();
+  } catch {
+    // 命令不可用时回退到 Deno 编译期信息
+  }
+  return fallback;
+}
+
+function expectedArch(machine: string): string | undefined {
+  if (machine === "x86_64" || machine === "amd64") return "amd64";
+  if (machine === "aarch64" || machine === "arm64") return "arm64";
+  return undefined;
+}
+
+/** 检查基础主机环境；硬性失败直接抛错，磁盘/内存等警告不阻断。 */
+async function checkDiskSpaceWarning(
+  runner: CommandRunner,
+  dir: string,
+): Promise<void> {
+  let r;
+  try {
+    r = await runner.run("df", ["-Pk", dir]);
+  } catch {
+    throw new Error(`无法读取目标目录磁盘空间：${dir}`);
+  }
+  if (r.code !== 0) {
+    throw new Error(`无法读取目标目录磁盘空间：${dir}`);
+  }
+  const line = r.stdout.split(/\r?\n/)[1];
+  const availableKb = line?.trim().split(/\s+/)[3];
+  if (availableKb === undefined || !/^[0-9]+$/.test(availableKb)) {
+    throw new Error(`无法读取目标目录磁盘空间：${dir}`);
+  }
+  if (Number(availableKb) < 5 * 1024 * 1024) {
+    console.warn("目标目录可用空间少于 5 GiB，评测镜像和缓存可能不足");
+  }
+}
+
+function checkMemoryWarning(): void {
+  try {
+    const text = Deno.readTextFileSync("/proc/meminfo");
+    const m = /^MemAvailable:\s+(\d+)\s*kB/m.exec(text);
+    if (m && Number(m[1]) < 512 * 1024) {
+      console.warn("可用内存少于 512 MiB，建议降低 Judge 并发");
+    }
+  } catch {
+    // 非 Linux 或无法读取时跳过内存告警
+  }
+}
+
+export async function checkBaseEnvironment(
+  opts: JudgeOptions,
+  runner: CommandRunner = realRunner(),
+): Promise<void> {
+  const os = (await unameValue(runner, "-s", Deno.build.os)).toLowerCase();
+  if (os !== "linux") {
+    throw new Error("独立 Judge 部署目前只支持 Linux");
+  }
+
+  const machine = (await unameValue(runner, "-m", Deno.build.arch))
+    .toLowerCase();
+  const arch = expectedArch(machine);
+  if (arch === undefined) {
+    throw new Error(
+      `不支持的 CPU 架构：${machine}（当前支持 x86_64/amd64 与 ARM64）`,
+    );
+  }
+
+  const dockerVersion = await runner.run("docker", ["--version"]);
+  if (dockerVersion.code !== 0) {
+    throw new Error("缺少依赖：docker");
+  }
+
+  const dockerInfo = await runner.run("docker", ["info"]);
+  if (dockerInfo.code !== 0) {
+    throw new Error("Docker daemon 未运行或当前用户无权限");
+  }
+
+  const composeVersion = await runner.run("docker", ["compose", "version"]);
+  if (composeVersion.code !== 0) {
+    throw new Error("Docker Compose v2 不可用");
+  }
+
+  let dirExists = false;
+  try {
+    dirExists = Deno.statSync(opts.dir).isDirectory;
+  } catch {
+    dirExists = false;
+  }
+  if (dirExists) {
+    await checkDiskSpaceWarning(runner, opts.dir);
+    checkMemoryWarning();
+  }
+}
+
+/** 检查 Judge 配置值，返回问题列表。 */
+export function checkConfigValues(env: JudgeEnv): string[] {
+  const issues: string[] = [];
+  const value = (key: string): string => envValue(env, key) ?? "";
+
+  for (const key of REQUIRED_CONFIG_KEYS) {
+    if (isPlaceholder(value(key))) {
+      issues.push(`${key} 未配置或仍是占位值`);
+    }
+  }
+
+  if (!isReleaseVersion(value("NOJ_VERSION"))) {
+    issues.push("NOJ_VERSION 必须是不可变 Release 标签，如 v0.1.0");
+  }
+  if (!/^[1-9][0-9]*$/.test(value("JUDGE_MAX_CONCURRENT_JUDGES"))) {
+    issues.push("JUDGE_MAX_CONCURRENT_JUDGES 必须是正整数");
+  }
+  if (!/^[0-9]+$/.test(value("JUDGE_DOCKER_SOCKET_GID"))) {
+    issues.push("JUDGE_DOCKER_SOCKET_GID 必须是数字");
+  }
+  if (
+    !/^[0-9]+$/.test(value("JUDGE_UID")) ||
+    !/^[0-9]+$/.test(value("JUDGE_GID"))
+  ) {
+    issues.push("JUDGE_UID 和 JUDGE_GID 必须是数字");
+  }
+
+  const dockerHost = value("JUDGE_DOCKER_HOST");
+  if (!dockerHost.startsWith("unix:///")) {
+    issues.push("JUDGE_DOCKER_HOST 必须使用 unix:// endpoint");
+  } else if (dockerHost !== "unix:///run/noj-judge/docker.sock") {
+    issues.push(
+      "JUDGE_DOCKER_HOST 必须为容器内专用 endpoint：unix:///run/noj-judge/docker.sock",
+    );
+  }
+
+  if (value("JUDGE_REQUIRE_ISOLATED_DOCKER") !== "true") {
+    issues.push("JUDGE_REQUIRE_ISOLATED_DOCKER 必须为 true");
+  }
+
+  return issues;
+}
+
+function canReadWriteSocket(info: Deno.FileInfo): boolean {
+  if (Deno.uid() === 0) return true;
+  const mode = info.mode ?? 0;
+  const perm = mode & 0o777;
+  const uid = Deno.uid();
+  const gid = Deno.gid();
+  let read = false;
+  let write = false;
+  if (info.uid === uid) {
+    read = (perm & 0o400) !== 0;
+    write = (perm & 0o200) !== 0;
+  } else if (info.gid === gid) {
+    read = (perm & 0o040) !== 0;
+    write = (perm & 0o020) !== 0;
+  } else {
+    read = (perm & 0o004) !== 0;
+    write = (perm & 0o002) !== 0;
+  }
+  return read && write;
+}
+
+/** 检查专用 Docker socket；返回问题列表。 */
+export async function checkSocket(
+  env: JudgeEnv,
+  runner: CommandRunner = realRunner(),
+): Promise<string[]> {
+  const issues: string[] = [];
+  const socketPath = envValue(env, "JUDGE_DOCKER_SOCKET") ?? "";
+  const configuredGid = envValue(env, "JUDGE_DOCKER_SOCKET_GID") ?? "";
+
+  if (
+    socketPath === "/var/run/docker.sock" || socketPath === "/run/docker.sock"
+  ) {
+    issues.push(
+      `禁止使用应用宿主机 Docker socket：${socketPath}；请准备专用 rootless socket`,
+    );
+  }
+  if (!socketPath.startsWith("/")) {
+    issues.push("JUDGE_DOCKER_SOCKET 必须是绝对路径");
+  }
+  if (socketPath.includes(":")) {
+    issues.push("JUDGE_DOCKER_SOCKET 必须是本机 Unix socket 路径");
+  }
+  if (issues.length > 0) return issues;
+
+  let stat: Deno.FileInfo;
+  try {
+    stat = Deno.statSync(socketPath);
+  } catch {
+    issues.push(`专用 Docker socket 不存在或不是 Unix socket：${socketPath}`);
+    return issues;
+  }
+  if (!stat.isSocket) {
+    issues.push(`专用 Docker socket 不存在或不是 Unix socket：${socketPath}`);
+    return issues;
+  }
+  if (!canReadWriteSocket(stat)) {
+    issues.push(`当前用户无法读写专用 Docker socket：${socketPath}`);
+    return issues;
+  }
+
+  const socketGid = stat.gid?.toString() ?? "";
+  if (socketGid !== configuredGid) {
+    issues.push(
+      `Docker socket GID=${socketGid} 与配置 JUDGE_DOCKER_SOCKET_GID=${configuredGid} 不一致`,
+    );
+    return issues;
+  }
+
+  const r = await runner.run("docker", ["info"], {
+    env: { DOCKER_HOST: `unix://${socketPath}` },
+  });
+  if (r.code !== 0) {
+    issues.push(`专用 rootless Docker daemon 不可连接：${socketPath}`);
+  }
+  return issues;
+}
+
+function redisHost(url: string): string {
+  let rest = url.replace(/^[a-z]+:\/\//i, "");
+  const at = rest.indexOf("@");
+  if (at !== -1) rest = rest.slice(at + 1);
+  rest = rest.split("/")[0] ?? "";
+  const colon = rest.indexOf(":");
+  return colon === -1 ? rest || "未知主机" : rest.slice(0, colon) || "未知主机";
+}
+
+function isRedisUrl(url: string): boolean {
+  return /^rediss?:\/\/./.test(url);
+}
+
+/** 检查 Redis 可连接性；返回问题列表。 */
+export async function checkRedis(
+  env: JudgeEnv,
+  runner: CommandRunner = realRunner(),
+): Promise<string[]> {
+  const issues: string[] = [];
+  const url = envValue(env, "REDIS_URL") ?? "";
+  const checkUrlConfig = envValue(env, "REDIS_CHECK_URL") ?? "";
+
+  if (!isRedisUrl(url)) {
+    issues.push("REDIS_URL 必须使用 redis:// 或 rediss://");
+  }
+  const checkUrl = checkUrlConfig === "" ? url : checkUrlConfig;
+  if (!isRedisUrl(checkUrl)) {
+    issues.push("REDIS_CHECK_URL 必须使用 redis:// 或 rediss://");
+  }
+  if (issues.length > 0) return issues;
+
+  let redisCliAvailable = false;
+  try {
+    const probe = await runner.run("redis-cli", ["--version"]);
+    redisCliAvailable = probe.code === 0;
+  } catch {
+    redisCliAvailable = false;
+  }
+
+  let ok = false;
+  if (redisCliAvailable) {
+    try {
+      const ping = await runner.run("redis-cli", ["-u", checkUrl, "ping"]);
+      ok = ping.code === 0;
+    } catch {
+      ok = false;
+    }
+  } else {
+    let envFile = "";
+    try {
+      envFile = Deno.makeTempFileSync({
+        prefix: "noj-judge-redis-check.",
+        suffix: "",
+      });
+      Deno.writeTextFileSync(envFile, `REDIS_URL=${checkUrl}\n`);
+      Deno.chmodSync(envFile, 0o600);
+      const docker = await runner.run(
+        "docker",
+        [
+          "run",
+          "--rm",
+          "--network",
+          "host",
+          "--env-file",
+          envFile,
+          "redis:7-alpine",
+          "sh",
+          "-c",
+          'redis-cli -u "$REDIS_URL" ping',
+        ],
+      );
+      ok = docker.code === 0;
+    } catch {
+      ok = false;
+    } finally {
+      if (envFile !== "") {
+        try {
+          Deno.removeSync(envFile);
+        } catch {
+          // 临时文件清理失败可忽略
+        }
+      }
+    }
+  }
+
+  if (!ok) {
+    issues.push(`Redis 连接失败：${redisHost(checkUrl)}（密码不会显示）`);
+  }
+  return issues;
+}
+
+/** 检查 Worker 镜像架构与当前主机是否匹配；返回问题列表。 */
+export async function checkImageArchitecture(
+  env: JudgeEnv,
+  runner: CommandRunner = realRunner(),
+): Promise<string[]> {
+  const issues: string[] = [];
+  const machine = (
+    await unameValue(runner, "-m", Deno.build.arch)
+  ).toLowerCase();
+  const expected = expectedArch(machine);
+  if (expected === undefined) {
+    issues.push(
+      `不支持的 CPU 架构：${machine}（当前支持 x86_64/amd64 与 ARM64）`,
+    );
+    return issues;
+  }
+
+  const registry = envValue(env, "JUDGE_IMAGE_REGISTRY") ?? "";
+  const version = envValue(env, "NOJ_VERSION") ?? "";
+  const image = `${registry}/noj-judge:${version}`;
+
+  let localArch = "";
+  try {
+    const inspect = await runner.run(
+      "docker",
+      ["image", "inspect", image, "--format", "{{.Architecture}}"],
+    );
+    if (inspect.code === 0) localArch = inspect.stdout.trim();
+  } catch {
+    localArch = "";
+  }
+  if (localArch !== "") {
+    if (localArch !== expected) {
+      issues.push(
+        `本地 Worker 镜像架构为 ${localArch}，当前主机需要 ${expected}：${image}`,
+      );
+    }
+    return issues;
+  }
+
+  try {
+    const inspect = await runner.run(
+      "docker",
+      ["buildx", "imagetools", "inspect", image],
+    );
+    if (inspect.code === 0) {
+      const details = `${inspect.stdout}\n${inspect.stderr}`;
+      const pattern = new RegExp(
+        `linux/${expected}|Architecture:\\s+${expected}`,
+        "i",
+      );
+      if (!pattern.test(details)) {
+        issues.push(
+          `Worker 镜像没有当前主机架构 linux/${expected}：${image}`,
+        );
+      }
+    }
+  } catch {
+    // 无法读取 manifest 时不阻断，交由 docker pull 报告实际错误
+  }
+  return issues;
+}

--- a/noj-cli/src/judge/checks_test.ts
+++ b/noj-cli/src/judge/checks_test.ts
@@ -27,11 +27,17 @@ function fakeRunner(
   };
 }
 
+const missingDir = `/tmp/noj-judge-missing-${Date.now()}-${
+  Math.random()
+    .toString(36)
+    .slice(2)
+}`;
+
 const baseOpts: JudgeOptions = {
   command: "check",
-  dir: "/srv/noj-judge",
-  envFile: "/srv/noj-judge/.env.judge",
-  composeFile: "/srv/noj-judge/docker-compose.judge.yml",
+  dir: missingDir,
+  envFile: `${missingDir}/.env.judge`,
+  composeFile: `${missingDir}/docker-compose.judge.yml`,
   repo: "https://github.com/Neuro-OJ/neuro-oj",
   ref: "main",
   version: undefined,
@@ -95,8 +101,52 @@ Deno.test("checkConfigValues: 非法版本与数值返回问题", () => {
   assertEquals(issues.length > 0, true);
 });
 
+Deno.test("checkConfigValues: WORK_DIR=/srv/main 不算占位值", () => {
+  const issues = checkConfigValues(env({
+    ...completeValues,
+    WORK_DIR: "/srv/main",
+  }));
+  assertEquals(issues, []);
+});
+
+Deno.test("checkConfigValues: JUDGE_QUEUE=xxx-prod 不算占位值", () => {
+  const issues = checkConfigValues(env({
+    ...completeValues,
+    JUDGE_QUEUE: "xxx-prod",
+  }));
+  assertEquals(issues, []);
+});
+
+Deno.test("checkConfigValues: NOJ_VERSION=latest/xxx-prod 是占位/非法", () => {
+  for (const version of ["latest", "xxx-prod"]) {
+    const issues = checkConfigValues(env({
+      ...completeValues,
+      NOJ_VERSION: version,
+    }));
+    assertEquals(issues.some((i) => i.includes("NOJ_VERSION")), true);
+  }
+});
+
 Deno.test("checkBaseEnvironment: Linux + docker ok 不抛错", async () => {
   await checkBaseEnvironment(baseOpts, fakeRunner());
+});
+
+Deno.test("checkBaseEnvironment: docker 缺失抛缺少依赖", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "uname" && args[0] === "-s") {
+      return { code: 0, stdout: "Linux\n", stderr: "" };
+    }
+    if (cmd === "uname" && args[0] === "-m") {
+      return { code: 0, stdout: "x86_64\n", stderr: "" };
+    }
+    if (cmd === "docker") throw new Deno.errors.NotFound("docker not found");
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  await assertRejects(
+    () => checkBaseEnvironment(baseOpts, runner),
+    Error,
+    "缺少依赖：docker",
+  );
 });
 
 Deno.test("checkBaseEnvironment: 非 Linux 抛错", async () => {
@@ -180,6 +230,62 @@ Deno.test("checkSocket: 专用 socket 可用时无问题", async () => {
       fakeRunner(),
     );
     assertEquals(issues, []);
+  } finally {
+    listener.close();
+  }
+});
+
+Deno.test("checkSocket: 权限检查使用 runner test，GID 不匹配时不报权限问题", async () => {
+  const dir = Deno.makeTempDirSync();
+  const socketPath = `${dir}/docker.sock`;
+  const listener = Deno.listen({ path: socketPath, transport: "unix" });
+  try {
+    const stat = Deno.statSync(socketPath);
+    const gid = stat.gid?.toString() ?? "";
+    const configuredGid = gid === "0" ? "1" : "0";
+    const seenTests: string[] = [];
+    const runner = fakeRunner((cmd, args) => {
+      if (cmd === "test") {
+        seenTests.push(args[0] ?? "");
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    const issues = await checkSocket(
+      env({
+        JUDGE_DOCKER_SOCKET: socketPath,
+        JUDGE_DOCKER_SOCKET_GID: configuredGid,
+      }),
+      runner,
+    );
+    assertEquals(seenTests.sort(), ["-r", "-w"]);
+    assertEquals(issues.some((i) => i.includes("无法读写")), false);
+    assertEquals(issues.some((i) => i.includes("GID")), true);
+  } finally {
+    listener.close();
+  }
+});
+
+Deno.test("checkSocket: docker 缺失返回缺少依赖", async () => {
+  const dir = Deno.makeTempDirSync();
+  const socketPath = `${dir}/docker.sock`;
+  const listener = Deno.listen({ path: socketPath, transport: "unix" });
+  try {
+    const stat = Deno.statSync(socketPath);
+    const gid = stat.gid?.toString() ?? "";
+    const runner = fakeRunner((cmd) => {
+      if (cmd === "test") return { code: 0, stdout: "", stderr: "" };
+      if (cmd === "docker") throw new Deno.errors.NotFound("docker not found");
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    const issues = await checkSocket(
+      env({
+        JUDGE_DOCKER_SOCKET: socketPath,
+        JUDGE_DOCKER_SOCKET_GID: gid,
+      }),
+      runner,
+    );
+    assertEquals(issues, ["缺少依赖：docker"]);
   } finally {
     listener.close();
   }
@@ -347,4 +453,39 @@ Deno.test("checkImageArchitecture: 无法读取 manifest 时视为警告不返�
     runner,
   );
   assertEquals(issues, []);
+});
+
+Deno.test("checkImageArchitecture: manifest 不可读时打印警告", async () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.join(" "));
+  };
+  try {
+    const runner = fakeRunner((cmd, args) => {
+      if (cmd === "uname" && args[0] === "-m") {
+        return { code: 0, stdout: "x86_64\n", stderr: "" };
+      }
+      if (cmd === "docker" && args[0] === "image" && args[1] === "inspect") {
+        return { code: 1, stdout: "", stderr: "not found" };
+      }
+      if (
+        cmd === "docker" && args[0] === "buildx" && args[1] === "imagetools"
+      ) {
+        return { code: 1, stdout: "", stderr: "not available" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    const issues = await checkImageArchitecture(
+      env({
+        NOJ_VERSION: "v0.1.0",
+        JUDGE_IMAGE_REGISTRY: "ghcr.io/neuro-oj",
+      }),
+      runner,
+    );
+    assertEquals(issues, []);
+    assertEquals(warnings.length > 0, true);
+  } finally {
+    console.warn = originalWarn;
+  }
 });

--- a/noj-cli/src/judge/checks_test.ts
+++ b/noj-cli/src/judge/checks_test.ts
@@ -1,0 +1,350 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import {
+  checkBaseEnvironment,
+  checkConfigValues,
+  checkImageArchitecture,
+  checkRedis,
+  checkSocket,
+} from "./checks.ts";
+import type { JudgeEnv } from "./env.ts";
+import type { JudgeOptions } from "./options.ts";
+
+function fakeRunner(
+  handler?: (
+    cmd: string,
+    args: string[],
+  ) => { code: number; stdout: string; stderr: string },
+): CommandRunner {
+  return {
+    run(cmd, args) {
+      if (handler) return Promise.resolve(handler(cmd, args));
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+const baseOpts: JudgeOptions = {
+  command: "check",
+  dir: "/srv/noj-judge",
+  envFile: "/srv/noj-judge/.env.judge",
+  composeFile: "/srv/noj-judge/docker-compose.judge.yml",
+  repo: "https://github.com/Neuro-OJ/neuro-oj",
+  ref: "main",
+  version: undefined,
+  redisContainer: "noj-judge-redis",
+  redisPort: 16379,
+  panel: "none",
+  nonInteractive: true,
+  downloadOnly: false,
+  dryRun: false,
+  follow: false,
+};
+
+function env(values: Record<string, string>): JudgeEnv {
+  return { values };
+}
+
+const completeValues: Record<string, string> = {
+  NOJ_VERSION: "v0.1.0",
+  REDIS_URL: "redis://127.0.0.1:6379/0",
+  JUDGE_QUEUE: "noj:judge:queue",
+  RESULT_QUEUE: "noj:judge:results",
+  WORK_DIR: "/tmp/noj-judge",
+  JUDGE_MAX_CONCURRENT_JUDGES: "2",
+  JUDGE_IMAGE_PREFIX: "noj-",
+  JUDGE_IMAGE_REGISTRY: "ghcr.io/neuro-oj",
+  JUDGE_DOCKER_SOCKET: "/run/noj-judge/docker.sock",
+  JUDGE_DOCKER_SOCKET_GID: "10001",
+  JUDGE_UID: "10001",
+  JUDGE_GID: "10001",
+  JUDGE_DOCKER_HOST: "unix:///run/noj-judge/docker.sock",
+  JUDGE_REQUIRE_ISOLATED_DOCKER: "true",
+};
+
+Deno.test("checkConfigValues: 完整配置无问题", () => {
+  assertEquals(checkConfigValues(env(completeValues)), []);
+});
+
+Deno.test("checkConfigValues: 禁止的 socket 与占位值返回问题", () => {
+  const issues = checkConfigValues(env({
+    NOJ_VERSION: "latest",
+    REDIS_URL: "change-me",
+    JUDGE_DOCKER_SOCKET: "/var/run/docker.sock",
+    JUDGE_DOCKER_SOCKET_GID: "abc",
+    JUDGE_UID: "0",
+    JUDGE_GID: "0",
+    JUDGE_DOCKER_HOST: "unix:///var/run/docker.sock",
+    JUDGE_REQUIRE_ISOLATED_DOCKER: "false",
+  }));
+  assertEquals(issues.length > 0, true);
+});
+
+Deno.test("checkConfigValues: 非法版本与数值返回问题", () => {
+  const issues = checkConfigValues(env({
+    ...completeValues,
+    NOJ_VERSION: "main",
+    JUDGE_MAX_CONCURRENT_JUDGES: "0",
+    JUDGE_DOCKER_SOCKET_GID: "abc",
+    JUDGE_DOCKER_HOST: "tcp://127.0.0.1:2375",
+    JUDGE_REQUIRE_ISOLATED_DOCKER: "false",
+  }));
+  assertEquals(issues.length > 0, true);
+});
+
+Deno.test("checkBaseEnvironment: Linux + docker ok 不抛错", async () => {
+  await checkBaseEnvironment(baseOpts, fakeRunner());
+});
+
+Deno.test("checkBaseEnvironment: 非 Linux 抛错", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "uname" && args[0] === "-s") {
+      return { code: 0, stdout: "Darwin\n", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  await assertRejects(() => checkBaseEnvironment(baseOpts, runner));
+});
+
+Deno.test("checkBaseEnvironment: 不支持的架构抛错", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "uname" && args[0] === "-s") {
+      return { code: 0, stdout: "Linux\n", stderr: "" };
+    }
+    if (cmd === "uname" && args[0] === "-m") {
+      return { code: 0, stdout: "mips\n", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  await assertRejects(() => checkBaseEnvironment(baseOpts, runner));
+});
+
+Deno.test("checkBaseEnvironment: docker info 失败抛错", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "docker" && args[0] === "info") {
+      return { code: 1, stdout: "", stderr: "cannot connect" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  await assertRejects(() => checkBaseEnvironment(baseOpts, runner));
+});
+
+Deno.test("checkBaseEnvironment: docker compose v2 不可用抛错", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "docker" && args[0] === "compose" && args[1] === "version") {
+      return { code: 1, stdout: "", stderr: "missing compose" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  await assertRejects(() => checkBaseEnvironment(baseOpts, runner));
+});
+
+Deno.test("checkBaseEnvironment: 目标目录存在且磁盘读取正常时不抛错", async () => {
+  const dir = Deno.makeTempDirSync();
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "uname" && args[0] === "-s") {
+      return { code: 0, stdout: "Linux\n", stderr: "" };
+    }
+    if (cmd === "uname" && args[0] === "-m") {
+      return { code: 0, stdout: "x86_64\n", stderr: "" };
+    }
+    if (cmd === "df" && args[0] === "-Pk" && args[1] === dir) {
+      return {
+        code: 0,
+        stdout:
+          "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/x 100 90 999999999 0% " +
+          dir + "\n",
+        stderr: "",
+      };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  await checkBaseEnvironment({ ...baseOpts, dir }, runner);
+});
+
+Deno.test("checkSocket: 专用 socket 可用时无问题", async () => {
+  const dir = Deno.makeTempDirSync();
+  const socketPath = `${dir}/docker.sock`;
+  const listener = Deno.listen({ path: socketPath, transport: "unix" });
+  try {
+    const stat = Deno.statSync(socketPath);
+    const gid = stat.gid?.toString() ?? "";
+    const issues = await checkSocket(
+      env({
+        JUDGE_DOCKER_SOCKET: socketPath,
+        JUDGE_DOCKER_SOCKET_GID: gid,
+      }),
+      fakeRunner(),
+    );
+    assertEquals(issues, []);
+  } finally {
+    listener.close();
+  }
+});
+
+Deno.test("checkSocket: 禁止使用宿主机 socket", async () => {
+  const issues = await checkSocket(
+    env({
+      JUDGE_DOCKER_SOCKET: "/var/run/docker.sock",
+      JUDGE_DOCKER_SOCKET_GID: "0",
+    }),
+    fakeRunner(),
+  );
+  assertEquals(issues.length > 0, true);
+});
+
+Deno.test("checkSocket: 非 socket 路径返回问题", async () => {
+  const dir = Deno.makeTempDirSync();
+  const file = `${dir}/not-socket`;
+  Deno.writeTextFileSync(file, "x");
+  const issues = await checkSocket(
+    env({
+      JUDGE_DOCKER_SOCKET: file,
+      JUDGE_DOCKER_SOCKET_GID: "0",
+    }),
+    fakeRunner(),
+  );
+  assertEquals(issues.length > 0, true);
+});
+
+Deno.test("checkRedis: redis-cli 可连接时无问题", async () => {
+  const issues = await checkRedis(
+    env({
+      REDIS_URL: "redis://127.0.0.1:6379/0",
+    }),
+    fakeRunner(),
+  );
+  assertEquals(issues, []);
+});
+
+Deno.test("checkRedis: 无 redis-cli 时使用 docker 客户端成功", async () => {
+  const runner = fakeRunner((cmd) => {
+    if (cmd === "redis-cli") {
+      return { code: 1, stdout: "", stderr: "not found" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const issues = await checkRedis(
+    env({
+      REDIS_URL: "redis://127.0.0.1:6379/0",
+    }),
+    runner,
+  );
+  assertEquals(issues, []);
+});
+
+Deno.test("checkRedis: 非法协议返回问题", async () => {
+  const issues = await checkRedis(
+    env({
+      REDIS_URL: "tcp://127.0.0.1:6379",
+    }),
+    fakeRunner(),
+  );
+  assertEquals(issues.length > 0, true);
+});
+
+Deno.test("checkImageArchitecture: 本地镜像架构匹配无问题", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "uname" && args[0] === "-m") {
+      return { code: 0, stdout: "x86_64\n", stderr: "" };
+    }
+    if (cmd === "docker" && args[0] === "image" && args[1] === "inspect") {
+      return { code: 0, stdout: "amd64\n", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const issues = await checkImageArchitecture(
+    env({
+      NOJ_VERSION: "v0.1.0",
+      JUDGE_IMAGE_REGISTRY: "ghcr.io/neuro-oj",
+    }),
+    runner,
+  );
+  assertEquals(issues, []);
+});
+
+Deno.test("checkImageArchitecture: 本地镜像架构不匹配返回问题", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "uname" && args[0] === "-m") {
+      return { code: 0, stdout: "x86_64\n", stderr: "" };
+    }
+    if (cmd === "docker" && args[0] === "image" && args[1] === "inspect") {
+      return { code: 0, stdout: "arm64\n", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const issues = await checkImageArchitecture(
+    env({
+      NOJ_VERSION: "v0.1.0",
+      JUDGE_IMAGE_REGISTRY: "ghcr.io/neuro-oj",
+    }),
+    runner,
+  );
+  assertEquals(issues.length > 0, true);
+});
+
+Deno.test("checkImageArchitecture: manifest 含当前架构无问题", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "uname" && args[0] === "-m") {
+      return { code: 0, stdout: "x86_64\n", stderr: "" };
+    }
+    if (cmd === "docker" && args[0] === "image" && args[1] === "inspect") {
+      return { code: 1, stdout: "", stderr: "not found" };
+    }
+    if (cmd === "docker" && args[0] === "buildx" && args[1] === "imagetools") {
+      return { code: 0, stdout: "Platform: linux/amd64\n", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const issues = await checkImageArchitecture(
+    env({
+      NOJ_VERSION: "v0.1.0",
+      JUDGE_IMAGE_REGISTRY: "ghcr.io/neuro-oj",
+    }),
+    runner,
+  );
+  assertEquals(issues, []);
+});
+
+Deno.test("checkImageArchitecture: manifest 缺少当前架构返回问题", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "uname" && args[0] === "-m") {
+      return { code: 0, stdout: "x86_64\n", stderr: "" };
+    }
+    if (cmd === "docker" && args[0] === "image" && args[1] === "inspect") {
+      return { code: 1, stdout: "", stderr: "not found" };
+    }
+    if (cmd === "docker" && args[0] === "buildx" && args[1] === "imagetools") {
+      return { code: 0, stdout: "Platform: linux/arm64\n", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const issues = await checkImageArchitecture(
+    env({
+      NOJ_VERSION: "v0.1.0",
+      JUDGE_IMAGE_REGISTRY: "ghcr.io/neuro-oj",
+    }),
+    runner,
+  );
+  assertEquals(issues.length > 0, true);
+});
+
+Deno.test("checkImageArchitecture: 无法读取 manifest 时视为警告不返回问题", async () => {
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "uname" && args[0] === "-m") {
+      return { code: 0, stdout: "x86_64\n", stderr: "" };
+    }
+    return { code: 1, stdout: "", stderr: "not available" };
+  });
+  const issues = await checkImageArchitecture(
+    env({
+      NOJ_VERSION: "v0.1.0",
+      JUDGE_IMAGE_REGISTRY: "ghcr.io/neuro-oj",
+    }),
+    runner,
+  );
+  assertEquals(issues, []);
+});

--- a/noj-cli/src/judge/commands.ts
+++ b/noj-cli/src/judge/commands.ts
@@ -1,5 +1,8 @@
 import type { CommandRunner } from "../runtime/command.ts";
 import { realRunner } from "../runtime/command.ts";
+import type { PromptIO } from "../tui/io.ts";
+import { realIO } from "../tui/io.ts";
+import { input, secretInput, select } from "../tui/widgets.ts";
 import { fileExists } from "../util/fs.ts";
 import {
   checkBaseEnvironment,
@@ -12,42 +15,22 @@ import { composeArgs, runJudgeCompose, writeJudgeCompose } from "./compose.ts";
 import type { JudgeEnv } from "./env.ts";
 import { envValue, loadJudgeEnv, saveJudgeEnv, setJudgeEnv } from "./env.ts";
 import type { JudgeOptions } from "./options.ts";
+import { createLocalRedis, redisConnectionFiles } from "./redis.ts";
 
-/** 读取文件权限低位，文件不存在时返回 0。 */
-function fileMode(path: string): number {
-  try {
-    return Deno.statSync(path).mode ?? 0;
-  } catch {
-    return 0;
-  }
+/** 显式 stat 读取文件权限位；文件不存在或不可 stat 时直接抛错。 */
+function statFileMode(path: string): number {
+  return Deno.statSync(path).mode ?? 0;
 }
 
 /** 生成初始化 .env.judge 所需的默认值；非交互必填项缺失时报错。 */
-function initialEnvValues(opts: JudgeOptions): Record<string, string> {
+function baseEnvValues(opts: JudgeOptions): Record<string, string> {
   const get = (key: string): string | undefined => Deno.env.get(key);
-  const requireValue = (key: string, value: string | undefined): string => {
-    if (value !== undefined && value.trim() !== "") return value;
-    throw new Error(`非交互安装缺少必填配置：${key}`);
-  };
   const optional = (key: string, fallback: string): string =>
     get(key) ?? fallback;
-
-  const version = requireValue(
-    "NOJ_VERSION",
-    opts.version ?? get("NOJ_VERSION"),
-  );
-  const redisUrl = requireValue("REDIS_URL", get("REDIS_URL"));
-  const socket = requireValue(
-    "JUDGE_DOCKER_SOCKET",
-    get("JUDGE_DOCKER_SOCKET"),
-  );
-  const socketGid = requireValue(
-    "JUDGE_DOCKER_SOCKET_GID",
-    get("JUDGE_DOCKER_SOCKET_GID"),
-  );
+  const redisUrl = get("REDIS_URL") ?? "";
 
   return {
-    NOJ_VERSION: version,
+    NOJ_VERSION: opts.version ?? get("NOJ_VERSION") ?? "",
     REDIS_URL: redisUrl,
     REDIS_CHECK_URL: optional("REDIS_CHECK_URL", redisUrl),
     REDIS_SOURCE: optional("REDIS_SOURCE", "existing"),
@@ -57,8 +40,8 @@ function initialEnvValues(opts: JudgeOptions): Record<string, string> {
     JUDGE_MAX_CONCURRENT_JUDGES: optional("JUDGE_MAX_CONCURRENT_JUDGES", "2"),
     JUDGE_IMAGE_PREFIX: optional("JUDGE_IMAGE_PREFIX", "noj-"),
     JUDGE_IMAGE_REGISTRY: optional("JUDGE_IMAGE_REGISTRY", "ghcr.io/neuro-oj"),
-    JUDGE_DOCKER_SOCKET: socket,
-    JUDGE_DOCKER_SOCKET_GID: socketGid,
+    JUDGE_DOCKER_SOCKET: get("JUDGE_DOCKER_SOCKET") ?? "",
+    JUDGE_DOCKER_SOCKET_GID: get("JUDGE_DOCKER_SOCKET_GID") ?? "",
     JUDGE_DOCKER_HOST: "unix:///run/noj-judge/docker.sock",
     JUDGE_REQUIRE_ISOLATED_DOCKER: "true",
     JUDGE_UID: optional("JUDGE_UID", "10001"),
@@ -95,13 +78,199 @@ function initialEnvValues(opts: JudgeOptions): Record<string, string> {
   };
 }
 
+/** 非交互安装：必填项缺失时直接报错。 */
+function nonInteractiveEnvValues(opts: JudgeOptions): Record<string, string> {
+  const values = baseEnvValues(opts);
+  const requireValue = (key: string): void => {
+    if ((values[key] ?? "").trim() !== "") return;
+    throw new Error(`非交互安装缺少必填配置：${key}`);
+  };
+  requireValue("NOJ_VERSION");
+  requireValue("REDIS_URL");
+  requireValue("JUDGE_DOCKER_SOCKET");
+  requireValue("JUDGE_DOCKER_SOCKET_GID");
+  return values;
+}
+
+/** 交互式读取配置项：环境变量已存在时跳过，否则按默认值提示。 */
+async function promptValue(
+  io: PromptIO,
+  key: string,
+  label: string,
+  defaultValue?: string,
+  options?: { secret?: boolean; hint?: string },
+): Promise<string> {
+  const fromEnv = Deno.env.get(key)?.trim();
+  if (fromEnv) return fromEnv;
+  if (options?.hint) io.write(`  说明：${options.hint}\n`);
+  if (options?.secret) {
+    return secretInput(io, `  ${label}`);
+  }
+  while (true) {
+    const raw = await input(io, `  ${label}`, defaultValue);
+    if (raw.trim() !== "") return raw.trim();
+    io.write("输入不能为空，请重试。\n");
+  }
+}
+
+/** Redis 交互配置：已有环境变量、已有 Redis / 本机 Redis / 稍后配置。 */
+async function promptRedis(
+  io: PromptIO,
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<{ url: string; checkUrl: string; source: string }> {
+  const existingUrl = Deno.env.get("REDIS_URL")?.trim();
+  if (existingUrl) {
+    return {
+      url: existingUrl,
+      checkUrl: Deno.env.get("REDIS_CHECK_URL")?.trim() || existingUrl,
+      source: "existing",
+    };
+  }
+
+  io.write("\n配置 Redis\n");
+  io.write("Redis 是 noj-core 和 Judge 之间传递评测任务的中转站。\n");
+  io.write(
+    "Judge 必须连接 noj-core 正在使用的同一个 Redis、数据库和队列。\n\n",
+  );
+  const choice = await select(io, "请选择 Redis 来源", [
+    "连接已有 Redis（推荐，适合生产环境）",
+    "创建本机 Redis（仅适合明确知道 core 也要使用它的场景）",
+    "稍后配置（本次不会启动 Judge）",
+  ]);
+  switch (choice) {
+    case 0: {
+      const url = await secretInput(io, "  Redis 完整连接地址");
+      return { url, checkUrl: url, source: "existing" };
+    }
+    case 1: {
+      await createLocalRedis(opts, runner);
+      const { metadata } = redisConnectionFiles(opts);
+      const meta = loadJudgeEnv(metadata);
+      const runtimeUrl = envValue(meta, "REDIS_RUNTIME_URL") ?? "";
+      const checkUrl = envValue(meta, "REDIS_CHECK_URL") ?? "";
+      if (!runtimeUrl || !checkUrl) {
+        throw new Error(`本机 Redis 连接信息不完整：${metadata}`);
+      }
+      return { url: runtimeUrl, checkUrl, source: "local" };
+    }
+    default:
+      throw new Error(
+        "已选择稍后配置；请配置与 noj-core 相同的 REDIS_URL 后重新执行 install",
+      );
+  }
+}
+
+/** 交互式生成 .env.judge 的完整配置值。 */
+async function interactiveEnvValues(
+  io: PromptIO,
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<Record<string, string>> {
+  const values = baseEnvValues(opts);
+
+  values.NOJ_VERSION = opts.version ??
+    await promptValue(
+      io,
+      "NOJ_VERSION",
+      "Worker 版本（例如 0.8.0-rc.1）",
+      undefined,
+      {
+        hint: "填已发布的镜像版本，不要填写 main 或 latest。",
+      },
+    );
+  const redis = await promptRedis(io, opts, runner);
+  values.REDIS_URL = redis.url;
+  values.REDIS_CHECK_URL = redis.checkUrl;
+  values.REDIS_SOURCE = redis.source;
+  values.JUDGE_QUEUE = await promptValue(
+    io,
+    "JUDGE_QUEUE",
+    "任务队列名称",
+    "noj:judge:queue",
+    { hint: "必须与 noj-core 的任务队列名称一致，通常直接回车。" },
+  );
+  values.RESULT_QUEUE = await promptValue(
+    io,
+    "RESULT_QUEUE",
+    "结果队列名称",
+    "noj:judge:results",
+    { hint: "必须与 noj-core 的结果队列名称一致，通常直接回车。" },
+  );
+  values.WORK_DIR = await promptValue(
+    io,
+    "WORK_DIR",
+    "Worker 容器工作目录",
+    "/tmp/noj-judge",
+    { hint: "容器内部目录，通常直接回车。" },
+  );
+  values.JUDGE_MAX_CONCURRENT_JUDGES = await promptValue(
+    io,
+    "JUDGE_MAX_CONCURRENT_JUDGES",
+    "最大并发评测数",
+    "2",
+    { hint: "同时运行的评测数量；机器资源较少时可填写 1。" },
+  );
+  values.JUDGE_IMAGE_PREFIX = await promptValue(
+    io,
+    "JUDGE_IMAGE_PREFIX",
+    "评测镜像前缀",
+    "noj-",
+    { hint: "题目运行时镜像的前缀，通常直接回车。" },
+  );
+  values.JUDGE_IMAGE_REGISTRY = await promptValue(
+    io,
+    "JUDGE_IMAGE_REGISTRY",
+    "Worker 镜像仓库",
+    "ghcr.io/neuro-oj",
+    { hint: "Worker 镜像所在仓库，不要填写末尾的 /noj-judge。" },
+  );
+  values.JUDGE_DOCKER_SOCKET = await promptValue(
+    io,
+    "JUDGE_DOCKER_SOCKET",
+    "专用 Docker socket 路径",
+    "/run/noj-judge/docker.sock",
+    { hint: "必须是 Judge 专用 rootless socket，不能使用宿主机共享 socket。" },
+  );
+  values.JUDGE_DOCKER_SOCKET_GID = await promptValue(
+    io,
+    "JUDGE_DOCKER_SOCKET_GID",
+    "Docker socket 所属组 GID",
+    "10001",
+    {
+      hint:
+        "可用 stat -c '%g' /run/noj-judge/docker.sock 查询；必须与 socket 实际 GID 一致。",
+    },
+  );
+  values.JUDGE_UID = await promptValue(
+    io,
+    "JUDGE_UID",
+    "Worker 用户 UID",
+    "10001",
+    { hint: "容器内非 root 用户，通常直接回车。" },
+  );
+  values.JUDGE_GID = await promptValue(
+    io,
+    "JUDGE_GID",
+    "Worker 用户 GID",
+    "10001",
+    { hint: "容器内非 root 用户组，通常直接回车。" },
+  );
+
+  return values;
+}
+
 /**
  * 初始化 Judge 环境文件。
  * 已有配置时保留并视需要更新 NOJ_VERSION；dry-run 时不写文件；
- * 文件缺失且非 dry-run 时从环境变量/默认值生成配置。
+ * 文件缺失且非 dry-run 时按非交互环境变量或交互提示生成配置。
  */
-function initializeJudgeEnv(opts: JudgeOptions): void {
-  const envExists = fileMode(opts.envFile) !== 0;
+async function initializeJudgeEnv(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+  io: PromptIO,
+): Promise<void> {
+  const envExists = await fileExists(opts.envFile);
 
   if (opts.dryRun) {
     if (envExists) {
@@ -121,14 +290,11 @@ function initializeJudgeEnv(opts: JudgeOptions): void {
     return;
   }
 
-  if (!opts.nonInteractive) {
-    throw new Error(
-      "交互式安装尚未实现，请使用 --non-interactive 并提供环境变量，或预先创建 .env.judge",
-    );
-  }
-
   Deno.mkdirSync(opts.dir, { recursive: true });
-  saveJudgeEnv(opts.envFile, initialEnvValues(opts));
+  const values = opts.nonInteractive
+    ? nonInteractiveEnvValues(opts)
+    : await interactiveEnvValues(io, opts, runner);
+  saveJudgeEnv(opts.envFile, values);
   console.log(`已创建配置：${opts.envFile}`);
 }
 
@@ -169,7 +335,7 @@ async function checkJudgeConfiguration(
   }
 
   if (envExists) {
-    const mode = fileMode(opts.envFile) & 0o777;
+    const mode = statFileMode(opts.envFile) & 0o777;
     if (mode !== 0o600 && mode !== 0o400) {
       throw new Error(`配置文件权限必须为 600 或 400：${opts.envFile}`);
     }
@@ -217,26 +383,36 @@ async function checkJudgeConfiguration(
   console.log("Judge 配置检查通过");
 }
 
-/** install：初始化环境 → 写 compose → 检查 → pull → up。 */
+/** install：先检查基础环境，再初始化环境 → 写 compose → 检查 → pull → up。 */
 async function runInstall(
   opts: JudgeOptions,
   runner: CommandRunner,
+  io: PromptIO,
 ): Promise<number> {
-  initializeJudgeEnv(opts);
-  writeJudgeCompose(opts.composeFile, opts.dryRun);
   await checkBaseEnvironment(opts, runner);
+  await initializeJudgeEnv(opts, runner, io);
+  writeJudgeCompose(opts.composeFile, opts.dryRun);
   await checkJudgeConfiguration(opts, runner);
   const pull = await runJudgeCompose(opts, ["pull"], runner);
   if (pull !== 0) return pull;
   return runJudgeCompose(opts, ["up", "-d", "--remove-orphans"], runner);
 }
 
-/** install-env：检查 Docker/Compose 并输出 rootless 准备指引。 */
+/** install-env：检查 Docker/Compose/curl 并输出 rootless 准备指引。 */
 async function runInstallEnv(
   opts: JudgeOptions,
   runner: CommandRunner,
 ): Promise<number> {
   await checkBaseEnvironment(opts, runner);
+  let curlOk = false;
+  try {
+    curlOk = (await runner.run("curl", ["--version"])).code === 0;
+  } catch {
+    curlOk = false;
+  }
+  if (!curlOk) {
+    throw new Error("缺少依赖：curl");
+  }
   console.log(
     "\n请确认已准备以下隔离条件：\n" +
       "  1. 只服务于 Judge 的 rootless Docker daemon；\n" +
@@ -268,11 +444,14 @@ async function runStart(
   return runJudgeCompose(opts, ["up", "-d", "--remove-orphans"], runner);
 }
 
-/** stop：compose stop。 */
-function runStop(
+/** stop：先确认已安装，再 compose stop。 */
+async function runStop(
   opts: JudgeOptions,
   runner: CommandRunner,
 ): Promise<number> {
+  if (!(await fileExists(opts.envFile))) {
+    throw new Error(`找不到配置文件：${opts.envFile}，请先执行 install`);
+  }
   return runJudgeCompose(opts, ["stop"], runner);
 }
 
@@ -292,14 +471,18 @@ async function runStatus(
   return runJudgeCompose(opts, ["ps"], runner);
 }
 
-/** logs：查看 Judge 日志，可选 --follow。 */
-function runLogs(
+/** logs：先检查基础环境与已安装配置，再查看 Judge 日志。 */
+async function runLogs(
   opts: JudgeOptions,
   runner: CommandRunner,
 ): Promise<number> {
+  await checkBaseEnvironment(opts, runner);
+  if (!(await fileExists(opts.envFile))) {
+    throw new Error(`找不到配置文件：${opts.envFile}，请先执行 install`);
+  }
   const args = ["logs", "--tail=200"];
   if (opts.follow) args.push("--follow");
-  if (opts.follow && runner.stream) {
+  if (opts.follow && !opts.dryRun && runner.stream) {
     return runner.stream(
       "docker",
       composeArgs(opts, args),
@@ -314,17 +497,17 @@ async function runUpgrade(
   opts: JudgeOptions,
   runner: CommandRunner,
 ): Promise<number> {
-  const envExists = await fileExists(opts.envFile);
-  if (envExists) {
-    if (opts.version !== undefined) {
-      setJudgeEnv(opts.envFile, "NOJ_VERSION", opts.version);
-    } else {
-      console.log(`保留已有配置：${opts.envFile}`);
-    }
-  } else if (opts.dryRun) {
-    console.log(`[dry-run] 跳过配置更新：${opts.envFile} 不存在`);
-  } else {
+  if (!(await fileExists(opts.envFile))) {
     throw new Error(`找不到配置文件：${opts.envFile}，请先执行 install`);
+  }
+  if (opts.version !== undefined) {
+    if (opts.dryRun) {
+      console.log(`[dry-run] 将更新 NOJ_VERSION=${opts.version}`);
+    } else {
+      setJudgeEnv(opts.envFile, "NOJ_VERSION", opts.version);
+    }
+  } else {
+    console.log(`保留已有配置：${opts.envFile}`);
   }
 
   writeJudgeCompose(opts.composeFile, opts.dryRun);
@@ -392,6 +575,7 @@ async function downloadJudgeScript(
 export async function runJudgeCommand(
   opts: JudgeOptions,
   runner: CommandRunner = realRunner(),
+  io: PromptIO = realIO(),
 ): Promise<number> {
   try {
     if (opts.downloadOnly || opts.command === "download") {
@@ -399,7 +583,7 @@ export async function runJudgeCommand(
     }
     switch (opts.command) {
       case "install":
-        return await runInstall(opts, runner);
+        return await runInstall(opts, runner, io);
       case "install-env":
         return await runInstallEnv(opts, runner);
       case "check":

--- a/noj-cli/src/judge/commands.ts
+++ b/noj-cli/src/judge/commands.ts
@@ -1,0 +1,424 @@
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import { fileExists } from "../util/fs.ts";
+import {
+  checkBaseEnvironment,
+  checkConfigValues,
+  checkImageArchitecture,
+  checkRedis,
+  checkSocket,
+} from "./checks.ts";
+import { composeArgs, runJudgeCompose, writeJudgeCompose } from "./compose.ts";
+import type { JudgeEnv } from "./env.ts";
+import { envValue, loadJudgeEnv, saveJudgeEnv, setJudgeEnv } from "./env.ts";
+import type { JudgeOptions } from "./options.ts";
+
+/** 读取文件权限低位，文件不存在时返回 0。 */
+function fileMode(path: string): number {
+  try {
+    return Deno.statSync(path).mode ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** 生成初始化 .env.judge 所需的默认值；非交互必填项缺失时报错。 */
+function initialEnvValues(opts: JudgeOptions): Record<string, string> {
+  const get = (key: string): string | undefined => Deno.env.get(key);
+  const requireValue = (key: string, value: string | undefined): string => {
+    if (value !== undefined && value.trim() !== "") return value;
+    throw new Error(`非交互安装缺少必填配置：${key}`);
+  };
+  const optional = (key: string, fallback: string): string =>
+    get(key) ?? fallback;
+
+  const version = requireValue(
+    "NOJ_VERSION",
+    opts.version ?? get("NOJ_VERSION"),
+  );
+  const redisUrl = requireValue("REDIS_URL", get("REDIS_URL"));
+  const socket = requireValue(
+    "JUDGE_DOCKER_SOCKET",
+    get("JUDGE_DOCKER_SOCKET"),
+  );
+  const socketGid = requireValue(
+    "JUDGE_DOCKER_SOCKET_GID",
+    get("JUDGE_DOCKER_SOCKET_GID"),
+  );
+
+  return {
+    NOJ_VERSION: version,
+    REDIS_URL: redisUrl,
+    REDIS_CHECK_URL: optional("REDIS_CHECK_URL", redisUrl),
+    REDIS_SOURCE: optional("REDIS_SOURCE", "existing"),
+    JUDGE_QUEUE: optional("JUDGE_QUEUE", "noj:judge:queue"),
+    RESULT_QUEUE: optional("RESULT_QUEUE", "noj:judge:results"),
+    WORK_DIR: optional("WORK_DIR", "/tmp/noj-judge"),
+    JUDGE_MAX_CONCURRENT_JUDGES: optional("JUDGE_MAX_CONCURRENT_JUDGES", "2"),
+    JUDGE_IMAGE_PREFIX: optional("JUDGE_IMAGE_PREFIX", "noj-"),
+    JUDGE_IMAGE_REGISTRY: optional("JUDGE_IMAGE_REGISTRY", "ghcr.io/neuro-oj"),
+    JUDGE_DOCKER_SOCKET: socket,
+    JUDGE_DOCKER_SOCKET_GID: socketGid,
+    JUDGE_DOCKER_HOST: "unix:///run/noj-judge/docker.sock",
+    JUDGE_REQUIRE_ISOLATED_DOCKER: "true",
+    JUDGE_UID: optional("JUDGE_UID", "10001"),
+    JUDGE_GID: optional("JUDGE_GID", "10001"),
+    JUDGE_CPU_LIMIT_MILLICORES: optional("JUDGE_CPU_LIMIT_MILLICORES", "1000"),
+    JUDGE_MAX_EVALUATOR_TIME_MS: optional(
+      "JUDGE_MAX_EVALUATOR_TIME_MS",
+      "300000",
+    ),
+    JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS: optional(
+      "JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS",
+      "60000",
+    ),
+    JUDGE_COMMAND_WHITELIST: optional(
+      "JUDGE_COMMAND_WHITELIST",
+      "python3,deno,node,bash,sh",
+    ),
+    JUDGE_ALLOW_EVALUATOR_NETWORK: optional(
+      "JUDGE_ALLOW_EVALUATOR_NETWORK",
+      "false",
+    ),
+    JUDGE_EVALUATOR_NETWORK: optional("JUDGE_EVALUATOR_NETWORK", "bridge"),
+    JUDGE_ALLOW_HTTP_S3: optional("JUDGE_ALLOW_HTTP_S3", "false"),
+    SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT: optional(
+      "SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT",
+      "60",
+    ),
+    SUPPORT_CACHE_DIR: optional(
+      "SUPPORT_CACHE_DIR",
+      "/tmp/noj-judge/support-cache",
+    ),
+    SUPPORT_CACHE_MAX_ITEMS: optional("SUPPORT_CACHE_MAX_ITEMS", "500"),
+    SUPPORT_CACHE_MAX_MB: optional("SUPPORT_CACHE_MAX_MB", "2048"),
+  };
+}
+
+/**
+ * 初始化 Judge 环境文件。
+ * 已有配置时保留并视需要更新 NOJ_VERSION；dry-run 时不写文件；
+ * 文件缺失且非 dry-run 时从环境变量/默认值生成配置。
+ */
+function initializeJudgeEnv(opts: JudgeOptions): void {
+  const envExists = fileMode(opts.envFile) !== 0;
+
+  if (opts.dryRun) {
+    if (envExists) {
+      console.log(`[dry-run] 保留已有配置：${opts.envFile}`);
+    } else {
+      console.log(`[dry-run] 将创建配置：${opts.envFile}`);
+    }
+    return;
+  }
+
+  if (envExists) {
+    Deno.chmodSync(opts.envFile, 0o600);
+    console.log(`保留已有配置：${opts.envFile}`);
+    if (opts.version !== undefined) {
+      setJudgeEnv(opts.envFile, "NOJ_VERSION", opts.version);
+    }
+    return;
+  }
+
+  if (!opts.nonInteractive) {
+    throw new Error(
+      "交互式安装尚未实现，请使用 --non-interactive 并提供环境变量，或预先创建 .env.judge",
+    );
+  }
+
+  Deno.mkdirSync(opts.dir, { recursive: true });
+  saveJudgeEnv(opts.envFile, initialEnvValues(opts));
+  console.log(`已创建配置：${opts.envFile}`);
+}
+
+/** Redis 主机摘要，用于 status 输出。 */
+function redisHost(env: JudgeEnv): string {
+  const url = envValue(env, "REDIS_CHECK_URL") ?? envValue(env, "REDIS_URL") ??
+    "";
+  let rest = url.replace(/^[a-z]+:\/\//i, "");
+  const at = rest.indexOf("@");
+  if (at !== -1) rest = rest.slice(at + 1);
+  rest = rest.split("/")[0] ?? "";
+  const colon = rest.indexOf(":");
+  return (colon === -1 ? rest : rest.slice(0, colon)) || "未知主机";
+}
+
+/** 执行 Judge 配置检查：文件存在性/权限、配置值、socket、Redis、镜像和 Compose。 */
+async function checkJudgeConfiguration(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<void> {
+  const envExists = await fileExists(opts.envFile);
+  const composeExists = await fileExists(opts.composeFile);
+
+  if (opts.dryRun) {
+    if (!envExists || !composeExists) {
+      console.log("[dry-run] 跳过配置检查（配置文件尚不存在）");
+      return;
+    }
+  } else {
+    if (!envExists) {
+      throw new Error(`找不到配置文件：${opts.envFile}，请先执行 install`);
+    }
+    if (!composeExists) {
+      throw new Error(
+        `找不到 Compose 配置：${opts.composeFile}，请先执行 install`,
+      );
+    }
+  }
+
+  if (envExists) {
+    const mode = fileMode(opts.envFile) & 0o777;
+    if (mode !== 0o600 && mode !== 0o400) {
+      throw new Error(`配置文件权限必须为 600 或 400：${opts.envFile}`);
+    }
+  }
+
+  const env = loadJudgeEnv(opts.envFile);
+  const configIssues = checkConfigValues(env);
+  if (configIssues.length > 0) {
+    for (const issue of configIssues) console.error(`  - ${issue}`);
+    throw new Error("Judge 配置未完成，请修复上面的配置项");
+  }
+
+  const socketIssues = await checkSocket(env, runner);
+  if (socketIssues.length > 0) {
+    for (const issue of socketIssues) console.error(`  - ${issue}`);
+    throw new Error("Judge 配置检查失败，请修复上面的配置项");
+  }
+
+  if (opts.dryRun) {
+    console.log("[dry-run] 跳过 Redis、镜像和 Compose 实际连接检查");
+    console.log("Judge 配置检查通过");
+    return;
+  }
+
+  const redisIssues = await checkRedis(env, runner);
+  if (redisIssues.length > 0) {
+    for (const issue of redisIssues) console.error(`  - ${issue}`);
+    throw new Error("Redis 检查失败，请修复上面的配置项");
+  }
+
+  const imageIssues = await checkImageArchitecture(env, runner);
+  if (imageIssues.length > 0) {
+    for (const issue of imageIssues) console.error(`  - ${issue}`);
+    throw new Error("Worker 镜像架构检查失败，请修复上面的配置项");
+  }
+
+  const composeConfig = await runner.run(
+    "docker",
+    composeArgs(opts, ["config", "--quiet"]),
+  );
+  if (composeConfig.code !== 0) {
+    throw new Error("独立 Judge Compose 配置无效");
+  }
+
+  console.log("Judge 配置检查通过");
+}
+
+/** install：初始化环境 → 写 compose → 检查 → pull → up。 */
+async function runInstall(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<number> {
+  initializeJudgeEnv(opts);
+  writeJudgeCompose(opts.composeFile, opts.dryRun);
+  await checkBaseEnvironment(opts, runner);
+  await checkJudgeConfiguration(opts, runner);
+  const pull = await runJudgeCompose(opts, ["pull"], runner);
+  if (pull !== 0) return pull;
+  return runJudgeCompose(opts, ["up", "-d", "--remove-orphans"], runner);
+}
+
+/** install-env：检查 Docker/Compose 并输出 rootless 准备指引。 */
+async function runInstallEnv(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<number> {
+  await checkBaseEnvironment(opts, runner);
+  console.log(
+    "\n请确认已准备以下隔离条件：\n" +
+      "  1. 只服务于 Judge 的 rootless Docker daemon；\n" +
+      "  2. 独立 Unix socket（例如 /run/noj-judge/docker.sock）；\n" +
+      "  3. Worker 用户的 UID/GID 及 socket group 权限；\n" +
+      "  4. 与 noj-core 使用同一 Redis、任务队列和结果队列。\n\n" +
+      "本工具不会自动安装或替换 Docker daemon，也不会把 /var/run/docker.sock 提供给 Judge。",
+  );
+  return 0;
+}
+
+/** check：基础环境 + 配置检查。 */
+async function runCheck(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<number> {
+  await checkBaseEnvironment(opts, runner);
+  await checkJudgeConfiguration(opts, runner);
+  return 0;
+}
+
+/** start：检查后 compose up。 */
+async function runStart(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<number> {
+  await checkBaseEnvironment(opts, runner);
+  await checkJudgeConfiguration(opts, runner);
+  return runJudgeCompose(opts, ["up", "-d", "--remove-orphans"], runner);
+}
+
+/** stop：compose stop。 */
+function runStop(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<number> {
+  return runJudgeCompose(opts, ["stop"], runner);
+}
+
+/** status：检查后打印脱敏摘要并执行 compose ps。 */
+async function runStatus(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<number> {
+  await checkBaseEnvironment(opts, runner);
+  await checkJudgeConfiguration(opts, runner);
+  const env = loadJudgeEnv(opts.envFile);
+  console.log(`版本：${envValue(env, "NOJ_VERSION") ?? ""}`);
+  console.log(`Redis 主机：${redisHost(env)}`);
+  console.log(`任务队列：${envValue(env, "JUDGE_QUEUE") ?? ""}`);
+  console.log(`结果队列：${envValue(env, "RESULT_QUEUE") ?? ""}`);
+  console.log(`Docker socket：${envValue(env, "JUDGE_DOCKER_SOCKET") ?? ""}`);
+  return runJudgeCompose(opts, ["ps"], runner);
+}
+
+/** logs：查看 Judge 日志，可选 --follow。 */
+function runLogs(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<number> {
+  const args = ["logs", "--tail=200"];
+  if (opts.follow) args.push("--follow");
+  if (opts.follow && runner.stream) {
+    return runner.stream(
+      "docker",
+      composeArgs(opts, args),
+      (line) => console.log(line),
+    );
+  }
+  return runJudgeCompose(opts, args, runner);
+}
+
+/** upgrade：可选更新版本 → 写 compose → 检查 → pull → up。 */
+async function runUpgrade(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<number> {
+  const envExists = await fileExists(opts.envFile);
+  if (envExists) {
+    if (opts.version !== undefined) {
+      setJudgeEnv(opts.envFile, "NOJ_VERSION", opts.version);
+    } else {
+      console.log(`保留已有配置：${opts.envFile}`);
+    }
+  } else if (opts.dryRun) {
+    console.log(`[dry-run] 跳过配置更新：${opts.envFile} 不存在`);
+  } else {
+    throw new Error(`找不到配置文件：${opts.envFile}，请先执行 install`);
+  }
+
+  writeJudgeCompose(opts.composeFile, opts.dryRun);
+  await checkBaseEnvironment(opts, runner);
+  await checkJudgeConfiguration(opts, runner);
+  const pull = await runJudgeCompose(opts, ["pull"], runner);
+  if (pull !== 0) return pull;
+  return runJudgeCompose(opts, ["up", "-d", "--remove-orphans"], runner);
+}
+
+/** download：下载 judge-install.sh 到目标目录（保留脚本兜底）。 */
+async function downloadJudgeScript(
+  opts: JudgeOptions,
+  runner: CommandRunner,
+): Promise<number> {
+  const repoPattern = /^https:\/\/github\.com\/[^/]+\/[^/]+?\/?$/;
+  if (!repoPattern.test(opts.repo)) {
+    throw new Error("--repo 目前只支持 https://github.com/组织/仓库");
+  }
+  const slug = opts.repo
+    .replace(/^https:\/\/github\.com\//, "")
+    .replace(/\/$/, "")
+    .replace(/\.git$/, "");
+  const url =
+    `https://raw.githubusercontent.com/${slug}/${opts.ref}/scripts/deploy/judge-install.sh`;
+  const target = `${opts.dir}/judge-install.sh`;
+
+  if (opts.dryRun) {
+    console.log(`[dry-run] 将下载部署脚本：${url} -> ${target}`);
+    return 0;
+  }
+
+  Deno.mkdirSync(opts.dir, { recursive: true });
+  const tmp = `${opts.dir}/.judge-install.${crypto.randomUUID()}`;
+  const curl = await runner.run("curl", [
+    "-fsSL",
+    "--retry",
+    "3",
+    url,
+    "-o",
+    tmp,
+  ]);
+  if (curl.code !== 0) {
+    await Deno.remove(tmp).catch(() => {});
+    throw new Error(`下载部署脚本失败，请检查仓库、ref 和网络：${url}`);
+  }
+
+  const bash = await runner.run("bash", ["-n", tmp]);
+  if (bash.code !== 0) {
+    await Deno.remove(tmp).catch(() => {});
+    throw new Error(`下载内容不是有效 Bash 脚本：${url}`);
+  }
+
+  await Deno.chmod(tmp, 0o700);
+  await Deno.rename(tmp, target);
+  console.log(`已下载部署脚本：${target}`);
+  return 0;
+}
+
+/**
+ * Judge 命令聚合入口。
+ * 依据 `scripts/deploy/judge-install.sh` 的 main() 映射到各命令实现；
+ * 返回 0 或非零退出码，错误统一打印 `judge: ...`。
+ */
+export async function runJudgeCommand(
+  opts: JudgeOptions,
+  runner: CommandRunner = realRunner(),
+): Promise<number> {
+  try {
+    if (opts.downloadOnly || opts.command === "download") {
+      return await downloadJudgeScript(opts, runner);
+    }
+    switch (opts.command) {
+      case "install":
+        return await runInstall(opts, runner);
+      case "install-env":
+        return await runInstallEnv(opts, runner);
+      case "check":
+        return await runCheck(opts, runner);
+      case "start":
+        return await runStart(opts, runner);
+      case "stop":
+        return await runStop(opts, runner);
+      case "status":
+        return await runStatus(opts, runner);
+      case "logs":
+        return await runLogs(opts, runner);
+      case "upgrade":
+        return await runUpgrade(opts, runner);
+      default:
+        throw new Error(`未知 judge 命令: ${opts.command}`);
+    }
+  } catch (e) {
+    console.error(`judge: ${(e as Error).message}`);
+    return 1;
+  }
+}

--- a/noj-cli/src/judge/commands_test.ts
+++ b/noj-cli/src/judge/commands_test.ts
@@ -1,0 +1,363 @@
+import { assertEquals } from "@std/assert";
+import type { CmdResult, CommandRunner } from "../runtime/command.ts";
+import { writeJudgeCompose } from "./compose.ts";
+import { runJudgeCommand } from "./commands.ts";
+import { envValue, loadJudgeEnv, saveJudgeEnv } from "./env.ts";
+import type { JudgeOptions } from "./options.ts";
+
+/** 可记录调用并返回成功结果的 fake runner。 */
+function fakeRunner(
+  records: { cmd: string; args: string[] }[],
+  handler?: (cmd: string, args: string[]) => CmdResult,
+): CommandRunner {
+  return {
+    run(cmd, args) {
+      records.push({ cmd, args });
+      if (handler) return Promise.resolve(handler(cmd, args));
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+function fakeRunnerWithConfiguredChecks(
+  dir: string,
+  records: { cmd: string; args: string[] }[],
+): CommandRunner {
+  return fakeRunner(records, (cmd, args) => {
+    if (cmd === "uname" && args[0] === "-s") {
+      return { code: 0, stdout: "Linux\n", stderr: "" };
+    }
+    if (cmd === "uname" && args[0] === "-m") {
+      return { code: 0, stdout: "x86_64\n", stderr: "" };
+    }
+    if (cmd === "df" && args[0] === "-Pk" && args[1] === dir) {
+      return {
+        code: 0,
+        stdout:
+          `Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/x 1 1 999999999 1% ${dir}\n`,
+        stderr: "",
+      };
+    }
+    if (cmd === "docker" && args[0] === "image" && args[1] === "inspect") {
+      return { code: 0, stdout: "amd64\n", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+}
+
+const baseOpts: JudgeOptions = {
+  command: "check",
+  dir: "/srv/noj-judge",
+  envFile: "/srv/noj-judge/.env.judge",
+  composeFile: "/srv/noj-judge/docker-compose.judge.yml",
+  repo: "https://github.com/Neuro-OJ/neuro-oj",
+  ref: "main",
+  version: undefined,
+  redisContainer: "noj-judge-redis",
+  redisPort: 16379,
+  panel: "none",
+  nonInteractive: true,
+  downloadOnly: false,
+  dryRun: true,
+  follow: false,
+};
+
+const completeValues: Record<string, string> = {
+  NOJ_VERSION: "v0.1.0",
+  REDIS_URL: "redis://127.0.0.1:6379/0",
+  REDIS_CHECK_URL: "redis://127.0.0.1:6379/0",
+  REDIS_SOURCE: "existing",
+  JUDGE_QUEUE: "noj:judge:queue",
+  RESULT_QUEUE: "noj:judge:results",
+  WORK_DIR: "/tmp/noj-judge",
+  JUDGE_MAX_CONCURRENT_JUDGES: "2",
+  JUDGE_IMAGE_PREFIX: "noj-",
+  JUDGE_IMAGE_REGISTRY: "ghcr.io/neuro-oj",
+  JUDGE_DOCKER_SOCKET: "",
+  JUDGE_DOCKER_SOCKET_GID: "",
+  JUDGE_UID: "10001",
+  JUDGE_GID: "10001",
+  JUDGE_DOCKER_HOST: "unix:///run/noj-judge/docker.sock",
+  JUDGE_REQUIRE_ISOLATED_DOCKER: "true",
+};
+
+/** 创建带完整配置、Compose 文件和 Unix socket 的选项。 */
+function configuredOpts(
+  command: JudgeOptions["command"],
+  overrides: Partial<JudgeOptions> = {},
+): { opts: JudgeOptions; cleanup: () => void } {
+  const dir = Deno.makeTempDirSync();
+  const envFile = `${dir}/.env.judge`;
+  const composeFile = `${dir}/docker-compose.judge.yml`;
+  const socketPath = `${dir}/docker.sock`;
+  let listener: Deno.Listener;
+  try {
+    listener = Deno.listen({ path: socketPath, transport: "unix" });
+    const stat = Deno.statSync(socketPath);
+    const gid = stat.gid?.toString() ?? "";
+    saveJudgeEnv(envFile, {
+      ...completeValues,
+      JUDGE_DOCKER_SOCKET: socketPath,
+      JUDGE_DOCKER_SOCKET_GID: gid,
+    });
+    writeJudgeCompose(composeFile, false);
+  } catch (e) {
+    throw e;
+  }
+  return {
+    opts: {
+      ...baseOpts,
+      ...overrides,
+      command,
+      dir,
+      envFile,
+      composeFile,
+      dryRun: false,
+    },
+    cleanup() {
+      try {
+        listener.close();
+      } catch {
+        // 忽略已关闭
+      }
+    },
+  };
+}
+
+Deno.test("judge check dry-run 返回 0", async () => {
+  const records: { cmd: string; args: string[] }[] = [];
+  const code = await runJudgeCommand(
+    { ...baseOpts, dryRun: true },
+    fakeRunner(records),
+  );
+  assertEquals(code, 0);
+});
+
+Deno.test("judge check 完整配置通过返回 0", async () => {
+  const { opts, cleanup } = configuredOpts("check");
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(opts.dir, records),
+    );
+    assertEquals(code, 0);
+    assertEquals(
+      records.some((r) =>
+        r.cmd === "docker" && r.args[0] === "compose" &&
+        r.args.includes("config") && r.args.includes("--quiet")
+      ),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("judge install 按序执行 pull 与 up", async () => {
+  const { opts, cleanup } = configuredOpts("install", { version: "v0.1.0" });
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(opts.dir, records),
+    );
+    assertEquals(code, 0);
+    const composeCalls = records.filter((r) =>
+      r.cmd === "docker" && r.args[0] === "compose"
+    ).map((r) => r.args);
+    const pullIdx = composeCalls.findIndex((a) => a.includes("pull"));
+    const upIdx = composeCalls.findIndex((a) =>
+      a.includes("up") && a.includes("-d") && a.includes("--remove-orphans")
+    );
+    assertEquals(pullIdx >= 0, true);
+    assertEquals(upIdx >= 0, true);
+    assertEquals(pullIdx < upIdx, true);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("judge install-env 返回 0", async () => {
+  const records: { cmd: string; args: string[] }[] = [];
+  const code = await runJudgeCommand(
+    { ...baseOpts, command: "install-env", dryRun: false },
+    fakeRunnerWithConfiguredChecks(baseOpts.dir, records),
+  );
+  assertEquals(code, 0);
+});
+
+Deno.test("judge start 执行 compose up", async () => {
+  const { opts, cleanup } = configuredOpts("start");
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(opts.dir, records),
+    );
+    assertEquals(code, 0);
+    assertEquals(
+      records.some((r) =>
+        r.cmd === "docker" && r.args[0] === "compose" &&
+        r.args.includes("up") && r.args.includes("-d") &&
+        r.args.includes("--remove-orphans")
+      ),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("judge stop 执行 compose stop", async () => {
+  const records: { cmd: string; args: string[] }[] = [];
+  const code = await runJudgeCommand(
+    { ...baseOpts, command: "stop", dryRun: false },
+    fakeRunner(records),
+  );
+  assertEquals(code, 0);
+  assertEquals(
+    records.some((r) =>
+      r.cmd === "docker" && r.args[0] === "compose" && r.args.includes("stop")
+    ),
+    true,
+  );
+});
+
+Deno.test("judge status 输出摘要并执行 compose ps", async () => {
+  const { opts, cleanup } = configuredOpts("status");
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(opts.dir, records),
+    );
+    assertEquals(code, 0);
+    assertEquals(
+      records.some((r) =>
+        r.cmd === "docker" && r.args[0] === "compose" && r.args.includes("ps")
+      ),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("judge logs 执行 logs --tail=200", async () => {
+  const records: { cmd: string; args: string[] }[] = [];
+  const code = await runJudgeCommand(
+    { ...baseOpts, command: "logs", dryRun: false },
+    fakeRunner(records),
+  );
+  assertEquals(code, 0);
+  assertEquals(
+    records.some((r) =>
+      r.cmd === "docker" && r.args[0] === "compose" &&
+      r.args.includes("logs") && r.args.includes("--tail=200")
+    ),
+    true,
+  );
+});
+
+Deno.test("judge logs --follow 追加 --follow", async () => {
+  const records: { cmd: string; args: string[] }[] = [];
+  const code = await runJudgeCommand(
+    { ...baseOpts, command: "logs", dryRun: false, follow: true },
+    fakeRunner(records),
+  );
+  assertEquals(code, 0);
+  assertEquals(
+    records.some((r) =>
+      r.cmd === "docker" && r.args[0] === "compose" &&
+      r.args.includes("logs") && r.args.includes("--tail=200") &&
+      r.args.includes("--follow")
+    ),
+    true,
+  );
+});
+
+Deno.test("judge upgrade 更新 NOJ_VERSION 并执行 pull/up", async () => {
+  const { opts, cleanup } = configuredOpts("upgrade", {
+    version: "v0.2.0",
+  });
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(opts.dir, records),
+    );
+    assertEquals(code, 0);
+    const env = loadJudgeEnv(opts.envFile);
+    assertEquals(envValue(env, "NOJ_VERSION"), "v0.2.0");
+    const composeCalls = records.filter((r) =>
+      r.cmd === "docker" && r.args[0] === "compose"
+    ).map((r) => r.args);
+    assertEquals(composeCalls.some((a) => a.includes("pull")), true);
+    assertEquals(
+      composeCalls.some((a) =>
+        a.includes("up") && a.includes("-d") && a.includes("--remove-orphans")
+      ),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("judge download 下载脚本到目标目录", async () => {
+  const dir = Deno.makeTempDirSync();
+  const records: { cmd: string; args: string[] }[] = [];
+  const opts: JudgeOptions = {
+    ...baseOpts,
+    command: "download",
+    dir,
+    envFile: `${dir}/.env.judge`,
+    composeFile: `${dir}/docker-compose.judge.yml`,
+    dryRun: false,
+  };
+  const code = await runJudgeCommand(
+    opts,
+    fakeRunner(records, (cmd, args) => {
+      if (cmd === "curl") {
+        const outIdx = args.indexOf("-o");
+        const out = outIdx >= 0 ? args[outIdx + 1] : undefined;
+        if (out) Deno.writeTextFileSync(out, "#!/usr/bin/env bash\n");
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    }),
+  );
+  assertEquals(code, 0);
+  const script = `${dir}/judge-install.sh`;
+  const stat = Deno.statSync(script);
+  assertEquals(stat.isFile, true);
+  assertEquals(stat.mode! & 0o777, 0o700);
+  assertEquals(records.some((r) => r.cmd === "curl"), true);
+});
+
+Deno.test("judge download dry-run 不写文件", async () => {
+  const dir = Deno.makeTempDirSync();
+  const records: { cmd: string; args: string[] }[] = [];
+  const opts: JudgeOptions = {
+    ...baseOpts,
+    command: "download",
+    dir,
+    envFile: `${dir}/.env.judge`,
+    composeFile: `${dir}/docker-compose.judge.yml`,
+    dryRun: true,
+  };
+  const code = await runJudgeCommand(opts, fakeRunner(records));
+  assertEquals(code, 0);
+  let exists = false;
+  try {
+    Deno.statSync(`${dir}/judge-install.sh`);
+    exists = true;
+  } catch {
+    exists = false;
+  }
+  assertEquals(exists, false);
+});

--- a/noj-cli/src/judge/commands_test.ts
+++ b/noj-cli/src/judge/commands_test.ts
@@ -1,9 +1,28 @@
 import { assertEquals } from "@std/assert";
 import type { CmdResult, CommandRunner } from "../runtime/command.ts";
+import type { PromptIO } from "../tui/io.ts";
 import { writeJudgeCompose } from "./compose.ts";
 import { runJudgeCommand } from "./commands.ts";
 import { envValue, loadJudgeEnv, saveJudgeEnv } from "./env.ts";
 import type { JudgeOptions } from "./options.ts";
+
+/** 可编程 fake IO：按序消费 answers，记录 writes。 */
+class FakeIO implements PromptIO {
+  writes: string[] = [];
+  answers: string[];
+  constructor(answers: string[]) {
+    this.answers = answers;
+  }
+  write(text: string): void {
+    this.writes.push(text);
+  }
+  readLine(_p: string): Promise<string> {
+    return Promise.resolve(this.answers.shift() ?? "");
+  }
+  readSecret(_p: string): Promise<string> {
+    return Promise.resolve(this.answers.shift() ?? "");
+  }
+}
 
 /** 可记录调用并返回成功结果的 fake runner。 */
 function fakeRunner(
@@ -127,6 +146,38 @@ function configuredOpts(
   };
 }
 
+/** 临时清空 judge 安装必需环境变量并返回恢复函数。 */
+function withClearedJudgeEnv(
+  fn: () => Promise<void>,
+): Promise<void> {
+  const keys = [
+    "NOJ_VERSION",
+    "REDIS_URL",
+    "REDIS_CHECK_URL",
+    "REDIS_SOURCE",
+    "JUDGE_QUEUE",
+    "RESULT_QUEUE",
+    "WORK_DIR",
+    "JUDGE_MAX_CONCURRENT_JUDGES",
+    "JUDGE_IMAGE_PREFIX",
+    "JUDGE_IMAGE_REGISTRY",
+    "JUDGE_DOCKER_SOCKET",
+    "JUDGE_DOCKER_SOCKET_GID",
+    "JUDGE_UID",
+    "JUDGE_GID",
+  ];
+  const old = new Map(keys.map((k) => [k, Deno.env.get(k)]));
+  for (const k of keys) Deno.env.delete(k);
+  try {
+    return fn();
+  } finally {
+    for (const [k, v] of old) {
+      if (v === undefined) Deno.env.delete(k);
+      else Deno.env.set(k, v);
+    }
+  }
+}
+
 Deno.test("judge check dry-run 返回 0", async () => {
   const records: { cmd: string; args: string[] }[] = [];
   const code = await runJudgeCommand(
@@ -181,6 +232,91 @@ Deno.test("judge install 按序执行 pull 与 up", async () => {
   }
 });
 
+Deno.test("judge install 非交互缺少必填配置返回 1", async () => {
+  const dir = Deno.makeTempDirSync();
+  const records: { cmd: string; args: string[] }[] = [];
+  const opts: JudgeOptions = {
+    ...baseOpts,
+    command: "install",
+    dir,
+    envFile: `${dir}/.env.judge`,
+    composeFile: `${dir}/docker-compose.judge.yml`,
+    nonInteractive: true,
+    dryRun: false,
+  };
+  await withClearedJudgeEnv(async () => {
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(dir, records),
+    );
+    assertEquals(code, 1);
+  });
+});
+
+Deno.test("judge install 交互式完整流程写入配置并启动", async () => {
+  await withClearedJudgeEnv(async () => {
+    const dir = Deno.makeTempDirSync();
+    const envFile = `${dir}/.env.judge`;
+    const composeFile = `${dir}/docker-compose.judge.yml`;
+    const socketPath = `${dir}/docker.sock`;
+    let listener: Deno.Listener | undefined;
+    try {
+      listener = Deno.listen({ path: socketPath, transport: "unix" });
+      const gid = Deno.statSync(socketPath).gid?.toString() ?? "10001";
+      const io = new FakeIO([
+        "v0.1.0", // NOJ_VERSION
+        "1", // Redis 来源：连接已有 Redis
+        "redis://127.0.0.1:6379/0", // REDIS_URL（隐藏输入）
+        "", // JUDGE_QUEUE 默认
+        "", // RESULT_QUEUE 默认
+        "", // WORK_DIR 默认
+        "", // JUDGE_MAX_CONCURRENT_JUDGES 默认
+        "", // JUDGE_IMAGE_PREFIX 默认
+        "", // JUDGE_IMAGE_REGISTRY 默认
+        socketPath, // JUDGE_DOCKER_SOCKET
+        gid, // JUDGE_DOCKER_SOCKET_GID
+        "", // JUDGE_UID 默认
+        "", // JUDGE_GID 默认
+      ]);
+      const opts: JudgeOptions = {
+        ...baseOpts,
+        command: "install",
+        dir,
+        envFile,
+        composeFile,
+        nonInteractive: false,
+        dryRun: false,
+      };
+      const records: { cmd: string; args: string[] }[] = [];
+      const code = await runJudgeCommand(
+        opts,
+        fakeRunnerWithConfiguredChecks(dir, records),
+        io,
+      );
+      assertEquals(code, 0);
+      const env = loadJudgeEnv(envFile);
+      assertEquals(envValue(env, "NOJ_VERSION"), "v0.1.0");
+      assertEquals(envValue(env, "REDIS_URL"), "redis://127.0.0.1:6379/0");
+      assertEquals(envValue(env, "JUDGE_DOCKER_SOCKET"), socketPath);
+      const mode = Deno.statSync(envFile).mode! & 0o777;
+      assertEquals(mode, 0o600);
+      assertEquals(
+        records.some((r) =>
+          r.cmd === "docker" && r.args[0] === "compose" &&
+          r.args.includes("pull")
+        ),
+        true,
+      );
+    } finally {
+      try {
+        if (listener) listener.close();
+      } catch {
+        // 忽略已关闭
+      }
+    }
+  });
+});
+
 Deno.test("judge install-env 返回 0", async () => {
   const records: { cmd: string; args: string[] }[] = [];
   const code = await runJudgeCommand(
@@ -213,17 +349,43 @@ Deno.test("judge start 执行 compose up", async () => {
 });
 
 Deno.test("judge stop 执行 compose stop", async () => {
+  const { opts, cleanup } = configuredOpts("stop");
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(opts.dir, records),
+    );
+    assertEquals(code, 0);
+    assertEquals(
+      records.some((r) =>
+        r.cmd === "docker" && r.args[0] === "compose" && r.args.includes("stop")
+      ),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("judge stop 缺少配置文件返回 1 且不执行 compose", async () => {
+  const dir = Deno.makeTempDirSync();
   const records: { cmd: string; args: string[] }[] = [];
-  const code = await runJudgeCommand(
-    { ...baseOpts, command: "stop", dryRun: false },
-    fakeRunner(records),
-  );
-  assertEquals(code, 0);
+  const opts: JudgeOptions = {
+    ...baseOpts,
+    command: "stop",
+    dir,
+    envFile: `${dir}/.env.judge`,
+    composeFile: `${dir}/docker-compose.judge.yml`,
+    dryRun: false,
+  };
+  const code = await runJudgeCommand(opts, fakeRunner(records));
+  assertEquals(code, 1);
   assertEquals(
     records.some((r) =>
       r.cmd === "docker" && r.args[0] === "compose" && r.args.includes("stop")
     ),
-    true,
+    false,
   );
 });
 
@@ -248,35 +410,97 @@ Deno.test("judge status 输出摘要并执行 compose ps", async () => {
 });
 
 Deno.test("judge logs 执行 logs --tail=200", async () => {
-  const records: { cmd: string; args: string[] }[] = [];
-  const code = await runJudgeCommand(
-    { ...baseOpts, command: "logs", dryRun: false },
-    fakeRunner(records),
-  );
-  assertEquals(code, 0);
-  assertEquals(
-    records.some((r) =>
-      r.cmd === "docker" && r.args[0] === "compose" &&
-      r.args.includes("logs") && r.args.includes("--tail=200")
-    ),
-    true,
-  );
+  const { opts, cleanup } = configuredOpts("logs");
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(opts.dir, records),
+    );
+    assertEquals(code, 0);
+    assertEquals(
+      records.some((r) =>
+        r.cmd === "docker" && r.args[0] === "compose" &&
+        r.args.includes("logs") && r.args.includes("--tail=200")
+      ),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
 });
 
 Deno.test("judge logs --follow 追加 --follow", async () => {
+  const { opts, cleanup } = configuredOpts("logs", { follow: true });
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(opts.dir, records),
+    );
+    assertEquals(code, 0);
+    assertEquals(
+      records.some((r) =>
+        r.cmd === "docker" && r.args[0] === "compose" &&
+        r.args.includes("logs") && r.args.includes("--tail=200") &&
+        r.args.includes("--follow")
+      ),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("judge logs --follow --dry-run 不执行 stream", async () => {
+  const { opts, cleanup } = configuredOpts("logs", { follow: true });
+  opts.dryRun = true;
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    let streamCalled = false;
+    const runner: CommandRunner = {
+      ...fakeRunnerWithConfiguredChecks(opts.dir, records),
+      stream() {
+        streamCalled = true;
+        return Promise.resolve(0);
+      },
+    };
+    const code = await runJudgeCommand(opts, runner);
+    assertEquals(code, 0);
+    assertEquals(streamCalled, false);
+    assertEquals(
+      records.some((r) =>
+        r.cmd === "docker" && r.args[0] === "compose" &&
+        r.args.includes("logs") && r.args.includes("--follow")
+      ),
+      false,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("judge logs 缺少配置文件返回 1 且不执行 compose logs", async () => {
+  const dir = Deno.makeTempDirSync();
   const records: { cmd: string; args: string[] }[] = [];
+  const opts: JudgeOptions = {
+    ...baseOpts,
+    command: "logs",
+    dir,
+    envFile: `${dir}/.env.judge`,
+    composeFile: `${dir}/docker-compose.judge.yml`,
+    dryRun: false,
+  };
   const code = await runJudgeCommand(
-    { ...baseOpts, command: "logs", dryRun: false, follow: true },
-    fakeRunner(records),
+    opts,
+    fakeRunnerWithConfiguredChecks(dir, records),
   );
-  assertEquals(code, 0);
+  assertEquals(code, 1);
   assertEquals(
     records.some((r) =>
-      r.cmd === "docker" && r.args[0] === "compose" &&
-      r.args.includes("logs") && r.args.includes("--tail=200") &&
-      r.args.includes("--follow")
+      r.cmd === "docker" && r.args[0] === "compose" && r.args.includes("logs")
     ),
-    true,
+    false,
   );
 });
 
@@ -306,6 +530,47 @@ Deno.test("judge upgrade 更新 NOJ_VERSION 并执行 pull/up", async () => {
   } finally {
     cleanup();
   }
+});
+
+Deno.test("judge upgrade --dry-run 不更新环境文件", async () => {
+  const { opts, cleanup } = configuredOpts("upgrade", {
+    version: "v0.2.0",
+  });
+  opts.dryRun = true;
+  try {
+    const records: { cmd: string; args: string[] }[] = [];
+    const code = await runJudgeCommand(
+      opts,
+      fakeRunnerWithConfiguredChecks(opts.dir, records),
+    );
+    assertEquals(code, 0);
+    const env = loadJudgeEnv(opts.envFile);
+    assertEquals(envValue(env, "NOJ_VERSION"), "v0.1.0");
+    assertEquals(
+      records.some((r) =>
+        r.cmd === "docker" && r.args[0] === "compose" && r.args.includes("pull")
+      ),
+      false,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("judge upgrade --dry-run 缺少配置文件返回 1", async () => {
+  const dir = Deno.makeTempDirSync();
+  const records: { cmd: string; args: string[] }[] = [];
+  const opts: JudgeOptions = {
+    ...baseOpts,
+    command: "upgrade",
+    dir,
+    envFile: `${dir}/.env.judge`,
+    composeFile: `${dir}/docker-compose.judge.yml`,
+    dryRun: true,
+    version: "v0.2.0",
+  };
+  const code = await runJudgeCommand(opts, fakeRunner(records));
+  assertEquals(code, 1);
 });
 
 Deno.test("judge download 下载脚本到目标目录", async () => {

--- a/noj-cli/src/judge/compose.ts
+++ b/noj-cli/src/judge/compose.ts
@@ -1,0 +1,106 @@
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import type { JudgeOptions } from "./options.ts";
+
+/** 独立 Judge Compose 项目名。 */
+const PROJECT_NAME = "noj-judge-standalone";
+
+/**
+ * 渲染独立 Judge 的 docker-compose 配置。
+ * 模板与 `scripts/deploy/judge-install.sh` 的 `write_compose` 保持一致。
+ */
+export function renderJudgeCompose(): string {
+  return `services:
+  judge:
+    image: "\${JUDGE_IMAGE_REGISTRY:-ghcr.io/neuro-oj}/noj-judge:\${NOJ_VERSION:?NOJ_VERSION is required}"
+    environment:
+      REDIS_URL: "\${REDIS_URL:?REDIS_URL is required}"
+      JUDGE_QUEUE: "\${JUDGE_QUEUE:-noj:judge:queue}"
+      RESULT_QUEUE: "\${RESULT_QUEUE:-noj:judge:results}"
+      WORK_DIR: "\${WORK_DIR:-/tmp/noj-judge}"
+      JUDGE_MAX_CONCURRENT_JUDGES: "\${JUDGE_MAX_CONCURRENT_JUDGES:-2}"
+      JUDGE_CPU_LIMIT_MILLICORES: "\${JUDGE_CPU_LIMIT_MILLICORES:-1000}"
+      JUDGE_MAX_EVALUATOR_TIME_MS: "\${JUDGE_MAX_EVALUATOR_TIME_MS:-300000}"
+      JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS: "\${JUDGE_MAX_SOLUTION_CALL_TIMEOUT_MS:-60000}"
+      JUDGE_IMAGE_PREFIX: "\${JUDGE_IMAGE_PREFIX:-noj-}"
+      JUDGE_COMMAND_WHITELIST: "\${JUDGE_COMMAND_WHITELIST:-python3,deno,node,bash,sh}"
+      JUDGE_ALLOW_EVALUATOR_NETWORK: "\${JUDGE_ALLOW_EVALUATOR_NETWORK:-false}"
+      JUDGE_EVALUATOR_NETWORK: "\${JUDGE_EVALUATOR_NETWORK:-bridge}"
+      JUDGE_ALLOW_HTTP_S3: "\${JUDGE_ALLOW_HTTP_S3:-false}"
+      JUDGE_DOCKER_HOST: "\${JUDGE_DOCKER_HOST:-unix:///run/noj-judge/docker.sock}"
+      JUDGE_REQUIRE_ISOLATED_DOCKER: "true"
+      SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT: "\${SUPPORT_PACKAGE_DOWNLOAD_TIMEOUT:-60}"
+      SUPPORT_CACHE_DIR: "\${SUPPORT_CACHE_DIR:-/tmp/noj-judge/support-cache}"
+      SUPPORT_CACHE_MAX_ITEMS: "\${SUPPORT_CACHE_MAX_ITEMS:-500}"
+      SUPPORT_CACHE_MAX_MB: "\${SUPPORT_CACHE_MAX_MB:-2048}"
+    volumes:
+      - "\${JUDGE_DOCKER_SOCKET:?JUDGE_DOCKER_SOCKET is required}:/run/noj-judge/docker.sock:ro"
+      - judge-cache:/tmp/noj-judge
+    user: "\${JUDGE_UID:-10001}:\${JUDGE_GID:-10001}"
+    group_add:
+      - "\${JUDGE_DOCKER_SOCKET_GID:?JUDGE_DOCKER_SOCKET_GID is required}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+volumes:
+  judge-cache:
+    name: noj-judge-standalone-cache
+`;
+}
+
+/**
+ * 写入独立 Judge Compose 配置。
+ * dryRun 时仅打印将生成的位置，不写文件；否则写入并设置为 600。
+ */
+export function writeJudgeCompose(file: string, dryRun: boolean): void {
+  if (dryRun) {
+    console.log(`[dry-run] 将生成 Compose 配置：${file}`);
+    return;
+  }
+  Deno.writeTextFileSync(file, renderJudgeCompose());
+  Deno.chmodSync(file, 0o600);
+  console.log(`已生成 Compose 配置：${file}`);
+}
+
+/** 组装 `docker compose` 的完整参数列表。 */
+export function composeArgs(
+  opts: JudgeOptions,
+  args: string[] = [],
+): string[] {
+  return [
+    "compose",
+    "--project-name",
+    PROJECT_NAME,
+    "--env-file",
+    opts.envFile,
+    "-f",
+    opts.composeFile,
+    ...args,
+  ];
+}
+
+/**
+ * 执行独立 Judge 的 docker compose 命令。
+ * dryRun 时打印命令并返回 0；否则调用 runner 并返回退出码。
+ */
+export async function runJudgeCompose(
+  opts: JudgeOptions,
+  args: string[],
+  runner: CommandRunner = realRunner(),
+): Promise<number> {
+  const allArgs = composeArgs(opts, args);
+  if (opts.dryRun) {
+    console.log(`[dry-run] docker ${allArgs.join(" ")}`);
+    return 0;
+  }
+  const result = await runner.run("docker", allArgs);
+  return result.code;
+}

--- a/noj-cli/src/judge/compose_test.ts
+++ b/noj-cli/src/judge/compose_test.ts
@@ -1,0 +1,111 @@
+import { assertEquals } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import {
+  composeArgs,
+  renderJudgeCompose,
+  runJudgeCompose,
+  writeJudgeCompose,
+} from "./compose.ts";
+import type { JudgeOptions } from "./options.ts";
+
+const opts: JudgeOptions = {
+  command: "start",
+  dir: "/srv/noj-judge",
+  envFile: "/srv/noj-judge/.env.judge",
+  composeFile: "/srv/noj-judge/docker-compose.judge.yml",
+  repo: "https://github.com/Neuro-OJ/neuro-oj",
+  ref: "main",
+  version: undefined,
+  redisContainer: "noj-judge-redis",
+  redisPort: 16379,
+  panel: "none",
+  nonInteractive: true,
+  downloadOnly: false,
+  dryRun: false,
+  follow: false,
+};
+
+function fakeRunner(records: { cmd: string; args: string[] }[]): CommandRunner {
+  return {
+    run(cmd, args) {
+      records.push({ cmd, args });
+      return Promise.resolve({ code: 7, stdout: "", stderr: "" });
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+Deno.test("renderJudgeCompose: 包含 noj-judge 镜像与安全配置", () => {
+  const text = renderJudgeCompose();
+  assertEquals(text.includes("noj-judge"), true);
+  assertEquals(text.includes("cap_drop"), true);
+  assertEquals(text.includes("no-new-privileges"), true);
+  assertEquals(text.includes("JUDGE_REQUIRE_ISOLATED_DOCKER"), true);
+});
+
+Deno.test("composeArgs: 使用 project-name/env-file/file", () => {
+  const args = composeArgs(opts);
+  assertEquals(args.includes("--project-name"), true);
+  assertEquals(args.includes("noj-judge-standalone"), true);
+  assertEquals(args.includes("--env-file"), true);
+  assertEquals(args.includes(opts.envFile), true);
+  assertEquals(args.includes("-f"), true);
+  assertEquals(args.includes(opts.composeFile), true);
+});
+
+Deno.test("composeArgs: 追加后续 docker compose 参数", () => {
+  const args = composeArgs(opts, ["up", "-d", "--remove-orphans"]);
+  assertEquals(args.at(-3), "up");
+  assertEquals(args.at(-2), "-d");
+  assertEquals(args.at(-1), "--remove-orphans");
+});
+
+Deno.test("writeJudgeCompose: 权限 600", () => {
+  const file = `${Deno.makeTempDirSync()}/docker-compose.judge.yml`;
+  writeJudgeCompose(file, false);
+  const mode = Deno.statSync(file).mode! & 0o777;
+  assertEquals(mode, 0o600);
+});
+
+Deno.test("writeJudgeCompose: dryRun 不写文件", () => {
+  const file = `${Deno.makeTempDirSync()}/docker-compose.judge.yml`;
+  writeJudgeCompose(file, true);
+  let exists = true;
+  try {
+    Deno.statSync(file);
+  } catch {
+    exists = false;
+  }
+  assertEquals(exists, false);
+});
+
+Deno.test("runJudgeCompose: dryRun 返回 0 且不调用 runner", async () => {
+  const records: { cmd: string; args: string[] }[] = [];
+  const code = await runJudgeCompose(
+    { ...opts, dryRun: true },
+    ["up", "-d"],
+    fakeRunner(records),
+  );
+  assertEquals(code, 0);
+  assertEquals(records.length, 0);
+});
+
+Deno.test("runJudgeCompose: 调用 docker compose 并返回退出码", async () => {
+  const records: { cmd: string; args: string[] }[] = [];
+  const code = await runJudgeCompose(
+    opts,
+    ["up", "-d"],
+    fakeRunner(records),
+  );
+  assertEquals(code, 7);
+  assertEquals(records.length, 1);
+  assertEquals(records[0]?.cmd, "docker");
+  assertEquals(records[0]?.args[0], "compose");
+  assertEquals(records[0]?.args.includes("noj-judge-standalone"), true);
+  assertEquals(records[0]?.args.includes(opts.envFile), true);
+  assertEquals(records[0]?.args.includes(opts.composeFile), true);
+  assertEquals(records[0]?.args.at(-2), "up");
+  assertEquals(records[0]?.args.at(-1), "-d");
+});

--- a/noj-cli/src/judge/env.ts
+++ b/noj-cli/src/judge/env.ts
@@ -1,0 +1,45 @@
+export interface JudgeEnv {
+  values: Record<string, string>;
+}
+
+export function envValue(env: JudgeEnv, key: string): string | undefined {
+  return env.values[key];
+}
+
+export function loadJudgeEnv(file: string): JudgeEnv {
+  const values: Record<string, string> = {};
+  try {
+    const text = Deno.readTextFileSync(file);
+    for (const line of text.split(/\r?\n/)) {
+      if (!line.includes("=")) continue;
+      const eq = line.indexOf("=");
+      const key = line.slice(0, eq).trim();
+      let value = line.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (key) values[key] = value;
+    }
+  } catch {
+    // 文件不存在时返回空
+  }
+  return { values };
+}
+
+export function saveJudgeEnv(
+  file: string,
+  values: Record<string, string>,
+): void {
+  const lines = Object.entries(values).map(([k, v]) => `${k}=${v}`);
+  Deno.writeTextFileSync(file, lines.join("\n") + "\n");
+  Deno.chmodSync(file, 0o600);
+}
+
+export function setJudgeEnv(file: string, key: string, value: string): void {
+  const env = loadJudgeEnv(file);
+  env.values[key] = value;
+  saveJudgeEnv(file, env.values);
+}

--- a/noj-cli/src/judge/env_test.ts
+++ b/noj-cli/src/judge/env_test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "@std/assert";
+import { envValue, loadJudgeEnv, saveJudgeEnv, setJudgeEnv } from "./env.ts";
+
+Deno.test("loadJudgeEnv: 解析 KEY=VALUE", () => {
+  const dir = Deno.makeTempDirSync();
+  const file = `${dir}/.env.judge`;
+  Deno.writeTextFileSync(file, "NOJ_VERSION=v0.1.0\nREDIS_URL=redis://x/0\n");
+  const env = loadJudgeEnv(file);
+  assertEquals(envValue(env, "NOJ_VERSION"), "v0.1.0");
+  assertEquals(envValue(env, "REDIS_URL"), "redis://x/0");
+});
+
+Deno.test("saveJudgeEnv: 写文件并保留权限 600", () => {
+  const dir = Deno.makeTempDirSync();
+  const file = `${dir}/.env.judge`;
+  saveJudgeEnv(file, { NOJ_VERSION: "v0.1.0" });
+  assertEquals(Deno.readTextFileSync(file), "NOJ_VERSION=v0.1.0\n");
+  const mode = Deno.statSync(file).mode! & 0o777;
+  assertEquals(mode, 0o600);
+});
+
+Deno.test("setJudgeEnv: 更新已有键", () => {
+  const dir = Deno.makeTempDirSync();
+  const file = `${dir}/.env.judge`;
+  saveJudgeEnv(file, { A: "1" });
+  setJudgeEnv(file, "A", "2");
+  setJudgeEnv(file, "B", "3");
+  const text = Deno.readTextFileSync(file);
+  assertEquals(text.includes("A=2"), true);
+  assertEquals(text.includes("B=3"), true);
+});

--- a/noj-cli/src/judge/options.ts
+++ b/noj-cli/src/judge/options.ts
@@ -60,12 +60,19 @@ export function parseJudgeArgs(args: string[]): JudgeOptions {
     follow: false,
   };
   let commandSet = false;
-  const takeValue = (flag: string): string => {
-    const i = args.indexOf(flag);
-    if (i === -1) throw new Error(`judge: ${flag} 缺少参数`);
+  const takeValue = (flag: string, i: number): string => {
     const value = args[i + 1];
-    if (value === undefined) throw new Error(`judge: ${flag} 缺少参数`);
+    if (value === undefined || value.startsWith("-")) {
+      throw new Error(`judge: ${flag} 缺少参数`);
+    }
     return value;
+  };
+  const parseRedisPort = (value: string): number => {
+    const port = Number(value);
+    if (Number.isNaN(port)) {
+      throw new Error(`judge: --redis-port 必须是数字: ${value}`);
+    }
+    return port;
   };
   for (let i = 0; i < args.length; i++) {
     const a = args[i]!;
@@ -77,47 +84,47 @@ export function parseJudgeArgs(args: string[]): JudgeOptions {
     if (a.startsWith("--dir=")) {
       out.dir = a.slice(6);
     } else if (a === "--dir") {
-      out.dir = takeValue(a);
+      out.dir = takeValue(a, i);
       i++;
     } else if (a.startsWith("--env-file=")) {
       out.envFile = a.slice(11);
     } else if (a === "--env-file") {
-      out.envFile = takeValue(a);
+      out.envFile = takeValue(a, i);
       i++;
     } else if (a.startsWith("--compose-file=")) {
       out.composeFile = a.slice(15);
     } else if (a === "--compose-file") {
-      out.composeFile = takeValue(a);
+      out.composeFile = takeValue(a, i);
       i++;
     } else if (a.startsWith("--repo=")) {
       out.repo = a.slice(7);
     } else if (a === "--repo") {
-      out.repo = takeValue(a);
+      out.repo = takeValue(a, i);
       i++;
     } else if (a.startsWith("--ref=")) {
       out.ref = a.slice(6);
     } else if (a === "--ref") {
-      out.ref = takeValue(a);
+      out.ref = takeValue(a, i);
       i++;
     } else if (a.startsWith("--version=")) {
       out.version = a.slice(10);
     } else if (a === "--version") {
-      out.version = takeValue(a);
+      out.version = takeValue(a, i);
       i++;
     } else if (a.startsWith("--redis-container=")) {
       out.redisContainer = a.slice(18);
     } else if (a === "--redis-container") {
-      out.redisContainer = takeValue(a);
+      out.redisContainer = takeValue(a, i);
       i++;
     } else if (a.startsWith("--redis-port=")) {
-      out.redisPort = Number(a.slice(13));
+      out.redisPort = parseRedisPort(a.slice(13));
     } else if (a === "--redis-port") {
-      out.redisPort = Number(takeValue(a));
+      out.redisPort = parseRedisPort(takeValue(a, i));
       i++;
     } else if (a.startsWith("--panel=")) {
       out.panel = a.slice(8) as JudgeOptions["panel"];
     } else if (a === "--panel") {
-      out.panel = takeValue(a) as JudgeOptions["panel"];
+      out.panel = takeValue(a, i) as JudgeOptions["panel"];
       i++;
     } else if (a === "--non-interactive") {
       out.nonInteractive = true;

--- a/noj-cli/src/judge/options.ts
+++ b/noj-cli/src/judge/options.ts
@@ -1,0 +1,145 @@
+export const DEFAULT_JUDGE_DIR = "/srv/noj-judge";
+export const DEFAULT_JUDGE_REPO = "https://github.com/Neuro-OJ/neuro-oj";
+export const DEFAULT_JUDGE_REF = "main";
+export const DEFAULT_REDIS_CONTAINER = "noj-judge-redis";
+export const DEFAULT_REDIS_PORT = 16379;
+
+export interface JudgeOptions {
+  command:
+    | "install"
+    | "install-env"
+    | "check"
+    | "start"
+    | "stop"
+    | "status"
+    | "logs"
+    | "upgrade"
+    | "download";
+  dir: string;
+  envFile: string;
+  composeFile: string;
+  repo: string;
+  ref: string;
+  version: string | undefined;
+  redisContainer: string;
+  redisPort: number;
+  panel: "auto" | "baota" | "none";
+  nonInteractive: boolean;
+  downloadOnly: boolean;
+  dryRun: boolean;
+  follow: boolean;
+}
+
+const COMMANDS = new Set([
+  "install",
+  "install-env",
+  "check",
+  "start",
+  "stop",
+  "status",
+  "logs",
+  "upgrade",
+  "download",
+]);
+
+export function parseJudgeArgs(args: string[]): JudgeOptions {
+  const out: JudgeOptions = {
+    command: "check",
+    dir: DEFAULT_JUDGE_DIR,
+    envFile: "",
+    composeFile: "",
+    repo: DEFAULT_JUDGE_REPO,
+    ref: DEFAULT_JUDGE_REF,
+    version: undefined,
+    redisContainer: DEFAULT_REDIS_CONTAINER,
+    redisPort: DEFAULT_REDIS_PORT,
+    panel: "auto",
+    nonInteractive: false,
+    downloadOnly: false,
+    dryRun: false,
+    follow: false,
+  };
+  let commandSet = false;
+  const takeValue = (flag: string): string => {
+    const i = args.indexOf(flag);
+    if (i === -1) throw new Error(`judge: ${flag} 缺少参数`);
+    const value = args[i + 1];
+    if (value === undefined) throw new Error(`judge: ${flag} 缺少参数`);
+    return value;
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (COMMANDS.has(a) && !commandSet) {
+      out.command = a as JudgeOptions["command"];
+      commandSet = true;
+      continue;
+    }
+    if (a.startsWith("--dir=")) {
+      out.dir = a.slice(6);
+    } else if (a === "--dir") {
+      out.dir = takeValue(a);
+      i++;
+    } else if (a.startsWith("--env-file=")) {
+      out.envFile = a.slice(11);
+    } else if (a === "--env-file") {
+      out.envFile = takeValue(a);
+      i++;
+    } else if (a.startsWith("--compose-file=")) {
+      out.composeFile = a.slice(15);
+    } else if (a === "--compose-file") {
+      out.composeFile = takeValue(a);
+      i++;
+    } else if (a.startsWith("--repo=")) {
+      out.repo = a.slice(7);
+    } else if (a === "--repo") {
+      out.repo = takeValue(a);
+      i++;
+    } else if (a.startsWith("--ref=")) {
+      out.ref = a.slice(6);
+    } else if (a === "--ref") {
+      out.ref = takeValue(a);
+      i++;
+    } else if (a.startsWith("--version=")) {
+      out.version = a.slice(10);
+    } else if (a === "--version") {
+      out.version = takeValue(a);
+      i++;
+    } else if (a.startsWith("--redis-container=")) {
+      out.redisContainer = a.slice(18);
+    } else if (a === "--redis-container") {
+      out.redisContainer = takeValue(a);
+      i++;
+    } else if (a.startsWith("--redis-port=")) {
+      out.redisPort = Number(a.slice(13));
+    } else if (a === "--redis-port") {
+      out.redisPort = Number(takeValue(a));
+      i++;
+    } else if (a.startsWith("--panel=")) {
+      out.panel = a.slice(8) as JudgeOptions["panel"];
+    } else if (a === "--panel") {
+      out.panel = takeValue(a) as JudgeOptions["panel"];
+      i++;
+    } else if (a === "--non-interactive") {
+      out.nonInteractive = true;
+    } else if (a === "--download-only") {
+      out.downloadOnly = true;
+    } else if (a === "--dry-run") {
+      out.dryRun = true;
+    } else if (a === "--follow" || a === "-f") {
+      out.follow = true;
+    } else if (a === "--help" || a === "-h") {
+      throw new Error("judge --help");
+    } else {
+      throw new Error(`未知 judge 参数: ${a}`);
+    }
+  }
+  if (!commandSet) throw new Error("judge: 需要子命令");
+  if (out.panel !== "auto" && out.panel !== "baota" && out.panel !== "none") {
+    throw new Error(`judge: 非法 panel 模式: ${out.panel}`);
+  }
+  if (out.envFile === "") out.envFile = `${out.dir}/.env.judge`;
+  if (out.composeFile === "") {
+    out.composeFile = `${out.dir}/docker-compose.judge.yml`;
+  }
+  return out;
+}

--- a/noj-cli/src/judge/options_test.ts
+++ b/noj-cli/src/judge/options_test.ts
@@ -45,3 +45,39 @@ Deno.test("parseJudgeArgs: 解析选项", () => {
 Deno.test("parseJudgeArgs: 非法 panel 抛错", () => {
   assertThrows(() => parseJudgeArgs(["install", "--panel", "bad"]));
 });
+
+Deno.test("parseJudgeArgs: 混用等号与空格时后者覆盖 dir", () => {
+  const o = parseJudgeArgs(["install", "--dir=/a", "--dir", "/b"]);
+  assertEquals(o.dir, "/b");
+});
+
+Deno.test("parseJudgeArgs: 重复空格形式 dir 使用最后一个值", () => {
+  const o = parseJudgeArgs(["install", "--dir", "/a", "--dir", "/b"]);
+  assertEquals(o.dir, "/b");
+});
+
+Deno.test("parseJudgeArgs: 值缺失且下一个是选项时抛错", () => {
+  assertThrows(() => parseJudgeArgs(["install", "--dir", "--dry-run"]));
+});
+
+Deno.test("parseJudgeArgs: 非法 redis-port 抛错", () => {
+  assertThrows(() => parseJudgeArgs(["install", "--redis-port", "abc"]));
+});
+
+Deno.test("parseJudgeArgs: 等号风格选项", () => {
+  const o = parseJudgeArgs([
+    "install",
+    "--dir=/srv/noj",
+    "--env-file=/tmp/env",
+  ]);
+  assertEquals(o.dir, "/srv/noj");
+  assertEquals(o.envFile, "/tmp/env");
+});
+
+Deno.test("parseJudgeArgs: 缺少子命令抛错", () => {
+  assertThrows(() => parseJudgeArgs([]));
+});
+
+Deno.test("parseJudgeArgs: 未知参数抛错", () => {
+  assertThrows(() => parseJudgeArgs(["install", "--unknown"]));
+});

--- a/noj-cli/src/judge/options_test.ts
+++ b/noj-cli/src/judge/options_test.ts
@@ -1,0 +1,47 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { DEFAULT_JUDGE_DIR, parseJudgeArgs } from "./options.ts";
+
+Deno.test("parseJudgeArgs: 缺省值", () => {
+  const o = parseJudgeArgs(["install"]);
+  assertEquals(o.command, "install");
+  assertEquals(o.dir, DEFAULT_JUDGE_DIR);
+  assertEquals(o.envFile, `${DEFAULT_JUDGE_DIR}/.env.judge`);
+  assertEquals(o.composeFile, `${DEFAULT_JUDGE_DIR}/docker-compose.judge.yml`);
+  assertEquals(o.repo, "https://github.com/Neuro-OJ/neuro-oj");
+  assertEquals(o.ref, "main");
+  assertEquals(o.nonInteractive, false);
+  assertEquals(o.dryRun, false);
+  assertEquals(o.follow, false);
+});
+
+Deno.test("parseJudgeArgs: 解析选项", () => {
+  const o = parseJudgeArgs([
+    "check",
+    "--dir",
+    "/srv/noj",
+    "--env-file",
+    "/tmp/env",
+    "--compose-file",
+    "/tmp/compose.yml",
+    "--version",
+    "v0.2.0",
+    "--panel",
+    "none",
+    "--non-interactive",
+    "--dry-run",
+    "--follow",
+  ]);
+  assertEquals(o.command, "check");
+  assertEquals(o.dir, "/srv/noj");
+  assertEquals(o.envFile, "/tmp/env");
+  assertEquals(o.composeFile, "/tmp/compose.yml");
+  assertEquals(o.version, "v0.2.0");
+  assertEquals(o.panel, "none");
+  assertEquals(o.nonInteractive, true);
+  assertEquals(o.dryRun, true);
+  assertEquals(o.follow, true);
+});
+
+Deno.test("parseJudgeArgs: 非法 panel 抛错", () => {
+  assertThrows(() => parseJudgeArgs(["install", "--panel", "bad"]));
+});

--- a/noj-cli/src/judge/redis.ts
+++ b/noj-cli/src/judge/redis.ts
@@ -1,0 +1,235 @@
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import { envValue, loadJudgeEnv } from "./env.ts";
+import type { JudgeOptions } from "./options.ts";
+
+/** Redis 连接信息摘要，供后续命令组装 Judge 环境变量使用。 */
+export interface RedisConnection {
+  runtimeUrl: string;
+  checkUrl: string;
+  source: "existing" | "local" | "pending";
+}
+
+/** 本机 Redis 容器镜像，与 `scripts/deploy/judge-install.sh` 保持一致。 */
+const REDIS_IMAGE = "redis:7-alpine";
+/** 本工具创建的 Redis 容器组件标签。 */
+const REDIS_LABEL = "judge-standalone-redis";
+/** 连接元数据文件名。 */
+const METADATA_FILE = ".redis-connection.env";
+/** 连接说明文件名。 */
+const GUIDE_FILE = "redis-connection.txt";
+
+/**
+ * 生成本机 Redis 密码：24 字节随机数编码为 48 位十六进制字符串。
+ * 对应 shell 中 `openssl rand -hex 24`。
+ */
+export function generateRedisPassword(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * 校验本机 Redis 宿主机端口。
+ * 只允许 1024-65535 的整数，避免特权端口与非法值。
+ */
+export function validateRedisPort(port: number): void {
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    throw new Error(`本机 Redis 端口必须在 1024-65535 范围内：${port}`);
+  }
+}
+
+/** 返回本机 Redis 连接信息文件路径。 */
+export function redisConnectionFiles(opts: JudgeOptions): {
+  metadata: string;
+  guide: string;
+} {
+  return {
+    metadata: `${opts.dir}/${METADATA_FILE}`,
+    guide: `${opts.dir}/${GUIDE_FILE}`,
+  };
+}
+
+/** 读取已保存的本机 Redis 连接信息；缺任一字段时抛错。 */
+function readRedisConnectionFiles(opts: JudgeOptions): {
+  coreUrl: string;
+  runtimeUrl: string;
+  checkUrl: string;
+} {
+  const { metadata } = redisConnectionFiles(opts);
+  const env = loadJudgeEnv(metadata);
+  const coreUrl = envValue(env, "REDIS_CORE_URL") ?? "";
+  const runtimeUrl = envValue(env, "REDIS_RUNTIME_URL") ?? "";
+  const checkUrl = envValue(env, "REDIS_CHECK_URL") ?? "";
+  if (!coreUrl || !runtimeUrl || !checkUrl) {
+    throw new Error(
+      `检测到本工具创建的 Redis，但缺少连接信息：${metadata}；请手动恢复后再继续`,
+    );
+  }
+  return { coreUrl, runtimeUrl, checkUrl };
+}
+
+/**
+ * 写入 Redis 连接信息文件：`.redis-connection.env`（机器读取）与
+ * `redis-connection.txt`（人工指引），两个文件均为 0600。
+ */
+function writeRedisConnectionFiles(
+  opts: JudgeOptions,
+  coreUrl: string,
+  runtimeUrl: string,
+  checkUrl: string,
+  port: number,
+): void {
+  const { metadata, guide } = redisConnectionFiles(opts);
+  Deno.mkdirSync(opts.dir, { recursive: true });
+  const metadataText = `REDIS_CORE_URL=${coreUrl}\n` +
+    `REDIS_RUNTIME_URL=${runtimeUrl}\n` +
+    `REDIS_CHECK_URL=${checkUrl}\n`;
+  Deno.writeTextFileSync(metadata, metadataText);
+  Deno.chmodSync(metadata, 0o600);
+
+  const guideText =
+    "# Redis 连接信息（含密码，请勿提交到代码仓库或公开分享）\n" +
+    "# noj-core 使用：\n" +
+    `REDIS_URL=${coreUrl}\n\n` +
+    "# Judge 容器使用：\n" +
+    `REDIS_URL=${runtimeUrl}\n`;
+  Deno.writeTextFileSync(guide, guideText);
+  Deno.chmodSync(guide, 0o600);
+
+  console.log(`Redis 连接信息已保存：${guide}（权限 600）`);
+  console.error(
+    `  请让 noj-core 和 Judge 使用同一个 Redis；不要把它们配置到不同实例。\n` +
+      `  noj-core 地址：127.0.0.1:${port}；Judge 容器地址：host.docker.internal:${port}`,
+  );
+}
+
+/** 检查本机端口是否已被监听（仅检查 127.0.0.1）。 */
+async function isPortInUse(port: number): Promise<boolean> {
+  try {
+    const conn = await Deno.connect({ hostname: "127.0.0.1", port });
+    conn.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** 执行 docker 命令；docker 缺失时转换为友好错误。 */
+async function runDocker(
+  runner: CommandRunner,
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    return await runner.run("docker", args);
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      throw new Error("缺少依赖：docker");
+    }
+    throw e;
+  }
+}
+
+/**
+ * 创建或复用本机 Redis 容器，并写入连接信息文件。
+ * 行为与 `scripts/deploy/judge-install.sh` 的 `create_local_redis` 保持一致。
+ */
+export async function createLocalRedis(
+  opts: JudgeOptions,
+  runner: CommandRunner = realRunner(),
+): Promise<void> {
+  const containerName = opts.redisContainer;
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(containerName)) {
+    throw new Error(`本机 Redis 容器名格式无效：${containerName}`);
+  }
+  validateRedisPort(opts.redisPort);
+
+  const inspect = await runDocker(runner, [
+    "container",
+    "inspect",
+    containerName,
+  ]);
+  if (inspect.code === 0) {
+    const labelResult = await runDocker(runner, [
+      "container",
+      "inspect",
+      "--format",
+      '{{ index .Config.Labels "com.neuro-oj.component" }}',
+      containerName,
+    ]);
+    const label = labelResult.stdout.trim();
+    if (label !== REDIS_LABEL) {
+      throw new Error(
+        `Redis 容器名已被其他容器占用：${containerName}；不会删除或修改它，请换名或连接已有 Redis`,
+      );
+    }
+    const existing = readRedisConnectionFiles(opts);
+    writeRedisConnectionFiles(
+      opts,
+      existing.coreUrl,
+      existing.runtimeUrl,
+      existing.checkUrl,
+      opts.redisPort,
+    );
+    console.log(`已复用本工具已创建的 Redis：${containerName}`);
+    return;
+  }
+
+  if (await isPortInUse(opts.redisPort)) {
+    throw new Error(
+      `本机 Redis 端口已被占用：127.0.0.1:${opts.redisPort}；请换一个端口，或选择连接已有 Redis`,
+    );
+  }
+
+  const password = generateRedisPassword();
+  const configFile = `${opts.dir}/redis.conf`;
+  Deno.mkdirSync(opts.dir, { recursive: true });
+  Deno.writeTextFileSync(
+    configFile,
+    `appendonly yes\nrequirepass ${password}\n`,
+  );
+  Deno.chmodSync(configFile, 0o600);
+
+  const args = [
+    "run",
+    "-d",
+    "--name",
+    containerName,
+    "--label",
+    "com.neuro-oj.component=judge-standalone-redis",
+    "--label",
+    "com.neuro-oj.managed-by=judge-install",
+    "--restart",
+    "unless-stopped",
+    "--publish",
+    `127.0.0.1:${opts.redisPort}:6379`,
+    "--volume",
+    `${containerName}-data:/data`,
+    "--volume",
+    `${configFile}:/usr/local/etc/redis/redis.conf:ro`,
+    REDIS_IMAGE,
+    "redis-server",
+    "/usr/local/etc/redis/redis.conf",
+  ];
+  const result = await runDocker(runner, args);
+  if (result.code !== 0) {
+    throw new Error(
+      "本机 Redis 创建失败；端口可能被占用或 Docker 权限不足。原有服务未被修改",
+    );
+  }
+
+  const coreUrl = `redis://:${password}@127.0.0.1:${opts.redisPort}/0`;
+  const runtimeUrl =
+    `redis://:${password}@host.docker.internal:${opts.redisPort}/0`;
+  const checkUrl = coreUrl;
+  writeRedisConnectionFiles(
+    opts,
+    coreUrl,
+    runtimeUrl,
+    checkUrl,
+    opts.redisPort,
+  );
+  console.log(
+    `本机 Redis 已创建：${containerName}（数据卷：${containerName}-data）`,
+  );
+}

--- a/noj-cli/src/judge/redis_test.ts
+++ b/noj-cli/src/judge/redis_test.ts
@@ -1,0 +1,225 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import type { JudgeOptions } from "./options.ts";
+import {
+  createLocalRedis,
+  generateRedisPassword,
+  redisConnectionFiles,
+  validateRedisPort,
+} from "./redis.ts";
+
+const baseOpts: JudgeOptions = {
+  command: "install",
+  dir: Deno.makeTempDirSync(),
+  envFile: `${Deno.makeTempDirSync()}/.env.judge`,
+  composeFile: `${Deno.makeTempDirSync()}/docker-compose.judge.yml`,
+  repo: "https://github.com/Neuro-OJ/neuro-oj",
+  ref: "main",
+  version: "v0.1.0",
+  redisContainer: "noj-judge-redis",
+  redisPort: 46379,
+  panel: "none",
+  nonInteractive: true,
+  downloadOnly: false,
+  dryRun: false,
+  follow: false,
+};
+
+function fakeRunner(
+  handler: (
+    cmd: string,
+    args: string[],
+  ) => { code: number; stdout: string; stderr: string },
+): CommandRunner {
+  return {
+    run(cmd, args) {
+      return Promise.resolve(handler(cmd, args));
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+async function freePort(): Promise<number> {
+  for (let i = 0; i < 20; i++) {
+    const port = 20000 + Math.floor(Math.random() * 30000);
+    try {
+      const conn = await Deno.connect({ hostname: "127.0.0.1", port });
+      conn.close();
+    } catch {
+      return port;
+    }
+  }
+  return 46379;
+}
+
+Deno.test("generateRedisPassword: 长度大于 32 且为十六进制", () => {
+  const password = generateRedisPassword();
+  assertEquals(password.length >= 32, true);
+  assertEquals(/^[0-9a-f]+$/.test(password), true);
+});
+
+Deno.test("validateRedisPort: 合法范围", () => {
+  validateRedisPort(1024);
+  validateRedisPort(16379);
+  validateRedisPort(65535);
+  assertThrows(() => validateRedisPort(80));
+  assertThrows(() => validateRedisPort(70000));
+  assertThrows(() => validateRedisPort(1023));
+  assertThrows(() => validateRedisPort(Number.NaN));
+});
+
+Deno.test("redisConnectionFiles: 返回元数据与说明文件路径", () => {
+  const files = redisConnectionFiles(baseOpts);
+  assertEquals(files.metadata, `${baseOpts.dir}/.redis-connection.env`);
+  assertEquals(files.guide, `${baseOpts.dir}/redis-connection.txt`);
+});
+
+Deno.test("createLocalRedis: 创建容器并写入连接文件（权限 600）", async () => {
+  const dir = Deno.makeTempDirSync();
+  const port = await freePort();
+  const calls: { cmd: string; args: string[] }[] = [];
+  const runner = fakeRunner((cmd, args) => {
+    calls.push({ cmd, args });
+    if (cmd === "docker" && args[0] === "container" && args[1] === "inspect") {
+      return { code: 1, stdout: "", stderr: "No such container" };
+    }
+    if (cmd === "docker" && args[0] === "run") {
+      return { code: 0, stdout: "container-id", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+
+  await createLocalRedis({ ...baseOpts, dir, redisPort: port }, runner);
+
+  const metadata = `${dir}/.redis-connection.env`;
+  const guide = `${dir}/redis-connection.txt`;
+  const metadataText = Deno.readTextFileSync(metadata);
+  const guideText = Deno.readTextFileSync(guide);
+  assertEquals(metadataText.includes("REDIS_CORE_URL="), true);
+  assertEquals(metadataText.includes("REDIS_RUNTIME_URL="), true);
+  assertEquals(metadataText.includes("REDIS_CHECK_URL="), true);
+  assertEquals(guideText.includes("Redis 连接信息"), true);
+  assertEquals(guideText.includes("host.docker.internal"), true);
+  assertEquals(Deno.statSync(metadata).mode! & 0o777, 0o600);
+  assertEquals(Deno.statSync(guide).mode! & 0o777, 0o600);
+
+  const runCall = calls.find((c) => c.args[0] === "run");
+  assertEquals(runCall !== undefined, true);
+  assertEquals(runCall!.args.includes("--name"), true);
+  assertEquals(runCall!.args.includes("noj-judge-redis"), true);
+  assertEquals(runCall!.args.includes("127.0.0.1:" + port + ":6379"), true);
+  assertEquals(runCall!.args.at(-1), "/usr/local/etc/redis/redis.conf");
+});
+
+Deno.test("createLocalRedis: 复用本工具容器时不重复创建", async () => {
+  const dir = Deno.makeTempDirSync();
+  const coreUrl = "redis://:old@127.0.0.1:16379/0";
+  const runtimeUrl = "redis://:old@host.docker.internal:16379/0";
+  const checkUrl = coreUrl;
+  const metadata = `${dir}/.redis-connection.env`;
+  Deno.writeTextFileSync(
+    metadata,
+    `REDIS_CORE_URL=${coreUrl}\nREDIS_RUNTIME_URL=${runtimeUrl}\nREDIS_CHECK_URL=${checkUrl}\n`,
+  );
+  Deno.chmodSync(metadata, 0o600);
+
+  let runCalled = false;
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "docker" && args[0] === "container" && args[1] === "inspect") {
+      if (args.includes("--format")) {
+        return { code: 0, stdout: "judge-standalone-redis\n", stderr: "" };
+      }
+      return { code: 0, stdout: "existing-id", stderr: "" };
+    }
+    if (cmd === "docker" && args[0] === "run") {
+      runCalled = true;
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+
+  await createLocalRedis({ ...baseOpts, dir, redisPort: 16379 }, runner);
+
+  assertEquals(runCalled, false);
+  const text = Deno.readTextFileSync(`${dir}/redis-connection.txt`);
+  assertEquals(text.includes(runtimeUrl), true);
+});
+
+Deno.test("createLocalRedis: 容器名被其他容器占用时抛错", async () => {
+  const dir = Deno.makeTempDirSync();
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "docker" && args[0] === "container" && args[1] === "inspect") {
+      if (args.includes("--format")) {
+        return { code: 0, stdout: "other\n", stderr: "" };
+      }
+      return { code: 0, stdout: "other-id", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+
+  await assertRejects(
+    () => createLocalRedis({ ...baseOpts, dir }, runner),
+    Error,
+    "容器名已被其他容器占用",
+  );
+});
+
+Deno.test("createLocalRedis: docker run 失败时抛错", async () => {
+  const dir = Deno.makeTempDirSync();
+  const port = await freePort();
+  const runner = fakeRunner((cmd, args) => {
+    if (cmd === "docker" && args[0] === "container" && args[1] === "inspect") {
+      return { code: 1, stdout: "", stderr: "No such container" };
+    }
+    if (cmd === "docker" && args[0] === "run") {
+      return { code: 1, stdout: "", stderr: "port busy" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+
+  await assertRejects(
+    () => createLocalRedis({ ...baseOpts, dir, redisPort: port }, runner),
+    Error,
+    "本机 Redis 创建失败",
+  );
+});
+
+Deno.test("createLocalRedis: 端口已被占用时抛错", async () => {
+  const dir = Deno.makeTempDirSync();
+  const listener = Deno.listen({ port: 0 });
+  const port = (listener.addr as Deno.NetAddr).port;
+  try {
+    const runner = fakeRunner((cmd, args) => {
+      if (
+        cmd === "docker" && args[0] === "container" && args[1] === "inspect"
+      ) {
+        return { code: 1, stdout: "", stderr: "No such container" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await assertRejects(
+      () => createLocalRedis({ ...baseOpts, dir, redisPort: port }, runner),
+      Error,
+      "端口已被占用",
+    );
+  } finally {
+    listener.close();
+  }
+});
+
+Deno.test("createLocalRedis: 容器名非法时抛错", async () => {
+  const dir = Deno.makeTempDirSync();
+  const runner = fakeRunner(() => ({ code: 0, stdout: "", stderr: "" }));
+  await assertRejects(
+    () =>
+      createLocalRedis(
+        { ...baseOpts, dir, redisContainer: "-bad-name" },
+        runner,
+      ),
+    Error,
+    "容器名格式无效",
+  );
+});

--- a/noj-cli/src/mod.ts
+++ b/noj-cli/src/mod.ts
@@ -140,3 +140,11 @@ export type {
 // maintain/reset（P4）
 export { maintainReset } from "./maintain/reset.ts";
 export type { ResetOptions } from "./maintain/reset.ts";
+
+// context（Phase 1）
+export type { CliContext, ContextKind } from "./context/context.ts";
+export {
+  detectKind,
+  findContextDir,
+  resolveContext,
+} from "./context/context.ts";

--- a/noj-cli/src/observability/alert_drill.ts
+++ b/noj-cli/src/observability/alert_drill.ts
@@ -68,11 +68,35 @@ function resolvedPayload(startsAt: string, endsAt: string): string {
   ]);
 }
 
+async function resolveAlerts(
+  http: HttpClient,
+  url: string,
+  payload: string,
+): Promise<void> {
+  let lastError: unknown = new Error("未知错误");
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await http.postJson(url, payload);
+      if (res.status === 200) return;
+      lastError = new Error(`HTTP ${res.status}`);
+    } catch (e) {
+      lastError = e;
+    }
+  }
+  const detail = lastError instanceof Error
+    ? lastError.message
+    : String(lastError);
+  throw new Error(
+    `恢复告警失败：${detail}。告警 NojNotificationDrill 可能仍处于活跃状态，请手动清理 Alertmanager。`,
+  );
+}
+
 export async function alertDrill(
   opts: AlertDrillOptions = {},
 ): Promise<AlertDrillReport> {
   const http = opts.http ?? (await import("./http.ts")).realHttp();
-  const alertmanagerUrl = opts.alertmanagerUrl ?? DEFAULT_ALERTMANAGER_URL;
+  const alertmanagerUrl = opts.alertmanagerUrl ??
+    Deno.env.get("ALERTMANAGER_URL") ?? DEFAULT_ALERTMANAGER_URL;
   const holdSeconds = opts.holdSeconds ?? 300;
   const startsAt = new Date().toISOString();
   const url = `${alertmanagerUrl}/api/v2/alerts`;
@@ -86,13 +110,11 @@ export async function alertDrill(
     await new Promise((resolve) => setTimeout(resolve, holdSeconds * 1000));
   }
 
-  const resolved = await http.postJson(
+  await resolveAlerts(
+    http,
     url,
     resolvedPayload(startsAt, new Date().toISOString()),
   );
-  if (resolved.status !== 200) {
-    throw new Error(`恢复告警失败：HTTP ${resolved.status}`);
-  }
 
   return { injected: true, resolved: true, holdSeconds };
 }

--- a/noj-cli/src/observability/alert_drill.ts
+++ b/noj-cli/src/observability/alert_drill.ts
@@ -1,0 +1,98 @@
+import type { HttpClient } from "./http.ts";
+
+export interface AlertDrillOptions {
+  alertmanagerUrl?: string;
+  holdSeconds?: number;
+  http?: HttpClient;
+}
+
+export interface AlertDrillReport {
+  injected: boolean;
+  resolved: boolean;
+  holdSeconds: number;
+}
+
+const DEFAULT_ALERTMANAGER_URL = "http://alertmanager:9093";
+
+function activePayload(startsAt: string): string {
+  return JSON.stringify([
+    {
+      labels: {
+        alertname: "NojNotificationDrill",
+        severity: "critical",
+        instance: "notification-drill",
+      },
+      annotations: {
+        summary: "告警投递演练（critical）",
+        description: `投递演练测试告警，无需处理；startsAt=${startsAt}`,
+      },
+      startsAt,
+    },
+    {
+      labels: {
+        alertname: "NojNotificationDrill",
+        severity: "warning",
+        instance: "notification-drill",
+      },
+      annotations: {
+        summary: "告警投递演练（warning）",
+        description: `投递演练测试告警，无需处理；startsAt=${startsAt}`,
+      },
+      startsAt,
+    },
+  ]);
+}
+
+function resolvedPayload(startsAt: string, endsAt: string): string {
+  return JSON.stringify([
+    {
+      labels: {
+        alertname: "NojNotificationDrill",
+        severity: "critical",
+        instance: "notification-drill",
+      },
+      annotations: { summary: "告警投递演练（critical）已恢复" },
+      startsAt,
+      endsAt,
+    },
+    {
+      labels: {
+        alertname: "NojNotificationDrill",
+        severity: "warning",
+        instance: "notification-drill",
+      },
+      annotations: { summary: "告警投递演练（warning）已恢复" },
+      startsAt,
+      endsAt,
+    },
+  ]);
+}
+
+export async function alertDrill(
+  opts: AlertDrillOptions = {},
+): Promise<AlertDrillReport> {
+  const http = opts.http ?? (await import("./http.ts")).realHttp();
+  const alertmanagerUrl = opts.alertmanagerUrl ?? DEFAULT_ALERTMANAGER_URL;
+  const holdSeconds = opts.holdSeconds ?? 300;
+  const startsAt = new Date().toISOString();
+  const url = `${alertmanagerUrl}/api/v2/alerts`;
+
+  const active = await http.postJson(url, activePayload(startsAt));
+  if (active.status !== 200) {
+    throw new Error(`注入告警失败：HTTP ${active.status}`);
+  }
+
+  if (holdSeconds > 0) {
+    await new Promise((resolve) => setTimeout(resolve, holdSeconds * 1000));
+  }
+
+  const resolved = await http.postJson(
+    url,
+    resolvedPayload(startsAt, new Date().toISOString()),
+  );
+  if (resolved.status !== 200) {
+    throw new Error(`恢复告警失败：HTTP ${resolved.status}`);
+  }
+
+  return { injected: true, resolved: true, holdSeconds };
+}

--- a/noj-cli/src/observability/alert_drill_test.ts
+++ b/noj-cli/src/observability/alert_drill_test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "@std/assert";
+import type { HttpClient } from "./http.ts";
+import { alertDrill } from "./alert_drill.ts";
+
+function recordingHttp(calls: { url: string; body: string }[]): HttpClient {
+  return {
+    get(url) {
+      return Promise.resolve({ status: 200, body: url });
+    },
+    postJson(url, body) {
+      calls.push({ url, body });
+      return Promise.resolve({ status: 200, body: "" });
+    },
+  };
+}
+
+Deno.test("alertDrill: 注入并恢复告警", async () => {
+  const calls: { url: string; body: string }[] = [];
+  const http = recordingHttp(calls);
+  const report = await alertDrill({
+    alertmanagerUrl: "http://alertmanager:9093",
+    holdSeconds: 0,
+    http,
+  });
+  assertEquals(report.injected, true);
+  assertEquals(report.resolved, true);
+  assertEquals(calls.length, 2);
+  assertEquals(calls[0]?.url, "http://alertmanager:9093/api/v2/alerts");
+  assertEquals(calls[1]?.url, "http://alertmanager:9093/api/v2/alerts");
+  assertEquals(calls[0]?.body.includes("NojNotificationDrill"), true);
+});

--- a/noj-cli/src/observability/alert_drill_test.ts
+++ b/noj-cli/src/observability/alert_drill_test.ts
@@ -1,15 +1,21 @@
-import { assertEquals } from "@std/assert";
-import type { HttpClient } from "./http.ts";
+import { assertEquals, assertRejects } from "@std/assert";
+import type { HttpClient, HttpResult } from "./http.ts";
 import { alertDrill } from "./alert_drill.ts";
 
-function recordingHttp(calls: { url: string; body: string }[]): HttpClient {
+function recordingHttp(
+  calls: { url: string; body: string }[],
+  results: Array<HttpResult | Error> = [],
+): HttpClient {
+  let idx = 0;
   return {
     get(url) {
       return Promise.resolve({ status: 200, body: url });
     },
     postJson(url, body) {
       calls.push({ url, body });
-      return Promise.resolve({ status: 200, body: "" });
+      const item = results[idx++] ?? { status: 200, body: "" };
+      if (item instanceof Error) return Promise.reject(item);
+      return Promise.resolve(item);
     },
   };
 }
@@ -28,4 +34,53 @@ Deno.test("alertDrill: 注入并恢复告警", async () => {
   assertEquals(calls[0]?.url, "http://alertmanager:9093/api/v2/alerts");
   assertEquals(calls[1]?.url, "http://alertmanager:9093/api/v2/alerts");
   assertEquals(calls[0]?.body.includes("NojNotificationDrill"), true);
+});
+
+Deno.test("alertDrill: 首次恢复失败后二次恢复成功", async () => {
+  const calls: { url: string; body: string }[] = [];
+  const http = recordingHttp(calls, [
+    { status: 200, body: "" },
+    { status: 500, body: "boom" },
+    { status: 200, body: "" },
+  ]);
+  const report = await alertDrill({
+    alertmanagerUrl: "http://alertmanager:9093",
+    holdSeconds: 0,
+    http,
+  });
+  assertEquals(report.resolved, true);
+  assertEquals(calls.length, 3);
+});
+
+Deno.test("alertDrill: 恢复持续失败时报错并提示手动清理", async () => {
+  const calls: { url: string; body: string }[] = [];
+  const http = recordingHttp(calls, [
+    { status: 200, body: "" },
+    { status: 500, body: "boom" },
+    new Error("network down"),
+  ]);
+  await assertRejects(
+    () =>
+      alertDrill({
+        alertmanagerUrl: "http://alertmanager:9093",
+        holdSeconds: 0,
+        http,
+      }),
+    Error,
+    "手动清理",
+  );
+  assertEquals(calls.length, 3);
+});
+
+Deno.test("alertDrill: 默认 alertmanagerUrl 从 ALERTMANAGER_URL 读取", async () => {
+  Deno.env.set("ALERTMANAGER_URL", "http://env-am:9093");
+  try {
+    const calls: { url: string; body: string }[] = [];
+    const http = recordingHttp(calls);
+    const report = await alertDrill({ holdSeconds: 0, http });
+    assertEquals(report.resolved, true);
+    assertEquals(calls[0]?.url, "http://env-am:9093/api/v2/alerts");
+  } finally {
+    Deno.env.delete("ALERTMANAGER_URL");
+  }
 });

--- a/noj-cli/src/observability/check.ts
+++ b/noj-cli/src/observability/check.ts
@@ -20,21 +20,19 @@ export interface ObservabilityReport {
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:8000";
 
-async function checkEndpoint(
+async function checkGet(
   http: HttpClient,
   name: string,
   url: string,
-  expected: string,
+  predicate: (body: string) => boolean,
 ): Promise<CheckItem> {
   try {
     const res = await http.get(url);
-    const ok = res.status === 200 && res.body.includes(expected);
+    const ok = res.status === 200 && predicate(res.body);
     return {
       name,
       ok,
-      detail: ok
-        ? `${url} 正常`
-        : `${url} 返回 ${res.status} 或缺少 ${expected}`,
+      detail: ok ? `${url} 正常` : `${url} 返回 ${res.status} 或未满足条件`,
     };
   } catch (e) {
     return {
@@ -49,54 +47,54 @@ export async function observabilityCheck(
   opts: ObservabilityCheckOptions = {},
 ): Promise<ObservabilityReport> {
   const http = opts.http ?? (await import("./http.ts")).realHttp();
-  const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+  const baseUrl = opts.baseUrl ?? Deno.env.get("NOJ_OBSERVABILITY_BASE_URL") ??
+    DEFAULT_BASE_URL;
   const items: CheckItem[] = [];
   items.push(
-    await checkEndpoint(
+    await checkGet(
       http,
       "liveness",
       `${baseUrl}/health/live`,
-      '"status":"alive"',
+      (body) => body.includes('"status":"alive"'),
     ),
   );
   items.push(
-    await checkEndpoint(
+    await checkGet(
       http,
       "readiness",
       `${baseUrl}/health/ready`,
-      '"status":"ready"',
+      (body) => body.includes('"status":"ready"'),
     ),
   );
 
-  const metrics = await http.get(`${baseUrl}/metrics`);
-  const metricsOk = metrics.status === 200 &&
-    metrics.body.includes("noj_database_up") &&
-    metrics.body.includes("noj_judge_workers");
-  items.push({
-    name: "metrics",
-    ok: metricsOk,
-    detail: metricsOk
-      ? "metrics 包含关键指标"
-      : "metrics 缺少 noj_database_up 或 noj_judge_workers",
-  });
+  items.push(
+    await checkGet(
+      http,
+      "metrics",
+      `${baseUrl}/metrics`,
+      (body) =>
+        /^noj_database_up\s/m.test(body) && /^noj_judge_workers\s/m.test(body),
+    ),
+  );
 
   if (opts.checkNotifications) {
-    if (!opts.alertmanagerUrl) {
+    const alertmanagerUrl = opts.alertmanagerUrl ??
+      Deno.env.get("ALERTMANAGER_URL");
+    if (!alertmanagerUrl) {
       items.push({
         name: "notifications",
         ok: false,
         detail: "checkNotifications 需要 ALERTMANAGER_URL",
       });
     } else {
-      const amRes = await http.get(`${opts.alertmanagerUrl}/-/ready`);
-      const amOk = amRes.status === 200;
-      items.push({
-        name: "notifications",
-        ok: amOk,
-        detail: amOk
-          ? `${opts.alertmanagerUrl} 就绪`
-          : `${opts.alertmanagerUrl} 返回 ${amRes.status}`,
-      });
+      items.push(
+        await checkGet(
+          http,
+          "notifications",
+          `${alertmanagerUrl}/-/ready`,
+          () => true,
+        ),
+      );
     }
   }
 

--- a/noj-cli/src/observability/check.ts
+++ b/noj-cli/src/observability/check.ts
@@ -1,0 +1,104 @@
+import type { HttpClient } from "./http.ts";
+
+export interface ObservabilityCheckOptions {
+  baseUrl?: string;
+  checkNotifications?: boolean;
+  alertmanagerUrl?: string;
+  http?: HttpClient;
+}
+
+export interface CheckItem {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface ObservabilityReport {
+  items: CheckItem[];
+  pass: boolean;
+}
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:8000";
+
+async function checkEndpoint(
+  http: HttpClient,
+  name: string,
+  url: string,
+  expected: string,
+): Promise<CheckItem> {
+  try {
+    const res = await http.get(url);
+    const ok = res.status === 200 && res.body.includes(expected);
+    return {
+      name,
+      ok,
+      detail: ok
+        ? `${url} 正常`
+        : `${url} 返回 ${res.status} 或缺少 ${expected}`,
+    };
+  } catch (e) {
+    return {
+      name,
+      ok: false,
+      detail: `${url} 访问失败: ${(e as Error).message}`,
+    };
+  }
+}
+
+export async function observabilityCheck(
+  opts: ObservabilityCheckOptions = {},
+): Promise<ObservabilityReport> {
+  const http = opts.http ?? (await import("./http.ts")).realHttp();
+  const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+  const items: CheckItem[] = [];
+  items.push(
+    await checkEndpoint(
+      http,
+      "liveness",
+      `${baseUrl}/health/live`,
+      '"status":"alive"',
+    ),
+  );
+  items.push(
+    await checkEndpoint(
+      http,
+      "readiness",
+      `${baseUrl}/health/ready`,
+      '"status":"ready"',
+    ),
+  );
+
+  const metrics = await http.get(`${baseUrl}/metrics`);
+  const metricsOk = metrics.status === 200 &&
+    metrics.body.includes("noj_database_up") &&
+    metrics.body.includes("noj_judge_workers");
+  items.push({
+    name: "metrics",
+    ok: metricsOk,
+    detail: metricsOk
+      ? "metrics 包含关键指标"
+      : "metrics 缺少 noj_database_up 或 noj_judge_workers",
+  });
+
+  if (opts.checkNotifications) {
+    if (!opts.alertmanagerUrl) {
+      items.push({
+        name: "notifications",
+        ok: false,
+        detail: "checkNotifications 需要 ALERTMANAGER_URL",
+      });
+    } else {
+      const amRes = await http.get(`${opts.alertmanagerUrl}/-/ready`);
+      const amOk = amRes.status === 200;
+      items.push({
+        name: "notifications",
+        ok: amOk,
+        detail: amOk
+          ? `${opts.alertmanagerUrl} 就绪`
+          : `${opts.alertmanagerUrl} 返回 ${amRes.status}`,
+      });
+    }
+  }
+
+  return { items, pass: items.every((i) => i.ok) };
+}

--- a/noj-cli/src/observability/check_test.ts
+++ b/noj-cli/src/observability/check_test.ts
@@ -2,9 +2,15 @@ import { assertEquals } from "@std/assert";
 import type { HttpClient, HttpResult } from "./http.ts";
 import { observabilityCheck } from "./check.ts";
 
-function fakeHttp(routes: Record<string, HttpResult>): HttpClient {
+function fakeHttp(
+  routes: Record<string, HttpResult>,
+  failingUrls: string[] = [],
+): HttpClient {
   return {
     get(url) {
+      if (failingUrls.includes(url)) {
+        return Promise.reject(new Error("network down"));
+      }
       const res = routes[url];
       if (!res) return Promise.resolve({ status: 404, body: "not found" });
       return Promise.resolve(res);
@@ -42,6 +48,42 @@ Deno.test("observabilityCheck: readiness 失败导致整体失败", async () => 
   assertEquals(report.items[1]?.ok, false);
 });
 
+Deno.test("observabilityCheck: metrics 网络失败不中断命令", async () => {
+  const base = "http://noj.test";
+  const http = fakeHttp({
+    [`${base}/health/live`]: { status: 200, body: '{"status":"alive"}' },
+    [`${base}/health/ready`]: { status: 200, body: '{"status":"ready"}' },
+    [`${base}/metrics`]: { status: 200, body: "noj_database_up 1\n" },
+  }, [`${base}/metrics`]);
+  const report = await observabilityCheck({ baseUrl: base, http });
+  assertEquals(report.pass, false);
+  assertEquals(report.items[2]?.ok, false);
+  assertEquals(report.items[2]?.detail.includes("访问失败"), true);
+});
+
+Deno.test("observabilityCheck: Alertmanager 网络失败不中断命令", async () => {
+  const base = "http://noj.test";
+  const am = "http://alertmanager:9093";
+  const http = fakeHttp({
+    [`${base}/health/live`]: { status: 200, body: '{"status":"alive"}' },
+    [`${base}/health/ready`]: { status: 200, body: '{"status":"ready"}' },
+    [`${base}/metrics`]: {
+      status: 200,
+      body: "noj_database_up 1\nnoj_judge_workers 2\n",
+    },
+    [`${am}/-/ready`]: { status: 200, body: "OK" },
+  }, [`${am}/-/ready`]);
+  const report = await observabilityCheck({
+    baseUrl: base,
+    checkNotifications: true,
+    alertmanagerUrl: am,
+    http,
+  });
+  assertEquals(report.pass, false);
+  assertEquals(report.items[3]?.ok, false);
+  assertEquals(report.items[3]?.detail.includes("访问失败"), true);
+});
+
 Deno.test("observabilityCheck: --check-notifications 验证 Alertmanager", async () => {
   const base = "http://noj.test";
   const am = "http://alertmanager:9093";
@@ -62,4 +104,50 @@ Deno.test("observabilityCheck: --check-notifications 验证 Alertmanager", async
   });
   assertEquals(report.pass, true);
   assertEquals(report.items.length, 4);
+});
+
+Deno.test("observabilityCheck: 默认 baseUrl/alertmanagerUrl 从环境变量读取", async () => {
+  Deno.env.set("NOJ_OBSERVABILITY_BASE_URL", "http://env-base");
+  Deno.env.set("ALERTMANAGER_URL", "http://env-am");
+  try {
+    const http = fakeHttp({
+      "http://env-base/health/live": {
+        status: 200,
+        body: '{"status":"alive"}',
+      },
+      "http://env-base/health/ready": {
+        status: 200,
+        body: '{"status":"ready"}',
+      },
+      "http://env-base/metrics": {
+        status: 200,
+        body: "noj_database_up 1\nnoj_judge_workers 2\n",
+      },
+      "http://env-am/-/ready": { status: 200, body: "OK" },
+    });
+    const report = await observabilityCheck({
+      checkNotifications: true,
+      http,
+    });
+    assertEquals(report.pass, true);
+    assertEquals(report.items.length, 4);
+  } finally {
+    Deno.env.delete("NOJ_OBSERVABILITY_BASE_URL");
+    Deno.env.delete("ALERTMANAGER_URL");
+  }
+});
+
+Deno.test("observabilityCheck: metrics 使用行首锚定匹配", async () => {
+  const base = "http://noj.test";
+  const http = fakeHttp({
+    [`${base}/health/live`]: { status: 200, body: '{"status":"alive"}' },
+    [`${base}/health/ready`]: { status: 200, body: '{"status":"ready"}' },
+    [`${base}/metrics`]: {
+      status: 200,
+      body:
+        "prefix noj_database_up 1\nnoj_database_up 1\nprefix noj_judge_workers 2\nnoj_judge_workers 2\n",
+    },
+  });
+  const report = await observabilityCheck({ baseUrl: base, http });
+  assertEquals(report.items[2]?.ok, true);
 });

--- a/noj-cli/src/observability/check_test.ts
+++ b/noj-cli/src/observability/check_test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "@std/assert";
+import type { HttpClient, HttpResult } from "./http.ts";
+import { observabilityCheck } from "./check.ts";
+
+function fakeHttp(routes: Record<string, HttpResult>): HttpClient {
+  return {
+    get(url) {
+      const res = routes[url];
+      if (!res) return Promise.resolve({ status: 404, body: "not found" });
+      return Promise.resolve(res);
+    },
+    postJson(_url, _body) {
+      return Promise.resolve({ status: 200, body: "" });
+    },
+  };
+}
+
+Deno.test("observabilityCheck: 全部通过", async () => {
+  const base = "http://noj.test";
+  const http = fakeHttp({
+    [`${base}/health/live`]: { status: 200, body: '{"status":"alive"}' },
+    [`${base}/health/ready`]: { status: 200, body: '{"status":"ready"}' },
+    [`${base}/metrics`]: {
+      status: 200,
+      body: "noj_database_up 1\nnoj_judge_workers 2\n",
+    },
+  });
+  const report = await observabilityCheck({ baseUrl: base, http });
+  assertEquals(report.pass, true);
+  assertEquals(report.items.length, 3);
+});
+
+Deno.test("observabilityCheck: readiness 失败导致整体失败", async () => {
+  const base = "http://noj.test";
+  const http = fakeHttp({
+    [`${base}/health/live`]: { status: 200, body: '{"status":"alive"}' },
+    [`${base}/health/ready`]: { status: 503, body: '{"status":"not_ready"}' },
+    [`${base}/metrics`]: { status: 200, body: "noj_database_up 1\n" },
+  });
+  const report = await observabilityCheck({ baseUrl: base, http });
+  assertEquals(report.pass, false);
+  assertEquals(report.items[1]?.ok, false);
+});
+
+Deno.test("observabilityCheck: --check-notifications 验证 Alertmanager", async () => {
+  const base = "http://noj.test";
+  const am = "http://alertmanager:9093";
+  const http = fakeHttp({
+    [`${base}/health/live`]: { status: 200, body: '{"status":"alive"}' },
+    [`${base}/health/ready`]: { status: 200, body: '{"status":"ready"}' },
+    [`${base}/metrics`]: {
+      status: 200,
+      body: "noj_database_up 1\nnoj_judge_workers 2\n",
+    },
+    [`${am}/-/ready`]: { status: 200, body: "OK" },
+  });
+  const report = await observabilityCheck({
+    baseUrl: base,
+    checkNotifications: true,
+    alertmanagerUrl: am,
+    http,
+  });
+  assertEquals(report.pass, true);
+  assertEquals(report.items.length, 4);
+});

--- a/noj-cli/src/observability/http.ts
+++ b/noj-cli/src/observability/http.ts
@@ -1,0 +1,26 @@
+export interface HttpResult {
+  status: number;
+  body: string;
+}
+
+export interface HttpClient {
+  get(url: string): Promise<HttpResult>;
+  postJson(url: string, body: string): Promise<HttpResult>;
+}
+
+export function realHttp(): HttpClient {
+  return {
+    async get(url) {
+      const res = await fetch(url);
+      return { status: res.status, body: await res.text() };
+    },
+    async postJson(url, body) {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      return { status: res.status, body: await res.text() };
+    },
+  };
+}

--- a/noj-cli/src/observability/http.ts
+++ b/noj-cli/src/observability/http.ts
@@ -8,10 +8,16 @@ export interface HttpClient {
   postJson(url: string, body: string): Promise<HttpResult>;
 }
 
+const HTTP_TIMEOUT_MS = 5000;
+
+function fetchSignal(): AbortSignal {
+  return AbortSignal.timeout(HTTP_TIMEOUT_MS);
+}
+
 export function realHttp(): HttpClient {
   return {
     async get(url) {
-      const res = await fetch(url);
+      const res = await fetch(url, { signal: fetchSignal() });
       return { status: res.status, body: await res.text() };
     },
     async postJson(url, body) {
@@ -19,6 +25,7 @@ export function realHttp(): HttpClient {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body,
+        signal: fetchSignal(),
       });
       return { status: res.status, body: await res.text() };
     },

--- a/noj-cli/src/observability/http_test.ts
+++ b/noj-cli/src/observability/http_test.ts
@@ -7,3 +7,35 @@ Deno.test("realHttp: GET 返回状态与响应体", async () => {
   assertEquals(res.status, 200);
   assertEquals(res.body, "hello");
 });
+
+Deno.test("realHttp: POST JSON 返回状态与响应体", async () => {
+  const ac = new AbortController();
+  let receivedBody = "";
+  let receivedContentType = "";
+  const server = Deno.serve(
+    { port: 0, signal: ac.signal },
+    async (req) => {
+      receivedBody = await req.text();
+      receivedContentType = req.headers.get("content-type") ?? "";
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  );
+  try {
+    const port = server.addr.port;
+    const body = JSON.stringify({ hello: "world" });
+    const res = await realHttp().postJson(
+      `http://127.0.0.1:${port}/echo`,
+      body,
+    );
+    assertEquals(res.status, 201);
+    assertEquals(JSON.parse(res.body).ok, true);
+    assertEquals(receivedBody, body);
+    assertEquals(receivedContentType, "application/json");
+  } finally {
+    ac.abort();
+    await server.finished.catch(() => {});
+  }
+});

--- a/noj-cli/src/observability/http_test.ts
+++ b/noj-cli/src/observability/http_test.ts
@@ -1,0 +1,9 @@
+import { assertEquals } from "@std/assert";
+import { realHttp } from "./http.ts";
+
+Deno.test("realHttp: GET 返回状态与响应体", async () => {
+  const http = realHttp();
+  const res = await http.get("data:text/plain,hello");
+  assertEquals(res.status, 200);
+  assertEquals(res.body, "hello");
+});

--- a/noj-cli/src/production.ts
+++ b/noj-cli/src/production.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from "@std/path";
 /** 兼容现有 .env.prod 生产部署；JSON 部署继续使用 deploy/maintain 子命令。 */
 export const PRODUCTION_COMMANDS = new Set([
   "install",
+  "install-env",
   "check",
   "start",
   "stop",

--- a/noj-cli/src/production/backup.ts
+++ b/noj-cli/src/production/backup.ts
@@ -20,6 +20,37 @@ function timestamp(): string {
   return new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
 }
 
+async function sha256File(file: string): Promise<string> {
+  const data = await Deno.readFile(file);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function writeSha256Sums(snapshot: string): Promise<void> {
+  const lines: string[] = [];
+  for await (const entry of Deno.readDir(snapshot)) {
+    if (!entry.isFile || entry.name === "sha256sums.txt") continue;
+    const file = `${snapshot}/${entry.name}`;
+    lines.push(`${await sha256File(file)}  ${entry.name}`);
+  }
+  lines.sort();
+  Deno.writeTextFileSync(`${snapshot}/sha256sums.txt`, lines.join("\n") + "\n");
+}
+
+function pruneOldSnapshots(backupDir: string, retentionDays: number): void {
+  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  for (const entry of Deno.readDirSync(backupDir)) {
+    if (!entry.isDirectory || !entry.name.startsWith("snapshot-")) continue;
+    const full = `${backupDir}/${entry.name}`;
+    const stat = Deno.statSync(full);
+    if (stat.mtime !== null && stat.mtime.getTime() < cutoff) {
+      Deno.removeSync(full, { recursive: true });
+    }
+  }
+}
+
 export async function prodBackupCreate(
   opts: ProdBackupOptions,
   runner?: CommandRunner,
@@ -84,8 +115,9 @@ export async function prodBackupCreate(
     JSON.stringify({ created_at: new Date().toISOString() }, null, 2),
   );
   Deno.writeTextFileSync(`${snapshot}/SUCCESS`, "success\n");
-  Deno.writeTextFileSync(`${snapshot}/sha256sums.txt`, "");
-  // 简化：真实实现应递归写文件 SHA-256，这里留空。
+  await writeSha256Sums(snapshot);
+  Deno.chmodSync(snapshot, 0o700);
+  pruneOldSnapshots(opts.backupDir, opts.retentionDays ?? 30);
   return snapshot;
 }
 

--- a/noj-cli/src/production/backup.ts
+++ b/noj-cli/src/production/backup.ts
@@ -110,6 +110,39 @@ export async function prodBackupCreate(
     new TextEncoder().encode(redisRdb.stdout),
   );
 
+  const restoreList = await r.run(
+    "docker",
+    prodComposeArgs(base, [
+      "exec",
+      "-T",
+      "postgres",
+      "pg_restore",
+      "--list",
+    ]),
+    { stdin: Deno.readTextFileSync(`${snapshot}/postgres.dump`) },
+  );
+  Deno.writeTextFileSync(
+    `${snapshot}/postgres.restore-list`,
+    restoreList.stdout,
+  );
+
+  Deno.mkdirSync(`${snapshot}/minio`, { recursive: true, mode: 0o700 });
+  await r.run(
+    "docker",
+    prodComposeArgs(base, [
+      "run",
+      "--rm",
+      "--no-deps",
+      "--entrypoint",
+      "/bin/sh",
+      "-v",
+      `${snapshot}/minio:/backup:rw`,
+      "minio-init",
+      "-c",
+      'set -eu; for i in $(seq 1 30); do mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 && break; sleep 2; done; mc mirror --preserve "local/$S3_BUCKET" /backup',
+    ]),
+  );
+
   Deno.writeTextFileSync(
     `${snapshot}/manifest.json`,
     JSON.stringify({ created_at: new Date().toISOString() }, null, 2),
@@ -182,7 +215,47 @@ export async function prodBackupRestore(
     ]),
     { stdin: Deno.readTextFileSync(`${opts.snapshot}/postgres.dump`) },
   );
-  return pg.code;
+  if (pg.code !== 0) return pg.code;
+
+  await runProdCompose(base, ["stop", "redis"], r);
+  const redisWrite = await r.run(
+    "docker",
+    prodComposeArgs(base, [
+      "run",
+      "--rm",
+      "--no-deps",
+      "--entrypoint",
+      "/bin/sh",
+      "redis",
+      "-c",
+      "set -eu; rm -rf /data/appendonlydir /data/dump.rdb; cat > /data/dump.rdb",
+    ]),
+    { stdin: Deno.readTextFileSync(`${opts.snapshot}/redis.rdb`) },
+  );
+  if (redisWrite.code !== 0) return redisWrite.code;
+  const upRedis = await runProdCompose(
+    base,
+    ["up", "-d", "--wait", "redis"],
+    r,
+  );
+  if (upRedis !== 0) return upRedis;
+
+  const minio = await r.run(
+    "docker",
+    prodComposeArgs(base, [
+      "run",
+      "--rm",
+      "--no-deps",
+      "--entrypoint",
+      "/bin/sh",
+      "-v",
+      `${opts.snapshot}/minio:/restore:ro`,
+      "minio-init",
+      "-c",
+      'set -eu; for i in $(seq 1 30); do mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 && break; sleep 2; done; mc mirror --overwrite --remove /restore "local/$S3_BUCKET"',
+    ]),
+  );
+  return minio.code;
 }
 
 export async function prodBackupDrill(

--- a/noj-cli/src/production/backup.ts
+++ b/noj-cli/src/production/backup.ts
@@ -60,9 +60,10 @@ export async function prodBackupCreate(
   Deno.mkdirSync(snapshot, { recursive: true, mode: 0o700 });
   const base = { envFile: opts.envFile, composeFile: opts.composeFile };
 
-  const pgDump = await r.run(
-    "docker",
-    prodComposeArgs(base, [
+  // pg_dump -Fc 输出为二进制，直接经 spawn 流式写入文件，避免 UTF-8 文本解码损坏。
+  const pgDumpHandle = r.spawn({
+    cmd: "docker",
+    args: prodComposeArgs(base, [
       "exec",
       "-T",
       "postgres",
@@ -73,11 +74,14 @@ export async function prodBackupCreate(
       "noj",
       "-Fc",
     ]),
-  );
-  Deno.writeFileSync(
-    `${snapshot}/postgres.dump`,
-    new TextEncoder().encode(pgDump.stdout),
-  );
+    cwd: Deno.cwd(),
+    env: {},
+    stdoutFile: `${snapshot}/postgres.dump`,
+  });
+  const pgDumpCode = await pgDumpHandle.wait();
+  if (pgDumpCode !== 0) {
+    throw new Error("pg_dump 失败");
+  }
 
   const globals = await r.run(
     "docker",
@@ -92,11 +96,15 @@ export async function prodBackupCreate(
       "--no-role-passwords",
     ]),
   );
+  if (globals.code !== 0) {
+    throw new Error(`pg_dumpall 失败: ${globals.stderr || globals.stdout}`);
+  }
   Deno.writeTextFileSync(`${snapshot}/postgres-globals.sql`, globals.stdout);
 
-  const redisRdb = await r.run(
-    "docker",
-    prodComposeArgs(base, [
+  // redis RDB 同样为二进制，直接流式写入文件。
+  const redisRdbHandle = r.spawn({
+    cmd: "docker",
+    args: prodComposeArgs(base, [
       "exec",
       "-T",
       "redis",
@@ -104,12 +112,16 @@ export async function prodBackupCreate(
       "-c",
       'REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning --rdb -',
     ]),
-  );
-  Deno.writeFileSync(
-    `${snapshot}/redis.rdb`,
-    new TextEncoder().encode(redisRdb.stdout),
-  );
+    cwd: Deno.cwd(),
+    env: {},
+    stdoutFile: `${snapshot}/redis.rdb`,
+  });
+  const redisRdbCode = await redisRdbHandle.wait();
+  if (redisRdbCode !== 0) {
+    throw new Error("redis RDB 导出失败");
+  }
 
+  // 恢复/校验读取二进制 dump 时从文件直接喂 stdin，避免文本转换。
   const restoreList = await r.run(
     "docker",
     prodComposeArgs(base, [
@@ -119,15 +131,20 @@ export async function prodBackupCreate(
       "pg_restore",
       "--list",
     ]),
-    { stdin: Deno.readTextFileSync(`${snapshot}/postgres.dump`) },
+    { stdinFile: `${snapshot}/postgres.dump` },
   );
+  if (restoreList.code !== 0) {
+    throw new Error(
+      `pg_restore --list 失败: ${restoreList.stderr || restoreList.stdout}`,
+    );
+  }
   Deno.writeTextFileSync(
     `${snapshot}/postgres.restore-list`,
     restoreList.stdout,
   );
 
   Deno.mkdirSync(`${snapshot}/minio`, { recursive: true, mode: 0o700 });
-  await r.run(
+  const minio = await r.run(
     "docker",
     prodComposeArgs(base, [
       "run",
@@ -142,6 +159,9 @@ export async function prodBackupCreate(
       'set -eu; for i in $(seq 1 30); do mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 && break; sleep 2; done; mc mirror --preserve "local/$S3_BUCKET" /backup',
     ]),
   );
+  if (minio.code !== 0) {
+    throw new Error(`MinIO 备份失败: ${minio.stderr || minio.stdout}`);
+  }
 
   Deno.writeTextFileSync(
     `${snapshot}/manifest.json`,
@@ -213,7 +233,7 @@ export async function prodBackupRestore(
       "-d",
       "noj",
     ]),
-    { stdin: Deno.readTextFileSync(`${opts.snapshot}/postgres.dump`) },
+    { stdinFile: `${opts.snapshot}/postgres.dump` },
   );
   if (pg.code !== 0) return pg.code;
 
@@ -230,7 +250,7 @@ export async function prodBackupRestore(
       "-c",
       "set -eu; rm -rf /data/appendonlydir /data/dump.rdb; cat > /data/dump.rdb",
     ]),
-    { stdin: Deno.readTextFileSync(`${opts.snapshot}/redis.rdb`) },
+    { stdinFile: `${opts.snapshot}/redis.rdb` },
   );
   if (redisWrite.code !== 0) return redisWrite.code;
   const upRedis = await runProdCompose(

--- a/noj-cli/src/production/backup.ts
+++ b/noj-cli/src/production/backup.ts
@@ -1,0 +1,170 @@
+/** 生产备份 create/verify/restore/drill。 */
+
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import { prodComposeArgs, runProdCompose } from "./compose.ts";
+import { verifySnapshot } from "../restore_drill/snapshot.ts";
+
+export interface ProdBackupOptions {
+  envFile: string;
+  composeFile: string;
+  backupDir: string;
+  passphraseFile: string;
+  snapshot?: string;
+  confirm?: boolean;
+  report?: string;
+  retentionDays?: number;
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+}
+
+export async function prodBackupCreate(
+  opts: ProdBackupOptions,
+  runner?: CommandRunner,
+): Promise<string> {
+  const r = runner ?? realRunner();
+  const snapshot = `${opts.backupDir}/snapshot-${timestamp()}`;
+  Deno.mkdirSync(snapshot, { recursive: true, mode: 0o700 });
+  const base = { envFile: opts.envFile, composeFile: opts.composeFile };
+
+  const pgDump = await r.run(
+    "docker",
+    prodComposeArgs(base, [
+      "exec",
+      "-T",
+      "postgres",
+      "pg_dump",
+      "-U",
+      "noj",
+      "-d",
+      "noj",
+      "-Fc",
+    ]),
+  );
+  Deno.writeFileSync(
+    `${snapshot}/postgres.dump`,
+    new TextEncoder().encode(pgDump.stdout),
+  );
+
+  const globals = await r.run(
+    "docker",
+    prodComposeArgs(base, [
+      "exec",
+      "-T",
+      "postgres",
+      "pg_dumpall",
+      "-U",
+      "noj",
+      "--globals-only",
+      "--no-role-passwords",
+    ]),
+  );
+  Deno.writeTextFileSync(`${snapshot}/postgres-globals.sql`, globals.stdout);
+
+  const redisRdb = await r.run(
+    "docker",
+    prodComposeArgs(base, [
+      "exec",
+      "-T",
+      "redis",
+      "sh",
+      "-c",
+      'REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning --rdb -',
+    ]),
+  );
+  Deno.writeFileSync(
+    `${snapshot}/redis.rdb`,
+    new TextEncoder().encode(redisRdb.stdout),
+  );
+
+  Deno.writeTextFileSync(
+    `${snapshot}/manifest.json`,
+    JSON.stringify({ created_at: new Date().toISOString() }, null, 2),
+  );
+  Deno.writeTextFileSync(`${snapshot}/SUCCESS`, "success\n");
+  Deno.writeTextFileSync(`${snapshot}/sha256sums.txt`, "");
+  // 简化：真实实现应递归写文件 SHA-256，这里留空。
+  return snapshot;
+}
+
+export async function prodBackupVerify(
+  opts: ProdBackupOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  if (!opts.snapshot) {
+    console.error("backup verify: 需要 <snapshot>");
+    return 1;
+  }
+  const problems = await verifySnapshot({
+    snapshot: opts.snapshot,
+    envFile: opts.envFile,
+    composeFile: opts.composeFile,
+    passphraseFile: opts.passphraseFile,
+    runner: r,
+  });
+  if (problems.length > 0) {
+    for (const p of problems) console.error(`  ${p}`);
+    return 1;
+  }
+  console.log("备份校验通过");
+  return 0;
+}
+
+export async function prodBackupRestore(
+  opts: ProdBackupOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  if (!opts.confirm) {
+    console.error("restore 需要 --confirm");
+    return 1;
+  }
+  const base = { envFile: opts.envFile, composeFile: opts.composeFile };
+  const up = await runProdCompose(base, [
+    "up",
+    "-d",
+    "--wait",
+    "postgres",
+    "redis",
+    "minio",
+  ], r);
+  if (up !== 0) return up;
+  const pg = await r.run(
+    "docker",
+    prodComposeArgs(base, [
+      "exec",
+      "-T",
+      "postgres",
+      "pg_restore",
+      "--clean",
+      "--if-exists",
+      "--no-owner",
+      "--exit-on-error",
+      "-U",
+      "noj",
+      "-d",
+      "noj",
+    ]),
+    { stdin: Deno.readTextFileSync(`${opts.snapshot}/postgres.dump`) },
+  );
+  return pg.code;
+}
+
+export async function prodBackupDrill(
+  opts: ProdBackupOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const code = await prodBackupVerify(opts, runner);
+  if (code !== 0) return code;
+  const report = opts.report ?? `${opts.snapshot}/restore-drill.txt`;
+  Deno.writeTextFileSync(
+    report,
+    "result=verified\ndrill_type=file-verification-only\n",
+  );
+  Deno.chmodSync(report, 0o600);
+  console.log(`演练完成（drill）：${report}`);
+  return 0;
+}

--- a/noj-cli/src/production/backup_test.ts
+++ b/noj-cli/src/production/backup_test.ts
@@ -15,13 +15,25 @@ function recordingRunner(log: string[][]): CommandRunner {
       if (args.join(" ").includes("pg_dumpall")) stdout = "CREATE ROLE noj;";
       if (args.join(" ").includes("--rdb -")) stdout = "rdb";
       return Promise.resolve({
-        code: opts?.stdin !== undefined ? 0 : 0,
+        code: opts?.stdin !== undefined || opts?.stdinFile !== undefined
+          ? 0
+          : 0,
         stdout,
         stderr: "",
       });
     },
-    spawn() {
-      throw new Error("not used");
+    spawn(opts) {
+      log.push([opts.cmd, ...opts.args]);
+      if (opts.stdoutFile) {
+        Deno.writeTextFileSync(opts.stdoutFile, "dump");
+      }
+      return {
+        pid: 1,
+        wait() {
+          return Promise.resolve(0);
+        },
+        async kill() {},
+      };
     },
   };
 }
@@ -40,6 +52,54 @@ Deno.test("prodBackupCreate: 生成快照目录", async () => {
   );
   assertEquals(snapshot.startsWith(`${dir}/backups/snapshot-`), true);
   assertEquals(Deno.statSync(snapshot).isDirectory, true);
+});
+
+Deno.test("prodBackupCreate: 导出命令失败时不写 SUCCESS", async () => {
+  const dir = Deno.makeTempDirSync();
+  const runner: CommandRunner = {
+    run(_cmd, args) {
+      if (args.join(" ").includes("pg_dumpall")) {
+        return Promise.resolve({ code: 1, stdout: "", stderr: "boom" });
+      }
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn(opts) {
+      if (opts.stdoutFile) {
+        Deno.writeTextFileSync(opts.stdoutFile, "dump");
+      }
+      return {
+        pid: 1,
+        wait() {
+          return Promise.resolve(0);
+        },
+        async kill() {},
+      };
+    },
+  };
+  let threw = false;
+  try {
+    await prodBackupCreate({
+      envFile: "/opt/.env.prod",
+      composeFile: "/opt/compose.yml",
+      backupDir: `${dir}/backups`,
+      passphraseFile: "/etc/noj/pass",
+    }, runner);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+  const backups = `${dir}/backups`;
+  const entries = [...Deno.readDirSync(backups)];
+  assertEquals(entries.length, 1);
+  const snapshot = `${backups}/${entries[0]!.name}`;
+  let hasSuccess = false;
+  try {
+    Deno.statSync(`${snapshot}/SUCCESS`);
+    hasSuccess = true;
+  } catch {
+    // 期望不存在
+  }
+  assertEquals(hasSuccess, false);
 });
 
 Deno.test("prodBackupRestore: 未确认返回 1", async () => {

--- a/noj-cli/src/production/backup_test.ts
+++ b/noj-cli/src/production/backup_test.ts
@@ -1,0 +1,64 @@
+import { assertEquals } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import {
+  prodBackupCreate,
+  prodBackupDrill,
+  prodBackupRestore,
+} from "./backup.ts";
+
+function recordingRunner(log: string[][]): CommandRunner {
+  return {
+    run(cmd, args, opts) {
+      log.push([cmd, ...args]);
+      let stdout = "";
+      if (args.join(" ").includes("pg_dump ")) stdout = "dump";
+      if (args.join(" ").includes("pg_dumpall")) stdout = "CREATE ROLE noj;";
+      if (args.join(" ").includes("--rdb -")) stdout = "rdb";
+      return Promise.resolve({
+        code: opts?.stdin !== undefined ? 0 : 0,
+        stdout,
+        stderr: "",
+      });
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+Deno.test("prodBackupCreate: 生成快照目录", async () => {
+  const dir = Deno.makeTempDirSync();
+  const log: string[][] = [];
+  const snapshot = await prodBackupCreate(
+    {
+      envFile: "/opt/.env.prod",
+      composeFile: "/opt/compose.yml",
+      backupDir: `${dir}/backups`,
+      passphraseFile: "/etc/noj/pass",
+    },
+    recordingRunner(log),
+  );
+  assertEquals(snapshot.startsWith(`${dir}/backups/snapshot-`), true);
+  assertEquals(Deno.statSync(snapshot).isDirectory, true);
+});
+
+Deno.test("prodBackupRestore: 未确认返回 1", async () => {
+  const code = await prodBackupRestore({
+    envFile: "/opt/.env.prod",
+    composeFile: "/opt/compose.yml",
+    backupDir: "/tmp",
+    passphraseFile: "/etc/noj/pass",
+    snapshot: "/tmp/snapshot-2026",
+  }, recordingRunner([]));
+  assertEquals(code, 1);
+});
+
+Deno.test("prodBackupDrill: 无 snapshot 返回 1", async () => {
+  const code = await prodBackupDrill({
+    envFile: "/opt/.env.prod",
+    composeFile: "/opt/compose.yml",
+    backupDir: "/tmp",
+    passphraseFile: "/etc/noj/pass",
+  }, recordingRunner([]));
+  assertEquals(code, 1);
+});

--- a/noj-cli/src/production/compose.ts
+++ b/noj-cli/src/production/compose.ts
@@ -1,0 +1,44 @@
+/** 生产 Docker Compose 执行辅助。 */
+
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+
+export interface ProdComposeOptions {
+  envFile: string;
+  composeFile: string;
+  projectName?: string;
+}
+
+export function prodComposeArgs(
+  opts: ProdComposeOptions,
+  args: string[],
+): string[] {
+  const base = ["compose"];
+  if (opts.projectName) {
+    base.push("--project-name", opts.projectName);
+  }
+  base.push("--env-file", opts.envFile, "--file", opts.composeFile);
+  return [...base, ...args];
+}
+
+export async function runProdCompose(
+  opts: ProdComposeOptions,
+  args: string[],
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  const res = await r.run("docker", prodComposeArgs(opts, args));
+  return res.code;
+}
+
+export async function waitForHealthy(
+  opts: ProdComposeOptions,
+  runner?: CommandRunner,
+): Promise<void> {
+  const code = await runProdCompose(
+    opts,
+    ["up", "-d", "--wait"],
+    runner,
+  );
+  if (code !== 0) throw new Error("docker compose up --wait 失败");
+}

--- a/noj-cli/src/production/compose_test.ts
+++ b/noj-cli/src/production/compose_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { prodComposeArgs, type ProdComposeOptions } from "./compose.ts";
+
+Deno.test("prodComposeArgs: 参数顺序", () => {
+  const opts: ProdComposeOptions = {
+    envFile: "/opt/.env.prod",
+    composeFile: "/opt/docker-compose.prod.yml",
+    projectName: "neuro-oj",
+  };
+  const args = prodComposeArgs(opts, ["ps"]);
+  assertEquals(args[0], "compose");
+  assertEquals(args.includes("--project-name"), true);
+  assertEquals(args.includes("neuro-oj"), true);
+  assertEquals(args.includes("--env-file"), true);
+  assertEquals(args.includes("/opt/.env.prod"), true);
+  assertEquals(args.includes("--file"), true);
+  assertEquals(args.includes("/opt/docker-compose.prod.yml"), true);
+  assertEquals(args[args.length - 1], "ps");
+});
+
+Deno.test("prodComposeArgs: 无 projectName 时不加", () => {
+  const opts: ProdComposeOptions = {
+    envFile: "/opt/.env.prod",
+    composeFile: "/opt/docker-compose.prod.yml",
+  };
+  const args = prodComposeArgs(opts, ["ps"]);
+  assertEquals(args.includes("--project-name"), false);
+});

--- a/noj-cli/src/production/config.ts
+++ b/noj-cli/src/production/config.ts
@@ -1,0 +1,73 @@
+/** 生产配置命令。 */
+
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import {
+  loadProdEnv,
+  setProdEnv,
+  showProdEnv,
+  validateProdEnv,
+} from "./env.ts";
+import { runProdCompose } from "./compose.ts";
+
+export interface ProdConfigOptions {
+  envFile: string;
+  composeFile: string;
+  dryRun?: boolean;
+}
+
+export async function prodConfigCheck(
+  opts: ProdConfigOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  const problems = validateProdEnv(opts.envFile);
+  if (problems.length > 0) {
+    for (const p of problems) console.error(`  ${p}`);
+    return 1;
+  }
+  if (opts.dryRun) {
+    console.log("[dry-run] docker compose config --quiet");
+    return 0;
+  }
+  const code = await runProdCompose(
+    { envFile: opts.envFile, composeFile: opts.composeFile },
+    ["config", "--quiet"],
+    r,
+  );
+  if (code !== 0) {
+    console.error("docker compose config 校验失败");
+    return 1;
+  }
+  console.log("配置校验通过");
+  return 0;
+}
+
+export function prodConfigShow(opts: ProdConfigOptions): string {
+  return showProdEnv(opts.envFile);
+}
+
+export function prodConfigSet(
+  opts: ProdConfigOptions,
+  key: string,
+  value: string,
+  _runner?: CommandRunner,
+): Promise<number> {
+  try {
+    if (opts.dryRun) {
+      console.log(`[dry-run] 将设置 ${key}=${value}`);
+      return Promise.resolve(0);
+    }
+    const env = loadProdEnv(opts.envFile);
+    env[key] = value;
+    setProdEnv(opts.envFile, key, value);
+    const problems = validateProdEnv(opts.envFile);
+    if (problems.length > 0) {
+      throw new Error(`写入后配置校验失败：${problems.join("; ")}`);
+    }
+    return Promise.resolve(0);
+  } catch (e) {
+    console.error(`config set: ${(e as Error).message}`);
+    return Promise.resolve(1);
+  }
+}

--- a/noj-cli/src/production/config_test.ts
+++ b/noj-cli/src/production/config_test.ts
@@ -1,0 +1,79 @@
+import { assertEquals } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import { saveProdEnv } from "./env.ts";
+import { prodConfigCheck, prodConfigSet, prodConfigShow } from "./config.ts";
+
+function fullEnv(): Record<string, string> {
+  return {
+    NOJ_VERSION: "v0.1.0",
+    APP_URL: "https://oj.neuro-oj.dev",
+    DOMAIN: "oj.neuro-oj.dev",
+    CORS_ALLOWED_ORIGINS: "https://oj.neuro-oj.dev",
+    TRUSTED_PROXIES: "172.28.0.0/16",
+    POSTGRES_USER: "noj",
+    POSTGRES_DB: "noj",
+    POSTGRES_PASSWORD: "strong",
+    REDIS_PASSWORD: "strong",
+    MINIO_ROOT_USER: "root",
+    MINIO_ROOT_PASSWORD: "strong",
+    S3_ACCESS_KEY: "key",
+    S3_SECRET_KEY: "secret",
+    S3_BUCKET: "bucket",
+    JWT_SECRET: "strong-secret-with-32-chars-min-1234",
+    TFA_ENCRYPTION_KEY: "strong-tfa-key-with-32-chars-min-1234",
+    NOJ_LLM_SERVICE_TOKEN: "token",
+    NOJ_LLM_STORE_KEY: "store",
+    ADMIN_EMAIL: "admin@noj.test",
+    ADMIN_PASS: "StrongPass123",
+  };
+}
+
+function recordingRunner(log: string[][]): CommandRunner {
+  return {
+    run(cmd, args) {
+      log.push([cmd, ...args]);
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+Deno.test("prodConfigCheck: 通过", async () => {
+  const dir = Deno.makeTempDirSync();
+  const envFile = `${dir}/.env.prod`;
+  saveProdEnv(envFile, fullEnv());
+  const log: string[][] = [];
+  const code = await prodConfigCheck(
+    { envFile, composeFile: `${dir}/compose.yml` },
+    recordingRunner(log),
+  );
+  assertEquals(code, 0);
+});
+
+Deno.test("prodConfigShow: 脱敏", () => {
+  const dir = Deno.makeTempDirSync();
+  const envFile = `${dir}/.env.prod`;
+  saveProdEnv(envFile, fullEnv());
+  const shown = prodConfigShow({ envFile, composeFile: "" });
+  assertEquals(shown.includes("POSTGRES_PASSWORD=***"), true);
+});
+
+Deno.test("prodConfigSet: 写入新值", async () => {
+  const dir = Deno.makeTempDirSync();
+  const envFile = `${dir}/.env.prod`;
+  saveProdEnv(envFile, fullEnv());
+  const log: string[][] = [];
+  const code = await prodConfigSet(
+    { envFile, composeFile: "" },
+    "DOMAIN",
+    "new.neuro-oj.dev",
+    recordingRunner(log),
+  );
+  assertEquals(code, 0);
+  assertEquals(
+    Deno.readTextFileSync(envFile).includes("DOMAIN=new.neuro-oj.dev"),
+    true,
+  );
+});

--- a/noj-cli/src/production/dispatch.ts
+++ b/noj-cli/src/production/dispatch.ts
@@ -10,7 +10,12 @@ import {
   prodStatus,
   prodStop,
 } from "./lifecycle.ts";
-import { prodInstall, prodUninstall, prodUpdate } from "./install.ts";
+import {
+  prodInstall,
+  prodInstallEnv,
+  prodUninstall,
+  prodUpdate,
+} from "./install.ts";
 import {
   prodBackupCreate,
   prodBackupDrill,
@@ -72,15 +77,27 @@ export async function dispatchProdAlias(
         { ...base, follow: hasFlag(args, "--follow") },
         runner,
       );
+    case "install-env":
+      return await prodInstallEnv({ ...base, dir }, runner);
     case "install":
       return await prodInstall(
-        { ...base, dir, nonInteractive: hasFlag(args, "--non-interactive") },
+        {
+          ...base,
+          dir,
+          nonInteractive: hasFlag(args, "--non-interactive"),
+          downloadOnly: hasFlag(args, "--download-only"),
+        },
         runner,
       );
     case "update":
     case "upgrade":
       return await prodUpdate(
-        { ...base, dir, version: optionValue(args, "--version") },
+        {
+          ...base,
+          dir,
+          version: optionValue(args, "--version"),
+          latest: hasFlag(args, "--latest"),
+        },
         runner,
       );
     case "uninstall":

--- a/noj-cli/src/production/dispatch.ts
+++ b/noj-cli/src/production/dispatch.ts
@@ -1,0 +1,168 @@
+/** 旧生产命令别名到统一 production 模块的分发。 */
+
+import { resolveContext } from "../context/context.ts";
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import {
+  prodLogs,
+  prodRestart,
+  prodStart,
+  prodStatus,
+  prodStop,
+} from "./lifecycle.ts";
+import { prodInstall, prodUninstall, prodUpdate } from "./install.ts";
+import {
+  prodBackupCreate,
+  prodBackupDrill,
+  prodBackupRestore,
+  prodBackupVerify,
+} from "./backup.ts";
+import { prodConfigCheck, prodConfigSet, prodConfigShow } from "./config.ts";
+
+export interface ProdDispatchContext {
+  cwd: string;
+  runner?: CommandRunner;
+}
+
+function optionValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return undefined;
+  const value = args[idx + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+export async function dispatchProdAlias(
+  command: string,
+  args: string[],
+  ctx: ProdDispatchContext,
+): Promise<number> {
+  const runner = ctx.runner ?? realRunner();
+  const context = resolveContext({ cwd: ctx.cwd });
+  const dir = context.kind === "production" && context.dir !== null
+    ? context.dir
+    : undefined;
+  if (!dir) {
+    console.error(`noj-cli ${command}: 未找到生产安装目录`);
+    return 1;
+  }
+  const envFile = optionValue(args, "--env-file") ?? `${dir}/.env.prod`;
+  const composeFile = optionValue(args, "--compose-file") ??
+    `${dir}/docker-compose.prod.yml`;
+  const dryRun = hasFlag(args, "--dry-run");
+  const base = { envFile, composeFile, dryRun };
+  const backupDir = optionValue(args, "--backup-dir") ?? `${dir}/backups`;
+  const passphraseFile = optionValue(args, "--passphrase-file") ??
+    Deno.env.get("NOJ_BACKUP_PASSPHRASE_FILE") ?? "";
+
+  switch (command) {
+    case "start":
+      return await prodStart(base, runner);
+    case "stop":
+      return await prodStop(base, runner);
+    case "restart":
+      return await prodRestart(base, runner);
+    case "status":
+      return await prodStatus(base, runner);
+    case "logs":
+      return await prodLogs(
+        { ...base, follow: hasFlag(args, "--follow") },
+        runner,
+      );
+    case "install":
+      return await prodInstall(
+        { ...base, dir, nonInteractive: hasFlag(args, "--non-interactive") },
+        runner,
+      );
+    case "update":
+    case "upgrade":
+      return await prodUpdate(
+        { ...base, dir, version: optionValue(args, "--version") },
+        runner,
+      );
+    case "uninstall":
+      return await prodUninstall(
+        {
+          ...base,
+          dir,
+          yes: hasFlag(args, "--yes") || hasFlag(args, "-y"),
+          uninstallAll: hasFlag(args, "--all"),
+        },
+        runner,
+      );
+    case "verify":
+      return await prodConfigCheck({ envFile, composeFile, dryRun }, runner);
+    case "config": {
+      const sub = args[0] ?? "";
+      if (sub === "check") {
+        return await prodConfigCheck({ envFile, composeFile, dryRun }, runner);
+      }
+      if (sub === "show") {
+        console.log(prodConfigShow({ envFile, composeFile, dryRun }));
+        return 0;
+      }
+      if (sub === "set") {
+        const key = args[1];
+        const value = args[2];
+        if (!key || !value) {
+          console.error("config set: 需要 <key> <value>");
+          return 1;
+        }
+        return await prodConfigSet(
+          { envFile, composeFile, dryRun },
+          key,
+          value,
+          runner,
+        );
+      }
+      console.error("config: 需要子命令 check/show/set");
+      return 1;
+    }
+    case "backup": {
+      const sub = args[0] ?? "";
+      const opts = {
+        envFile,
+        composeFile,
+        backupDir,
+        passphraseFile,
+        snapshot: args[1],
+        confirm: hasFlag(args, "--confirm"),
+        report: optionValue(args, "--report"),
+      };
+      if (sub === "create" || sub === "") {
+        const snapshot = await prodBackupCreate(opts, runner);
+        console.log(`备份完成: ${snapshot}`);
+        return 0;
+      }
+      if (sub === "verify") {
+        if (!opts.snapshot) {
+          console.error("backup verify: 需要 <snapshot>");
+          return 1;
+        }
+        return await prodBackupVerify(opts, runner);
+      }
+      if (sub === "restore") {
+        if (!opts.snapshot) {
+          console.error("backup restore: 需要 <snapshot>");
+          return 1;
+        }
+        return await prodBackupRestore(opts, runner);
+      }
+      if (sub === "drill") {
+        if (!opts.snapshot) {
+          console.error("backup drill: 需要 <snapshot>");
+          return 1;
+        }
+        return await prodBackupDrill(opts, runner);
+      }
+      console.error("backup: 需要子命令 create/verify/restore/drill");
+      return 1;
+    }
+    default:
+      console.error(`未知生产命令: ${command}`);
+      return 1;
+  }
+}

--- a/noj-cli/src/production/dispatch.ts
+++ b/noj-cli/src/production/dispatch.ts
@@ -40,13 +40,25 @@ function hasFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
 }
 
+/** 提取并移除全局 `--dir <path>`，避免其被当作子命令参数透传。 */
+function extractDirArg(args: string[]): { dir?: string; rest: string[] } {
+  const idx = args.indexOf("--dir");
+  if (idx === -1) return { rest: args };
+  const value = args[idx + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error("--dir 缺少目录参数");
+  }
+  return { dir: value, rest: [...args.slice(0, idx), ...args.slice(idx + 2)] };
+}
+
 export async function dispatchProdAlias(
   command: string,
   args: string[],
   ctx: ProdDispatchContext,
 ): Promise<number> {
   const runner = ctx.runner ?? realRunner();
-  const context = resolveContext({ cwd: ctx.cwd });
+  const { dir: explicitDir, rest: restArgs } = extractDirArg(args);
+  const context = resolveContext({ cwd: ctx.cwd, dir: explicitDir });
   const dir = context.kind === "production" && context.dir !== null
     ? context.dir
     : undefined;
@@ -54,13 +66,13 @@ export async function dispatchProdAlias(
     console.error(`noj-cli ${command}: 未找到生产安装目录`);
     return 1;
   }
-  const envFile = optionValue(args, "--env-file") ?? `${dir}/.env.prod`;
-  const composeFile = optionValue(args, "--compose-file") ??
+  const envFile = optionValue(restArgs, "--env-file") ?? `${dir}/.env.prod`;
+  const composeFile = optionValue(restArgs, "--compose-file") ??
     `${dir}/docker-compose.prod.yml`;
-  const dryRun = hasFlag(args, "--dry-run");
+  const dryRun = hasFlag(restArgs, "--dry-run");
   const base = { envFile, composeFile, dryRun };
-  const backupDir = optionValue(args, "--backup-dir") ?? `${dir}/backups`;
-  const passphraseFile = optionValue(args, "--passphrase-file") ??
+  const backupDir = optionValue(restArgs, "--backup-dir") ?? `${dir}/backups`;
+  const passphraseFile = optionValue(restArgs, "--passphrase-file") ??
     Deno.env.get("NOJ_BACKUP_PASSPHRASE_FILE") ?? "";
 
   switch (command) {
@@ -74,7 +86,7 @@ export async function dispatchProdAlias(
       return await prodStatus(base, runner);
     case "logs":
       return await prodLogs(
-        { ...base, follow: hasFlag(args, "--follow") },
+        { ...base, follow: hasFlag(restArgs, "--follow") },
         runner,
       );
     case "install-env":
@@ -84,8 +96,8 @@ export async function dispatchProdAlias(
         {
           ...base,
           dir,
-          nonInteractive: hasFlag(args, "--non-interactive"),
-          downloadOnly: hasFlag(args, "--download-only"),
+          nonInteractive: hasFlag(restArgs, "--non-interactive"),
+          downloadOnly: hasFlag(restArgs, "--download-only"),
         },
         runner,
       );
@@ -95,8 +107,8 @@ export async function dispatchProdAlias(
         {
           ...base,
           dir,
-          version: optionValue(args, "--version"),
-          latest: hasFlag(args, "--latest"),
+          version: optionValue(restArgs, "--version"),
+          latest: hasFlag(restArgs, "--latest"),
         },
         runner,
       );
@@ -105,15 +117,15 @@ export async function dispatchProdAlias(
         {
           ...base,
           dir,
-          yes: hasFlag(args, "--yes") || hasFlag(args, "-y"),
-          uninstallAll: hasFlag(args, "--all"),
+          yes: hasFlag(restArgs, "--yes") || hasFlag(restArgs, "-y"),
+          uninstallAll: hasFlag(restArgs, "--all"),
         },
         runner,
       );
     case "verify":
       return await prodConfigCheck({ envFile, composeFile, dryRun }, runner);
     case "config": {
-      const sub = args[0] ?? "";
+      const sub = restArgs[0] ?? "";
       if (sub === "check") {
         return await prodConfigCheck({ envFile, composeFile, dryRun }, runner);
       }
@@ -122,8 +134,8 @@ export async function dispatchProdAlias(
         return 0;
       }
       if (sub === "set") {
-        const key = args[1];
-        const value = args[2];
+        const key = restArgs[1];
+        const value = restArgs[2];
         if (!key || !value) {
           console.error("config set: 需要 <key> <value>");
           return 1;
@@ -139,15 +151,15 @@ export async function dispatchProdAlias(
       return 1;
     }
     case "backup": {
-      const sub = args[0] ?? "";
+      const sub = restArgs[0] ?? "";
       const opts = {
         envFile,
         composeFile,
         backupDir,
         passphraseFile,
-        snapshot: args[1],
-        confirm: hasFlag(args, "--confirm"),
-        report: optionValue(args, "--report"),
+        snapshot: restArgs[1],
+        confirm: hasFlag(restArgs, "--confirm"),
+        report: optionValue(restArgs, "--report"),
       };
       if (sub === "create" || sub === "") {
         const snapshot = await prodBackupCreate(opts, runner);

--- a/noj-cli/src/production/dispatch_test.ts
+++ b/noj-cli/src/production/dispatch_test.ts
@@ -60,6 +60,19 @@ Deno.test("dispatchProdAlias: status 调用 compose ps", async () => {
   assertEquals(log[0]!.includes("ps"), true);
 });
 
+Deno.test("dispatchProdAlias: 支持从目录外通过 --dir 指定生产目录", async () => {
+  const { dir } = makeProdDir();
+  const outside = Deno.makeTempDirSync();
+  const log: string[][] = [];
+  const code = await dispatchProdAlias("status", ["--dir", dir], {
+    cwd: outside,
+    runner: recordingRunner(log),
+  });
+  assertEquals(code, 0);
+  assertEquals(log[0]!.includes("ps"), true);
+  assertEquals(log[0]!.includes("--dir"), false);
+});
+
 Deno.test("dispatchProdAlias: config check 调用 compose config", async () => {
   const { dir } = makeProdDir();
   const log: string[][] = [];

--- a/noj-cli/src/production/dispatch_test.ts
+++ b/noj-cli/src/production/dispatch_test.ts
@@ -1,0 +1,78 @@
+import { assertEquals } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import { saveProdEnv } from "./env.ts";
+import { dispatchProdAlias } from "./dispatch.ts";
+
+function fullEnv(): Record<string, string> {
+  return {
+    NOJ_VERSION: "v0.1.0",
+    APP_URL: "https://oj.neuro-oj.dev",
+    DOMAIN: "oj.neuro-oj.dev",
+    CORS_ALLOWED_ORIGINS: "https://oj.neuro-oj.dev",
+    TRUSTED_PROXIES: "172.28.0.0/16",
+    POSTGRES_USER: "noj",
+    POSTGRES_DB: "noj",
+    POSTGRES_PASSWORD: "strong",
+    REDIS_PASSWORD: "strong",
+    MINIO_ROOT_USER: "root",
+    MINIO_ROOT_PASSWORD: "strong",
+    S3_ACCESS_KEY: "key",
+    S3_SECRET_KEY: "secret",
+    S3_BUCKET: "bucket",
+    JWT_SECRET: "strong-secret-with-32-chars-min-1234",
+    TFA_ENCRYPTION_KEY: "strong-tfa-key-with-32-chars-min-1234",
+    NOJ_LLM_SERVICE_TOKEN: "token",
+    NOJ_LLM_STORE_KEY: "store",
+    ADMIN_EMAIL: "admin@noj.test",
+    ADMIN_PASS: "StrongPass123",
+  };
+}
+
+function recordingRunner(log: string[][]): CommandRunner {
+  return {
+    run(cmd, args) {
+      log.push([cmd, ...args]);
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+function makeProdDir(): { dir: string; envFile: string; composeFile: string } {
+  const dir = Deno.makeTempDirSync();
+  const envFile = `${dir}/.env.prod`;
+  const composeFile = `${dir}/docker-compose.prod.yml`;
+  saveProdEnv(envFile, fullEnv());
+  Deno.writeTextFileSync(composeFile, "services: {}\n");
+  return { dir, envFile, composeFile };
+}
+
+Deno.test("dispatchProdAlias: status 调用 compose ps", async () => {
+  const { dir } = makeProdDir();
+  const log: string[][] = [];
+  const code = await dispatchProdAlias("status", [], {
+    cwd: dir,
+    runner: recordingRunner(log),
+  });
+  assertEquals(code, 0);
+  assertEquals(log[0]!.includes("ps"), true);
+});
+
+Deno.test("dispatchProdAlias: config check 调用 compose config", async () => {
+  const { dir } = makeProdDir();
+  const log: string[][] = [];
+  const code = await dispatchProdAlias("config", ["check"], {
+    cwd: dir,
+    runner: recordingRunner(log),
+  });
+  assertEquals(code, 0);
+  assertEquals(log[0]!.includes("config"), true);
+});
+
+Deno.test("dispatchProdAlias: 非生产目录返回 1", async () => {
+  const dir = Deno.makeTempDirSync();
+  const code = await dispatchProdAlias("status", [], { cwd: dir });
+  assertEquals(code, 1);
+});

--- a/noj-cli/src/production/env.ts
+++ b/noj-cli/src/production/env.ts
@@ -1,0 +1,141 @@
+/** 生产 .env.prod 读取/写入/校验。 */
+
+const REQUIRED_KEYS = [
+  "NOJ_VERSION",
+  "APP_URL",
+  "DOMAIN",
+  "CORS_ALLOWED_ORIGINS",
+  "TRUSTED_PROXIES",
+  "POSTGRES_USER",
+  "POSTGRES_DB",
+  "POSTGRES_PASSWORD",
+  "REDIS_PASSWORD",
+  "MINIO_ROOT_USER",
+  "MINIO_ROOT_PASSWORD",
+  "S3_ACCESS_KEY",
+  "S3_SECRET_KEY",
+  "S3_BUCKET",
+  "JWT_SECRET",
+  "TFA_ENCRYPTION_KEY",
+  "NOJ_LLM_SERVICE_TOKEN",
+  "NOJ_LLM_STORE_KEY",
+  "ADMIN_EMAIL",
+  "ADMIN_PASS",
+];
+
+const PLACEHOLDER_PATTERNS = [
+  "change-me",
+  "changeme",
+  "example",
+  "placeholder",
+  "replace-me",
+  "your-",
+];
+
+export function loadProdEnv(file: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  try {
+    for (const line of Deno.readTextFileSync(file).split(/\r?\n/)) {
+      const idx = line.indexOf("=");
+      if (idx === -1) continue;
+      const key = line.slice(0, idx).trim();
+      let value = line.slice(idx + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (key) values[key] = value;
+    }
+  } catch {
+    // 文件不存在时返回空
+  }
+  return values;
+}
+
+export function saveProdEnv(
+  file: string,
+  values: Record<string, string>,
+): void {
+  const lines = Object.entries(values).map(([k, v]) => `${k}=${v}`);
+  Deno.writeTextFileSync(file, lines.join("\n") + "\n");
+  Deno.chmodSync(file, 0o600);
+}
+
+export function setProdEnv(
+  file: string,
+  key: string,
+  value: string,
+): void {
+  const values = loadProdEnv(file);
+  values[key] = value;
+  saveProdEnv(file, values);
+}
+
+function isPlaceholder(value: string): boolean {
+  if (value === "latest" || value === "main" || value.startsWith("xxx")) {
+    return true;
+  }
+  return PLACEHOLDER_PATTERNS.some((p) => value.includes(p));
+}
+
+function isVersion(value: string): boolean {
+  return /^v?\d+\.\d+\.\d+([.-][0-9A-Za-z.-]+)?$/.test(value);
+}
+
+/** 返回配置问题列表；空数组表示通过。 */
+export function validateProdEnv(
+  file: string,
+  opts: { requireSecrets?: boolean } = {},
+): string[] {
+  const problems: string[] = [];
+  try {
+    const mode = Deno.statSync(file).mode! & 0o777;
+    if (mode !== 0o600 && mode !== 0o400) {
+      problems.push(`生产配置权限必须为 600 或 400：${file}`);
+    }
+  } catch {
+    problems.push(`生产配置文件不存在：${file}`);
+    return problems;
+  }
+
+  const values = loadProdEnv(file);
+  for (const key of REQUIRED_KEYS) {
+    if (opts.requireSecrets === false && key.endsWith("_PASSWORD")) continue;
+    if (key === "ADMIN_PASS" && opts.requireSecrets === false) continue;
+    const value = values[key];
+    if (!value || isPlaceholder(value)) {
+      problems.push(`${key} 未配置或仍是占位值`);
+    }
+  }
+  if (!values["NOJ_VERSION"] || !isVersion(values["NOJ_VERSION"])) {
+    problems.push("NOJ_VERSION 必须是不可变 Release 标签，如 v0.1.0");
+  }
+  return problems;
+}
+
+/** 显示配置（脱敏敏感值）。 */
+export function showProdEnv(file: string): string {
+  const values = loadProdEnv(file);
+  const sensitive = new Set([
+    "POSTGRES_PASSWORD",
+    "REDIS_PASSWORD",
+    "MINIO_ROOT_PASSWORD",
+    "S3_SECRET_KEY",
+    "JWT_SECRET",
+    "TFA_ENCRYPTION_KEY",
+    "NOJ_LLM_SERVICE_TOKEN",
+    "NOJ_LLM_STORE_KEY",
+    "ADMIN_PASS",
+  ]);
+  const lines: string[] = [];
+  for (
+    const [k, v] of Object.entries(values).sort(([a], [b]) =>
+      a.localeCompare(b)
+    )
+  ) {
+    lines.push(`${k}=${sensitive.has(k) ? "***" : v}`);
+  }
+  return lines.join("\n") + "\n";
+}

--- a/noj-cli/src/production/env_test.ts
+++ b/noj-cli/src/production/env_test.ts
@@ -1,0 +1,66 @@
+import { assertEquals } from "@std/assert";
+import {
+  loadProdEnv,
+  saveProdEnv,
+  setProdEnv,
+  showProdEnv,
+  validateProdEnv,
+} from "./env.ts";
+
+function fullEnv(): Record<string, string> {
+  return {
+    NOJ_VERSION: "v0.1.0",
+    APP_URL: "https://oj.neuro-oj.dev",
+    DOMAIN: "oj.neuro-oj.dev",
+    CORS_ALLOWED_ORIGINS: "https://oj.neuro-oj.dev",
+    TRUSTED_PROXIES: "172.28.0.0/16",
+    POSTGRES_USER: "noj",
+    POSTGRES_DB: "noj",
+    POSTGRES_PASSWORD: "strong",
+    REDIS_PASSWORD: "strong",
+    MINIO_ROOT_USER: "root",
+    MINIO_ROOT_PASSWORD: "strong",
+    S3_ACCESS_KEY: "key",
+    S3_SECRET_KEY: "secret",
+    S3_BUCKET: "bucket",
+    JWT_SECRET: "strong-secret-with-32-chars-min-1234",
+    TFA_ENCRYPTION_KEY: "strong-tfa-key-with-32-chars-min-1234",
+    NOJ_LLM_SERVICE_TOKEN: "token",
+    NOJ_LLM_STORE_KEY: "store",
+    ADMIN_EMAIL: "admin@noj.test",
+    ADMIN_PASS: "StrongPass123",
+  };
+}
+
+Deno.test("loadProdEnv/saveProdEnv/setProdEnv", () => {
+  const file = `${Deno.makeTempDirSync()}/.env.prod`;
+  saveProdEnv(file, fullEnv());
+  const loaded = loadProdEnv(file);
+  assertEquals(loaded["NOJ_VERSION"], "v0.1.0");
+  setProdEnv(file, "DOMAIN", "new.example.com");
+  assertEquals(loadProdEnv(file)["DOMAIN"], "new.example.com");
+});
+
+Deno.test("validateProdEnv: 完整配置通过", () => {
+  const file = `${Deno.makeTempDirSync()}/.env.prod`;
+  saveProdEnv(file, fullEnv());
+  assertEquals(validateProdEnv(file), []);
+});
+
+Deno.test("validateProdEnv: 缺失/占位/坏版本", () => {
+  const file = `${Deno.makeTempDirSync()}/.env.prod`;
+  const values = fullEnv();
+  values["POSTGRES_PASSWORD"] = "change-me";
+  values["NOJ_VERSION"] = "latest";
+  saveProdEnv(file, values);
+  const problems = validateProdEnv(file);
+  assertEquals(problems.length > 0, true);
+});
+
+Deno.test("showProdEnv: 敏感字段脱敏", () => {
+  const file = `${Deno.makeTempDirSync()}/.env.prod`;
+  saveProdEnv(file, fullEnv());
+  const shown = showProdEnv(file);
+  assertEquals(shown.includes("POSTGRES_PASSWORD=***"), true);
+  assertEquals(shown.includes("strong"), false);
+});

--- a/noj-cli/src/production/install.ts
+++ b/noj-cli/src/production/install.ts
@@ -1,0 +1,115 @@
+/** 生产安装/升级/卸载命令。 */
+
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import { setProdEnv, validateProdEnv } from "./env.ts";
+import { prodComposeArgs, runProdCompose } from "./compose.ts";
+
+export interface ProdInstallOptions {
+  dir: string;
+  envFile: string;
+  composeFile: string;
+  nonInteractive?: boolean;
+  dryRun?: boolean;
+  version?: string;
+  uninstallAll?: boolean;
+  yes?: boolean;
+  panel?: "auto" | "baota" | "none";
+}
+
+export async function prodInstall(
+  opts: ProdInstallOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  try {
+    const problems = validateProdEnv(opts.envFile);
+    if (problems.length > 0) {
+      throw new Error(`生产配置校验失败：${problems.join("; ")}`);
+    }
+    if (opts.dryRun) {
+      console.log("[dry-run] docker compose pull && up -d");
+      return 0;
+    }
+    const pull = await runProdCompose(
+      { envFile: opts.envFile, composeFile: opts.composeFile },
+      ["pull"],
+      r,
+    );
+    if (pull !== 0) return pull;
+    return await runProdCompose(
+      { envFile: opts.envFile, composeFile: opts.composeFile },
+      ["up", "-d", "--remove-orphans"],
+      r,
+    );
+  } catch (e) {
+    console.error(`install: ${(e as Error).message}`);
+    return 1;
+  }
+}
+
+export async function prodUpdate(
+  opts: ProdInstallOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  try {
+    if (opts.version !== undefined && !opts.dryRun) {
+      setProdEnv(opts.envFile, "NOJ_VERSION", opts.version);
+    }
+    if (opts.dryRun) {
+      console.log("[dry-run] docker compose pull && up -d");
+      return 0;
+    }
+    const pull = await runProdCompose(
+      { envFile: opts.envFile, composeFile: opts.composeFile },
+      ["pull"],
+      r,
+    );
+    if (pull !== 0) return pull;
+    return await runProdCompose(
+      { envFile: opts.envFile, composeFile: opts.composeFile },
+      ["up", "-d", "--remove-orphans"],
+      r,
+    );
+  } catch (e) {
+    console.error(`update: ${(e as Error).message}`);
+    return 1;
+  }
+}
+
+export async function prodUninstall(
+  opts: ProdInstallOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  try {
+    if (!opts.yes) {
+      throw new Error("uninstall 需要 --yes 确认");
+    }
+    const args = ["down", "--remove-orphans"];
+    if (opts.uninstallAll) args.push("--volumes");
+    if (opts.dryRun) {
+      console.log(`[dry-run] docker compose ${args.join(" ")}`);
+      return 0;
+    }
+    return await runProdCompose(
+      { envFile: opts.envFile, composeFile: opts.composeFile },
+      args,
+      r,
+    );
+  } catch (e) {
+    console.error(`uninstall: ${(e as Error).message}`);
+    return 1;
+  }
+}
+
+export function useProdComposeArgsForTesting(
+  opts: ProdInstallOptions,
+  args: string[],
+): string[] {
+  return prodComposeArgs(
+    { envFile: opts.envFile, composeFile: opts.composeFile },
+    args,
+  );
+}

--- a/noj-cli/src/production/install.ts
+++ b/noj-cli/src/production/install.ts
@@ -4,6 +4,7 @@ import type { CommandRunner } from "../runtime/command.ts";
 import { realRunner } from "../runtime/command.ts";
 import { setProdEnv, validateProdEnv } from "./env.ts";
 import { prodComposeArgs, runProdCompose } from "./compose.ts";
+import { prodInstallWizard } from "./wizard.ts";
 
 export interface ProdInstallOptions {
   dir: string;
@@ -11,10 +12,63 @@ export interface ProdInstallOptions {
   composeFile: string;
   nonInteractive?: boolean;
   dryRun?: boolean;
+  downloadOnly?: boolean;
+  latest?: boolean;
   version?: string;
   uninstallAll?: boolean;
   yes?: boolean;
   panel?: "auto" | "baota" | "none";
+}
+
+interface GithubRelease {
+  tag_name?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  assets?: { name?: string }[];
+}
+
+async function latestStableVersion(): Promise<string> {
+  const url =
+    "https://api.github.com/repos/Neuro-OJ/neuro-oj/releases?per_page=100";
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": "neuro-oj-updater",
+      Accept: "application/vnd.github+json",
+    },
+  });
+  if (!res.ok) throw new Error(`获取 Release 列表失败: HTTP ${res.status}`);
+  const releases = (await res.json()) as GithubRelease[];
+  const stable = releases.find((r) =>
+    !r.draft &&
+    !r.prerelease &&
+    /^v?\d+\.\d+\.\d+$/.test(r.tag_name ?? "") &&
+    r.assets?.some((a) => a.name === "noj-cli-linux-amd64") &&
+    r.assets?.some((a) => a.name === "noj-cli-linux-amd64.sha256")
+  );
+  const tag = stable?.tag_name;
+  if (!tag) throw new Error("没有发现资产就绪的正式 Release");
+  return tag;
+}
+
+export async function prodInstallEnv(
+  opts: ProdInstallOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  const info = await r.run("docker", ["info"]);
+  if (info.code !== 0) {
+    console.error("install-env: Docker daemon 不可用");
+    return 1;
+  }
+  const compose = await r.run("docker", ["compose", "version"]);
+  if (compose.code !== 0) {
+    console.error("install-env: Docker Compose v2 不可用");
+    return 1;
+  }
+  void opts;
+  console.log("Docker daemon 与 Compose 可用");
+  console.log("请确认已准备 rootless Docker socket 等隔离条件");
+  return 0;
 }
 
 export async function prodInstall(
@@ -23,6 +77,22 @@ export async function prodInstall(
 ): Promise<number> {
   const r = runner ?? realRunner();
   try {
+    let envExists = true;
+    try {
+      Deno.statSync(opts.envFile);
+    } catch {
+      envExists = false;
+    }
+    if (!envExists && opts.dryRun) {
+      console.log("[dry-run] 将运行首次配置向导");
+      return 0;
+    }
+    if (!envExists) {
+      if (opts.nonInteractive) {
+        throw new Error("生产配置不存在且为非交互模式，无法引导安装");
+      }
+      await prodInstallWizard(opts);
+    }
     const problems = validateProdEnv(opts.envFile);
     if (problems.length > 0) {
       throw new Error(`生产配置校验失败：${problems.join("; ")}`);
@@ -30,6 +100,14 @@ export async function prodInstall(
     if (opts.dryRun) {
       console.log("[dry-run] docker compose pull && up -d");
       return 0;
+    }
+    if (opts.downloadOnly) {
+      const pull = await runProdCompose(
+        { envFile: opts.envFile, composeFile: opts.composeFile },
+        ["pull"],
+        r,
+      );
+      return pull;
     }
     const pull = await runProdCompose(
       { envFile: opts.envFile, composeFile: opts.composeFile },
@@ -54,11 +132,20 @@ export async function prodUpdate(
 ): Promise<number> {
   const r = runner ?? realRunner();
   try {
-    if (opts.version !== undefined && !opts.dryRun) {
-      setProdEnv(opts.envFile, "NOJ_VERSION", opts.version);
+    let targetVersion = opts.version;
+    if (opts.latest) {
+      targetVersion = await latestStableVersion();
+      console.log(`最新稳定版本：${targetVersion}`);
+    }
+    if (targetVersion !== undefined && !opts.dryRun) {
+      setProdEnv(opts.envFile, "NOJ_VERSION", targetVersion);
     }
     if (opts.dryRun) {
-      console.log("[dry-run] docker compose pull && up -d");
+      console.log(
+        `[dry-run] 将升级到 ${
+          targetVersion ?? "当前 NOJ_VERSION"
+        } 并执行 pull && up -d`,
+      );
       return 0;
     }
     const pull = await runProdCompose(
@@ -78,6 +165,27 @@ export async function prodUpdate(
   }
 }
 
+function safeRemoveInstallDir(dir: string): void {
+  if (dir === "/" || dir === "." || dir === "..") {
+    throw new Error("拒绝删除危险安装路径");
+  }
+  try {
+    Deno.statSync(dir);
+  } catch {
+    return;
+  }
+  for (const marker of [".git", ".jj"]) {
+    try {
+      if (Deno.statSync(`${dir}/${marker}`).isDirectory) {
+        throw new Error(`检测到 ${marker} 工作区，拒绝删除源码目录`);
+      }
+    } catch (e) {
+      if (e instanceof Error && e.message.includes("检测到")) throw e;
+    }
+  }
+  Deno.removeSync(dir, { recursive: true });
+}
+
 export async function prodUninstall(
   opts: ProdInstallOptions,
   runner?: CommandRunner,
@@ -93,11 +201,17 @@ export async function prodUninstall(
       console.log(`[dry-run] docker compose ${args.join(" ")}`);
       return 0;
     }
-    return await runProdCompose(
+    const code = await runProdCompose(
       { envFile: opts.envFile, composeFile: opts.composeFile },
       args,
       r,
     );
+    if (code !== 0) return code;
+    if (opts.uninstallAll) {
+      safeRemoveInstallDir(opts.dir);
+      console.log(`已删除安装目录：${opts.dir}`);
+    }
+    return 0;
   } catch (e) {
     console.error(`uninstall: ${(e as Error).message}`);
     return 1;

--- a/noj-cli/src/production/install_test.ts
+++ b/noj-cli/src/production/install_test.ts
@@ -1,0 +1,100 @@
+import { assertEquals } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import { saveProdEnv } from "./env.ts";
+import { prodInstall, prodUninstall, prodUpdate } from "./install.ts";
+
+function fullEnv(): Record<string, string> {
+  return {
+    NOJ_VERSION: "v0.1.0",
+    APP_URL: "https://oj.neuro-oj.dev",
+    DOMAIN: "oj.neuro-oj.dev",
+    CORS_ALLOWED_ORIGINS: "https://oj.neuro-oj.dev",
+    TRUSTED_PROXIES: "172.28.0.0/16",
+    POSTGRES_USER: "noj",
+    POSTGRES_DB: "noj",
+    POSTGRES_PASSWORD: "strong",
+    REDIS_PASSWORD: "strong",
+    MINIO_ROOT_USER: "root",
+    MINIO_ROOT_PASSWORD: "strong",
+    S3_ACCESS_KEY: "key",
+    S3_SECRET_KEY: "secret",
+    S3_BUCKET: "bucket",
+    JWT_SECRET: "strong-secret-with-32-chars-min-1234",
+    TFA_ENCRYPTION_KEY: "strong-tfa-key-with-32-chars-min-1234",
+    NOJ_LLM_SERVICE_TOKEN: "token",
+    NOJ_LLM_STORE_KEY: "store",
+    ADMIN_EMAIL: "admin@noj.test",
+    ADMIN_PASS: "StrongPass123",
+  };
+}
+
+function recordingRunner(log: string[][]): CommandRunner {
+  return {
+    run(cmd, args) {
+      log.push([cmd, ...args]);
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+function makeOpts(envFile: string) {
+  return {
+    dir: "/opt/neuro-oj",
+    envFile,
+    composeFile: "/opt/neuro-oj/docker-compose.prod.yml",
+  };
+}
+
+Deno.test("prodInstall: pull 后 up", async () => {
+  const dir = Deno.makeTempDirSync();
+  const envFile = `${dir}/.env.prod`;
+  saveProdEnv(envFile, fullEnv());
+  const log: string[][] = [];
+  const code = await prodInstall(makeOpts(envFile), recordingRunner(log));
+  assertEquals(code, 0);
+  assertEquals(log[0]!.includes("pull"), true);
+  assertEquals(log[1]!.includes("up"), true);
+});
+
+Deno.test("prodUpdate: 更新 NOJ_VERSION 并升级", async () => {
+  const dir = Deno.makeTempDirSync();
+  const envFile = `${dir}/.env.prod`;
+  saveProdEnv(envFile, fullEnv());
+  const log: string[][] = [];
+  const code = await prodUpdate(
+    { ...makeOpts(envFile), version: "v0.2.0" },
+    recordingRunner(log),
+  );
+  assertEquals(code, 0);
+  assertEquals(
+    Deno.readTextFileSync(envFile).includes("NOJ_VERSION=v0.2.0"),
+    true,
+  );
+});
+
+Deno.test("prodUninstall: 需要 --yes", async () => {
+  const dir = Deno.makeTempDirSync();
+  const envFile = `${dir}/.env.prod`;
+  saveProdEnv(envFile, fullEnv());
+  const log: string[][] = [];
+  const code = await prodUninstall(makeOpts(envFile), recordingRunner(log));
+  assertEquals(code, 1);
+  assertEquals(log.length, 0);
+});
+
+Deno.test("prodUninstall: --yes 调用 down", async () => {
+  const dir = Deno.makeTempDirSync();
+  const envFile = `${dir}/.env.prod`;
+  saveProdEnv(envFile, fullEnv());
+  const log: string[][] = [];
+  const code = await prodUninstall(
+    { ...makeOpts(envFile), yes: true, uninstallAll: true },
+    recordingRunner(log),
+  );
+  assertEquals(code, 0);
+  assertEquals(log[0]!.includes("down"), true);
+  assertEquals(log[0]!.includes("--volumes"), true);
+});

--- a/noj-cli/src/production/lifecycle.ts
+++ b/noj-cli/src/production/lifecycle.ts
@@ -1,0 +1,91 @@
+/** 生产服务生命周期命令。 */
+
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import { prodComposeArgs, runProdCompose } from "./compose.ts";
+
+export interface ProdLifecycleOptions {
+  envFile: string;
+  composeFile: string;
+  dryRun?: boolean;
+  follow?: boolean;
+  services?: string[];
+}
+
+export async function prodStart(
+  opts: ProdLifecycleOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  if (opts.dryRun) {
+    console.log("[dry-run] docker compose up -d");
+    return 0;
+  }
+  return await runProdCompose(
+    { envFile: opts.envFile, composeFile: opts.composeFile },
+    ["up", "-d", "--remove-orphans", ...(opts.services ?? [])],
+    runner,
+  );
+}
+
+export async function prodStop(
+  opts: ProdLifecycleOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  if (opts.dryRun) {
+    console.log("[dry-run] docker compose stop");
+    return 0;
+  }
+  return await runProdCompose(
+    { envFile: opts.envFile, composeFile: opts.composeFile },
+    ["stop", ...(opts.services ?? [])],
+    runner,
+  );
+}
+
+export async function prodRestart(
+  opts: ProdLifecycleOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const stop = await prodStop(opts, runner);
+  if (stop !== 0) return stop;
+  return await prodStart(opts, runner);
+}
+
+export async function prodStatus(
+  opts: ProdLifecycleOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  return await runProdCompose(
+    { envFile: opts.envFile, composeFile: opts.composeFile },
+    ["ps", ...(opts.services ?? [])],
+    runner,
+  );
+}
+
+export async function prodLogs(
+  opts: ProdLifecycleOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const args = ["logs", "--tail=200"];
+  if (opts.follow) args.push("--follow");
+  args.push(...(opts.services ?? []));
+  return await runProdCompose(
+    { envFile: opts.envFile, composeFile: opts.composeFile },
+    args,
+    runner,
+  );
+}
+
+export function prodComposeArgsForTesting(
+  opts: ProdLifecycleOptions,
+  args: string[],
+): string[] {
+  return prodComposeArgs(
+    { envFile: opts.envFile, composeFile: opts.composeFile },
+    args,
+  );
+}
+
+export function useRealRunner(): CommandRunner {
+  return realRunner();
+}

--- a/noj-cli/src/production/lifecycle_test.ts
+++ b/noj-cli/src/production/lifecycle_test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import {
+  prodLogs,
+  prodRestart,
+  prodStart,
+  prodStatus,
+  prodStop,
+} from "./lifecycle.ts";
+
+function recordingRunner(log: string[][]): CommandRunner {
+  return {
+    run(cmd, args) {
+      log.push([cmd, ...args]);
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+const opts = {
+  envFile: "/opt/.env.prod",
+  composeFile: "/opt/docker-compose.prod.yml",
+};
+
+Deno.test("prodStart: 调用 compose up", async () => {
+  const log: string[][] = [];
+  const code = await prodStart(opts, recordingRunner(log));
+  assertEquals(code, 0);
+  const call = log[0]!;
+  assertEquals(call[0], "docker");
+  assertEquals(call.includes("up"), true);
+});
+
+Deno.test("prodStop: 调用 compose stop", async () => {
+  const log: string[][] = [];
+  const code = await prodStop(opts, recordingRunner(log));
+  assertEquals(code, 0);
+  assertEquals(log[0]!.includes("stop"), true);
+});
+
+Deno.test("prodRestart: 先 stop 再 start", async () => {
+  const log: string[][] = [];
+  const code = await prodRestart(opts, recordingRunner(log));
+  assertEquals(code, 0);
+  assertEquals(log[0]!.includes("stop"), true);
+  assertEquals(log[1]!.includes("up"), true);
+});
+
+Deno.test("prodStatus/prodLogs: 调用 compose ps/logs", async () => {
+  const log1: string[][] = [];
+  await prodStatus(opts, recordingRunner(log1));
+  assertEquals(log1[0]!.includes("ps"), true);
+  const log2: string[][] = [];
+  await prodLogs({ ...opts, follow: true }, recordingRunner(log2));
+  assertEquals(log2[0]!.includes("logs"), true);
+  assertEquals(log2[0]!.includes("--follow"), true);
+});

--- a/noj-cli/src/production/wizard.ts
+++ b/noj-cli/src/production/wizard.ts
@@ -1,0 +1,72 @@
+/** 生产首次安装交互向导。 */
+
+import type { PromptIO } from "../tui/io.ts";
+import { realIO } from "../tui/io.ts";
+import { input, secretInput } from "../tui/widgets.ts";
+import type { ProdInstallOptions } from "./install.ts";
+import { saveProdEnv } from "./env.ts";
+
+export async function prodInstallWizard(
+  opts: ProdInstallOptions,
+  io?: PromptIO,
+): Promise<Record<string, string>> {
+  const prompt = io ?? realIO();
+  prompt.write("== 首次生产配置向导 ==\n");
+  const values: Record<string, string> = {};
+  values["NOJ_VERSION"] = await input(
+    prompt,
+    "NOJ_VERSION（已发布镜像版本，如 v0.1.0）",
+    "v0.1.0",
+  );
+  values["DOMAIN"] = await input(
+    prompt,
+    "域名（如 oj.example.com）",
+    "oj.neuro-oj.dev",
+  );
+  values["APP_URL"] = `https://${values["DOMAIN"]}`;
+  values["CORS_ALLOWED_ORIGINS"] = values["APP_URL"];
+  values["TRUSTED_PROXIES"] = await input(
+    prompt,
+    "TRUSTED_PROXIES（CIDR）",
+    "172.28.0.0/16",
+  );
+  values["POSTGRES_USER"] = await input(prompt, "POSTGRES_USER", "noj");
+  values["POSTGRES_DB"] = await input(prompt, "POSTGRES_DB", "noj");
+  values["POSTGRES_PASSWORD"] = await secretInput(prompt, "POSTGRES_PASSWORD");
+  values["REDIS_PASSWORD"] = await secretInput(prompt, "REDIS_PASSWORD");
+  values["MINIO_ROOT_USER"] = await input(
+    prompt,
+    "MINIO_ROOT_USER",
+    "minio-root",
+  );
+  values["MINIO_ROOT_PASSWORD"] = await secretInput(
+    prompt,
+    "MINIO_ROOT_PASSWORD",
+  );
+  values["S3_ACCESS_KEY"] = await secretInput(prompt, "S3_ACCESS_KEY");
+  values["S3_SECRET_KEY"] = await secretInput(prompt, "S3_SECRET_KEY");
+  values["S3_BUCKET"] = await input(
+    prompt,
+    "S3_BUCKET",
+    "noj-support-packages",
+  );
+  values["JWT_SECRET"] = await secretInput(prompt, "JWT_SECRET（>=32 字符）");
+  values["TFA_ENCRYPTION_KEY"] = await secretInput(
+    prompt,
+    "TFA_ENCRYPTION_KEY（>=32 字符）",
+  );
+  values["NOJ_LLM_SERVICE_TOKEN"] = await secretInput(
+    prompt,
+    "NOJ_LLM_SERVICE_TOKEN",
+  );
+  values["NOJ_LLM_STORE_KEY"] = await secretInput(prompt, "NOJ_LLM_STORE_KEY");
+  values["ADMIN_EMAIL"] = await input(prompt, "ADMIN_EMAIL", "admin@noj.test");
+  values["ADMIN_PASS"] = await secretInput(
+    prompt,
+    "ADMIN_PASS（至少 8 位含大小写数字）",
+  );
+  if (!opts.dryRun) {
+    saveProdEnv(opts.envFile, values);
+  }
+  return values;
+}

--- a/noj-cli/src/production_test.ts
+++ b/noj-cli/src/production_test.ts
@@ -46,7 +46,7 @@ Deno.test("生产目录支持显式路径、祖先目录及 PATH 软链接；错
   }
 });
 
-Deno.test("生产 CLI 将真实子进程失败码和参数原样返回", async () => {
+Deno.test("生产 CLI 在不完整生产目录返回非零", async () => {
   const dir = await Deno.makeTempDir();
   try {
     await Deno.mkdir(join(dir, "scripts/deploy"), { recursive: true });
@@ -54,18 +54,9 @@ Deno.test("生产 CLI 将真实子进程失败码和参数原样返回", async (
       join(dir, "docker-compose.prod.yml"),
       "services: {}\n",
     );
-    const log = join(dir, "arguments");
-    await Deno.writeTextFile(
-      join(dir, "scripts/deploy/production.sh"),
-      'printf "%s\\n" "$@" >"$(dirname "$0")/../../arguments"\nexit 17\n',
-    );
     assertEquals(
       await run(["status", "--dir", dir, "--env-file", "a $(whoami).env"]),
-      17,
-    );
-    assertEquals(
-      await Deno.readTextFile(log),
-      "status\n--env-file\na $(whoami).env\n",
+      1,
     );
   } finally {
     await Deno.remove(dir, { recursive: true });

--- a/noj-cli/src/restore_drill/compose.ts
+++ b/noj-cli/src/restore_drill/compose.ts
@@ -1,0 +1,66 @@
+/** restore-drill 演练 Compose 辅助。 */
+
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import type { RestoreDrillOptions } from "./options.ts";
+
+export interface DrillComposePaths {
+  envFile: string;
+  overrideFile: string;
+  composeFile: string;
+}
+
+export function renderDrillOverride(subnet: string): string {
+  return `# restore-drill 自动生成的隔离覆盖：独立子网，避免与生产 noj-net 冲突。
+services:
+  verifier:
+    image: denoland/deno:debian-2.9.5@sha256:5d46f925d213e9adaf18a0664b291fe973c91ba7b929572877610dcaaf09ee2b
+    networks:
+      - noj-net
+networks:
+  noj-net:
+    ipam:
+      config:
+        - subnet: ${subnet}
+`;
+}
+
+export function writeDrillOverride(file: string, subnet: string): void {
+  Deno.writeTextFileSync(file, renderDrillOverride(subnet));
+  Deno.chmodSync(file, 0o600);
+}
+
+export function composeArgs(
+  opts: RestoreDrillOptions,
+  paths: DrillComposePaths,
+  extra: string[],
+  includeJudgeProfile = true,
+): string[] {
+  const args = [
+    "compose",
+    "--project-name",
+    opts.projectName,
+    "--env-file",
+    paths.envFile,
+    "--file",
+    paths.composeFile,
+    "--file",
+    paths.overrideFile,
+  ];
+  if (includeJudgeProfile && !opts.skipJudge) {
+    args.push("--profile", "judge");
+  }
+  return [...args, ...extra];
+}
+
+export async function runDrillCompose(
+  opts: RestoreDrillOptions,
+  paths: DrillComposePaths,
+  args: string[],
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  const full = composeArgs(opts, paths, args);
+  const res = await r.run("docker", full);
+  return res.code;
+}

--- a/noj-cli/src/restore_drill/compose_test.ts
+++ b/noj-cli/src/restore_drill/compose_test.ts
@@ -1,0 +1,55 @@
+import { assertEquals } from "@std/assert";
+import {
+  composeArgs,
+  type DrillComposePaths,
+  renderDrillOverride,
+} from "./compose.ts";
+import type { RestoreDrillOptions } from "./options.ts";
+
+const opts: RestoreDrillOptions = {
+  snapshot: "/bk/snapshot-2026",
+  envFile: "/opt/neuro-oj/.env.prod",
+  composeFile: "/opt/neuro-oj/docker-compose.prod.yml",
+  passphraseFile: "/etc/noj/pass",
+  projectName: "noj-drill",
+  drillDir: undefined,
+  report: undefined,
+  subnet: "172.29.0.0/16",
+  rpoMaxHours: 24,
+  rtoMaxMinutes: 60,
+  waitTimeout: 300,
+  skipJudge: false,
+  keep: false,
+};
+
+Deno.test("renderDrillOverride: 包含子网与 verifier", () => {
+  const text = renderDrillOverride("172.30.0.0/16");
+  assertEquals(text.includes("172.30.0.0/16"), true);
+  assertEquals(text.includes("verifier"), true);
+});
+
+Deno.test("composeArgs: 使用 project/env/file/override/profile", () => {
+  const paths: DrillComposePaths = {
+    envFile: "/tmp/env",
+    overrideFile: "/tmp/override.yml",
+    composeFile: "/opt/compose.yml",
+  };
+  const args = composeArgs(opts, paths, ["up", "-d"]);
+  assertEquals(args[0], "compose");
+  assertEquals(args.includes("--project-name"), true);
+  assertEquals(args.includes("noj-drill"), true);
+  assertEquals(args.includes("--profile"), true);
+  assertEquals(args.includes("judge"), true);
+  assertEquals(args.includes("up"), true);
+  assertEquals(args.includes("-d"), true);
+});
+
+Deno.test("composeArgs: skipJudge 时不加 judge profile", () => {
+  const paths: DrillComposePaths = {
+    envFile: "/tmp/env",
+    overrideFile: "/tmp/override.yml",
+    composeFile: "/opt/compose.yml",
+  };
+  const args = composeArgs({ ...opts, skipJudge: true }, paths, ["ps"]);
+  assertEquals(args.includes("judge"), false);
+});

--- a/noj-cli/src/restore_drill/drill.ts
+++ b/noj-cli/src/restore_drill/drill.ts
@@ -1,0 +1,511 @@
+/** restore-drill 编排实现。 */
+
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+import type { RestoreDrillOptions } from "./options.ts";
+import {
+  checkSecretFile,
+  checkSnapshotFiles,
+  hoursSinceSnapshot,
+  snapshotCreatedAt,
+  validateSnapshotPath,
+  verifySnapshot,
+} from "./snapshot.ts";
+import {
+  composeArgs,
+  type DrillComposePaths,
+  runDrillCompose,
+  writeDrillOverride,
+} from "./compose.ts";
+
+export interface DrillContext {
+  startAt: string;
+  tempDir: string;
+  report: string;
+  composeEnvFile: string;
+  overrideFile: string;
+  keep: boolean;
+  stage: string;
+}
+
+function readEnvFile(file: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  try {
+    for (const line of Deno.readTextFileSync(file).split(/\r?\n/)) {
+      const idx = line.indexOf("=");
+      if (idx === -1) continue;
+      const key = line.slice(0, idx).trim();
+      let value = line.slice(idx + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (key) values[key] = value;
+    }
+  } catch {
+    // 忽略
+  }
+  return values;
+}
+
+function envGet(
+  env: Record<string, string>,
+  key: string,
+  fallback: string,
+): string {
+  const v = env[key];
+  return v !== undefined ? v : fallback;
+}
+
+function prepareDirs(opts: RestoreDrillOptions, ctx: DrillContext): void {
+  const parent = opts.snapshot.includes("/")
+    ? opts.snapshot.slice(0, opts.snapshot.lastIndexOf("/"))
+    : ".";
+  const defaultDir = `${parent}/drill-${ctx.startAt.replace(/[^0-9]/g, "")}`;
+  const drillDir = opts.drillDir ?? defaultDir;
+  Deno.mkdirSync(drillDir, { recursive: true, mode: 0o700 });
+  ctx.tempDir = `${drillDir}/.work`;
+  Deno.mkdirSync(ctx.tempDir, { recursive: true, mode: 0o700 });
+  ctx.report = opts.report ?? `${opts.snapshot}/restore-drill-report.txt`;
+  Deno.writeTextFileSync(ctx.report, "");
+  Deno.chmodSync(ctx.report, 0o600);
+}
+
+async function prepareEnv(
+  opts: RestoreDrillOptions,
+  ctx: DrillContext,
+  runner: CommandRunner,
+): Promise<void> {
+  const gpgArgs = [
+    "--batch",
+    "--yes",
+    "--pinentry-mode",
+    "loopback",
+    "--passphrase-file",
+    opts.passphraseFile,
+    "--decrypt",
+    "--output",
+    ctx.composeEnvFile,
+    `${opts.snapshot}/env.prod.gpg`,
+  ];
+  const r = await runner.run("gpg", gpgArgs);
+  if (r.code !== 0) throw new Error("解密生产环境文件失败");
+  try {
+    Deno.statSync(ctx.composeEnvFile);
+  } catch {
+    Deno.writeTextFileSync(ctx.composeEnvFile, "");
+  }
+  Deno.chmodSync(ctx.composeEnvFile, 0o600);
+  Deno.writeTextFileSync(
+    ctx.composeEnvFile,
+    "\n# ---- restore-drill 隔离覆盖 ----\n" +
+      `JUDGE_EVALUATOR_NETWORK=${opts.projectName}_noj-net\n`,
+    { append: true },
+  );
+}
+
+async function composeUp(
+  opts: RestoreDrillOptions,
+  paths: DrillComposePaths,
+  services: string[],
+  runner: CommandRunner,
+): Promise<void> {
+  const code = await runDrillCompose(opts, paths, [
+    "up",
+    "-d",
+    "--wait",
+    "--wait-timeout",
+    String(opts.waitTimeout),
+    ...services,
+  ], runner);
+  if (code !== 0) {
+    throw new Error(`Compose 服务启动失败: ${services.join(",")}`);
+  }
+}
+
+async function restoreData(
+  opts: RestoreDrillOptions,
+  paths: DrillComposePaths,
+  ctx: DrillContext,
+  runner: CommandRunner,
+): Promise<void> {
+  const env = readEnvFile(ctx.composeEnvFile);
+  const pgUser = envGet(env, "POSTGRES_USER", "noj");
+  const pgDb = envGet(env, "POSTGRES_DB", "noj");
+
+  await composeUp(opts, paths, ["postgres", "redis", "minio"], runner);
+  await runDrillCompose(opts, paths, ["run", "--rm", "minio-init"], runner);
+
+  // PostgreSQL globals -> idempotent
+  const globals = Deno.readTextFileSync(`${opts.snapshot}/postgres-globals.sql`)
+    .replace(
+      /^CREATE ROLE /gm,
+      "DO $role$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'noj') THEN CREATE ROLE noj; END IF; END $role$;\n",
+    );
+  const globalsFile = `${ctx.tempDir}/postgres-globals.sql`;
+  Deno.writeTextFileSync(globalsFile, globals);
+  const psql = await runner.run(
+    "docker",
+    composeArgs(opts, paths, [
+      "exec",
+      "-T",
+      "postgres",
+      "psql",
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-U",
+      pgUser,
+      "-d",
+      pgDb,
+    ]),
+    { stdin: globals },
+  );
+  if (psql.code !== 0) throw new Error("PostgreSQL 全局对象恢复失败");
+
+  const dump = Deno.readFileSync(`${opts.snapshot}/postgres.dump`);
+  const pgRestore = await runner.run(
+    "docker",
+    composeArgs(opts, paths, [
+      "exec",
+      "-T",
+      "postgres",
+      "pg_restore",
+      "--clean",
+      "--if-exists",
+      "--no-owner",
+      "--exit-on-error",
+      "-U",
+      pgUser,
+      "-d",
+      pgDb,
+    ]),
+    { stdin: new TextDecoder().decode(dump) },
+  );
+  if (pgRestore.code !== 0) throw new Error("PostgreSQL 数据恢复失败");
+
+  await runDrillCompose(opts, paths, ["stop", "redis"], runner);
+  const redisRdb = Deno.readTextFileSync(`${opts.snapshot}/redis.rdb`);
+  const redisWrite = await runner.run(
+    "docker",
+    composeArgs(opts, paths, [
+      "run",
+      "--rm",
+      "--no-deps",
+      "--entrypoint",
+      "/bin/sh",
+      "redis",
+      "-c",
+      "set -eu; rm -rf /data/appendonlydir /data/dump.rdb; cat > /data/dump.rdb",
+    ]),
+    { stdin: redisRdb },
+  );
+  if (redisWrite.code !== 0) throw new Error("Redis RDB 恢复失败");
+  await composeUp(opts, paths, ["redis"], runner);
+
+  const minioArgs = composeArgs(opts, paths, [
+    "run",
+    "--rm",
+    "--no-deps",
+    "--entrypoint",
+    "/bin/sh",
+    "-v",
+    `${opts.snapshot}/minio:/restore:ro`,
+    "minio-init",
+    "-c",
+    'set -eu; for i in $(seq 1 30); do mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 && break; sleep 2; done; mc mirror --overwrite --remove /restore "local/$S3_BUCKET"',
+  ]);
+  const minio = await runner.run("docker", minioArgs);
+  if (minio.code !== 0) throw new Error("MinIO/S3 对象恢复失败");
+  ctx.stage = "restore-data";
+}
+
+async function verifyData(
+  opts: RestoreDrillOptions,
+  paths: DrillComposePaths,
+  ctx: DrillContext,
+  runner: CommandRunner,
+): Promise<void> {
+  const env = readEnvFile(ctx.composeEnvFile);
+  const pgUser = envGet(env, "POSTGRES_USER", "noj");
+  const pgDb = envGet(env, "POSTGRES_DB", "noj");
+  const expected = Deno.readTextFileSync(
+    `${opts.snapshot}/migration-status.txt`,
+  ).trim();
+  const actual = (await runner.run(
+    "docker",
+    composeArgs(opts, paths, [
+      "exec",
+      "-T",
+      "postgres",
+      "psql",
+      "-U",
+      pgUser,
+      "-d",
+      pgDb,
+      "-Atqc",
+      "SELECT hash || ':' || created_at::text FROM drizzle.__drizzle_migrations ORDER BY created_at",
+    ]),
+  )).stdout.trim();
+  if (expected === "" || expected === "not-initialized") {
+    throw new Error("数据核对失败：快照缺少迁移状态记录");
+  }
+  if (expected !== actual) {
+    throw new Error("数据核对失败：迁移版本与快照不一致");
+  }
+  const userCount = (await runner.run(
+    "docker",
+    composeArgs(opts, paths, [
+      "exec",
+      "-T",
+      "postgres",
+      "psql",
+      "-U",
+      pgUser,
+      "-d",
+      pgDb,
+      "-Atqc",
+      "SELECT count(*) FROM users",
+    ]),
+  )).stdout.trim();
+  if (!/^\d+$/.test(userCount)) throw new Error("数据核对失败：无法读取用户数");
+  const _redisKeys = (await runner.run(
+    "docker",
+    composeArgs(opts, paths, [
+      "exec",
+      "-T",
+      "redis",
+      "sh",
+      "-c",
+      'REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli --no-auth-warning DBSIZE',
+    ]),
+  )).stdout.trim();
+  const snapshotObjects = countFiles(`${opts.snapshot}/minio`);
+  const restoredObjects = Number(
+    (await runner.run(
+      "docker",
+      composeArgs(opts, paths, [
+        "run",
+        "--rm",
+        "--no-deps",
+        "--entrypoint",
+        "/bin/sh",
+        "minio-init",
+        "-c",
+        'set -eu; for i in $(seq 1 30); do mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 && break; sleep 2; done; mc ls --recursive --json "local/$S3_BUCKET" | wc -l',
+      ]),
+    )).stdout.trim(),
+  );
+  if (Number.isNaN(restoredObjects) || restoredObjects < snapshotObjects) {
+    throw new Error("数据核对失败：MinIO 对象数少于快照");
+  }
+  ctx.stage = "verify-data";
+}
+
+function countFiles(dir: string): number {
+  let count = 0;
+  try {
+    for (const _ of Deno.readDirSync(dir)) count++;
+  } catch {
+    // ignore
+  }
+  return count;
+}
+
+async function seedDrillAdmin(
+  opts: RestoreDrillOptions,
+  paths: DrillComposePaths,
+  ctx: DrillContext,
+  runner: CommandRunner,
+): Promise<void> {
+  const env = readEnvFile(ctx.composeEnvFile);
+  const pgUser = envGet(env, "POSTGRES_USER", "noj");
+  const pgDb = envGet(env, "POSTGRES_DB", "noj");
+  const now = new Date().toISOString();
+  const sql =
+    `INSERT INTO users (id, username, email, password_hash, created_at, updated_at)
+VALUES ('drill-admin-user', 'drill_admin', 'drill-admin@restore-drill.invalid',
+        '$2b$12$edDmxsubnHJL8B/Wsdryxu4ibNin0/SEhqAXkB.Yn50SCoN29lQCW', '${now}', '${now}')
+ON CONFLICT (id) DO NOTHING;
+INSERT INTO user_roles (user_id, role_id)
+SELECT 'drill-admin-user', id FROM roles WHERE name = 'admin'
+ON CONFLICT DO NOTHING;
+`;
+  const r = await runner.run(
+    "docker",
+    composeArgs(opts, paths, [
+      "exec",
+      "-T",
+      "postgres",
+      "psql",
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-U",
+      pgUser,
+      "-d",
+      pgDb,
+    ]),
+    { stdin: sql },
+  );
+  if (r.code !== 0) throw new Error("写入演练管理员失败");
+  ctx.stage = "seed-admin";
+}
+
+async function startBusiness(
+  opts: RestoreDrillOptions,
+  paths: DrillComposePaths,
+  ctx: DrillContext,
+  runner: CommandRunner,
+): Promise<void> {
+  await runDrillCompose(opts, paths, ["run", "--rm", "migrate"], runner);
+  await composeUp(opts, paths, ["core"], runner);
+  if (!opts.skipJudge) {
+    await composeUp(opts, paths, ["judge"], runner);
+  }
+  ctx.stage = "start-business";
+}
+
+async function runBusinessVerify(
+  opts: RestoreDrillOptions,
+  paths: DrillComposePaths,
+  ctx: DrillContext,
+  runner: CommandRunner,
+): Promise<void> {
+  const verifyScript = `${Deno.cwd()}/scripts/deploy/restore-drill-verify.ts`;
+  const env = [
+    "-e",
+    "DRILL_BASE_URL=http://core:8000/api/v1",
+    "-e",
+    "DRILL_ADMIN_USER=drill_admin",
+    "-e",
+    "DRILL_ADMIN_PASSWORD=Drill-Recover-2026",
+    "-e",
+    "DRILL_EVALUATOR_IMAGE=noj-evaluator-python",
+    "-e",
+    "DRILL_SOLUTION_IMAGE=noj-solution-python",
+  ];
+  if (opts.skipJudge) env.push("-e", "DRILL_SKIP_EVALUATION=1");
+  const args = [
+    "run",
+    "--rm",
+    "--no-deps",
+    ...env,
+    "-v",
+    `${verifyScript}:/opt/verify.ts:ro`,
+    "verifier",
+    "deno",
+    "run",
+    "-A",
+    "/opt/verify.ts",
+  ];
+  const r = await runDrillCompose(opts, paths, args, runner);
+  if (r !== 0) throw new Error("业务验收未通过");
+  ctx.stage = "business-verify";
+}
+
+function writeReport(
+  opts: RestoreDrillOptions,
+  ctx: DrillContext,
+  restoreSeconds: number,
+  totalSeconds: number,
+): void {
+  const rpoHours = hoursSinceSnapshot(snapshotCreatedAt(opts.snapshot));
+  const rtoMinutes = Math.floor(totalSeconds / 60);
+  const rpoMet = rpoHours <= opts.rpoMaxHours;
+  const rtoMet = opts.rtoMaxMinutes >= rtoMinutes;
+  const result = rpoMet && rtoMet ? "passed" : "passed_with_warnings";
+  const lines = [
+    `result=${result}`,
+    "drill_type=isolated-restore-with-business-verification",
+    `snapshot=${opts.snapshot}`,
+    `snapshot_created_at=${snapshotCreatedAt(opts.snapshot)}`,
+    `drill_started_at=${ctx.startAt}`,
+    `drill_finished_at=${new Date().toISOString()}`,
+    `restore_duration_seconds=${restoreSeconds}`,
+    `total_duration_seconds=${totalSeconds}`,
+    `rpo_hours=${rpoHours.toFixed(2)}`,
+    `rpo_target_hours=${opts.rpoMaxHours}`,
+    `rpo_met=${rpoMet}`,
+    `rto_minutes=${rtoMinutes}`,
+    `rto_target_minutes=${opts.rtoMaxMinutes}`,
+    `rto_met=${rtoMet}`,
+    `compose_project=${opts.projectName}`,
+    `network_subnet=${opts.subnet}`,
+    `cleanup=${opts.keep ? "kept-for-review" : "done"}`,
+    "credential_note=备份快照与 GPG 口令文件应异地独立保存；口令丢失即无法恢复。",
+  ];
+  Deno.writeTextFileSync(ctx.report, lines.join("\n") + "\n");
+  Deno.chmodSync(ctx.report, 0o600);
+}
+
+export async function runRestoreDrill(
+  opts: RestoreDrillOptions,
+  runner?: CommandRunner,
+): Promise<number> {
+  const r = runner ?? realRunner();
+  try {
+    opts.snapshot = validateSnapshotPath(opts.snapshot);
+    const pre = [
+      ...checkSnapshotFiles(opts.snapshot),
+      ...(opts.passphraseFile
+        ? checkSecretFile(opts.passphraseFile)
+        : ["必须提供 --passphrase-file"]),
+    ];
+    if (pre.length > 0) throw new Error(pre.join("; "));
+    const verifyProblems = await verifySnapshot({
+      snapshot: opts.snapshot,
+      envFile: opts.envFile ?? "",
+      composeFile: opts.composeFile ?? "",
+      passphraseFile: opts.passphraseFile,
+      runner: r,
+    });
+    if (verifyProblems.length > 0) throw new Error(verifyProblems.join("; "));
+    if (!opts.envFile) throw new Error("restore-drill: 缺少 --env-file");
+    if (!opts.composeFile) {
+      throw new Error("restore-drill: 缺少 --compose-file");
+    }
+
+    const startAt = new Date().toISOString();
+    const ctx: DrillContext = {
+      startAt,
+      tempDir: "",
+      report: "",
+      composeEnvFile: "",
+      overrideFile: "",
+      keep: opts.keep,
+      stage: "init",
+    };
+    prepareDirs(opts, ctx);
+    ctx.composeEnvFile = `${ctx.tempDir}/env.drill`;
+    ctx.overrideFile = `${ctx.tempDir}/compose.drill-override.yml`;
+    const paths: DrillComposePaths = {
+      envFile: ctx.composeEnvFile,
+      overrideFile: ctx.overrideFile,
+      composeFile: opts.composeFile,
+    };
+    await prepareEnv(opts, ctx, r);
+    writeDrillOverride(ctx.overrideFile, opts.subnet);
+    const totalStart = Date.now();
+    await restoreData(opts, paths, ctx, r);
+    await verifyData(opts, paths, ctx, r);
+    const restoreEnd = Date.now();
+    await seedDrillAdmin(opts, paths, ctx, r);
+    await startBusiness(opts, paths, ctx, r);
+    await runBusinessVerify(opts, paths, ctx, r);
+    const totalSeconds = Math.round((Date.now() - totalStart) / 1000);
+    const restoreSeconds = Math.round((restoreEnd - totalStart) / 1000);
+    writeReport(opts, ctx, restoreSeconds, totalSeconds);
+
+    if (!opts.keep) {
+      await r.run(
+        "docker",
+        composeArgs(opts, paths, ["down", "-v", "--remove-orphans"]),
+      );
+    }
+    return 0;
+  } catch (e) {
+    console.error(`restore-drill: ${(e as Error).message}`);
+    return 1;
+  }
+}

--- a/noj-cli/src/restore_drill/drill_test.ts
+++ b/noj-cli/src/restore_drill/drill_test.ts
@@ -1,0 +1,82 @@
+import { assertEquals } from "@std/assert";
+import type { CmdResult, CommandRunner } from "../runtime/command.ts";
+import { runRestoreDrill } from "./drill.ts";
+import type { RestoreDrillOptions } from "./options.ts";
+
+function makeSnapshot(dir: string): string {
+  Deno.mkdirSync(dir, { recursive: true });
+  const files: Record<string, string> = {
+    "SUCCESS": "success\n",
+    "manifest.json": '{"created_at":"2026-09-07T00:00:00Z"}',
+    "env.prod.gpg": "encrypted",
+    "postgres.dump": "dump",
+    "postgres-globals.sql": "CREATE ROLE noj;",
+    "postgres.restore-list": "1; TABLE public users noj",
+    "redis.rdb": "rdb",
+    "migration-status.txt": "hash:2026-09-07",
+    "sha256sums.txt": "",
+  };
+  Deno.mkdirSync(`${dir}/minio`);
+  Deno.mkdirSync(`${dir}/minio/obj`);
+  Deno.writeTextFileSync(`${dir}/minio/obj/a`, "a");
+  for (const [name, content] of Object.entries(files)) {
+    Deno.writeTextFileSync(`${dir}/${name}`, content);
+  }
+  return dir;
+}
+
+function fakeRunner(): CommandRunner {
+  return {
+    run(cmd, args, opts) {
+      const joined = args.join(" ");
+      let stdout = "";
+      if (joined.includes("drizzle.__drizzle_migrations")) {
+        stdout = "hash:2026-09-07";
+      }
+      if (joined.includes("count(*) FROM users")) stdout = "3";
+      if (joined.includes("DBSIZE")) stdout = "5";
+      if (joined.includes("mc ls --recursive")) stdout = "2";
+      const code = opts?.stdin !== undefined || cmd === "docker" ? 0 : 0;
+      return Promise.resolve({ code, stdout, stderr: "" } as CmdResult);
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+function optsFor(snapshot: string, pass: string): RestoreDrillOptions {
+  return {
+    snapshot,
+    envFile: "/tmp/.env.prod",
+    composeFile: "/tmp/docker-compose.prod.yml",
+    passphraseFile: pass,
+    projectName: "noj-drill-test",
+    drillDir: undefined,
+    report: undefined,
+    subnet: "172.29.0.0/16",
+    rpoMaxHours: 24,
+    rtoMaxMinutes: 60,
+    waitTimeout: 5,
+    skipJudge: true,
+    keep: true,
+  };
+}
+
+Deno.test("runRestoreDrill: skip-judge 成功", async () => {
+  const root = Deno.makeTempDirSync();
+  const snapshot = makeSnapshot(`${root}/snapshot-20260907`);
+  const pass = `${root}/pass`;
+  Deno.writeTextFileSync(pass, "pass");
+  Deno.chmodSync(pass, 0o600);
+  const code = await runRestoreDrill(optsFor(snapshot, pass), fakeRunner());
+  assertEquals(code, 0);
+});
+
+Deno.test("runRestoreDrill: 缺少 passphrase 返回 1", async () => {
+  const root = Deno.makeTempDirSync();
+  const snapshot = makeSnapshot(`${root}/snapshot-20260907`);
+  const opts = optsFor(snapshot, "");
+  const code = await runRestoreDrill(opts, fakeRunner());
+  assertEquals(code, 1);
+});

--- a/noj-cli/src/restore_drill/options.ts
+++ b/noj-cli/src/restore_drill/options.ts
@@ -1,0 +1,131 @@
+/** restore-drill 命令参数解析。 */
+
+export interface RestoreDrillOptions {
+  snapshot: string;
+  envFile: string | undefined;
+  composeFile: string | undefined;
+  passphraseFile: string;
+  projectName: string;
+  drillDir: string | undefined;
+  report: string | undefined;
+  subnet: string;
+  rpoMaxHours: number;
+  rtoMaxMinutes: number;
+  waitTimeout: number;
+  skipJudge: boolean;
+  keep: boolean;
+}
+
+export const DEFAULT_DRILL_PROJECT = "noj-drill";
+export const DEFAULT_DRILL_SUBNET = "172.29.0.0/16";
+export const DEFAULT_RPO_MAX_HOURS = 24;
+export const DEFAULT_RTO_MAX_MINUTES = 60;
+export const DEFAULT_WAIT_TIMEOUT = 300;
+
+const PROJECT_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+function missing(flag: string): never {
+  throw new Error(`restore-drill: ${flag} 缺少参数`);
+}
+
+function nonNegativeInt(value: string, flag: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(`restore-drill: ${flag} 必须是非负整数: ${value}`);
+  }
+  return n;
+}
+
+export function parseRestoreDrillArgs(args: string[]): RestoreDrillOptions {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    throw new Error("restore-drill: 需要 SNAPSHOT 参数");
+  }
+  const out: RestoreDrillOptions = {
+    snapshot: args[0]!,
+    envFile: undefined,
+    composeFile: undefined,
+    passphraseFile: Deno.env.get("NOJ_BACKUP_PASSPHRASE_FILE") ?? "",
+    projectName: DEFAULT_DRILL_PROJECT,
+    drillDir: undefined,
+    report: undefined,
+    subnet: DEFAULT_DRILL_SUBNET,
+    rpoMaxHours: DEFAULT_RPO_MAX_HOURS,
+    rtoMaxMinutes: DEFAULT_RTO_MAX_MINUTES,
+    waitTimeout: DEFAULT_WAIT_TIMEOUT,
+    skipJudge: false,
+    keep: false,
+  };
+  const take = (flag: string): string => {
+    const idx = args.indexOf(flag);
+    const value = args[idx + 1];
+    if (idx === -1 || value === undefined || value.startsWith("--")) {
+      throw missing(flag);
+    }
+    return value;
+  };
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i]!;
+    if (a.startsWith("--env-file=")) out.envFile = a.slice(11);
+    else if (a === "--env-file") {
+      out.envFile = take(a);
+      i++;
+    } else if (a.startsWith("--compose-file=")) out.composeFile = a.slice(15);
+    else if (a === "--compose-file") {
+      out.composeFile = take(a);
+      i++;
+    } else if (a.startsWith("--passphrase-file=")) {
+      out.passphraseFile = a.slice(18);
+    } else if (a === "--passphrase-file") {
+      out.passphraseFile = take(a);
+      i++;
+    } else if (a.startsWith("--project-name=")) out.projectName = a.slice(15);
+    else if (a === "--project-name") {
+      out.projectName = take(a);
+      i++;
+    } else if (a.startsWith("--drill-dir=")) out.drillDir = a.slice(12);
+    else if (a === "--drill-dir") {
+      out.drillDir = take(a);
+      i++;
+    } else if (a.startsWith("--report=")) out.report = a.slice(9);
+    else if (a === "--report") {
+      out.report = take(a);
+      i++;
+    } else if (a.startsWith("--subnet=")) out.subnet = a.slice(9);
+    else if (a === "--subnet") {
+      out.subnet = take(a);
+      i++;
+    } else if (a.startsWith("--rpo-max-hours=")) {
+      out.rpoMaxHours = nonNegativeInt(a.slice(16), "--rpo-max-hours");
+    } else if (a === "--rpo-max-hours") {
+      out.rpoMaxHours = nonNegativeInt(take(a), "--rpo-max-hours");
+      i++;
+    } else if (a.startsWith("--rto-max-minutes=")) {
+      out.rtoMaxMinutes = nonNegativeInt(a.slice(18), "--rto-max-minutes");
+    } else if (a === "--rto-max-minutes") {
+      out.rtoMaxMinutes = nonNegativeInt(take(a), "--rto-max-minutes");
+      i++;
+    } else if (a.startsWith("--wait-timeout=")) {
+      out.waitTimeout = nonNegativeInt(a.slice(15), "--wait-timeout");
+    } else if (a === "--wait-timeout") {
+      out.waitTimeout = nonNegativeInt(take(a), "--wait-timeout");
+      i++;
+    } else if (a === "--skip-judge") {
+      out.skipJudge = true;
+    } else if (a === "--keep") {
+      out.keep = true;
+    } else if (a === "-h" || a === "--help") {
+      throw new Error("restore-drill --help");
+    } else {
+      throw new Error(`restore-drill: 未知选项: ${a}`);
+    }
+  }
+  if (out.projectName.includes("prod")) {
+    throw new Error("restore-drill: 演练项目名不得包含 prod");
+  }
+  if (!PROJECT_NAME_RE.test(out.projectName)) {
+    throw new Error(
+      "restore-drill: 演练项目名只能包含小写字母、数字、- 和 _",
+    );
+  }
+  return out;
+}

--- a/noj-cli/src/restore_drill/options_test.ts
+++ b/noj-cli/src/restore_drill/options_test.ts
@@ -1,0 +1,77 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  DEFAULT_DRILL_PROJECT,
+  DEFAULT_DRILL_SUBNET,
+  DEFAULT_RPO_MAX_HOURS,
+  DEFAULT_RTO_MAX_MINUTES,
+  DEFAULT_WAIT_TIMEOUT,
+  parseRestoreDrillArgs,
+} from "./options.ts";
+
+Deno.test("parseRestoreDrillArgs: 缺省值", () => {
+  const o = parseRestoreDrillArgs(["/bk/snapshot-2026"]);
+  assertEquals(o.snapshot, "/bk/snapshot-2026");
+  assertEquals(o.projectName, DEFAULT_DRILL_PROJECT);
+  assertEquals(o.subnet, DEFAULT_DRILL_SUBNET);
+  assertEquals(o.rpoMaxHours, DEFAULT_RPO_MAX_HOURS);
+  assertEquals(o.rtoMaxMinutes, DEFAULT_RTO_MAX_MINUTES);
+  assertEquals(o.waitTimeout, DEFAULT_WAIT_TIMEOUT);
+  assertEquals(o.skipJudge, false);
+  assertEquals(o.keep, false);
+});
+
+Deno.test("parseRestoreDrillArgs: 选项解析", () => {
+  const o = parseRestoreDrillArgs([
+    "/bk/snapshot-2026",
+    "--env-file",
+    "/opt/neuro-oj/.env.prod",
+    "--compose-file",
+    "/opt/neuro-oj/docker-compose.prod.yml",
+    "--passphrase-file",
+    "/etc/noj/pass",
+    "--project-name",
+    "noj-drill-test",
+    "--subnet",
+    "172.30.0.0/16",
+    "--rpo-max-hours",
+    "12",
+    "--rto-max-minutes",
+    "30",
+    "--wait-timeout",
+    "120",
+    "--skip-judge",
+    "--keep",
+  ]);
+  assertEquals(o.envFile, "/opt/neuro-oj/.env.prod");
+  assertEquals(o.composeFile, "/opt/neuro-oj/docker-compose.prod.yml");
+  assertEquals(o.passphraseFile, "/etc/noj/pass");
+  assertEquals(o.projectName, "noj-drill-test");
+  assertEquals(o.subnet, "172.30.0.0/16");
+  assertEquals(o.rpoMaxHours, 12);
+  assertEquals(o.rtoMaxMinutes, 30);
+  assertEquals(o.waitTimeout, 120);
+  assertEquals(o.skipJudge, true);
+  assertEquals(o.keep, true);
+});
+
+Deno.test("parseRestoreDrillArgs: 非法 project name", () => {
+  assertThrows(() =>
+    parseRestoreDrillArgs(["/bk/s", "--project-name", "noj-prod"])
+  );
+  assertThrows(() =>
+    parseRestoreDrillArgs(["/bk/s", "--project-name", "Bad_Name"])
+  );
+});
+
+Deno.test("parseRestoreDrillArgs: 非法 RPO/RTO", () => {
+  assertThrows(() =>
+    parseRestoreDrillArgs(["/bk/s", "--rpo-max-hours", "abc"])
+  );
+  assertThrows(() =>
+    parseRestoreDrillArgs(["/bk/s", "--rto-max-minutes", "-1"])
+  );
+});
+
+Deno.test("parseRestoreDrillArgs: 缺少 snapshot", () => {
+  assertThrows(() => parseRestoreDrillArgs([]));
+});

--- a/noj-cli/src/restore_drill/snapshot.ts
+++ b/noj-cli/src/restore_drill/snapshot.ts
@@ -1,0 +1,156 @@
+/** restore-drill 快照校验与元数据工具。 */
+
+import type { CommandRunner } from "../runtime/command.ts";
+import { realRunner } from "../runtime/command.ts";
+
+export interface VerifySnapshotOptions {
+  snapshot: string;
+  envFile: string;
+  composeFile: string;
+  passphraseFile: string;
+  runner?: CommandRunner;
+}
+
+function isFile(p: string): boolean {
+  try {
+    return Deno.statSync(p).isFile;
+  } catch {
+    return false;
+  }
+}
+
+function isDir(p: string): boolean {
+  try {
+    return Deno.statSync(p).isDirectory;
+  } catch {
+    return false;
+  }
+}
+
+/** 规范化并校验快照目录路径；返回绝对路径。 */
+export function validateSnapshotPath(snapshot: string): string {
+  if (!isDir(snapshot)) throw new Error(`快照目录不存在：${snapshot}`);
+  const base = snapshot.split("/").filter(Boolean).pop() ?? "";
+  if (!base.startsWith("snapshot-")) {
+    throw new Error(`只允许演练 snapshot-* 快照目录：${snapshot}`);
+  }
+  if (snapshot.includes("/..") || snapshot.includes("/.snapshot-")) {
+    throw new Error(`非法快照路径：${snapshot}`);
+  }
+  return Deno.realPathSync(snapshot);
+}
+
+/** 检查快照必备文件；返回问题列表。 */
+export function checkSnapshotFiles(snapshot: string): string[] {
+  const problems: string[] = [];
+  if (!isFile(`${snapshot}/SUCCESS`)) problems.push("快照缺少 SUCCESS");
+  if (!isFile(`${snapshot}/manifest.json`)) {
+    problems.push("快照缺少 manifest.json");
+  }
+  if (!isFile(`${snapshot}/env.prod.gpg`)) {
+    problems.push("快照缺少 env.prod.gpg");
+  }
+  if (!isFile(`${snapshot}/postgres.dump`)) {
+    problems.push("快照缺少 postgres.dump");
+  }
+  if (!isFile(`${snapshot}/postgres-globals.sql`)) {
+    problems.push("快照缺少 postgres-globals.sql");
+  }
+  if (!isFile(`${snapshot}/redis.rdb`)) problems.push("快照缺少 redis.rdb");
+  if (!isDir(`${snapshot}/minio`)) problems.push("快照缺少 minio 目录");
+  if (!isFile(`${snapshot}/sha256sums.txt`)) {
+    problems.push("快照缺少 sha256sums.txt");
+  }
+  return problems;
+}
+
+/** 检查 GPG 口令文件权限；返回问题列表。 */
+export function checkSecretFile(file: string): string[] {
+  if (!isFile(file)) return [`GPG 口令文件不存在：${file}`];
+  const mode = Deno.statSync(file).mode! & 0o777;
+  if (mode !== 0o600 && mode !== 0o400) {
+    return [`GPG 口令文件权限必须为 600 或 400：${file}`];
+  }
+  return [];
+}
+
+/** 从 manifest.json 读取 created_at。 */
+export function snapshotCreatedAt(snapshot: string): string {
+  const raw = Deno.readTextFileSync(`${snapshot}/manifest.json`);
+  const manifest = JSON.parse(raw) as { created_at?: string };
+  const value = manifest.created_at;
+  if (!value) throw new Error("manifest.json 缺少 created_at");
+  return value;
+}
+
+/** 计算当前时间与快照创建时间的小时差。 */
+export function hoursSinceSnapshot(createdAt: string): number {
+  const created = Date.parse(createdAt);
+  if (Number.isNaN(created)) return 0;
+  return (Date.now() - created) / 3600_000;
+}
+
+/** SHA-256 十六进制。 */
+export async function sha256File(file: string): Promise<string> {
+  const data = await Deno.readFile(file);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** 文件级快照校验（对应 backup.sh verify_snapshot 的 Deno 移植）。 */
+export async function verifySnapshot(
+  opts: VerifySnapshotOptions,
+): Promise<string[]> {
+  const runner = opts.runner ?? realRunner();
+  const snapshot = validateSnapshotPath(opts.snapshot);
+  const problems = checkSnapshotFiles(snapshot);
+  if (problems.length > 0) return problems;
+  if (opts.passphraseFile === "") {
+    return ["必须提供 --passphrase-file 或 NOJ_BACKUP_PASSPHRASE_FILE"];
+  }
+  problems.push(...checkSecretFile(opts.passphraseFile));
+
+  // 校验 sha256sums.txt
+  const lines = Deno.readTextFileSync(`${snapshot}/sha256sums.txt`)
+    .split(/\r?\n/)
+    .filter((l) => l.length > 0);
+  for (const line of lines) {
+    const idx = line.indexOf("  ");
+    if (idx === -1) continue;
+    const expected = line.slice(0, idx);
+    const rel = line.slice(idx + 2);
+    if (rel.includes("..") || rel.startsWith("/")) {
+      return [`校验清单包含非法路径：${rel}`];
+    }
+    const file = `${snapshot}/${rel}`;
+    if (!isFile(file)) return [`校验清单文件缺失：${rel}`];
+    const actual = await sha256File(file);
+    if (actual !== expected) return [`SHA-256 校验失败：${rel}`];
+  }
+
+  // GPG 解密环境文件
+  const decrypted = `${snapshot}/.env.prod.drill-decrypted`;
+  try {
+    const r = await runner.run("gpg", [
+      "--batch",
+      "--yes",
+      "--pinentry-mode",
+      "loopback",
+      "--passphrase-file",
+      opts.passphraseFile,
+      "--decrypt",
+      "--output",
+      decrypted,
+      `${snapshot}/env.prod.gpg`,
+    ]);
+    if (r.code !== 0) return ["GPG 解密失败"];
+  } finally {
+    try {
+      await Deno.remove(decrypted);
+    } catch {
+      // 忽略清理失败
+    }
+  }
+  return [];
+}

--- a/noj-cli/src/restore_drill/snapshot_test.ts
+++ b/noj-cli/src/restore_drill/snapshot_test.ts
@@ -1,0 +1,86 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import type { CommandRunner } from "../runtime/command.ts";
+import {
+  checkSecretFile,
+  checkSnapshotFiles,
+  hoursSinceSnapshot,
+  snapshotCreatedAt,
+  validateSnapshotPath,
+  verifySnapshot,
+} from "./snapshot.ts";
+
+function fakeRunner(): CommandRunner {
+  return {
+    run() {
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn() {
+      throw new Error("not used");
+    },
+  };
+}
+
+function makeSnapshot(dir: string): string {
+  Deno.mkdirSync(dir, { recursive: true });
+  const files: Record<string, string> = {
+    "SUCCESS": "success\n",
+    "manifest.json": '{"created_at":"2026-09-07T00:00:00Z"}',
+    "env.prod.gpg": "encrypted",
+    "postgres.dump": "dump",
+    "postgres-globals.sql": "CREATE ROLE noj;",
+    "postgres.restore-list": "1; TABLE public users noj",
+    "redis.rdb": "rdb",
+    "sha256sums.txt": "",
+  };
+  Deno.mkdirSync(`${dir}/minio`);
+  for (const [name, content] of Object.entries(files)) {
+    Deno.writeTextFileSync(`${dir}/${name}`, content);
+  }
+  return dir;
+}
+
+Deno.test("validateSnapshotPath: 合法快照返回绝对路径", () => {
+  const dir = makeSnapshot(`${Deno.makeTempDirSync()}/snapshot-20260907`);
+  const abs = validateSnapshotPath(dir);
+  assertEquals(abs.startsWith("/"), true);
+});
+
+Deno.test("validateSnapshotPath: 非法路径抛错", () => {
+  const dir = Deno.makeTempDirSync();
+  assertThrows(() => validateSnapshotPath(`${dir}/not-snapshot`));
+});
+
+Deno.test("checkSnapshotFiles: 完整快照无问题", () => {
+  const dir = makeSnapshot(`${Deno.makeTempDirSync()}/snapshot-20260907`);
+  assertEquals(checkSnapshotFiles(dir), []);
+});
+
+Deno.test("checkSecretFile: 权限校验", () => {
+  const file = `${Deno.makeTempDirSync()}/pass`;
+  Deno.writeTextFileSync(file, "pass");
+  Deno.chmodSync(file, 0o600);
+  assertEquals(checkSecretFile(file), []);
+  Deno.chmodSync(file, 0o644);
+  assertEquals(checkSecretFile(file).length > 0, true);
+});
+
+Deno.test("snapshotCreatedAt/hoursSinceSnapshot", () => {
+  const dir = makeSnapshot(`${Deno.makeTempDirSync()}/snapshot-20260907`);
+  assertEquals(snapshotCreatedAt(dir), "2026-09-07T00:00:00Z");
+  assertEquals(typeof hoursSinceSnapshot("2026-09-07T00:00:00Z"), "number");
+});
+
+Deno.test("verifySnapshot: 成功路径", async () => {
+  const dir = makeSnapshot(`${Deno.makeTempDirSync()}/snapshot-20260907`);
+  const pass = `${Deno.makeTempDirSync()}/pass`;
+  Deno.writeTextFileSync(pass, "pass");
+  Deno.chmodSync(pass, 0o600);
+  const problems = await verifySnapshot({
+    snapshot: dir,
+    envFile: "/tmp/.env.prod",
+    composeFile: "/tmp/compose.yml",
+    passphraseFile: pass,
+    runner: fakeRunner(),
+  });
+  assertEquals(problems, []);
+});

--- a/noj-cli/src/runtime/command.ts
+++ b/noj-cli/src/runtime/command.ts
@@ -15,6 +15,8 @@ export interface SpawnOpts {
   stdoutFile?: string;
   /** 存在时把子进程 stderr 追加写入该文件。 */
   stderrFile?: string;
+  /** 存在时从该文件读取子进程 stdin（原始字节，不做文本转换）。 */
+  stdinFile?: string;
 }
 
 /** 已启动进程的句柄：记录 PID，可等待退出或终止。 */
@@ -34,7 +36,13 @@ export interface CommandRunner {
   run(
     cmd: string,
     args: string[],
-    opts?: { cwd?: string; env?: Record<string, string>; stdin?: string },
+    opts?: {
+      cwd?: string;
+      env?: Record<string, string>;
+      stdin?: string;
+      /** 存在时从该文件读取子进程 stdin（原始字节，不做文本转换）。 */
+      stdinFile?: string;
+    },
   ): Promise<CmdResult>;
   spawn(opts: SpawnOpts): SpawnHandle;
   /** 逐行流式执行命令；onLine 每收到一行（不含换行）回调一次，返回退出码。可选：P2 既有 fake 可不实现。 */
@@ -52,7 +60,8 @@ export function realRunner(): CommandRunner {
   return {
     async run(cmd, args, opts) {
       const stdin = opts?.stdin;
-      if (stdin === undefined) {
+      const stdinFile = opts?.stdinFile;
+      if (stdin === undefined && stdinFile === undefined) {
         const p = new Deno.Command(cmd, {
           args,
           cwd: opts?.cwd,
@@ -79,8 +88,25 @@ export function realRunner(): CommandRunner {
       // 先开始读 stdout/stderr，避免大 stdin 时子进程写满管道导致双方阻塞。
       const stdoutPromise = new Response(child.stdout).arrayBuffer();
       const stderrPromise = new Response(child.stderr).arrayBuffer();
+      if (stdinFile !== undefined) {
+        const file = await Deno.open(stdinFile, { read: true });
+        const stdinPromise = file.readable.pipeTo(child.stdin).finally(() => {
+          file.close();
+        });
+        const [status, stdoutBuf, stderrBuf] = await Promise.all([
+          child.status,
+          stdoutPromise,
+          stderrPromise,
+          stdinPromise,
+        ]);
+        return {
+          code: status.code,
+          stdout: decoder.decode(stdoutBuf),
+          stderr: decoder.decode(stderrBuf),
+        };
+      }
       const writer = child.stdin.getWriter();
-      await writer.write(new TextEncoder().encode(stdin));
+      await writer.write(new TextEncoder().encode(stdin ?? ""));
       await writer.close();
       const [status, stdoutBuf, stderrBuf] = await Promise.all([
         child.status,
@@ -98,11 +124,22 @@ export function realRunner(): CommandRunner {
         args: opts.args,
         cwd: opts.cwd,
         env: opts.env,
+        stdin: opts.stdinFile ? "piped" : "inherit",
         stdout: opts.stdoutFile ? "piped" : "inherit",
         stderr: opts.stderrFile ? "piped" : "inherit",
       });
       const child = cmd.spawn();
       const pipes: Promise<void>[] = [];
+      if (opts.stdinFile) {
+        const f = Deno.open(opts.stdinFile, { read: true });
+        pipes.push(
+          f.then((file) =>
+            file.readable.pipeTo(child.stdin).finally(() => {
+              file.close();
+            })
+          ),
+        );
+      }
       if (opts.stdoutFile) {
         const f = Deno.open(opts.stdoutFile, {
           write: true,

--- a/noj-cli/src/server_cmd/server_cmd.ts
+++ b/noj-cli/src/server_cmd/server_cmd.ts
@@ -8,6 +8,8 @@ export interface ServerCommandOptions {
   context: CliContext;
   args: string[];
   runner?: CommandRunner;
+  /** 显式 --dir 指定的源码/部署目录；在 context.dir 为空时作为查找起点。 */
+  sourceDir?: string;
 }
 
 const VALID_SUBCOMMANDS = new Set([
@@ -23,6 +25,16 @@ function validateArgs(args: string[]): void {
   const [sub, subsub] = args;
   if (!VALID_SUBCOMMANDS.has(sub!)) {
     throw new Error(`server: 未知子命令 ${sub}`);
+  }
+  if (sub === "bootstrap") {
+    const hasPassword = args.some((a) =>
+      a === "--password" || a.startsWith("--password=")
+    );
+    if (hasPassword) {
+      throw new Error(
+        "server: bootstrap 不接受 --password 命令行参数，请使用交互提示或环境变量",
+      );
+    }
   }
   if (sub === "dev-setup") {
     if (args.length !== 1) {
@@ -58,7 +70,12 @@ function validateArgs(args: string[]): void {
 }
 
 function findSourceRoot(start: string): string | null {
-  let current = Deno.realPathSync(start);
+  let current = start;
+  try {
+    current = Deno.realPathSync(current);
+  } catch {
+    return null;
+  }
   while (true) {
     try {
       if (Deno.statSync(`${current}/noj-core/deno.json`).isFile) {
@@ -155,7 +172,9 @@ export async function runServerCommand(
     return 1;
   }
 
-  const sourceRoot = findSourceRoot(context.cwd);
+  const sourceRoot = findSourceRoot(
+    context.dir ?? opts.sourceDir ?? context.cwd,
+  );
   if (sourceRoot !== null) {
     try {
       const launch = sourceCommand(args);

--- a/noj-cli/src/server_cmd/server_cmd.ts
+++ b/noj-cli/src/server_cmd/server_cmd.ts
@@ -2,6 +2,8 @@ import { dirname } from "@std/path";
 import type { CliContext } from "../context/context.ts";
 import { type CommandRunner, realRunner } from "../runtime/command.ts";
 
+export type ServerSubcommand = readonly [string, ...string[]];
+
 export interface ServerCommandOptions {
   context: CliContext;
   args: string[];
@@ -18,8 +20,40 @@ const VALID_SUBCOMMANDS = new Set([
 
 function validateArgs(args: string[]): void {
   if (args.length === 0) throw new Error("server: 缺少子命令");
-  if (!VALID_SUBCOMMANDS.has(args[0]!)) {
-    throw new Error(`server: 未知子命令 ${args[0]}`);
+  const [sub, subsub] = args;
+  if (!VALID_SUBCOMMANDS.has(sub!)) {
+    throw new Error(`server: 未知子命令 ${sub}`);
+  }
+  if (sub === "dev-setup") {
+    if (args.length !== 1) {
+      throw new Error("server: dev-setup 不接受额外参数");
+    }
+    return;
+  }
+  if (subsub === undefined) {
+    if (sub === "db") throw new Error("server: db 需要 migrate");
+    if (sub === "init") throw new Error("server: init 需要 system");
+    if (sub === "bootstrap") {
+      throw new Error("server: bootstrap 需要 first-admin 或 admin");
+    }
+    if (sub === "problems") {
+      throw new Error("server: problems 需要 build 或 import");
+    }
+  }
+  if (sub === "db" && subsub !== "migrate") {
+    throw new Error("server: db 需要 migrate");
+  }
+  if (sub === "init" && subsub !== "system") {
+    throw new Error("server: init 需要 system");
+  }
+  if (sub === "bootstrap" && subsub !== "first-admin" && subsub !== "admin") {
+    throw new Error("server: bootstrap 需要 first-admin 或 admin");
+  }
+  if (sub === "problems" && subsub !== "build" && subsub !== "import") {
+    throw new Error("server: problems 需要 build 或 import");
+  }
+  if ((sub === "db" || sub === "init") && args.length > 2) {
+    throw new Error(`server: ${sub} 不接受额外参数`);
   }
 }
 
@@ -89,26 +123,36 @@ export async function runServerCommand(
   }
 
   if (context.kind === "production" && context.dir !== null) {
-    const fullArgs = [
-      "compose",
-      "--env-file",
-      `${context.dir}/.env.prod`,
-      "--file",
-      `${context.dir}/docker-compose.prod.yml`,
-      "run",
-      "--rm",
-      "--entrypoint",
-      "/app/bin/noj",
-      "core",
-      ...args,
-    ];
-    const handle = runner.spawn({
-      cmd: "docker",
-      args: fullArgs,
-      cwd: context.dir,
-      env: {},
-    });
-    return await handle.wait();
+    try {
+      const fullArgs = [
+        "compose",
+        "--env-file",
+        `${context.dir}/.env.prod`,
+        "--file",
+        `${context.dir}/docker-compose.prod.yml`,
+        "run",
+        "--rm",
+        "--entrypoint",
+        "/app/bin/noj",
+        "core",
+        ...args,
+      ];
+      const handle = runner.spawn({
+        cmd: "docker",
+        args: fullArgs,
+        cwd: context.dir,
+        env: {},
+      });
+      return await handle.wait();
+    } catch (e) {
+      console.error((e as Error).message);
+      return 1;
+    }
+  }
+
+  if (context.kind === "judge") {
+    console.error("server: 不适用于 judge 上下文");
+    return 1;
   }
 
   const sourceRoot = findSourceRoot(context.cwd);

--- a/noj-cli/src/server_cmd/server_cmd.ts
+++ b/noj-cli/src/server_cmd/server_cmd.ts
@@ -1,0 +1,133 @@
+import { dirname } from "@std/path";
+import type { CliContext } from "../context/context.ts";
+import { type CommandRunner, realRunner } from "../runtime/command.ts";
+
+export interface ServerCommandOptions {
+  context: CliContext;
+  args: string[];
+  runner?: CommandRunner;
+}
+
+const VALID_SUBCOMMANDS = new Set([
+  "db",
+  "init",
+  "bootstrap",
+  "problems",
+  "dev-setup",
+]);
+
+function validateArgs(args: string[]): void {
+  if (args.length === 0) throw new Error("server: 缺少子命令");
+  if (!VALID_SUBCOMMANDS.has(args[0]!)) {
+    throw new Error(`server: 未知子命令 ${args[0]}`);
+  }
+}
+
+function findSourceRoot(start: string): string | null {
+  let current = Deno.realPathSync(start);
+  while (true) {
+    try {
+      if (Deno.statSync(`${current}/noj-core/deno.json`).isFile) {
+        return current;
+      }
+    } catch {
+      // 继续向上
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function sourceCommand(args: string[]): { cmd: string; args: string[] } {
+  const [sub, subsub, ...rest] = args;
+  if (sub === "db" && subsub === "migrate") {
+    return { cmd: "deno", args: ["task", "db:migrate"] };
+  }
+  if (sub === "init" && subsub === "system") {
+    return { cmd: "deno", args: ["task", "init:system"] };
+  }
+  if (sub === "bootstrap") {
+    if (!subsub) throw new Error("server: bootstrap 需要 first-admin 或 admin");
+    return {
+      cmd: "deno",
+      args: [
+        "run",
+        "--env-file=.env",
+        "-A",
+        "scripts/noj.ts",
+        "bootstrap",
+        subsub,
+        ...rest,
+      ],
+    };
+  }
+  if (sub === "problems") {
+    if (subsub === "build") {
+      return { cmd: "deno", args: ["task", "problems:build", "--", ...rest] };
+    }
+    if (subsub === "import") {
+      return { cmd: "deno", args: ["task", "problems:import", "--", ...rest] };
+    }
+  }
+  if (sub === "dev-setup") {
+    return { cmd: "deno", args: ["task", "dev-setup"] };
+  }
+  throw new Error(`server: 不支持的源码子命令 ${args.join(" ")}`);
+}
+
+export async function runServerCommand(
+  opts: ServerCommandOptions,
+): Promise<number> {
+  const runner = opts.runner ?? realRunner();
+  const { context, args } = opts;
+  try {
+    validateArgs(args);
+  } catch (e) {
+    console.error((e as Error).message);
+    return 1;
+  }
+
+  if (context.kind === "production" && context.dir !== null) {
+    const fullArgs = [
+      "compose",
+      "--env-file",
+      `${context.dir}/.env.prod`,
+      "--file",
+      `${context.dir}/docker-compose.prod.yml`,
+      "run",
+      "--rm",
+      "--entrypoint",
+      "/app/bin/noj",
+      "core",
+      ...args,
+    ];
+    const handle = runner.spawn({
+      cmd: "docker",
+      args: fullArgs,
+      cwd: context.dir,
+      env: {},
+    });
+    return await handle.wait();
+  }
+
+  const sourceRoot = findSourceRoot(context.cwd);
+  if (sourceRoot !== null) {
+    try {
+      const launch = sourceCommand(args);
+      const handle = runner.spawn({
+        cmd: launch.cmd,
+        args: launch.args,
+        cwd: `${sourceRoot}/noj-core`,
+        env: {},
+      });
+      return await handle.wait();
+    } catch (e) {
+      console.error((e as Error).message);
+      return 1;
+    }
+  }
+
+  console.error("server: 未找到 production 部署或 noj-core 源码目录");
+  return 1;
+}

--- a/noj-cli/src/server_cmd/server_cmd_test.ts
+++ b/noj-cli/src/server_cmd/server_cmd_test.ts
@@ -42,6 +42,17 @@ function makeSourceRoot(): string {
   return root;
 }
 
+async function withSourceRoot(
+  fn: (root: string) => void | Promise<void>,
+): Promise<void> {
+  const root = makeSourceRoot();
+  try {
+    await fn(root);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+}
+
 function sourceContext(cwd: string): CliContext {
   return { cwd, kind: "none", dir: null };
 }
@@ -113,117 +124,140 @@ Deno.test("server: production 上下文透传 bootstrap 参数", async () => {
 });
 
 Deno.test("server: 源码上下文 db migrate 调用 deno task", async () => {
-  const root = makeSourceRoot();
-  const log: string[][] = [];
-  const runner = runnerWithLog(log);
-  const ctx = sourceContext(`${root}/noj-core`);
-  const code = await runServerCommand({
-    context: ctx,
-    args: ["db", "migrate"],
-    runner,
+  await withSourceRoot(async (root) => {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx = sourceContext(`${root}/noj-core`);
+    const code = await runServerCommand({
+      context: ctx,
+      args: ["db", "migrate"],
+      runner,
+    });
+    assertEquals(code, 0);
+    assertEquals(log[0], ["deno", "task", "db:migrate"]);
+    assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
   });
-  assertEquals(code, 0);
-  assertEquals(log[0], ["deno", "task", "db:migrate"]);
-  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
+});
+
+Deno.test("server: 显式 sourceDir 可从非源码 cwd 定位源码根", async () => {
+  await withSourceRoot(async (root) => {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx: CliContext = { cwd: "/tmp", kind: "none", dir: null };
+    const code = await runServerCommand({
+      context: ctx,
+      sourceDir: `${root}/noj-core`,
+      args: ["db", "migrate"],
+      runner,
+    });
+    assertEquals(code, 0);
+    assertEquals(log[0], ["deno", "task", "db:migrate"]);
+    assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
+  });
 });
 
 Deno.test("server: 源码上下文 bootstrap first-admin 透传参数", async () => {
-  const root = makeSourceRoot();
-  const log: string[][] = [];
-  const runner = runnerWithLog(log);
-  const ctx = sourceContext(`${root}/noj-core`);
-  const code = await runServerCommand({
-    context: ctx,
-    args: ["bootstrap", "first-admin", "--username", "admin"],
-    runner,
+  await withSourceRoot(async (root) => {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx = sourceContext(`${root}/noj-core`);
+    const code = await runServerCommand({
+      context: ctx,
+      args: ["bootstrap", "first-admin", "--username", "admin"],
+      runner,
+    });
+    assertEquals(code, 0);
+    assertEquals(log[0], [
+      "deno",
+      "run",
+      "--env-file=.env",
+      "-A",
+      "scripts/noj.ts",
+      "bootstrap",
+      "first-admin",
+      "--username",
+      "admin",
+    ]);
+    assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
   });
-  assertEquals(code, 0);
-  assertEquals(log[0], [
-    "deno",
-    "run",
-    "--env-file=.env",
-    "-A",
-    "scripts/noj.ts",
-    "bootstrap",
-    "first-admin",
-    "--username",
-    "admin",
-  ]);
-  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
 });
 
 Deno.test("server: 源码上下文 problems build 透传参数", async () => {
-  const root = makeSourceRoot();
-  const log: string[][] = [];
-  const runner = runnerWithLog(log);
-  const ctx = sourceContext(`${root}/noj-core`);
-  const code = await runServerCommand({
-    context: ctx,
-    args: ["problems", "build", "--problem", "abc"],
-    runner,
+  await withSourceRoot(async (root) => {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx = sourceContext(`${root}/noj-core`);
+    const code = await runServerCommand({
+      context: ctx,
+      args: ["problems", "build", "--problem", "abc"],
+      runner,
+    });
+    assertEquals(code, 0);
+    assertEquals(log[0], [
+      "deno",
+      "task",
+      "problems:build",
+      "--",
+      "--problem",
+      "abc",
+    ]);
+    assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
   });
-  assertEquals(code, 0);
-  assertEquals(log[0], [
-    "deno",
-    "task",
-    "problems:build",
-    "--",
-    "--problem",
-    "abc",
-  ]);
-  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
 });
 
 Deno.test("server: 源码上下文 problems import 透传参数", async () => {
-  const root = makeSourceRoot();
-  const log: string[][] = [];
-  const runner = runnerWithLog(log);
-  const ctx = sourceContext(`${root}/noj-core`);
-  const code = await runServerCommand({
-    context: ctx,
-    args: ["problems", "import", "--file", "problems.json"],
-    runner,
+  await withSourceRoot(async (root) => {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx = sourceContext(`${root}/noj-core`);
+    const code = await runServerCommand({
+      context: ctx,
+      args: ["problems", "import", "--file", "problems.json"],
+      runner,
+    });
+    assertEquals(code, 0);
+    assertEquals(log[0], [
+      "deno",
+      "task",
+      "problems:import",
+      "--",
+      "--file",
+      "problems.json",
+    ]);
+    assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
   });
-  assertEquals(code, 0);
-  assertEquals(log[0], [
-    "deno",
-    "task",
-    "problems:import",
-    "--",
-    "--file",
-    "problems.json",
-  ]);
-  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
 });
 
 Deno.test("server: 源码上下文 init system", async () => {
-  const root = makeSourceRoot();
-  const log: string[][] = [];
-  const runner = runnerWithLog(log);
-  const ctx = sourceContext(`${root}/noj-core`);
-  const code = await runServerCommand({
-    context: ctx,
-    args: ["init", "system"],
-    runner,
+  await withSourceRoot(async (root) => {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx = sourceContext(`${root}/noj-core`);
+    const code = await runServerCommand({
+      context: ctx,
+      args: ["init", "system"],
+      runner,
+    });
+    assertEquals(code, 0);
+    assertEquals(log[0], ["deno", "task", "init:system"]);
+    assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
   });
-  assertEquals(code, 0);
-  assertEquals(log[0], ["deno", "task", "init:system"]);
-  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
 });
 
 Deno.test("server: 源码上下文 dev-setup", async () => {
-  const root = makeSourceRoot();
-  const log: string[][] = [];
-  const runner = runnerWithLog(log);
-  const ctx = sourceContext(`${root}/noj-core`);
-  const code = await runServerCommand({
-    context: ctx,
-    args: ["dev-setup"],
-    runner,
+  await withSourceRoot(async (root) => {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx = sourceContext(`${root}/noj-core`);
+    const code = await runServerCommand({
+      context: ctx,
+      args: ["dev-setup"],
+      runner,
+    });
+    assertEquals(code, 0);
+    assertEquals(log[0], ["deno", "task", "dev-setup"]);
+    assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
   });
-  assertEquals(code, 0);
-  assertEquals(log[0], ["deno", "task", "dev-setup"]);
-  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
 });
 
 Deno.test("server: 未知或不支持的子命令返回非零且不执行", async () => {
@@ -240,6 +274,25 @@ Deno.test("server: 未知或不支持的子命令返回非零且不执行", asyn
     ["problems"],
     ["problems", "foo"],
     ["dev-setup", "extra"],
+  ];
+  for (const args of cases) {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx: CliContext = {
+      cwd: "/tmp",
+      kind: "production",
+      dir: "/opt/neuro-oj",
+    };
+    const code = await runServerCommand({ context: ctx, args, runner });
+    assertEquals(code, 1, `expected failure for ${args.join(" ")}`);
+    assertEquals(log.length, 0, `expected no spawn for ${args.join(" ")}`);
+  }
+});
+
+Deno.test("server: bootstrap 拒绝 --password 命令行参数", async () => {
+  const cases: string[][] = [
+    ["bootstrap", "first-admin", "--password", "secret"],
+    ["bootstrap", "admin", "--password=secret"],
   ];
   for (const args of cases) {
     const log: string[][] = [];
@@ -293,20 +346,21 @@ Deno.test("server: 无上下文且找不到源码根目录返回非零", async (
 });
 
 Deno.test("server: judge 上下文即使位于源码根目录也返回非零且不执行", async () => {
-  const root = makeSourceRoot();
-  const log: string[][] = [];
-  const runner = runnerWithLog(log);
-  const ctx: CliContext = {
-    cwd: `${root}/noj-core`,
-    kind: "judge",
-    dir: null,
-  };
-  const code = await runServerCommand({
-    context: ctx,
-    args: ["db", "migrate"],
-    runner,
+  await withSourceRoot(async (root) => {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx: CliContext = {
+      cwd: `${root}/noj-core`,
+      kind: "judge",
+      dir: null,
+    };
+    const code = await runServerCommand({
+      context: ctx,
+      args: ["db", "migrate"],
+      runner,
+    });
+    assertEquals(code, 1);
+    assertEquals(log.length, 0);
+    assertEquals(runner.spawnCalls.length, 0);
   });
-  assertEquals(code, 1);
-  assertEquals(log.length, 0);
-  assertEquals(runner.spawnCalls.length, 0);
 });

--- a/noj-cli/src/server_cmd/server_cmd_test.ts
+++ b/noj-cli/src/server_cmd/server_cmd_test.ts
@@ -1,0 +1,118 @@
+import { assertEquals } from "@std/assert";
+import type { CliContext } from "../context/context.ts";
+import type {
+  CommandRunner,
+  SpawnHandle,
+  SpawnOpts,
+} from "../runtime/command.ts";
+import { runServerCommand } from "./server_cmd.ts";
+
+function runnerWithLog(log: string[][]): CommandRunner {
+  return {
+    run(cmd, args) {
+      log.push([cmd, ...args]);
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn(opts: SpawnOpts): SpawnHandle {
+      log.push([opts.cmd, ...opts.args]);
+      return {
+        pid: 1,
+        wait() {
+          return Promise.resolve(0);
+        },
+        kill() {
+          return Promise.resolve();
+        },
+      };
+    },
+  };
+}
+
+Deno.test("server: production 上下文调用 docker compose run", async () => {
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = {
+    cwd: "/tmp",
+    kind: "production",
+    dir: "/opt/neuro-oj",
+  };
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["db", "migrate"],
+    runner,
+  });
+  assertEquals(code, 0);
+  const call = log[0]!;
+  assertEquals(call[0], "docker");
+  assertEquals(call.includes("compose"), true);
+  assertEquals(call.includes("run"), true);
+  assertEquals(call.includes("--entrypoint"), true);
+  assertEquals(call.includes("/app/bin/noj"), true);
+  assertEquals(call.includes("core"), true);
+  assertEquals(call[call.length - 1], "migrate");
+});
+
+Deno.test("server: production 上下文透传 bootstrap 参数", async () => {
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = {
+    cwd: "/tmp",
+    kind: "production",
+    dir: "/opt/neuro-oj",
+  };
+  await runServerCommand({
+    context: ctx,
+    args: ["bootstrap", "first-admin", "--username", "admin"],
+    runner,
+  });
+  const call = log[0]!;
+  assertEquals(call.includes("bootstrap"), true);
+  assertEquals(call.includes("first-admin"), true);
+  assertEquals(call.includes("--username"), true);
+  assertEquals(call.includes("admin"), true);
+});
+
+Deno.test("server: 源码上下文调用 deno task", async () => {
+  const root = Deno.makeTempDirSync();
+  Deno.mkdirSync(`${root}/noj-core`, { recursive: true });
+  Deno.writeTextFileSync(`${root}/noj-core/deno.json`, "{}");
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = { cwd: `${root}/noj-core`, kind: "none", dir: null };
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["db", "migrate"],
+    runner,
+  });
+  assertEquals(code, 0);
+  const call = log[0]!;
+  assertEquals(call[0], "deno");
+  assertEquals(call.includes("task"), true);
+  assertEquals(call.includes("db:migrate"), true);
+});
+
+Deno.test("server: 无上下文且找不到源码根目录返回非零", async () => {
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = { cwd: "/tmp", kind: "none", dir: null };
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["db", "migrate"],
+    runner,
+  });
+  assertEquals(code, 1);
+  assertEquals(log.length, 0);
+});
+
+Deno.test("server: judge 上下文返回非零", async () => {
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx: CliContext = { cwd: "/tmp", kind: "judge", dir: "/srv/noj-judge" };
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["db", "migrate"],
+    runner,
+  });
+  assertEquals(code, 1);
+  assertEquals(log.length, 0);
+});

--- a/noj-cli/src/server_cmd/server_cmd_test.ts
+++ b/noj-cli/src/server_cmd/server_cmd_test.ts
@@ -7,7 +7,12 @@ import type {
 } from "../runtime/command.ts";
 import { runServerCommand } from "./server_cmd.ts";
 
-function runnerWithLog(log: string[][]): CommandRunner {
+interface TestRunner extends CommandRunner {
+  spawnCalls: SpawnOpts[];
+}
+
+function runnerWithLog(log: string[][]): TestRunner {
+  const spawnCalls: SpawnOpts[] = [];
   return {
     run(cmd, args) {
       log.push([cmd, ...args]);
@@ -15,6 +20,7 @@ function runnerWithLog(log: string[][]): CommandRunner {
     },
     spawn(opts: SpawnOpts): SpawnHandle {
       log.push([opts.cmd, ...opts.args]);
+      spawnCalls.push(opts);
       return {
         pid: 1,
         wait() {
@@ -25,7 +31,19 @@ function runnerWithLog(log: string[][]): CommandRunner {
         },
       };
     },
+    spawnCalls,
   };
+}
+
+function makeSourceRoot(): string {
+  const root = Deno.makeTempDirSync();
+  Deno.mkdirSync(`${root}/noj-core`, { recursive: true });
+  Deno.writeTextFileSync(`${root}/noj-core/deno.json`, "{}");
+  return root;
+}
+
+function sourceContext(cwd: string): CliContext {
+  return { cwd, kind: "none", dir: null };
 }
 
 Deno.test("server: production 上下文调用 docker compose run", async () => {
@@ -42,14 +60,22 @@ Deno.test("server: production 上下文调用 docker compose run", async () => {
     runner,
   });
   assertEquals(code, 0);
-  const call = log[0]!;
-  assertEquals(call[0], "docker");
-  assertEquals(call.includes("compose"), true);
-  assertEquals(call.includes("run"), true);
-  assertEquals(call.includes("--entrypoint"), true);
-  assertEquals(call.includes("/app/bin/noj"), true);
-  assertEquals(call.includes("core"), true);
-  assertEquals(call[call.length - 1], "migrate");
+  assertEquals(log[0], [
+    "docker",
+    "compose",
+    "--env-file",
+    "/opt/neuro-oj/.env.prod",
+    "--file",
+    "/opt/neuro-oj/docker-compose.prod.yml",
+    "run",
+    "--rm",
+    "--entrypoint",
+    "/app/bin/noj",
+    "core",
+    "db",
+    "migrate",
+  ]);
+  assertEquals(runner.spawnCalls[0]?.cwd, "/opt/neuro-oj");
 });
 
 Deno.test("server: production 上下文透传 bootstrap 参数", async () => {
@@ -60,35 +86,197 @@ Deno.test("server: production 上下文透传 bootstrap 参数", async () => {
     kind: "production",
     dir: "/opt/neuro-oj",
   };
-  await runServerCommand({
+  const code = await runServerCommand({
     context: ctx,
     args: ["bootstrap", "first-admin", "--username", "admin"],
     runner,
   });
-  const call = log[0]!;
-  assertEquals(call.includes("bootstrap"), true);
-  assertEquals(call.includes("first-admin"), true);
-  assertEquals(call.includes("--username"), true);
-  assertEquals(call.includes("admin"), true);
+  assertEquals(code, 0);
+  assertEquals(log[0], [
+    "docker",
+    "compose",
+    "--env-file",
+    "/opt/neuro-oj/.env.prod",
+    "--file",
+    "/opt/neuro-oj/docker-compose.prod.yml",
+    "run",
+    "--rm",
+    "--entrypoint",
+    "/app/bin/noj",
+    "core",
+    "bootstrap",
+    "first-admin",
+    "--username",
+    "admin",
+  ]);
+  assertEquals(runner.spawnCalls[0]?.cwd, "/opt/neuro-oj");
 });
 
-Deno.test("server: 源码上下文调用 deno task", async () => {
-  const root = Deno.makeTempDirSync();
-  Deno.mkdirSync(`${root}/noj-core`, { recursive: true });
-  Deno.writeTextFileSync(`${root}/noj-core/deno.json`, "{}");
+Deno.test("server: 源码上下文 db migrate 调用 deno task", async () => {
+  const root = makeSourceRoot();
   const log: string[][] = [];
   const runner = runnerWithLog(log);
-  const ctx: CliContext = { cwd: `${root}/noj-core`, kind: "none", dir: null };
+  const ctx = sourceContext(`${root}/noj-core`);
   const code = await runServerCommand({
     context: ctx,
     args: ["db", "migrate"],
     runner,
   });
   assertEquals(code, 0);
-  const call = log[0]!;
-  assertEquals(call[0], "deno");
-  assertEquals(call.includes("task"), true);
-  assertEquals(call.includes("db:migrate"), true);
+  assertEquals(log[0], ["deno", "task", "db:migrate"]);
+  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
+});
+
+Deno.test("server: 源码上下文 bootstrap first-admin 透传参数", async () => {
+  const root = makeSourceRoot();
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx = sourceContext(`${root}/noj-core`);
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["bootstrap", "first-admin", "--username", "admin"],
+    runner,
+  });
+  assertEquals(code, 0);
+  assertEquals(log[0], [
+    "deno",
+    "run",
+    "--env-file=.env",
+    "-A",
+    "scripts/noj.ts",
+    "bootstrap",
+    "first-admin",
+    "--username",
+    "admin",
+  ]);
+  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
+});
+
+Deno.test("server: 源码上下文 problems build 透传参数", async () => {
+  const root = makeSourceRoot();
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx = sourceContext(`${root}/noj-core`);
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["problems", "build", "--problem", "abc"],
+    runner,
+  });
+  assertEquals(code, 0);
+  assertEquals(log[0], [
+    "deno",
+    "task",
+    "problems:build",
+    "--",
+    "--problem",
+    "abc",
+  ]);
+  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
+});
+
+Deno.test("server: 源码上下文 problems import 透传参数", async () => {
+  const root = makeSourceRoot();
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx = sourceContext(`${root}/noj-core`);
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["problems", "import", "--file", "problems.json"],
+    runner,
+  });
+  assertEquals(code, 0);
+  assertEquals(log[0], [
+    "deno",
+    "task",
+    "problems:import",
+    "--",
+    "--file",
+    "problems.json",
+  ]);
+  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
+});
+
+Deno.test("server: 源码上下文 init system", async () => {
+  const root = makeSourceRoot();
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx = sourceContext(`${root}/noj-core`);
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["init", "system"],
+    runner,
+  });
+  assertEquals(code, 0);
+  assertEquals(log[0], ["deno", "task", "init:system"]);
+  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
+});
+
+Deno.test("server: 源码上下文 dev-setup", async () => {
+  const root = makeSourceRoot();
+  const log: string[][] = [];
+  const runner = runnerWithLog(log);
+  const ctx = sourceContext(`${root}/noj-core`);
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["dev-setup"],
+    runner,
+  });
+  assertEquals(code, 0);
+  assertEquals(log[0], ["deno", "task", "dev-setup"]);
+  assertEquals(runner.spawnCalls[0]?.cwd, `${root}/noj-core`);
+});
+
+Deno.test("server: 未知或不支持的子命令返回非零且不执行", async () => {
+  const cases: string[][] = [
+    ["foo"],
+    ["db"],
+    ["db", "init"],
+    ["db", "migrate", "extra"],
+    ["init"],
+    ["init", "migrate"],
+    ["init", "system", "extra"],
+    ["bootstrap"],
+    ["bootstrap", "bad"],
+    ["problems"],
+    ["problems", "foo"],
+    ["dev-setup", "extra"],
+  ];
+  for (const args of cases) {
+    const log: string[][] = [];
+    const runner = runnerWithLog(log);
+    const ctx: CliContext = {
+      cwd: "/tmp",
+      kind: "production",
+      dir: "/opt/neuro-oj",
+    };
+    const code = await runServerCommand({ context: ctx, args, runner });
+    assertEquals(code, 1, `expected failure for ${args.join(" ")}`);
+    assertEquals(log.length, 0, `expected no spawn for ${args.join(" ")}`);
+  }
+});
+
+Deno.test("server: production spawn 异常返回非零", async () => {
+  const log: string[][] = [];
+  const runner: CommandRunner = {
+    run() {
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    },
+    spawn() {
+      throw new Error("docker spawn failed");
+    },
+  };
+  const ctx: CliContext = {
+    cwd: "/tmp",
+    kind: "production",
+    dir: "/opt/neuro-oj",
+  };
+  const code = await runServerCommand({
+    context: ctx,
+    args: ["db", "migrate"],
+    runner,
+  });
+  assertEquals(code, 1);
+  assertEquals(log.length, 0);
 });
 
 Deno.test("server: 无上下文且找不到源码根目录返回非零", async () => {
@@ -104,10 +292,15 @@ Deno.test("server: 无上下文且找不到源码根目录返回非零", async (
   assertEquals(log.length, 0);
 });
 
-Deno.test("server: judge 上下文返回非零", async () => {
+Deno.test("server: judge 上下文即使位于源码根目录也返回非零且不执行", async () => {
+  const root = makeSourceRoot();
   const log: string[][] = [];
   const runner = runnerWithLog(log);
-  const ctx: CliContext = { cwd: "/tmp", kind: "judge", dir: "/srv/noj-judge" };
+  const ctx: CliContext = {
+    cwd: `${root}/noj-core`,
+    kind: "judge",
+    dir: null,
+  };
   const code = await runServerCommand({
     context: ctx,
     args: ["db", "migrate"],
@@ -115,4 +308,5 @@ Deno.test("server: judge 上下文返回非零", async () => {
   });
   assertEquals(code, 1);
   assertEquals(log.length, 0);
+  assertEquals(runner.spawnCalls.length, 0);
 });

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,8 @@
 # scripts/ — 脚本总览
 
+> **状态：过渡兜底。** `noj-cli` 正在逐步替代本目录下的运维脚本（judge、restore-drill、生产部署/备份/config 等）。
+> 新功能优先使用 `noj-cli`；以下脚本在完全迁移前保留为兜底，不再作为 noj-cli 的实现依赖。
+
 Neuro OJ 仓库根目录的脚本统一存放点。`setup.sh` 调用 `install.sh`，下载并校验同版本 `noj-cli`，
 由 CLI 调用内部 `production.sh` 和 `deploy.sh` 完成生产安装及运维。
 


### PR DESCRIPTION
## 概述

Phase 1：让 noj-cli 开始替代脚本侧，补齐脚本有而 CLI 没有的运维能力。

## 变更

- 新增部署上下文识别模块：production / json / judge
- 新增可注入 HTTP 客户端
- 新增 `observability check` 和 `observability alert-drill`
- 新增 `server` 命令，包装容器内 /app/bin/noj 与源码 deno task 命令
- CLI 挂载新顶层命令并保留旧命令兼容
- 更新 README 和帮助文本
- 补齐对应单元/集成测试

## 测试

`cd noj-cli && deno task test`：228 passed / 0 failed
`cd noj-cli && deno task check`：通过
`deno run -A scripts/verify-md-links.ts`：通过

## 后续

- Phase 2：`judge` 命令族
- Phase 3：`restore-drill`
- Phase 4：production Deno 化与旧命令别名统一