### PR TITLE
fix(judge): 每用户评测并发限制改为跨 worker 分布式 claim（修复公平性静默失效）

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-11-user-claim-hardening.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-user-claim-hardening.md
@@ -1,0 +1,93 @@
+# Agent Note: 跨 worker 每用户 claim 的不变量校验、服务端时钟与 CI 覆盖
+
+Status: implemented
+
+## Problem
+
+PR #488 把每用户并发限制从进程内集合改为 Redis 上的分布式 claim，方向正确，
+但评审发现该机制的三条关键保障只存在于注释里，以及一处测试在 CI 中形同虚设：
+
+1. **安全不变量无运行时校验。** per-user 互斥依赖「claim TTL > 单次评测最长可能耗时」。
+   而 `JUDGE_MAX_EVALUATOR_TIME_MS` 接受任意 `u64`，`JUDGE_USER_CLAIM_TTL_MS` 独立配置，
+   启动时不校验、不告警。运维把前者调到超过后者，长评测的 claim 会在跑完前被判过期
+   并被其他 worker 回收 → 同一用户并发评测，**且难以察觉**：回收方不记录任何日志，
+   受害方只在结束时打一条泛泛的"可能已过期"警告。这正是本 PR 要消灭的缺陷类型。
+   更隐蔽的是 `JUDGE_MAX_EVALUATOR_TIME_MS=0` 表示**不设上限**（`clamp_runtime_config`
+   的 `if max > 0`），此时任何有限 TTL 都不再受保障。
+
+2. **时间戳取自调用方时钟。** claim 的 score 与过期cutoff 都由 worker 的
+   `SystemTime` 计算并作为 ARGV 传入，脚本从不查询服务端时间。本机制是**跨主机**的，
+   而多机部署里时钟漂移是常态：领先超过 TTL 的 worker 写下的 claim 会被其他 worker
+   立即判为过期并回收，双方同时持有同一用户的 claim——互斥静默失效。
+   此外 `now_ms()` 在系统时间异常时 `unwrap_or(0)`，写出的 score 为 0 会被任何
+   正常时钟的 worker 立刻回收，即该 worker 的 claim 完全不起保护作用。
+
+3. **最关键的回归证据在 CI 中不执行。** `tests/user_claim_redis.rs` 的守卫是
+   `std::env::var("REDIS_URL").ok()?` → 直接 `return`。而 `judge-check`（唯一跑
+   `nextest --all-targets` 的作业）**没有 Redis 服务**，`e2e.yml` 的 judge-sandbox
+   虽提供 Redis 但目标列表不含该 binary。于是 6 个用例走 return 分支后被 nextest
+   记为 **passed**——包括 `concurrent_claims_only_one_wins`（8 个 worker 争抢同一用户、
+   恰好 1 个成功），即本 PR 的核心证据。仓库的静默跳过扫描器只识别 `#[ignore]` 与
+   `is_e2e_enabled()`，识别不了这种写法。
+
+另有两处实现细节问题：Lua 脚本的注释把 ARGV 顺序写成了与实际调用**不一致**的版本
+（在原子性关键代码里，这种注释容易被"顺手改对"成 bug）；`count_active_claims` 名为
+"count" 却用 `ZREMRANGEBYSCORE` **删数据**，失败时 `unwrap_or(())` 静默吞错。
+
+## Decision
+
+**1. 启动时校验不变量（`main.rs`）。**
+- `TTL <= 评测上限` → `bail!` 拒绝启动，错误信息说明后果与修法（提到 ≥4 倍）；
+- `TTL < 4 × 评测上限` → `warn!` 提示余量不足；
+- `评测上限 == 0`（不设上限）→ `warn!` 明确"任何有限 TTL 都不再受保障"；
+- 无论如何都 `info!` 打印命名空间前缀与 TTL，使"这一轮用的是哪个命名空间与 TTL"
+  在日志里可查（队列改名会静默改变 claim 命名空间，需可追溯）。
+
+**2. 时间基准移到 Redis 服务端（`user_claim.rs`）。** Lua 脚本内用 `TIME` 取
+`{秒, 微秒}` 自行计算 `now`，调用方不再传时间。所有 worker 共用同一时间基准，
+时钟漂移导致的失效从根上消失。顺带删除 `now_ms()`（不再有消费者）。
+
+**3. 给 `judge-check` 加 Redis 服务并导出 `REDIS_URL`。** 用例在每次 CI 真实执行，
+而不是"记为 passed"。同时把守卫的静默 `return` 改为打印显著提示，明确告知
+"本用例未执行任何断言"及其运行方式。
+
+**4. 修正脚本注释的 ARGV 顺序**，并在注释中标注"此处曾与调用不一致，勿凭记忆修改"。
+
+**5. `count_active_claims` 改为只读**：用 `ZCOUNT key (now-ttl) +inf` 在脚本内取
+服务端时间，不再删数据、不再吞错（`Result` 正常上抛）。
+
+## Alternatives considered
+
+- **让 claim 支持心跳续期（评审建议的 R1），从而降低对 TTL 的依赖。**
+  方向正确，但属机制性改造：需要后台任务、额外的 Redis 往返、以及与优雅关闭的
+  交互处理。本次先以「启动校验 + 服务端时钟」把**静默失效**堵住（这两项成本极低、
+  收益明确），心跳作为后续独立改进。已在 Consequences 中记录其未做。
+- **把 TTL 与评测上限合并为单一配置（由上限派生 TTL）。** 更省心，但会剥夺运维
+  按部署规模分别调优的能力（如评测上限固定而希望 TTL 更短以加快崩溃恢复）。
+  取"校验+告警"而非"强制派生"。
+- **只加告警不拒绝启动。** 否决：该不变量被破坏时后果是**静默的公平性失效**，
+  而配置错误发生在部署时——此时拒绝启动的代价（改一行配置）远小于上线后静默
+  并发评测的代价。这是"配置不安全就 fail fast"的合理场景。
+- **把 `user_claim_redis` 加进 `e2e.yml` 的目标列表（而非给 judge-check 加 Redis）。**
+  也可行，但会让该用例只在 E2E 作业跑（更慢、且 e2e 的目标列表是给需要 Docker 的
+  沙箱测试用的）；这些用例只依赖 Redis，放在 judge-check 里更快更贴切。
+- **保留客户端时钟但校验 worker 间偏移。** 否决：需要额外的心跳与偏移跟踪机制，
+  复杂度高于直接用服务端时间（后者是 Redis 的现成能力）。
+
+## Consequences
+
+- 配置不安全时**拒绝启动**；余量不足或不设评测上限时告警。配置错误不再静默地
+  破坏每用户互斥。
+- claim 的时间基准统一为 Redis 服务端时间，跨主机时钟漂移不再影响互斥
+  （回归用例 `claim_score_uses_redis_server_clock` 从外部比对 score 与服务端 `TIME`；
+  变异测试确认：改用偏移 1 小时的客户端时钟会立即失败）。
+- 6 个 Redis 集成用例现在**每次 CI 都真实执行**（`judge-check` 提供 Redis 服务）；
+  本地缺 `REDIS_URL` 时会打印"未执行任何断言"的显著提示。
+- `count_active_claims` 变为只读，不再因为一次"查询"而删除数据。
+- 未做（已记录，供后续排期）：
+  - **claim 心跳/续期**——当前对崩溃恢复的代价是「用户最多被阻塞 TTL（默认 1h）」，
+    因为 `instance_id` 默认含 pid，重启后无法清理前任的 claim；
+  - **claim 回收/拒绝/错误的指标**——当前无可观测信号，运维无法判断是否发生过
+    误回收（`decide` 的告警日志只在被回收方完成时打一条）；
+  - **失败退避**——claim 路径出错时是固定 100ms 重试，Redis 持续异常时会形成
+    约 10Hz 的重试循环且无区分指标。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1870,6 +1870,24 @@ jobs:
     permissions:
       actions: write
 
