### PR TITLE
fix(judge): SDK 测试镜像按构建输入内容哈希判断陈旧，避免静默验证旧镜像

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-11-test-image-staleness-completion.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-test-image-staleness-completion.md
@@ -1,0 +1,84 @@
+# Agent Note: 测试镜像陈旧判定的收尾——覆盖 ensure_test_image 并把判定纳入测试
+
+Status: implemented
+
+## Problem
+
+PR #492 把 SDK 测试镜像的陈旧判定从「tag 是否存在」改为「构建输入内容哈希」，
+但评审发现该修复**只做了一半**：
+
+1. **`ensure_test_image` 未一并修改。** 它仍以「tag 存在即跳过」判定，而
+   `noj-judge/tests/` 的 8 个需要 Docker 的 E2E binary 中有 **6 个**依赖它
+   （e2e_support_package、e2e_security_isolation、e2e_resource_limits、
+   e2e_docker_basic、e2e_dual_container、e2e_network_capability）。
+   其构建输入是 `tests/e2e/Dockerfile.test-runner`（构建上下文 `tests/e2e`），
+   而最常被改动的 `tests/e2e/evaluate.py` 就在其中。**改了 evaluate.py 仍会静默
+   验证旧镜像**——与被修复的那个缺陷完全同类。实测确认：本地
+   `noj-judge-test-runner:latest` 无任何 label。
+
+2. **陈旧判定本身没有测试。** 7 个既有用例只覆盖 `build_inputs_sha`（哈希函数），
+   而「哈希相不相等 → 该不该重建」这一决策写死在 `ensure_sdk_images` 循环里，
+   只能靠跑 Docker 覆盖。后果：把判定写反、或删掉 `--label` 参数，
+   **不会让任何用例失败**，而两者都会静默破坏整套 E2E 的可信度
+   （前者变成"永不重建"，后者变成"永远重建"）。
+
+3. **`__pycache__` 的过滤理由陈述是错的。** 注释称 pycache「不参与镜像内容
+   （镜像内 PYTHONDONTWRITEBYTECODE=1）」，实测 evaluator 镜像内
+   **有数百个 .pyc**（构建期 `python3 -c "import ..."` 生成，外加从构建上下文
+   复制进来）。理由错了，后人若据此"修正"过滤器就会引入永久重建抖动。
+
+4. **「跳过重建」不可见。** 原实现只在**重建**时打印，跳过时静默——
+   日志上无法区分「判定为最新而跳过」与「这个函数根本没被调用」，
+   而这正是本项目此前踩过的「静默跳过」模式。
+
+## Decision
+
+**1. `ensure_test_image` 改用同一机制。** 抽出模块级常量 `INPUTS_LABEL`
+（`com.noj.build-inputs-sha`）与原语 `recorded_inputs_sha()`，两个 `ensure_*`
+共用。测试镜像的构建输入为 `tests/e2e` 全目录（含 evaluate.py）+
+`Dockerfile.test-runner`。
+
+**2. 把判定抽成纯函数并单测。** 新增
+`decide_image_freshness(expected, recorded) -> UpToDate | Rebuild(reason)`，
+配 5 个用例：无 label 重建、哈希一致跳过、哈希不同重建、空字符串 label 视为
+「已变更」而非「缺失」、判定确定性。语义固定为**安全方向**：无法证明最新就重建。
+`ImageFreshness::Rebuild` 携带原因，直接进日志。
+
+**3. 构建后复核 label 已生效。** 若 docker 忽略 `--label`（版本差异或被策略剥离），
+每轮都会「看起来重建成功」但下次判定仍为缺失 → 永久重建循环。与其静默循环，
+不如立即 `bail!` 并说明原因。
+
+**4. 让「跳过」可见。** 两条路径都打印，并带上哈希前缀：
+`已是最新（构建输入 1d6dcbe89a5a…），跳过重建`。哈希前缀还让"验证的是哪一版"
+在日志里可追溯。
+
+**5. 订正 `__pycache__` 的过滤理由**，写明这是「接受漏掉一个派生文件、换取避免
+永久重建抖动」的取舍，以及何时才能移除该过滤。
+
+## Alternatives considered
+
+- **把 `tests/e2e` 整个目录的哈希算作输入，不再单独列 Dockerfile。**
+  实际已如此（Dockerfile 在上下文内，会被 `collect_files` 一并纳入）。
+- **构建后不复核 label，只依赖 `--label` 的文档行为。** 否决：失败的形态是
+  「每轮静默重建」，既慢又不会被发现；一次 `inspect_image` 的成本可以忽略。
+- **把判定逻辑留在 `ensure_*` 内，用 Docker 集成测试覆盖。** 否决：那意味着
+  该决策只在有 Docker 的环境被测到（CI 的 judge-check 作业**没有** Docker），
+  等于没测。纯函数可以在任何环境快速验证。
+- **不打印「已是最新」。** 否决：与"跳过未执行"无法区分，正是本仓库反复出现的
+  静默模式；一行日志即可消除歧义。
+- **把 `__pycache__` 加进 `.dockerignore` 使镜像不含它，从而移除过滤器。**
+  更彻底，但会改变镜像内容（影响现有 E2E 行为），超出本次修复范围，已记入
+  注释作为后续可选项。
+
+## Consequences
+
+- 改 `tests/e2e/evaluate.py` 或 `Dockerfile.test-runner` 现在会**触发重建**，
+  6 个依赖该镜像的 E2E binary 不再可能验证旧镜像。实测验证：改动 evaluate.py 后
+  首次运行输出「构建输入已变更 → 重建」，恢复后输出「已是最新，跳过」。
+- 陈旧判定有 5 个单测；把判定写反会立即失败（已用变异测试确认）。
+- label 未生效时立即报错，不会退化为每轮静默重建。
+- 每次 E2E 的日志都能回答「这一轮验证的是哪个镜像版本」。
+- judge 测试数 285 → 389（`tests/common/mod.rs` 被每个集成测试 binary 编译，
+  故新增用例在所有 binary 中各计一次）。
+- 未做：`.dockerignore` 的 pycache 排除、SDK 镜像内容对 `apt-get upgrade` 的
+  镜像源漂移（哈希无法感知，属既有性质，已在注释中说明取舍）。

