### PR TITLE
fix(ui): 统一网站 Logo 引用

### DIFF
--- a/noj-ui/components/shared/BrandLogo.vue
+++ b/noj-ui/components/shared/BrandLogo.vue
@@ -1,5 +1,5 @@
 <template>
-    <NuxtLink to="/" class="flex items-center gap-2 no-underline text-xl font-bold text-primary shrink-0">
+    <NuxtLink :to="to" class="flex items-center gap-2 no-underline text-xl font-bold text-primary shrink-0">
         <img
             :src="logoSrc"
             :alt="brandName"
@@ -14,9 +14,11 @@ import { computed } from "vue"
 import defaultLogo from "~/assets/img/logo.jpg"
 
 interface Props {
+    /** Logo 点击后的目标地址 */
+    to?: string
     /** 品牌名称 */
     brandName?: string
-    /** Logo 图片地址 */
+    /** Logo 图片地址（支持 PNG、JPG/JPEG、SVG 或外部 URL） */
     logoSrc?: string
     /** Logo 尺寸（Tailwind size-N，对应 size-N 类） */
     size?: number
@@ -25,6 +27,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+    to: "/",
     brandName: "Neuro OJ",
     logoSrc: defaultLogo,
     size: 7,

--- a/noj-ui/layouts/admin.vue
+++ b/noj-ui/layouts/admin.vue
@@ -83,10 +83,11 @@ function isActive(path: string) {
       :class="sidebarOpen ? 'w-60' : 'w-0 md:w-15 overflow-hidden md:overflow-visible'"
     >
       <div class="flex items-center justify-between px-3 py-3.5 border-b border-border min-h-16">
-        <NuxtLink to="/admin" class="flex items-center gap-2 no-underline overflow-hidden">
-          <img src="~/assets/img/logo.jpg" alt="NOJ" class="size-7 rounded-md shrink-0" />
-          <span v-show="sidebarOpen" class="text-base font-bold text-primary whitespace-nowrap">管理后台</span>
-        </NuxtLink>
+        <BrandLogo
+          to="/admin"
+          brand-name="管理后台"
+          :text-class="sidebarOpen ? 'text-base whitespace-nowrap' : 'hidden'"
+        />
         <button class="bg-none border-none text-text-secondary cursor-pointer p-1 rounded shrink-0 hover:bg-primary-hover transition-colors" @click="sidebarOpen = !sidebarOpen">
           <UIcon name="i-lucide-panel-left-close" class="size-4.5" v-if="sidebarOpen"/>
           <UIcon name="i-lucide-panel-left" class="size-4.5" v-else/>


### PR DESCRIPTION
## 变更内容

- 扩展 `BrandLogo`，支持配置点击目标地址
- 管理后台复用统一的 `BrandLogo` 组件
- 明确 Logo 资源支持 PNG、JPG/JPEG、SVG 和外部 URL
- 保留当前 JPG Logo，不改变现有视觉资源

## 验证

- `cd noj-ui && deno fmt --check components/shared/BrandLogo.vue layouts/admin.vue`
- `cd noj-ui && deno lint`
- `cd noj-ui && deno task check:types:nuxt`
- `git diff --check`