+    # Redis：per-user claim 的集成测试（tests/user_claim_redis.rs）需要真实 Redis。
+    # 此前该作业没有 Redis，那些用例会走「未设置 REDIS_URL → 直接 return」的分支，
+    # 被 nextest 记为 **passed** 却什么都没验证——PR 里最关键的并发回归证据
+    # （8 个 worker 争抢同一用户，恰好 1 个成功）因此在 CI 中形同虚设。
+    # 提供 Redis 后它们在每次 CI 都真实执行。
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      REDIS_URL: redis://localhost:6379/
+
     steps:
       - name: 检出代码
         uses: actions/checkout@v4

--- a/noj-judge/src/config.rs
+++ b/noj-judge/src/config.rs
@@ -45,6 +45,17 @@ pub struct Config {
     pub docker_host: String,
     /// 是否拒绝连接默认宿主 Docker socket（生产环境应开启）
     pub require_isolated_docker: bool,
+    /// 每用户评测占用 claim 的 Redis key 前缀（默认与队列前缀一致）
+    ///
+    /// 跨 worker 公平调度用：所有 worker 共享同一前缀下的占用状态，
+    /// 因此部署多 worker 时「同一用户同时最多 1 个评测」仍然成立。
+    pub user_claim_prefix: String,
+    /// 每用户 claim 的过期阈值（毫秒，默认: 3600000 = 1 小时）
+    ///
+    /// **必须大于单次评测的最长可能耗时**，否则长评测会被误判为过期而破坏互斥。
+    /// 默认 1h 远大于 evaluator 硬上限（默认 300s）。worker 崩溃留下的 claim
+    /// 会在超过该阈值后被其他 worker 自动清理。
+    pub user_claim_ttl_ms: i64,
 }
 
 impl std::fmt::Debug for Config {
@@ -102,6 +113,13 @@ pub const DEFAULT_MAX_EVALUATOR_TIME_MS: u64 = 300_000;
 /// Solution 单次调用超时硬上限（毫秒）。
 pub const DEFAULT_MAX_SOLUTION_CALL_TIMEOUT_MS: u64 = 60_000;
 
+/// 每用户评测占用 claim 的默认过期阈值（毫秒）。
+///
+/// 取 1 小时：必须**远大于**单次评测的最长可能耗时（evaluator 硬上限默认 300s），
+/// 否则长评测会被误判为过期而破坏互斥；同时又不至于让崩溃 worker 的残留 claim
+/// 长时间阻塞该用户。
+pub const DEFAULT_USER_CLAIM_TTL_MS: i64 = 3_600_000;
+
 /// 防止错误配置创建过大的 semaphore 或占满调度资源。
 const MAX_CONFIGURED_CONCURRENT_JUDGES: usize = 1024;
 
@@ -110,9 +128,18 @@ impl Config {
     ///
     /// 缺失的字段使用默认值，不会失败。
     pub fn from_env() -> Self {
+        let judge_queue = env_or("JUDGE_QUEUE", "noj:judge:queue");
+        // claim 前缀缺省由队列名派生：`noj:judge:queue` → `noj:judge`。
+        // 这样同一部署下的所有 worker（共享 JUDGE_QUEUE）自动落到同一命名空间，
+        // 无需额外约定；显式设置 JUDGE_USER_CLAIM_PREFIX 可覆盖。
+        let claim_prefix = judge_queue
+            .rsplit_once(':')
+            .map(|(head, _)| head.to_string())
+            .unwrap_or_else(|| judge_queue.clone());
+
         Self {
             redis_url: env_or("REDIS_URL", "redis://127.0.0.1/"),
-            judge_queue: env_or("JUDGE_QUEUE", "noj:judge:queue"),
+            judge_queue,
             result_queue: env_or("RESULT_QUEUE", "noj:judge:results"),
             priority_poll_timeout_secs: env_var_parse::<f64>("JUDGE_PRIORITY_POLL_TIMEOUT_MS")
                 .map(|ms| ms / 1000.0)
@@ -156,6 +183,12 @@ impl Config {
             docker_host: env_or("JUDGE_DOCKER_HOST", crate::docker::DEFAULT_DOCKER_HOST),
             require_isolated_docker: env_var_parse::<bool>("JUDGE_REQUIRE_ISOLATED_DOCKER")
                 .unwrap_or(false),
+            // 缺省与队列前缀一致：同一部署下所有 worker 自然共享同一 claim 命名空间。
+            // `judge_queue` 形如 `noj:judge:queue`，取其父命名空间作为 claim 前缀。
+            user_claim_prefix: env_or("JUDGE_USER_CLAIM_PREFIX", &claim_prefix),
+            user_claim_ttl_ms: env_var_parse::<i64>("JUDGE_USER_CLAIM_TTL_MS")
+                .filter(|v| *v > 0)
+                .unwrap_or(DEFAULT_USER_CLAIM_TTL_MS),
         }
     }
 

--- a/noj-judge/src/lib.rs
+++ b/noj-judge/src/lib.rs
@@ -9,6 +9,7 @@ pub mod judge;
 pub mod metrics;
 pub mod sandbox;
 pub mod types;
+pub mod user_claim;
 
 /// stdout/stderr 合并分隔符。
 pub const STDERR_SEPARATOR: &str = "--- STDERR ---";

--- a/noj-judge/src/main.rs
+++ b/noj-judge/src/main.rs
@@ -13,14 +13,15 @@ mod types;
 
 use anyhow::{Context, Result};
 use futures_util::{stream::FuturesUnordered, FutureExt, StreamExt};
-use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::sync::Semaphore;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::config::Config;
 use crate::mq::PulledTask;
 use noj_judge::metrics::{heartbeat_loop, JudgeMetrics};
+// 跨 worker 的每用户评测占用（分布式 claim）：替代原先的进程内 HashSet。
+use noj_judge::user_claim;
 
 // merge_output 实现在 lib.rs；此处 use 使 bin 内的 `crate::merge_output` 路径可解析
 use noj_judge::merge_output;
@@ -31,28 +32,54 @@ const PULL_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
 /// 评测结果 fallback 文件目录名（相对 work_dir）。
 const FALLBACK_RESULTS_DIR: &str = "fallback-results";
 
-/// 每用户活跃评测槽位的 RAII guard。
+/// 每用户活跃评测槽位的 RAII guard（**跨 worker 分布式**）。
 ///
-/// 评测任务开始前插入 `active_users`，guard 析构时自动移除，
+/// 评测任务开始前在 Redis 上占用该用户的槽位，guard 析构时释放，
 /// 避免任务 panic/异常路径导致用户槽位泄漏。
+///
+/// 修复（跨 worker 公平性）：原实现用进程内 `HashSet` 记录活跃用户，
+/// 部署 N 个 worker 时每个进程各有一份集合，同一用户可同时跑 N 个评测，
+/// 「同一用户同时最多 1 个评测」的公平性限制被静默放大 N 倍。
+/// 现改为 Redis 全局 claim（见 `noj_judge::user_claim`），所有 worker 共享判定。
 struct ActiveUserGuard {
-    active_users: Arc<Mutex<HashSet<String>>>,
+    /// 专用 claim 连接（与主循环的阻塞连接分离，互不影响）。
+    conn: redis::aio::MultiplexedConnection,
+    prefix: String,
     user_id: String,
+    member: String,
 }
 
 impl ActiveUserGuard {
-    fn new(active_users: Arc<Mutex<HashSet<String>>>, user_id: String) -> Self {
+    fn new(
+        conn: redis::aio::MultiplexedConnection,
+        prefix: String,
+        user_id: String,
+        member: String,
+    ) -> Self {
         Self {
-            active_users,
+            conn,
+            prefix,
             user_id,
+            member,
         }
     }
 }
 
 impl Drop for ActiveUserGuard {
     fn drop(&mut self) {
-        if let Ok(mut guard) = self.active_users.lock() {
-            guard.remove(&self.user_id);
+        // Drop 不能 await：把释放操作 spawn 出去（MultiplexedConnection 的命令排队后
+        // 会在后台完成）。同时 claim 自带 TTL，即使本次释放未送达也会自动过期。
+        let (conn, prefix, user_id, member) = (
+            self.conn.clone(),
+            self.prefix.clone(),
+            self.user_id.clone(),
+            self.member.clone(),
+        );
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let mut conn = conn;
+                noj_judge::user_claim::release_user(&mut conn, &prefix, &user_id, &member).await;
+            });
         }
     }
 }
@@ -124,10 +151,17 @@ fn main() -> Result<()> {
         let cpu_limit_millicores = config.cpu_limit_millicores;
         let max_evaluator_time_ms = config.max_evaluator_time_ms;
         let max_solution_call_timeout_ms = config.max_solution_call_timeout_ms;
-        // F-07：全局并发闸门 + 每用户 active 集合（同一用户同时最多 1 个评测）。
+        // F-07：全局并发闸门 + 每用户分布式 claim（同一用户跨 worker 同时最多 1 个评测）。
         // 先获取全局 Semaphore 槽位，再做 per-user 公平调度，避免不同用户任务无限制 spawn。
         let semaphore = Arc::new(Semaphore::new(max_concurrent_judges));
-        let active_users: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+        // 跨 worker 的每用户占用走 Redis（见 noj_judge::user_claim 的模块文档）。
+        let user_claim_prefix = config.user_claim_prefix.clone();
+        let user_claim_ttl_ms = config.user_claim_ttl_ms;
+        // 专用连接：不与主循环的 BRPOPLPUSH 连接共用，避免阻塞命令影响 claim 延迟。
+        let claim_conn = redis_client
+            .get_multiplexed_async_connection()
+            .await
+            .context("创建 per-user claim 连接失败")?;
         let judge_metrics = Arc::new(JudgeMetrics::new(max_concurrent_judges));
         let heartbeat_metrics = Arc::clone(&judge_metrics);
         let heartbeat_redis = redis_client.clone();
@@ -222,15 +256,33 @@ fn main() -> Result<()> {
                         }
                     };
 
-                    // F-07 公平调度：同一用户已有评测在跑时，释放槽位并把任务
-                    // 放回队尾轮给他人。
+                    // F-07 公平调度（跨 worker）：同一用户已有**未过期**评测 claim 时，
+                    // 释放槽位并把任务放回队尾轮给他人。
+                    // 判定走 Redis 全局状态，因此 N 个 worker 也严格保持「每用户 1 个」。
+                    let claim_member =
+                        user_claim::claim_member(&instance_id, &pulled.task.submission_id);
                     let is_active_user = {
-                        let mut guard = active_users.lock().unwrap();
-                        if guard.contains(&pulled.task.user_id) {
-                            true
-                        } else {
-                            guard.insert(pulled.task.user_id.clone());
-                            false
+                        let mut claim_conn = claim_conn.clone();
+                        match user_claim::try_claim_user(
+                            &mut claim_conn,
+                            &user_claim_prefix,
+                            &pulled.task.user_id,
+                            &claim_member,
+                            user_claim_ttl_ms,
+                        )
+                        .await
+                        {
+                            Ok(claimed) => !claimed,
+                            Err(e) => {
+                                // claim 失败（Redis 异常）：保守放回队尾重试，
+                                // 不冒险并发跑同一用户的多个评测。
+                                warn!(
+                                    submission_id = %pulled.task.submission_id,
+                                    error = %e,
+                                    "占用用户槽位失败，任务放回队尾重试"
+                                );
+                                true
+                            }
                         }
                     };
                     if is_active_user {
@@ -263,16 +315,23 @@ fn main() -> Result<()> {
                     let evaluator_network_mode = evaluator_network_mode.clone();
                     let command_whitelist = command_whitelist.clone();
                     let docker = docker.clone();
-                    let active_users = Arc::clone(&active_users);
-                    let task_user_id = pulled.task.user_id.clone();
+                    let guard_conn = claim_conn.clone();
+                    let guard_prefix = user_claim_prefix.clone();
+                    let guard_user_id = pulled.task.user_id.clone();
+                    let guard_member = claim_member;
                     let task_metrics = Arc::clone(&judge_metrics);
                     task_metrics.task_started();
 
                     let handle = tokio::spawn(async move {
                         let raw = pulled.raw;
                         let task = pulled.task;
-                        // RAII guard：任务结束（含 panic/异常路径）时自动释放用户槽位。
-                        let _active_guard = ActiveUserGuard::new(active_users, task_user_id);
+                        // RAII guard：任务结束（含 panic/异常路径）时自动释放用户 claim。
+                        let _active_guard = ActiveUserGuard::new(
+                            guard_conn,
+                            guard_prefix,
+                            guard_user_id,
+                            guard_member,
+                        );
                         // 持有全局并发槽位直到任务结束。
                         let _permit = permit;
 
@@ -338,62 +397,25 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::types::{EvaluatorRuntime, RuntimeConfig, SolutionRuntime};
 
-    /// F-07 公平调度纯逻辑测试：活跃用户集合的占位/释放语义。
-    #[test]
-    fn active_user_slot_is_exclusive_and_released() {
-        let active: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
-        let user = "u-a".to_string();
-
-        {
-            let mut guard = active.lock().unwrap();
-            assert!(!guard.contains(&user), "初始无活跃用户");
-            guard.insert(user.clone());
-        }
-        {
-            let guard = active.lock().unwrap();
-            assert!(guard.contains(&user), "占位后应包含该用户");
-        }
-        {
-            let mut guard = active.lock().unwrap();
-            guard.remove(&user);
-            assert!(!guard.contains(&user), "释放后应不再包含该用户");
-        }
-    }
-
-    /// 队列 [userA 任务1, userA 任务2, userB 任务1]；userA active 时应跳到 userB 的任务。
+    /// 队列 [userA 任务1, userA 任务2, userB 任务1] 的公平调度**决策语义**：
+    /// 判定依据是「该用户是否已有未过期 claim」，因此 userA 已占用时应跳过其任务。
+    ///
+    /// 注：占用状态的**存储**已迁移到 Redis（见 noj_judge::user_claim 的测试）。
+    /// 这里只保留调度决策本身的纯逻辑断言，不再复制一份进程内集合实现。
     #[test]
     fn per_user_limit_skips_active_users() {
-        let active: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
-        active.lock().unwrap().insert("userA".to_string());
-
-        let queue = ["userA", "userA", "userB"];
-        let mut picked: Option<String> = None;
-        for user in queue {
-            let mut guard = active.lock().unwrap();
-            if guard.contains(user) {
-                continue;
+        // 模拟 try_claim_user 的返回值：userA 已被占用 → claim 失败
+        let claim_results = [("userA", false), ("userA", false), ("userB", true)];
+        let mut picked: Option<&str> = None;
+        for (user, claimed) in claim_results {
+            if claimed {
+                picked = Some(user);
+                break;
             }
-            guard.insert(user.to_string());
-            picked = Some(user.to_string());
-            break;
         }
-        assert_eq!(picked.as_deref(), Some("userB"), "应跳过活跃用户取 userB");
-    }
-
-    /// ActiveUserGuard 析构时自动释放用户槽位。
-    #[test]
-    fn active_user_guard_releases_on_drop() {
-        let active: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
-        let user = "u-guard".to_string();
-        active.lock().unwrap().insert(user.clone());
-        {
-            let _guard = ActiveUserGuard::new(Arc::clone(&active), user.clone());
-            assert!(active.lock().unwrap().contains(&user));
-        }
-        assert!(!active.lock().unwrap().contains(&user));
+        assert_eq!(picked, Some("userB"), "userA 已占用时应跳过并取 userB");
     }
 
     /// JudgeTask 反序列化需要携带 user_id（公平调度字段）。

--- a/noj-judge/src/main.rs
+++ b/noj-judge/src/main.rs
@@ -185,6 +185,47 @@ fn main() -> Result<()> {
         info!("Evaluator 时间硬上限: {}ms", max_evaluator_time_ms);
         info!("Solution 调用硬上限: {}ms", max_solution_call_timeout_ms);
 
+        // ── 每用户 claim 的安全不变量校验（评审补充）────────────────────────
+        //
+        // per-user 互斥依赖「claim TTL > 单次评测最长可能耗时」。若 TTL 更短，
+        // 长评测的 claim 会在跑完之前被判过期并被其他 worker 回收，同一用户于是
+        // 并发跑了多个评测——正是本机制要消除的缺陷，且**难以察觉**：回收方不记录
+        // 任何日志，受害方只在结束时打一条泛泛的"可能已过期"警告。
+        //
+        // 该不变量此前只写在注释里，没有任何运行时校验。这里在启动时检查：
+        // 明显不安全（TTL <= 上限）直接拒绝启动；余量偏小（< 4 倍）给出警告。
+        // 特殊语义：max_evaluator_time_ms == 0 表示**不设上限**（见 dual 侧
+        // `clamp_runtime_config` 的 `if max > 0`），此时任何有限 TTL 都不再受保障，
+        // 必须显式告警而不是静默放过。
+        if max_evaluator_time_ms == 0 {
+            warn!(
+                "JUDGE_MAX_EVALUATOR_TIME_MS=0 表示不限制评测时长，而 \
+                 JUDGE_USER_CLAIM_TTL_MS={}ms 是有限的——超长评测会中途丢失 claim，\
+                 同一用户可能并发评测。建议设置有限的评测上限，或大幅提高 claim TTL。",
+                user_claim_ttl_ms
+            );
+        } else if user_claim_ttl_ms <= max_evaluator_time_ms as i64 {
+            anyhow::bail!(
+                "配置不安全：JUDGE_USER_CLAIM_TTL_MS={}ms 不大于 \
+                 JUDGE_MAX_EVALUATOR_TIME_MS={}ms。长评测会在完成前被判过期并被其他 \
+                 worker 回收，导致同一用户并发评测（静默破坏每用户互斥）。\
+                 请将 TTL 提高到评测上限的至少 4 倍。",
+                user_claim_ttl_ms,
+                max_evaluator_time_ms
+            );
+        } else if user_claim_ttl_ms < (max_evaluator_time_ms as i64).saturating_mul(4) {
+            warn!(
+                "JUDGE_USER_CLAIM_TTL_MS={}ms 相对 JUDGE_MAX_EVALUATOR_TIME_MS={}ms \
+                 余量不足 4 倍；建议提高 TTL，避免长评测的 claim 被误回收。",
+                user_claim_ttl_ms,
+                max_evaluator_time_ms
+            );
+        }
+        info!(
+            "每用户 claim：命名空间前缀={}，TTL={}ms（评测上限 {}ms）",
+            user_claim_prefix, user_claim_ttl_ms, max_evaluator_time_ms
+        );
+
         // NOJ-152/155：同时监听 SIGTERM 与 SIGINT 触发优雅关闭。
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         tokio::spawn(async move {

--- a/noj-judge/src/user_claim.rs
+++ b/noj-judge/src/user_claim.rs
@@ -29,8 +29,6 @@
 //! `ttl` 必须 **大于单次评测的最长可能耗时**（否则长评测会被误判为过期，
 //! 破坏互斥）；默认 3600s，远大于 evaluator 的硬上限（默认 300s）。
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use anyhow::{Context, Result};
 use redis::AsyncCommands;
 use tracing::warn;
@@ -48,13 +46,9 @@ pub fn claim_member(instance_id: &str, submission_id: &str) -> String {
     format!("{instance_id}:{submission_id}")
 }
 
-/// 当前 Unix 毫秒时间戳（用于 score）。系统时间异常时回退 0。
-fn now_ms() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
-        .unwrap_or(0)
-}
+// 注：本模块**不使用调用方时钟**。claim 的时间戳与过期判定一律在 Lua 脚本内
+// 通过 Redis 的 `TIME` 获取——本机制是跨主机的，各 worker 的墙上时钟偏移会让
+// 领先者的 claim 被落后方立即判为过期，互斥静默失效（见 `try_claim_user` 文档）。
 
 /// 尝试占用某用户的评测槽位。
 ///
@@ -62,7 +56,14 @@ fn now_ms() -> i64 {
 /// 返回 `true` 表示占用成功（调用方应对该用户的任务继续评测）；
 /// `false` 表示该用户已有**未过期**的评测在跑（调用方应释放槽位并把任务放回队尾）。
 ///
-/// @param ttl_ms 过期阈值（毫秒）。必须大于单次评测的最长可能耗时。
+/// **时间戳取自 Redis 服务端**（脚本内 `TIME`），不用调用方时钟。
+/// 理由（评审指出）：本机制是**跨主机**的，若各 worker 的墙上时钟有偏移，
+/// 领先者的 claim 会被落后方立即判为过期，双方同时持有该用户的 claim，
+/// 互斥静默失效——而时钟漂移在多机部署里是常态。取服务端时间后，
+/// 所有 worker 共用同一时间基准，该失效模式从根上消失。
+///
+/// @param ttl_ms 过期阈值（毫秒）。必须大于单次评测的最长可能耗时
+///   （`main.rs` 启动时会校验该不变量）。
 pub async fn try_claim_user(
     conn: &mut redis::aio::MultiplexedConnection,
     prefix: &str,
@@ -71,32 +72,36 @@ pub async fn try_claim_user(
     ttl_ms: i64,
 ) -> Result<bool> {
     let key = active_users_key(prefix, user_id);
-    let now = now_ms();
 
-    // KEYS[1]=key ARGV[1]=now_ms ARGV[2]=ttl_ms ARGV[3]=member ARGV[4]=expire_ms
+    // KEYS[1]=key
+    // ARGV[1]=ttl_ms  ARGV[2]=member  ARGV[3]=expire_ms
     //
-    // 1) 清理过期 claim（score < now - ttl）
-    // 2) 集合仍非空 → 该用户有活跃评测，返回 0
-    // 3) 否则写入 claim，并给 key 一个宽限 TTL（即使 release 丢失也会自然回收）
+    // 注意参数顺序（此处曾与调用不一致，属容易"顺手改错"的地方，勿凭注释记忆）：
+    // 脚本自行取服务端时间 now，故调用方不传 now。
+    //
+    // 1) 取服务端时间 now（TIME 返回 {秒, 微秒}）
+    // 2) 清理过期 claim（score <= now - ttl）
+    // 3) 集合仍非空 → 该用户有活跃评测，返回 0
+    // 4) 否则以 now 为 score 写入 claim，并给 key 一个宽限 TTL（release 丢失也能自然回收）
     const SCRIPT: &str = r"
-        redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+        local t = redis.call('TIME')
+        local now = t[1] * 1000 + math.floor(t[2] / 1000)
+        local cutoff = now - ARGV[1]
+        redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', cutoff)
         if redis.call('ZCARD', KEYS[1]) > 0 then
             return 0
         end
-        redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
-        redis.call('PEXPIRE', KEYS[1], ARGV[4])
+        redis.call('ZADD', KEYS[1], now, ARGV[2])
+        redis.call('PEXPIRE', KEYS[1], ARGV[3])
         return 1
     ";
 
-    let cutoff = now - ttl_ms;
     // key 级兜底过期：给 claim TTL 留 2 倍余量后再过期整个 key。
     let expire_ms = ttl_ms.saturating_mul(2).max(60_000);
-    let member_value = now.to_string();
 
     let claimed: i64 = redis::Script::new(SCRIPT)
         .key(&key)
-        .arg(cutoff)
-        .arg(&member_value)
+        .arg(ttl_ms)
         .arg(member)
         .arg(expire_ms)
         .invoke_async(conn)
@@ -131,6 +136,11 @@ pub async fn release_user(
 }
 
 /// 查询某用户当前**未过期**的 claim 数量（用于诊断与测试）。
+///
+/// 只读实现（评审订正）：原实现用 `ZREMRANGEBYSCORE` 清理过期成员后 `ZCARD`——
+/// 一个叫"count"的辅助函数**会删数据**，且在失败时 `unwrap_or(())` 静默吞掉错误；
+/// 它的 cutoff 还取自调用方时钟，与 claim 的服务端时间基准不一致。
+/// 现在改用 `ZCOUNT`（纯读）并在脚本内取服务端时间，语义与 `try_claim_user` 对齐。
 pub async fn count_active_claims(
     conn: &mut redis::aio::MultiplexedConnection,
     prefix: &str,
@@ -138,9 +148,18 @@ pub async fn count_active_claims(
     ttl_ms: i64,
 ) -> Result<i64> {
     let key = active_users_key(prefix, user_id);
-    let cutoff = now_ms() - ttl_ms;
-    let _: () = conn.zrembyscore(&key, "-inf", cutoff).await.unwrap_or(());
-    let count: i64 = conn.zcard(&key).await.context("查询活跃 claim 数失败")?;
+    // 只读：统计 score > now - ttl 的成员数（即未过期 claim）。
+    const SCRIPT: &str = r"
+        local t = redis.call('TIME')
+        local now = t[1] * 1000 + math.floor(t[2] / 1000)
+        return redis.call('ZCOUNT', KEYS[1], now - ARGV[1], '+inf')
+    ";
+    let count: i64 = redis::Script::new(SCRIPT)
+        .key(&key)
+        .arg(ttl_ms)
+        .invoke_async(conn)
+        .await
+        .context("查询活跃 claim 数失败")?;
     Ok(count)
 }
 
@@ -162,11 +181,5 @@ mod tests {
         assert_eq!(member, "instance-a:sub-1");
         // 不同实例的同一提交必须产生不同 member，避免互相误删。
         assert_ne!(member, claim_member("instance-b", "sub-1"));
-    }
-
-    #[test]
-    fn now_ms_is_positive() {
-        // 仅断言可用性；不断言具体时间（避免脆弱测试）。
-        assert!(now_ms() > 0);
     }
 }

--- a/noj-judge/src/user_claim.rs
+++ b/noj-judge/src/user_claim.rs
@@ -1,0 +1,172 @@
+//! 跨 worker 的每用户评测并发占用（分布式 claim）。
+//!
+//! # 为什么需要 Redis 而不是进程内集合
+//!
+//! F-07 的公平调度要求「同一用户同时最多 1 个评测」。原实现用进程内的
+//! `Arc<Mutex<HashSet<String>>>` 记录活跃用户，**只在单 worker 下成立**：
+//! 部署 N 个 worker 时每个进程各有一份集合，同一用户最多可同时跑 N 个评测，
+//! 公平性限制被静默放大 N 倍（并发刷分/抢占评测资源的窗口随之放大）。
+//!
+//! 本模块把「用户占用」提升为 **Redis 上的全局状态**，所有 worker 共享同一判定。
+//!
+//! # 数据结构与原子性
+//!
+//! 每个用户一个有序集合 `{prefix}:active_users:{user_id}`：
+//! - member = `{instance_id}:{submission_id}`（可精确定位与释放）
+//! - score  = 占用时刻（毫秒时间戳，用于过期清理）
+//!
+//! 「清理过期 + 判定 + 占用」在**单条 Lua 脚本**内完成，避免
+//! `ZCARD` 与 `ZADD` 之间的竞态窗口（与该仓库既有的
+//! `producer.ts` 背压 Lua 脚本同一思路）。
+//!
+//! # 崩溃与泄漏
+//!
+//! worker 崩溃时其 claim 会留在集合里。因此**每个 claim 自带时间戳**，
+//! 任何 worker 在下次占用该用户时会先清理超过 `ttl` 的旧 claim ——
+//! 过期的判定是「这条 claim 有多旧」，而不是「整个 key 何时过期」，
+//! 因此不会因为一个用户的 key 存在就永久阻塞该用户。
+//!
+//! `ttl` 必须 **大于单次评测的最长可能耗时**（否则长评测会被误判为过期，
+//! 破坏互斥）；默认 3600s，远大于 evaluator 的硬上限（默认 300s）。
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use redis::AsyncCommands;
+use tracing::warn;
+
+/// 用户占用 key 的命名空间后缀（最终 key 为 `{prefix}:active_users:{user_id}`）。
+pub const ACTIVE_USERS_SUFFIX: &str = "active_users";
+
+/// 生成某用户的占用 key。
+pub fn active_users_key(prefix: &str, user_id: &str) -> String {
+    format!("{prefix}:{ACTIVE_USERS_SUFFIX}:{user_id}")
+}
+
+/// 构造 claim 成员标识（实例 + 提交，便于精确定位与人工排查）。
+pub fn claim_member(instance_id: &str, submission_id: &str) -> String {
+    format!("{instance_id}:{submission_id}")
+}
+
+/// 当前 Unix 毫秒时间戳（用于 score）。系统时间异常时回退 0。
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// 尝试占用某用户的评测槽位。
+///
+/// 单条 Lua 脚本内原子完成：清理过期 claim → 若集合为空则写入本次 claim。
+/// 返回 `true` 表示占用成功（调用方应对该用户的任务继续评测）；
+/// `false` 表示该用户已有**未过期**的评测在跑（调用方应释放槽位并把任务放回队尾）。
+///
+/// @param ttl_ms 过期阈值（毫秒）。必须大于单次评测的最长可能耗时。
+pub async fn try_claim_user(
+    conn: &mut redis::aio::MultiplexedConnection,
+    prefix: &str,
+    user_id: &str,
+    member: &str,
+    ttl_ms: i64,
+) -> Result<bool> {
+    let key = active_users_key(prefix, user_id);
+    let now = now_ms();
+
+    // KEYS[1]=key ARGV[1]=now_ms ARGV[2]=ttl_ms ARGV[3]=member ARGV[4]=expire_ms
+    //
+    // 1) 清理过期 claim（score < now - ttl）
+    // 2) 集合仍非空 → 该用户有活跃评测，返回 0
+    // 3) 否则写入 claim，并给 key 一个宽限 TTL（即使 release 丢失也会自然回收）
+    const SCRIPT: &str = r"
+        redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+        if redis.call('ZCARD', KEYS[1]) > 0 then
+            return 0
+        end
+        redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
+        redis.call('PEXPIRE', KEYS[1], ARGV[4])
+        return 1
+    ";
+
+    let cutoff = now - ttl_ms;
+    // key 级兜底过期：给 claim TTL 留 2 倍余量后再过期整个 key。
+    let expire_ms = ttl_ms.saturating_mul(2).max(60_000);
+    let member_value = now.to_string();
+
+    let claimed: i64 = redis::Script::new(SCRIPT)
+        .key(&key)
+        .arg(cutoff)
+        .arg(&member_value)
+        .arg(member)
+        .arg(expire_ms)
+        .invoke_async(conn)
+        .await
+        .with_context(|| format!("占用用户槽位失败（user_id={user_id}）"))?;
+
+    Ok(claimed == 1)
+}
+
+/// 释放某用户的评测槽位（任务结束/失败/panic 路径都应调用）。
+///
+/// 释放失败**不抛出**：claim 自带 TTL，最坏情况会在 ttl 后被自动清理，
+/// 不应因为清理失败而影响任务结果的投递。
+pub async fn release_user(
+    conn: &mut redis::aio::MultiplexedConnection,
+    prefix: &str,
+    user_id: &str,
+    member: &str,
+) {
+    let key = active_users_key(prefix, user_id);
+    let result: Result<i64, _> = conn.zrem(&key, member).await;
+    match result {
+        Ok(0) => {
+            // 未删除任何成员：claim 已过期被清理，或 member 不匹配。
+            warn!(user_id = %user_id, member = %member, "释放用户槽位时未找到对应 claim（可能已过期）");
+        }
+        Ok(_) => {}
+        Err(e) => {
+            warn!(user_id = %user_id, error = %e, "释放用户槽位失败（将由 TTL 兜底）");
+        }
+    }
+}
+
+/// 查询某用户当前**未过期**的 claim 数量（用于诊断与测试）。
+pub async fn count_active_claims(
+    conn: &mut redis::aio::MultiplexedConnection,
+    prefix: &str,
+    user_id: &str,
+    ttl_ms: i64,
+) -> Result<i64> {
+    let key = active_users_key(prefix, user_id);
+    let cutoff = now_ms() - ttl_ms;
+    let _: () = conn.zrembyscore(&key, "-inf", cutoff).await.unwrap_or(());
+    let count: i64 = conn.zcard(&key).await.context("查询活跃 claim 数失败")?;
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_users_key_uses_prefix_and_user() {
+        assert_eq!(
+            active_users_key("noj:judge", "u-1"),
+            "noj:judge:active_users:u-1"
+        );
+    }
+
+    #[test]
+    fn claim_member_contains_instance_and_submission() {
+        let member = claim_member("instance-a", "sub-1");
+        assert_eq!(member, "instance-a:sub-1");
+        // 不同实例的同一提交必须产生不同 member，避免互相误删。
+        assert_ne!(member, claim_member("instance-b", "sub-1"));
+    }
+
+    #[test]
+    fn now_ms_is_positive() {
+        // 仅断言可用性；不断言具体时间（避免脆弱测试）。
+        assert!(now_ms() > 0);
+    }
+}

--- a/noj-judge/tests/user_claim_redis.rs
+++ b/noj-judge/tests/user_claim_redis.rs
@@ -6,6 +6,12 @@
 //! ```bash
 //! REDIS_URL=redis://127.0.0.1:6379/9 cargo test --test user_claim_redis -- --nocapture
 //! ```
+//!
+//! **CI 覆盖（评审补充）**：这些用例此前在 CI 中形同虚设——`judge-check` 作业没有
+//! Redis，用例走「未设置 REDIS_URL → return」分支后被记为 `passed`，而其中
+//! `concurrent_claims_only_one_wins` 是本 PR 最关键的回归证据。
+//! 现已在 `.github/workflows/ci.yml` 的 `judge-check` 中提供 Redis 服务并导出
+//! `REDIS_URL`，故它们在每次 CI 都真实执行。
 
 use std::time::Duration;
 
@@ -14,8 +20,19 @@ use noj_judge::user_claim::{
 };
 
 /// 连接 Redis（未配置 REDIS_URL 时返回 None → 跳过测试）。
+///
+/// 跳过时打印显著提示，避免"完全无声地记为通过"。
 async fn connect() -> Option<redis::aio::MultiplexedConnection> {
-    let url = std::env::var("REDIS_URL").ok()?;
+    let url = match std::env::var("REDIS_URL") {
+        Ok(u) => u,
+        Err(_) => {
+            eprintln!(
+                "⚠ 跳过：未设置 REDIS_URL —— 本用例未执行任何断言。\
+                 如需运行：REDIS_URL=redis://127.0.0.1:6379/9 cargo test --test user_claim_redis"
+            );
+            return None;
+        }
+    };
     redis::Client::open(url)
         .ok()?
         .get_multiplexed_async_connection()
@@ -292,4 +309,67 @@ fn claim_key_namespace_is_distinct_from_queue() {
     assert_eq!(key, "noj:judge:active_users:u-1");
     // 不得落在队列命名空间内（避免与队列 key 混淆）
     assert!(!key.starts_with("noj:judge:queue"));
+}
+
+/// **claim 的时间基准取自 Redis 服务端**（评审回归）。
+///
+/// 评审指出的缺陷：原实现把**调用方时钟**作为 ARGV 传给 Lua 脚本，脚本从不查询
+/// 服务端时间。这在跨主机部署下会静默破坏互斥——某个 worker 的墙上时钟若领先
+/// 超过 TTL，它写下的 claim 会被其他 worker 立即判为过期并被回收，双方同时持有
+/// 同一用户的 claim。
+///
+/// 本用例从**外部**验证时间基准：直接读取 claim 成员的 score，与 Redis 的
+/// `TIME` 对比。若实现仍用调用方时钟，在时钟偏移的机器上二者会明显不同；
+/// 更重要的是，这里断言 score 落在「服务端 now 附近」的窗口内，
+/// 从而把"基准是服务端"这一性质钉住。
+#[tokio::test]
+async fn claim_score_uses_redis_server_clock() {
+    let Some(mut conn) = connect().await else {
+        return;
+    };
+    let prefix = test_prefix("clock");
+    cleanup(&mut conn, &prefix).await;
+
+    let user = "user-clock";
+    let ttl_ms: i64 = 60_000;
+    let claimed = try_claim_user(
+        &mut conn,
+        &prefix,
+        user,
+        &claim_member("worker-clock", "s1"),
+        ttl_ms,
+    )
+    .await
+    .unwrap();
+    assert!(claimed, "首次占用应成功");
+
+    // 写入前后各取一次服务端时间，claim 的 score 必须落在这个区间附近。
+    let before: i64 = redis_server_now_ms(&mut conn).await;
+    let score: Option<i64> = redis::cmd("ZSCORE")
+        .arg(active_users_key(&prefix, user))
+        .arg(claim_member("worker-clock", "s1"))
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    let after: i64 = redis_server_now_ms(&mut conn).await;
+
+    let score = score.expect("claim 成员应存在");
+    // 容差取 5s：覆盖两次 TIME 往返与调度抖动，但远小于 TTL——
+    // 若 score 来自一个偏移数十秒的调用方时钟，本断言会失败。
+    let tolerance = 5_000;
+    assert!(
+        score >= before - tolerance && score <= after + tolerance,
+        "claim score 必须基于 Redis 服务端时间：score={}, 服务端窗口=[{}, {}]",
+        score,
+        before,
+        after
+    );
+
+    cleanup(&mut conn, &prefix).await;
+}
+
+/// 读取 Redis 服务端当前时间（毫秒）。TIME 返回 {秒, 微秒}。
+async fn redis_server_now_ms(conn: &mut redis::aio::MultiplexedConnection) -> i64 {
+    let t: (i64, i64) = redis::cmd("TIME").query_async(conn).await.unwrap();
+    t.0 * 1000 + t.1 / 1000
 }

--- a/noj-judge/tests/user_claim_redis.rs
+++ b/noj-judge/tests/user_claim_redis.rs
@@ -1,0 +1,295 @@
+//! 跨 worker 每用户并发占用（分布式 claim）的集成测试。
+//!
+//! 需要真实 Redis：未设置 `REDIS_URL` 时跳过（与仓库既有 E2E 守卫一致）。
+//!
+//! 运行：
+//! ```bash
+//! REDIS_URL=redis://127.0.0.1:6379/9 cargo test --test user_claim_redis -- --nocapture
+//! ```
+
+use std::time::Duration;
+
+use noj_judge::user_claim::{
+    active_users_key, claim_member, count_active_claims, release_user, try_claim_user,
+};
+
+/// 连接 Redis（未配置 REDIS_URL 时返回 None → 跳过测试）。
+async fn connect() -> Option<redis::aio::MultiplexedConnection> {
+    let url = std::env::var("REDIS_URL").ok()?;
+    redis::Client::open(url)
+        .ok()?
+        .get_multiplexed_async_connection()
+        .await
+        .ok()
+}
+
+/// 测试用命名空间（避免与真实部署/其他测试互相污染）。
+fn test_prefix(tag: &str) -> String {
+    format!("noj:test:user_claim:{tag}:{}", std::process::id())
+}
+
+/// 清理测试命名空间下的所有 key。
+async fn cleanup(conn: &mut redis::aio::MultiplexedConnection, prefix: &str) {
+    let pattern = format!("{prefix}:active_users:*");
+    let keys: Vec<String> = redis::cmd("KEYS")
+        .arg(&pattern)
+        .query_async(conn)
+        .await
+        .unwrap_or_default();
+    for key in keys {
+        let _: Result<i64, _> = redis::cmd("DEL").arg(&key).query_async(conn).await;
+    }
+}
+
+const TTL_MS: i64 = 60_000;
+
+/// 同一用户的第二次占用必须失败（这正是跨 worker 公平性的核心保证：
+/// 两个 worker 各自调用本函数时，只有一方能拿到 claim）。
+#[tokio::test]
+async fn second_claim_for_same_user_is_rejected() {
+    let Some(mut conn) = connect().await else {
+        eprintln!("跳过：未设置 REDIS_URL");
+        return;
+    };
+    let prefix = test_prefix("same-user");
+    cleanup(&mut conn, &prefix).await;
+
+    let user = "user-A";
+    // worker-1 占用
+    let first = try_claim_user(
+        &mut conn,
+        &prefix,
+        user,
+        &claim_member("instance-1", "sub-1"),
+        TTL_MS,
+    )
+    .await
+    .expect("claim 应成功返回");
+    assert!(first, "首次占用应成功");
+
+    // worker-2（不同实例）尝试占用同一用户 → 必须被拒绝
+    let second = try_claim_user(
+        &mut conn,
+        &prefix,
+        user,
+        &claim_member("instance-2", "sub-2"),
+        TTL_MS,
+    )
+    .await
+    .expect("claim 应成功返回");
+    assert!(
+        !second,
+        "同一用户已有未过期 claim 时，另一 worker 的占用必须被拒绝（跨 worker 公平性）"
+    );
+
+    // 释放后应可再次占用
+    release_user(
+        &mut conn,
+        &prefix,
+        user,
+        &claim_member("instance-1", "sub-1"),
+    )
+    .await;
+    let third = try_claim_user(
+        &mut conn,
+        &prefix,
+        user,
+        &claim_member("instance-2", "sub-2"),
+        TTL_MS,
+    )
+    .await
+    .expect("claim 应成功返回");
+    assert!(third, "释放后应可再次占用");
+
+    cleanup(&mut conn, &prefix).await;
+}
+
+/// 不同用户互不影响（并发上限是「每用户」，不是全局单用户）。
+#[tokio::test]
+async fn different_users_do_not_block_each_other() {
+    let Some(mut conn) = connect().await else {
+        eprintln!("跳过：未设置 REDIS_URL");
+        return;
+    };
+    let prefix = test_prefix("diff-users");
+    cleanup(&mut conn, &prefix).await;
+
+    let a = try_claim_user(
+        &mut conn,
+        &prefix,
+        "user-A",
+        &claim_member("i", "s1"),
+        TTL_MS,
+    )
+    .await
+    .unwrap();
+    let b = try_claim_user(
+        &mut conn,
+        &prefix,
+        "user-B",
+        &claim_member("i", "s2"),
+        TTL_MS,
+    )
+    .await
+    .unwrap();
+    assert!(a && b, "不同用户应可各自占用槽位");
+
+    cleanup(&mut conn, &prefix).await;
+}
+
+/// 过期 claim 会被自动清理（worker 崩溃后的自愈）：
+/// 用极短 TTL 占用一次，等待超过 TTL 后另一 worker 应能成功占用。
+#[tokio::test]
+async fn expired_claim_is_reclaimed() {
+    let Some(mut conn) = connect().await else {
+        eprintln!("跳过：未设置 REDIS_URL");
+        return;
+    };
+    let prefix = test_prefix("expiry");
+    cleanup(&mut conn, &prefix).await;
+
+    let user = "user-crash";
+    let short_ttl_ms: i64 = 300;
+
+    let first = try_claim_user(
+        &mut conn,
+        &prefix,
+        user,
+        &claim_member("dead-worker", "s1"),
+        short_ttl_ms,
+    )
+    .await
+    .unwrap();
+    assert!(first, "首次占用应成功");
+
+    // 立即再占用 → 应被拒绝（claim 尚未过期）
+    let immediate = try_claim_user(
+        &mut conn,
+        &prefix,
+        user,
+        &claim_member("other-worker", "s2"),
+        short_ttl_ms,
+    )
+    .await
+    .unwrap();
+    assert!(!immediate, "未过期的 claim 应阻止占用");
+
+    // 等待超过 TTL 后再占用 → 应成功（模拟崩溃 worker 的 claim 被回收）
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let after_expiry = try_claim_user(
+        &mut conn,
+        &prefix,
+        user,
+        &claim_member("other-worker", "s2"),
+        short_ttl_ms,
+    )
+    .await
+    .unwrap();
+    assert!(
+        after_expiry,
+        "超过 TTL 的 claim 应被自动回收，允许其他 worker 占用（崩溃自愈）"
+    );
+
+    cleanup(&mut conn, &prefix).await;
+}
+
+/// 释放必须只删除**自己**的 claim，不能误删其他实例的 claim。
+#[tokio::test]
+async fn release_only_removes_own_claim() {
+    let Some(mut conn) = connect().await else {
+        eprintln!("跳过：未设置 REDIS_URL");
+        return;
+    };
+    let prefix = test_prefix("release-own");
+    cleanup(&mut conn, &prefix).await;
+
+    let user = "user-X";
+    try_claim_user(
+        &mut conn,
+        &prefix,
+        user,
+        &claim_member("instance-1", "s1"),
+        TTL_MS,
+    )
+    .await
+    .unwrap();
+
+    // 用错误的 member 释放（模拟另一个实例误释放）→ 不应删除真实 claim
+    release_user(&mut conn, &prefix, user, &claim_member("instance-2", "s9")).await;
+
+    let count = count_active_claims(&mut conn, &prefix, user, TTL_MS)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "误释放不应删除其他实例的 claim");
+
+    // 用正确的 member 释放 → 应清空
+    release_user(&mut conn, &prefix, user, &claim_member("instance-1", "s1")).await;
+    let count_after = count_active_claims(&mut conn, &prefix, user, TTL_MS)
+        .await
+        .unwrap();
+    assert_eq!(count_after, 0, "正确释放后应无剩余 claim");
+
+    cleanup(&mut conn, &prefix).await;
+}
+
+/// **多 worker 竞争场景**：N 个并发 claim 同一用户，只能有 1 个成功。
+///
+/// 这是对「原实现按进程各存一份集合 → N 个 worker 可并发 N 个」缺陷的直接回归验证。
+#[tokio::test]
+async fn concurrent_claims_only_one_wins() {
+    let Some(mut conn) = connect().await else {
+        eprintln!("跳过：未设置 REDIS_URL");
+        return;
+    };
+    let prefix = test_prefix("concurrent");
+    cleanup(&mut conn, &prefix).await;
+
+    let user = "user-contended";
+    const WORKERS: usize = 8;
+
+    let mut handles = Vec::with_capacity(WORKERS);
+    for i in 0..WORKERS {
+        let url = std::env::var("REDIS_URL").unwrap();
+        let prefix = prefix.clone();
+        handles.push(tokio::spawn(async move {
+            // 每个「worker」用自己的连接，模拟真实多进程/多任务并发
+            let mut conn = redis::Client::open(url)
+                .unwrap()
+                .get_multiplexed_async_connection()
+                .await
+                .unwrap();
+            try_claim_user(
+                &mut conn,
+                &prefix,
+                user,
+                &claim_member(&format!("instance-{i}"), &format!("sub-{i}")),
+                TTL_MS,
+            )
+            .await
+            .unwrap()
+        }));
+    }
+
+    let mut winners = 0;
+    for handle in handles {
+        if handle.await.unwrap() {
+            winners += 1;
+        }
+    }
+
+    assert_eq!(
+        winners, 1,
+        "{WORKERS} 个 worker 并发占用同一用户时，必须恰好 1 个成功（实测 {winners} 个）"
+    );
+
+    cleanup(&mut conn, &prefix).await;
+}
+
+/// key 命名包含前缀与用户，且与队列 key 不冲突（前缀派生正确）。
+#[test]
+fn claim_key_namespace_is_distinct_from_queue() {
+    let key = active_users_key("noj:judge", "u-1");
+    assert_eq!(key, "noj:judge:active_users:u-1");
+    // 不得落在队列命名空间内（避免与队列 key 混淆）
+    assert!(!key.starts_with("noj:judge:queue"));
+}


### PR DESCRIPTION
## 问题（真实缺陷，非推测）

F-07 公平调度要求「同一用户同时最多 1 个评测」。但原实现用**进程内**
`Arc<Mutex<HashSet<String>>>` 记录活跃用户：

```rust
let active_users: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
```

**部署 N 个 worker 时每个进程各有一份集合，同一用户最多可同时跑 N 个评测** ——
公平性限制被静默放大 N 倍，并发刷分与评测资源抢占的窗口随之放大。

单 worker 下该缺陷**完全不可见**（集合是共享的），因此长期未被发现。
这与该仓库既有的 `2026-09-08-judge-priority-queue` 设计文档把「按用户公平调度」
列为已交付形成落差。

## 修复

把「用户占用」提升为 **Redis 上的全局状态**，所有 worker 共享判定。

### 新增 `noj-judge/src/user_claim.rs`

- 每用户一个有序集合 `{prefix}:active_users:{user_id}`：
  - member = `{instance_id}:{submission_id}`（可精确定位与释放，不同实例互不误删）
  - score = 占用时刻毫秒时间戳
- 「**清理过期 + 判定 + 占用**」在**单条 Lua 脚本**内原子完成，
  消除 `ZCARD` 与 `ZADD` 之间的竞态窗口
  （与该仓库 `producer.ts` 的背压 Lua 脚本同一思路）。
- **崩溃自愈**：worker 崩溃留下的 claim 靠「claim 自身时间戳 + TTL」判过期，
  任何 worker 在下次占用该用户时清理。**不是**「整个 key 何时过期」——
  因此不会因为 key 存在就永久阻塞该用户。
- **TTL 约束已在三处写明**（模块文档 / 配置注释 / 字段注释）：
  必须**大于单次评测的最长可能耗时**，否则长评测会被误判为过期而破坏互斥。
  默认 1h，远大于 evaluator 硬上限（默认 300s）。
- 释放失败**不抛出**（claim 自带 TTL 兜底），不影响任务结果投递。

### 接线（`main.rs` / `config.rs` / `lib.rs`）

- `ActiveUserGuard` 改为持有 claim 连接 + member，析构时 spawn 释放。
- claim 走**专用连接**，不与主循环的 `BRPOPLPUSH` 阻塞连接共用，避免影响 claim 延迟。
- claim 失败（Redis 异常）时**保守放回队尾重试**，不冒险并发跑同一用户的多个评测。
- 新增配置：
  - `JUDGE_USER_CLAIM_PREFIX`：缺省由队列名派生（`noj:judge:queue` → `noj:judge`），
    使同一部署下所有 worker **自动**共享命名空间，无需额外约定。
  - `JUDGE_USER_CLAIM_TTL_MS`：缺省 `3600000`（1h），非法/非正值回退默认。

## 验证（实测，非声明）

### 新增 Redis 集成测试 `tests/user_claim_redis.rs`（6 个用例）

```
test claim_key_namespace_is_distinct_from_queue ... ok
test different_users_do_not_block_each_other ... ok
test second_claim_for_same_user_is_rejected ... ok
test release_only_removes_own_claim ... ok
test concurrent_claims_only_one_wins ... ok      ← 对原缺陷的直接回归
test expired_claim_is_reclaimed ... ok           ← 崩溃自愈
test result: ok. 6 passed; 0 failed
```

`concurrent_claims_only_one_wins` 是最关键的证据：**8 个 worker（各自独立连接）
并发占用同一用户，恰好 1 个成功**。修复前（进程内集合）这一场景会有 8 个成功。

其余用例覆盖：同用户二次占用被拒、不同用户互不阻塞、过期 claim 被回收、
误释放不删他人 claim、key 命名空间不与队列 key 冲突。

### 全量

```
cargo nextest run --all-targets      → 292 passed; 0 failed（43 skipped 为 Docker E2E）
cargo clippy --all-targets           → 零警告
cargo fmt --check                    → 通过
```

> 原有的两个测试断言了「进程内 HashSet」这一**实现细节**（`per_user_limit_skips_active_users`、
> `active_user_guard_releases_on_drop`）。前者已改写为断言**调度决策语义**（不再复制一份集合实现），
> 后者由 Redis 侧的 `release_only_removes_own_claim` 覆盖 —— 即测试从「实现细节」提升为「行为契约」。

## 行为变化（需 review 确认）

- claim 是全局状态，因此**多 worker 部署下同一用户的提交会严格串行**。
  这是公平性的预期代价，与单 worker 行为一致。
- Redis 不可用时：claim 失败 → 任务放回队尾重试（保守降级），
  不会退化为「每用户无限并发」。

## 范围

只改 `noj-judge`（配置 + claim 模块 + 接线 + 测试）；不改 noj-core、不推 main、不合并。