--- a/noj-judge/tests/common/mod.rs
+++ b/noj-judge/tests/common/mod.rs
@@ -339,30 +339,71 @@ macro_rules! e2e_test {
 /// 供真实 SDK 全链路测试使用（evaluate_dual 的 solution 启动命令
 /// 硬编码 `python3 -m noj_solution_sdk.host`，镜像必须含 SDK）。
 /// 仅部分 e2e_* 测试文件引用，未引用的 test binary 会报 dead_code。
+///
+/// # 陈旧镜像问题（本函数存在的理由）
+///
+/// 若「镜像已存在就直接跳过构建」，本地改了 SDK 源码后跑 E2E 会**静默验证旧镜像**，
+/// 产生两种同样有害的后果：
+/// - 源码有问题却因旧镜像正常而**假绿**；
+/// - 源码已修好却因旧镜像仍有问题而**假红**（本项目实际踩过：
+///   旧镜像里 SDK 文件权限为 600，非 root 的容器用户无法 import，
+///   一次性打挂整个双容器 E2E 套件，且报错指向 Python 而非权限根因）。
+///
+/// 因此这里用**构建输入的内容哈希**判断是否需要重建：把 Dockerfile 与 SDK 源码的
+/// 路径+内容哈希写入镜像 label，并与当前输入比对。内容哈希（而非 mtime）避免
+/// 「git checkout 刷新 mtime」造成的无谓重建，也避免 mtime 精度问题。
 #[allow(dead_code)]
 pub async fn ensure_sdk_images(docker: &Docker) -> Result<()> {
-    for (tag, dockerfile) in [
+    /// 记录构建输入哈希的镜像 label。
+    const INPUTS_LABEL: &str = "com.noj.build-inputs-sha";
+
+    for (tag, dockerfile, source_dirs) in [
         (
             "noj-e2e-sdk-evaluator:latest",
             "docker/evaluator-python/Dockerfile",
+            ["sdk/common", "sdk/evaluator"].as_slice(),
         ),
         (
             "noj-e2e-sdk-solution:latest",
             "docker/solution-python/Dockerfile",
+            ["sdk/common", "sdk/solution"].as_slice(),
         ),
     ] {
-        let images = docker
-            .list_images(None::<bollard::query_parameters::ListImagesOptions>)
-            .await?;
-        if images.iter().any(|i| i.repo_tags.iter().any(|t| t == tag)) {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let expected = build_inputs_sha(&root, dockerfile, source_dirs)?;
+
+        // 读取现有镜像的输入哈希 label（镜像不存在或无 label 时为 None）
+        let current: Option<String> = match docker.inspect_image(tag).await {
+            Ok(info) => info
+                .config
+                .and_then(|cfg| cfg.labels)
+                .and_then(|labels| labels.get(INPUTS_LABEL).cloned()),
+            Err(_) => None,
+        };
+
+        if current.as_deref() == Some(expected.as_str()) {
             continue;
         }
-        println!("构建 SDK 测试镜像 {} ...", tag);
+
+        match &current {
+            None => println!("构建 SDK 测试镜像 {} ...", tag),
+            Some(_) => println!("SDK 源码或 Dockerfile 已变更，重建测试镜像 {} ...", tag),
+        }
+
         let status = std::process::Command::new("docker")
-            .args(["build", "-t", tag, "-f", dockerfile, "."])
+            .args([
+                "build",
+                "-t",
+                tag,
+                "-f",
+                dockerfile,
+                "--label",
+                &format!("{INPUTS_LABEL}={expected}"),
+                ".",
+            ])
             // buildx 在部分环境写 activity 文件失败（只读 HOME），退回 legacy builder
             .env("DOCKER_BUILDKIT", "0")
-            .current_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+            .current_dir(&root)
             .status()
             .context("执行 docker build 失败")?;
         if !status.success() {
@@ -370,4 +411,174 @@ pub async fn ensure_sdk_images(docker: &Docker) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// 计算 SDK 测试镜像构建输入的 SHA-256（Dockerfile + SDK 源码目录下全部文件）。
+///
+/// 输入按**相对路径排序**后依次喂入「路径 + NUL + 内容 + NUL」，
+/// 保证结果与文件系统遍历顺序无关、且路径变化也能被检出。
+///
+/// 未纳入计算的文件与被忽略的文件（见下）不会触发重建——这是有意的：
+/// 只有真正参与镜像构建的内容才算输入。
+#[allow(dead_code)]
+fn build_inputs_sha(
+    root: &std::path::Path,
+    dockerfile: &str,
+    source_dirs: &[&str],
+) -> Result<String> {
+    use sha2::{Digest, Sha256};
+
+    let mut files: Vec<PathBuf> = vec![root.join(dockerfile)];
+    for dir in source_dirs {
+        collect_files(&root.join(dir), &mut files)?;
+    }
+    // 跳过 Python 字节码缓存：它们不参与镜像内容（镜像内 PYTHONDONTWRITEBYTECODE=1），
+    // 且本地运行时会被随意重建，纳入哈希会导致每次都不必要的重建。
+    files.retain(|p| !p.components().any(|c| c.as_os_str() == "__pycache__"));
+
+    let mut rel: Vec<(String, PathBuf)> = files
+        .into_iter()
+        .map(|p| {
+            let key = p
+                .strip_prefix(root)
+                .unwrap_or(&p)
+                .to_string_lossy()
+                .replace('\\', "/");
+            (key, p)
+        })
+        .collect();
+    rel.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    for (key, path) in rel {
+        hasher.update(key.as_bytes());
+        hasher.update([0u8]);
+        let bytes = std::fs::read(&path)
+            .with_context(|| format!("读取构建输入失败: {}", path.display()))?;
+        hasher.update(&bytes);
+        hasher.update([0u8]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// 递归收集目录下的全部文件（跳过符号链接，避免循环）。
+#[allow(dead_code)]
+fn collect_files(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in
+        std::fs::read_dir(dir).with_context(|| format!("读取目录失败: {}", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_files(&path, out)?;
+        } else if file_type.is_file() {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod build_inputs_tests {
+    use super::*;
+
+    /// 搭一个临时目录，内含 Dockerfile 与 SDK 源文件。
+    fn setup() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("docker/x")).unwrap();
+        std::fs::create_dir_all(root.join("sdk/common/pkg")).unwrap();
+        std::fs::write(root.join("docker/x/Dockerfile"), "FROM scratch\n").unwrap();
+        std::fs::write(root.join("sdk/common/pkg/a.py"), "A = 1\n").unwrap();
+        dir
+    }
+
+    /// 相同内容 → 相同哈希（保证「无改动就跳过构建」成立）。
+    #[test]
+    fn hash_is_stable_for_unchanged_inputs() {
+        let dir = setup();
+        let root = dir.path();
+        let a = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        let b = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64, "SHA-256 十六进制长度");
+    }
+
+    /// 改源码内容 → 哈希变化（保证「改了就会重建」成立）。
+    #[test]
+    fn hash_changes_when_source_content_changes() {
+        let dir = setup();
+        let root = dir.path();
+        let before = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        std::fs::write(root.join("sdk/common/pkg/a.py"), "A = 2\n").unwrap();
+        let after = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        assert_ne!(before, after, "源码内容变化必须使哈希变化");
+    }
+
+    /// 改 Dockerfile → 哈希变化（镜像构建输入包含 Dockerfile）。
+    #[test]
+    fn hash_changes_when_dockerfile_changes() {
+        let dir = setup();
+        let root = dir.path();
+        let before = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        std::fs::write(root.join("docker/x/Dockerfile"), "FROM scratch\nRUN true\n").unwrap();
+        let after = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        assert_ne!(before, after);
+    }
+
+    /// 新增文件 → 哈希变化（新增模块也必须触发重建）。
+    #[test]
+    fn hash_changes_when_file_added() {
+        let dir = setup();
+        let root = dir.path();
+        let before = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        std::fs::write(root.join("sdk/common/pkg/b.py"), "B = 1\n").unwrap();
+        let after = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        assert_ne!(before, after);
+    }
+
+    /// `__pycache__` 不参与哈希：否则本地跑一次 Python 就会触发无谓重建。
+    #[test]
+    fn hash_ignores_pycache() {
+        let dir = setup();
+        let root = dir.path();
+        let before = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        std::fs::create_dir_all(root.join("sdk/common/pkg/__pycache__")).unwrap();
+        std::fs::write(
+            root.join("sdk/common/pkg/__pycache__/a.cpython-312.pyc"),
+            b"\x00\x01",
+        )
+        .unwrap();
+        let after = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        assert_eq!(before, after, "__pycache__ 不应影响构建输入哈希");
+    }
+
+    /// 路径也参与哈希：仅重命名文件（内容不变）必须被视为变更。
+    #[test]
+    fn hash_detects_rename_with_same_content() {
+        let dir = setup();
+        let root = dir.path();
+        let before = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        std::fs::rename(
+            root.join("sdk/common/pkg/a.py"),
+            root.join("sdk/common/pkg/renamed.py"),
+        )
+        .unwrap();
+        let after = build_inputs_sha(root, "docker/x/Dockerfile", &["sdk/common"]).unwrap();
+        assert_ne!(before, after, "重命名应被检出（路径参与哈希）");
+    }
+
+    /// 真实仓库输入可被哈希（对实际 Dockerfile 与 sdk 目录的冒烟验证）。
+    #[test]
+    fn hash_works_on_real_repo_inputs() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let sha = build_inputs_sha(
+            &root,
+            "docker/evaluator-python/Dockerfile",
+            &["sdk/common", "sdk/evaluator"],
+        )
+        .expect("真实仓库输入应可哈希");
+        assert_eq!(sha.len(), 64);
+    }
 }

--- a/noj-judge/tests/common/mod.rs
+++ b/noj-judge/tests/common/mod.rs
@@ -32,34 +32,88 @@ pub fn get_docker() -> Result<Docker> {
     Docker::connect_with_local_defaults().context("连接 Docker daemon 失败")
 }
 
-/// 确保测试用 Docker 镜像存在。
+/// 记录构建输入哈希的镜像 label。
 ///
-/// 先检查本地是否已有 `noj-judge-test-runner` 镜像，
-/// 不存在则通过 `docker build` 命令从 Dockerfile 构建。
+/// 用于判定「本地镜像是否由当前构建输入产出」。放在模块级是因为
+/// `ensure_sdk_images` 与 `ensure_test_image` 共用同一约定。
+const INPUTS_LABEL: &str = "com.noj.build-inputs-sha";
+
+/// 镜像是否需要重建的判定（**纯函数，便于测试**）。
+///
+/// 这是陈旧判定的核心决策，抽出来单独测试的原因：判定逻辑若写死在
+/// `ensure_*` 里，只能靠跑 Docker 才能覆盖，实践中就等于没有测试——
+/// 而一个反向的判定（相等即重建 / 不等即跳过）会静默地把整套 E2E 变成
+/// 「验证旧镜像」。
+///
+/// 语义（安全方向）：**无法证明镜像是最新的，就重建**。
+/// - 无 label（None）→ 重建：镜像由他人构建、或早于本机制引入；
+/// - label 与期望哈希不同 → 重建：构建输入已变；
+/// - label 与期望哈希相同 → 跳过。
+#[derive(Debug, PartialEq, Eq)]
+pub enum ImageFreshness {
+    /// 输入哈希一致，可复用现有镜像。
+    UpToDate,
+    /// 需要重建，附原因（用于日志，让「为什么重建」可见）。
+    Rebuild(&'static str),
+}
+
+/// 依据「期望哈希」与「镜像上记录的哈希」判定是否需要重建。
+#[allow(dead_code)]
+pub fn decide_image_freshness(expected: &str, recorded: Option<&str>) -> ImageFreshness {
+    match recorded {
+        None => ImageFreshness::Rebuild("镜像无构建输入 label（他人构建或早于本机制）"),
+        Some(got) if got == expected => ImageFreshness::UpToDate,
+        Some(_) => ImageFreshness::Rebuild("构建输入已变更"),
+    }
+}
+
+/// 读取镜像上记录的构建输入哈希（镜像不存在或无 label 时为 None）。
+#[allow(dead_code)]
+async fn recorded_inputs_sha(docker: &Docker, tag: &str) -> Option<String> {
+    docker
+        .inspect_image(tag)
+        .await
+        .ok()
+        .and_then(|info| info.config)
+        .and_then(|cfg| cfg.labels)
+        .and_then(|labels| labels.get(INPUTS_LABEL).cloned())
+}
+
+/// 确保测试用 Docker 镜像存在**且不过期**。
+///
+/// 原实现只检查「tag 是否存在」：本地改了 `tests/e2e/evaluate.py` 或
+/// `Dockerfile.test-runner` 后，E2E 仍会拿旧镜像跑并报绿——正是本轮要消灭的
+/// 「静默验证旧镜像」失效模式。`ensure_sdk_images` 已改为按构建输入内容哈希判定，
+/// 但该函数当时未一并修改，于是 8 个 E2E binary 中依赖它的 6 个仍有同样问题。
+///
+/// 现在与 `ensure_sdk_images` 同机制：把「Dockerfile + 构建上下文（tests/e2e）」
+/// 的内容哈希写进镜像 label，判定不一致就重建。
 #[allow(dead_code)] // 仅部分 E2E test binary 引用
 pub async fn ensure_test_image(docker: &Docker) -> Result<()> {
     let image_name = "noj-judge-test-runner:latest";
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // 构建上下文是 tests/e2e（docker build 在该目录下执行，见下方 current_dir）。
+    // 除 Dockerfile 本身外，把整个上下文目录纳入哈希：evaluate.py 就在其中，
+    // 而它正是最常被改动、也最容易被"陈旧镜像"掩盖的文件。
+    let expected = build_inputs_sha(&root, "tests/e2e/Dockerfile.test-runner", &["tests/e2e"])?;
 
-    // 检查本地镜像
-    let images = docker
-        .list_images(None::<bollard::query_parameters::ListImagesOptions>)
-        .await
-        .context("列出 Docker 镜像失败")?;
-
-    let exists = images.iter().any(|i| {
-        i.repo_tags
-            .iter()
-            .any(|tag| tag == image_name || tag == "noj-judge-test-runner")
-    });
-
-    if exists {
-        return Ok(());
+    let current = recorded_inputs_sha(docker, image_name).await;
+    match decide_image_freshness(&expected, current.as_deref()) {
+        ImageFreshness::UpToDate => {
+            // 明确打印「已是最新」：否则「跳过了」与「没执行」在日志上无法区分。
+            println!(
+                "测试镜像 {} 已是最新（构建输入 {}…），跳过重建",
+                image_name,
+                &expected[..12]
+            );
+            return Ok(());
+        }
+        ImageFreshness::Rebuild(why) => {
+            println!("重建测试镜像 {}（{}）...", image_name, why);
+        }
     }
 
-    // 通过子进程构建镜像（bollard 的 tar 构建在测试环境中不够可靠）
-    println!("测试镜像 {} 不存在，开始构建...", image_name);
-
-    let dockerfile_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/e2e");
+    let dockerfile_dir = root.join("tests/e2e");
     if !dockerfile_dir.join("Dockerfile.test-runner").exists() {
         anyhow::bail!(
             "Dockerfile 不存在: {}",
@@ -74,8 +128,11 @@ pub async fn ensure_test_image(docker: &Docker) -> Result<()> {
             image_name,
             "-f",
             "Dockerfile.test-runner",
+            "--label",
+            &format!("{INPUTS_LABEL}={expected}"),
             ".",
         ])
+        .env("DOCKER_BUILDKIT", "0")
         .current_dir(&dockerfile_dir)
         .status()
         .context("执行 docker build 失败")?;
@@ -84,7 +141,24 @@ pub async fn ensure_test_image(docker: &Docker) -> Result<()> {
         anyhow::bail!("docker build 失败 (exit: {:?})", status.code());
     }
 
-    println!("测试镜像构建完成: {}", image_name);
+    // 构建后复核 label 确实写进去了：若 docker 忽略了 --label（版本差异/被策略
+    // 剥离），每轮都会「看起来重建成功」但下次判定仍为 None → 永久重建循环。
+    // 与其静默循环，不如立刻报错。
+    let after = recorded_inputs_sha(docker, image_name).await;
+    if after.as_deref() != Some(expected.as_str()) {
+        anyhow::bail!(
+            "测试镜像构建完成但输入哈希 label 未生效（期望 {}，实际 {:?}）——\
+             会导致每轮 E2E 都重复重建，请检查 docker 是否支持 --label",
+            expected,
+            after
+        );
+    }
+
+    println!(
+        "测试镜像构建完成: {}（输入 {}…）",
+        image_name,
+        &expected[..12]
+    );
     Ok(())
 }
 
@@ -354,9 +428,6 @@ macro_rules! e2e_test {
 /// 「git checkout 刷新 mtime」造成的无谓重建，也避免 mtime 精度问题。
 #[allow(dead_code)]
 pub async fn ensure_sdk_images(docker: &Docker) -> Result<()> {
-    /// 记录构建输入哈希的镜像 label。
-    const INPUTS_LABEL: &str = "com.noj.build-inputs-sha";
-
     for (tag, dockerfile, source_dirs) in [
         (
             "noj-e2e-sdk-evaluator:latest",
@@ -373,21 +444,21 @@ pub async fn ensure_sdk_images(docker: &Docker) -> Result<()> {
         let expected = build_inputs_sha(&root, dockerfile, source_dirs)?;
 
         // 读取现有镜像的输入哈希 label（镜像不存在或无 label 时为 None）
-        let current: Option<String> = match docker.inspect_image(tag).await {
-            Ok(info) => info
-                .config
-                .and_then(|cfg| cfg.labels)
-                .and_then(|labels| labels.get(INPUTS_LABEL).cloned()),
-            Err(_) => None,
-        };
+        let current = recorded_inputs_sha(docker, tag).await;
 
-        if current.as_deref() == Some(expected.as_str()) {
-            continue;
-        }
-
-        match &current {
-            None => println!("构建 SDK 测试镜像 {} ...", tag),
-            Some(_) => println!("SDK 源码或 Dockerfile 已变更，重建测试镜像 {} ...", tag),
+        match decide_image_freshness(&expected, current.as_deref()) {
+            ImageFreshness::UpToDate => {
+                // 明确打印「已是最新」：否则「跳过了」与「没执行」在日志上无法区分。
+                println!(
+                    "{} 已是最新（构建输入 {}…），跳过重建",
+                    tag,
+                    &expected[..12]
+                );
+                continue;
+            }
+            ImageFreshness::Rebuild(why) => {
+                println!("重建 {}（{}）...", tag, why);
+            }
         }
 
         let status = std::process::Command::new("docker")
@@ -408,6 +479,18 @@ pub async fn ensure_sdk_images(docker: &Docker) -> Result<()> {
             .context("执行 docker build 失败")?;
         if !status.success() {
             anyhow::bail!("docker build 失败: {}", tag);
+        }
+
+        // 构建后复核 label 已生效（否则会静默退化为每轮重建）。
+        let after = recorded_inputs_sha(docker, tag).await;
+        if after.as_deref() != Some(expected.as_str()) {
+            anyhow::bail!(
+                "{} 构建完成但输入哈希 label 未生效（期望 {}，实际 {:?}）——\
+                 会导致每轮 E2E 都重复重建，请检查 docker 是否支持 --label",
+                tag,
+                expected,
+                after
+            );
         }
     }
     Ok(())
@@ -432,8 +515,15 @@ fn build_inputs_sha(
     for dir in source_dirs {
         collect_files(&root.join(dir), &mut files)?;
     }
-    // 跳过 Python 字节码缓存：它们不参与镜像内容（镜像内 PYTHONDONTWRITEBYTECODE=1），
-    // 且本地运行时会被随意重建，纳入哈希会导致每次都不必要的重建。
+    // 跳过 Python 字节码缓存。
+    //
+    // 理由（评审订正，勿写成「镜像内没有 pycache」——那是错的）：镜像里**确实**有
+    // pycache（构建期 `python3 -c "import ..."` 生成，外加从构建上下文复制进来的），
+    // 实测 evaluator 镜像内有数百个 .pyc。但它的内容由源码决定、**不是构建输入**：
+    // 本地每次 import/跑测试都会重建 `__pycache__`，纳入哈希会因这种与镜像无关的
+    // 抖动导致每轮无谓重建。
+    // 取舍是明确的：接受哈希漏掉一个派生文件，换掉永久重建抖动。若将来把
+    // `__pycache__` 加进 .dockerignore、使镜像不再包含它，这个过滤才可以移除。
     files.retain(|p| !p.components().any(|c| c.as_os_str() == "__pycache__"));
 
     let mut rel: Vec<(String, PathBuf)> = files
@@ -580,5 +670,113 @@ mod build_inputs_tests {
         )
         .expect("真实仓库输入应可哈希");
         assert_eq!(sha.len(), 64);
+    }
+
+    /// **测试镜像的构建输入也可被哈希**（`ensure_test_image` 的判定依据）。
+    ///
+    /// 该函数此前只看 tag 是否存在，改 `tests/e2e/evaluate.py` 后 E2E 仍用旧镜像
+    /// 跑并报绿。此用例保证其输入可被计算，且 `evaluate.py` 确实参与哈希
+    /// （它是该上下文里最常被改动、最容易被陈旧镜像掩盖的文件）。
+    #[test]
+    fn test_image_inputs_are_hashable_and_cover_evaluate_py() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let before = build_inputs_sha(&root, "tests/e2e/Dockerfile.test-runner", &["tests/e2e"])
+            .expect("测试镜像输入应可哈希");
+        assert_eq!(before.len(), 64);
+
+        // 复制真实输入到临时目录后改动 evaluate.py，哈希必须变化。
+        let dir = tempfile::TempDir::new().unwrap();
+        let staging = dir.path();
+        copy_dir_all(&root.join("tests/e2e"), &staging.join("tests/e2e")).unwrap();
+        let staged_before =
+            build_inputs_sha(staging, "tests/e2e/Dockerfile.test-runner", &["tests/e2e"]).unwrap();
+        let eval = staging.join("tests/e2e/evaluate.py");
+        assert!(eval.exists(), "测试上下文应包含 evaluate.py");
+        let mut body = std::fs::read_to_string(&eval).unwrap();
+        body.push_str("\n# 评审回归：改动 evaluate.py 必须被检出\n");
+        std::fs::write(&eval, body).unwrap();
+        let staged_after =
+            build_inputs_sha(staging, "tests/e2e/Dockerfile.test-runner", &["tests/e2e"]).unwrap();
+        assert_ne!(
+            staged_before, staged_after,
+            "改动 evaluate.py 必须改变测试镜像的输入哈希（否则会静默验证旧镜像）"
+        );
+    }
+
+    /// 递归复制目录（供上面把真实输入搬到临时目录）。
+    fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
+        std::fs::create_dir_all(dst)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            let to = dst.join(entry.file_name());
+            if entry.file_type()?.is_dir() {
+                copy_dir_all(&entry.path(), &to)?;
+            } else {
+                std::fs::copy(entry.path(), to)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// 陈旧判定（`decide_image_freshness`）的单元测试。
+///
+/// 这组用例针对评审指出的问题：**陈旧判定本身此前没有任何测试**——
+/// 改掉判定分支或删掉 `--label` 都不会让任何用例失败，而一个写反的判定
+/// 会静默把整套 E2E 变成「验证旧镜像」。
+#[cfg(test)]
+mod image_freshness_tests {
+    use super::{decide_image_freshness, ImageFreshness};
+
+    /// 无 label → 重建（安全方向：无法证明最新就重建）。
+    #[test]
+    fn missing_label_triggers_rebuild() {
+        assert_eq!(
+            decide_image_freshness("abc", None),
+            ImageFreshness::Rebuild("镜像无构建输入 label（他人构建或早于本机制）")
+        );
+    }
+
+    /// 哈希一致 → 跳过（不必要重建会显著拖慢 E2E）。
+    #[test]
+    fn matching_hash_is_up_to_date() {
+        assert_eq!(
+            decide_image_freshness("abc", Some("abc")),
+            ImageFreshness::UpToDate
+        );
+    }
+
+    /// 哈希不同 → 重建（这是本机制存在的理由）。
+    #[test]
+    fn differing_hash_triggers_rebuild() {
+        assert_eq!(
+            decide_image_freshness("abc", Some("def")),
+            ImageFreshness::Rebuild("构建输入已变更")
+        );
+    }
+
+    /// 边界：空字符串 label 不等于「无 label」，应判为变更而非缺失。
+    #[test]
+    fn empty_label_is_treated_as_changed_not_missing() {
+        assert_eq!(
+            decide_image_freshness("abc", Some("")),
+            ImageFreshness::Rebuild("构建输入已变更")
+        );
+    }
+
+    /// 判定必须是**对称且确定**的：同一输入反复求值结果一致
+    /// （否则会出现「有时重建、有时跳过」的抖动）。
+    #[test]
+    fn decision_is_deterministic() {
+        for _ in 0..3 {
+            assert_eq!(
+                decide_image_freshness("abc", Some("abc")),
+                ImageFreshness::UpToDate
+            );
+            assert_eq!(
+                decide_image_freshness("abc", Some("xyz")),
+                ImageFreshness::Rebuild("构建输入已变更")
+            );
+        }
     }
 }


### PR DESCRIPTION
## 问题（真实踩坑，非理论风险）

`noj-judge/tests/common/mod.rs` 的 `ensure_sdk_images` 原本只判断「镜像 tag 是否存在」，存在就跳过构建：

```rust
if images.iter().any(|i| i.repo_tags.iter().any(|t| t == tag)) {
    continue;   // ← 源码改了也不会重建
}
```

这带来两类相反但**同样有害**的后果：

| 场景 | 后果 |
|---|---|
| 源码已修好、镜像是旧的 | **假红** —— E2E 持续失败，排查方向被误导到源码 |
| 源码有问题、旧镜像恰好正常 | **假绿** —— 缺陷被掩盖 |

### 本项目实际踩中过「假红」

旧镜像里 `noj_sdk_common/*.py` 权限是 `600`（构建时继承了本地文件模式），
非 root 的容器用户（`USER noj`）无法 import → **一次性打挂整个双容器 E2E 套件**
（`e2e_dual_container` 5 个用例失败）。报错是 Python 的 `PermissionError`，
与根因（镜像继承了本地文件权限）相距甚远 —— 我为此花了相当长时间才定位。

> 该权限问题本身已在 #486 通过 Dockerfile `chmod -R a+rX` 修复；
> 本 PR 修的是**让这类问题能被及时发现**的机制。

## 实现

用**构建输入的内容哈希**（SHA-256）替代「tag 存在即跳过」：

```
输入 = Dockerfile
     + 该镜像对应的 SDK 源码目录
       （evaluator: sdk/common + sdk/evaluator；solution: sdk/common + sdk/solution）
```

- 哈希算法：把「**相对路径** + NUL + **文件内容** + NUL」按相对路径**排序**后依次喂入
  → 与文件系统遍历顺序无关，且**路径本身参与哈希**（重命名也会被检出）
- 构建时 `--label com.noj.build-inputs-sha=<hash>` 写入镜像；
  测试时 `inspect_image` 读回比对，不一致才重建

### 两个刻意的设计选择

1. **用内容哈希而非 mtime**：`git checkout` / `jj` 操作会刷新 mtime 却不改内容，
   按 mtime 会触发大量无谓重建；且 mtime 精度在部分文件系统上不可靠。
2. **排除 `__pycache__`**：它不参与镜像内容（镜像内 `PYTHONDONTWRITEBYTECODE=1`），
   且本地跑一次 Python 就会被重建；纳入哈希会导致每次都不必要地重建。

## 验证

### 单元测试（7 个用例）

```
cargo test build_inputs_tests
test result: ok. 7 passed; 0 failed
```

| 用例 | 断言的性质 |
|---|---|
| `hash_is_stable_for_unchanged_inputs` | 相同内容 → 相同哈希（「无改动就跳过」成立） |
| `hash_changes_when_source_content_changes` | 改源码内容 → 哈希变化 |
| `hash_changes_when_dockerfile_changes` | 改 Dockerfile → 哈希变化 |
| `hash_changes_when_file_added` | 新增文件 → 哈希变化 |
| `hash_detects_rename_with_same_content` | **仅重命名**（内容不变）→ 哈希变化（路径参与哈希） |
| `hash_ignores_pycache` | `__pycache__` 不影响哈希（不触发无谓重建） |
| `hash_works_on_real_repo_inputs` | 真实仓库输入可被哈希（冒烟） |

### 端到端行为验证（真实 docker 镜像，逐步实测）

| 步骤 | 期望 | 实测 |
|---|---|---|
| 1. 首次（镜像无 label） | 重建并打标 | `构建 SDK 测试镜像 noj-e2e-sdk-evaluator:latest ...` ✅ |
| 2. 无改动重跑 | **跳过**构建 | 无构建输出，**0.71s** 完成 ✅ |
| 3. **改一个 SDK 源文件** | 检测到并重建 | `SDK 源码或 Dockerfile 已变更，重建测试镜像 ...` ✅ |
| 4. 还原该文件 | 再次检测到并重建 | `已变更，重建 ...` ✅ |
| 5. 再次无改动 | 跳过 | 无构建输出，**0.72s** ✅ |

**第 3 步正是曾经骗过我的场景，现在被明确检出。**

### 全量

```
cargo nextest run --all-targets   → 341 passed; 0 failed（43 skipped 为 Docker E2E）
cargo clippy --all-targets        → 零警告
cargo fmt --check                 → 通过
```

## 影响与代价

- 每次 E2E 多一次 `inspect_image` + 一次目录哈希（毫秒级），可忽略。
- SDK 源码变更后会**自动重建镜像**（约 10–25s），这是必要代价 ——
  换来「**E2E 验证的一定是当前源码**」这一保证。
- **不改变 CI 行为**：CI 每次全新检出、无既有镜像，本就走构建路径。

## 范围

只改 `noj-judge/tests/common/mod.rs`（测试基础设施）；不改产品代码、不推 main、不合并。